### PR TITLE
Adopt Lato/Inconsolata font stack for docs

### DIFF
--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -30,6 +30,23 @@
  * limitations under the License.
  */
 
+/* Lato (normal, regular) */
+@font-face {
+    font-family: Lato;
+    font-weight: 400;
+    font-style: normal;
+    src: url("https://assets.gradle.com/lato/fonts/lato-normal/lato-normal.woff2") format("woff2"),
+    url("https://assets.gradle.com/lato/fonts/lato-normal/lato-normal.woff") format("woff");
+}
+/* Lato (normal, italic) */
+@font-face {
+    font-display: swap;
+    font-family: Lato;
+    font-weight: 400;
+    font-style: italic;
+    src: url("https://assets.gradle.com/lato/fonts/lato-normal-italic/lato-normal-italic.woff2") format("woff2"),
+    url("https://assets.gradle.com/lato/fonts/lato-normal-italic/lato-normal-italic.woff") format("woff");
+}
 /* Lato (bold, regular) */
 @font-face {
     font-display: swap;
@@ -38,6 +55,36 @@
     font-style: normal;
     src: url("https://assets.gradle.com/lato/fonts/lato-semibold/lato-semibold.woff2") format("woff2"),
     url("https://assets.gradle.com/lato/fonts/lato-semibold/lato-semibold.woff") format("woff");
+}
+/* Lato (bold, regular) */
+@font-face {
+    font-display: swap;
+    font-family: Lato;
+    font-weight: 800;
+    font-style: normal;
+    src: url("https://assets.gradle.com/lato/fonts/lato-heavy/lato-heavy.woff2") format("woff2"),
+    url("https://assets.gradle.com/lato/fonts/lato-heavy/lato-heavy.woff") format("woff");
+}
+
+/* inconsolata-regular - latin */
+@font-face {
+    font-display: swap;
+    font-family: 'Inconsolata';
+    font-style: normal;
+    font-weight: 400;
+    src: local('Inconsolata Regular'), local('Inconsolata-Regular'),
+    url('https://assets.gradle.com/inconsolata/inconsolata-v15-latin-regular.woff2') format('woff2'),
+    url('https://assets.gradle.com/inconsolata/inconsolata-v15-latin-regular.woff') format('woff');
+}
+/* inconsolata-700 - latin */
+@font-face {
+    font-display: swap;
+    font-family: 'Inconsolata';
+    font-style: normal;
+    font-weight: 700;
+    src: local('Inconsolata Bold'), local('Inconsolata-Bold'),
+    url('https://assets.gradle.com/inconsolata/inconsolata-v15-latin-700.woff2') format('woff2'),
+    url('https://assets.gradle.com/inconsolata/inconsolata-v15-latin-700.woff') format('woff');
 }
 
 
@@ -218,10 +265,10 @@ object, svg { display: inline-block; vertical-align: middle; }
 
 p.lead, .paragraph.lead > p, #preamble > .sectionbody > .paragraph:first-of-type p { font-size: 1.21875em; line-height: 1.6; }
 
-.subheader, .admonitionblock td#content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.45; color: #7a2518; font-weight: normal; margin-top: 0; margin-bottom: 0.25em; }
+.subheader, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { line-height: 1.45; color: #7a2518; font-weight: normal; margin-top: 0; margin-bottom: 0.25em; }
 
 /* Typography resets */
-div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > #content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
+div, dl, dt, dd, ul, ol, li, h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6, pre, form, p, blockquote, th, td { margin: 0; padding: 0; direction: ltr; }
 
 /* Default Link Styles */
 a { color: #2156a5; text-decoration: underline; line-height: inherit; }
@@ -233,14 +280,14 @@ p { font-family: inherit; font-weight: normal; font-size: 1em; line-height: 1.6;
 p aside { font-size: 0.875em; line-height: 1.35; font-style: italic; }
 
 /* Default header styles */
-h1, h2, h3, #toctitle, .sidebarblock > #content > .title, h4, h5, h6 { font-family: "Open Sans", "DejaVu Sans", sans-serif; font-weight: 300; font-style: normal; color: #ba3925; text-rendering: optimizeLegibility; margin-top: 1em; margin-bottom: 0.5em; line-height: 1.0125em; }
-h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > #content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #e99b8f; line-height: 0; }
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { font-family: "Open Sans", "DejaVu Sans", sans-serif; font-weight: 300; font-style: normal; color: #ba3925; text-rendering: optimizeLegibility; margin-top: 1em; margin-bottom: 0.5em; line-height: 1.0125em; }
+h1 small, h2 small, h3 small, #toctitle small, .sidebarblock > .content > .title small, h4 small, h5 small, h6 small { font-size: 60%; color: #e99b8f; line-height: 0; }
 
 h1 { font-size: 2.125em; }
 
 h2 { font-size: 1.6875em; }
 
-h3, #toctitle, .sidebarblock > #content > .title { font-size: 1.375em; }
+h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.375em; }
 
 h4 { font-size: 1.125em; }
 
@@ -301,10 +348,10 @@ blockquote, blockquote p { line-height: 1.6; color: rgba(0, 0, 0, 0.85); }
 .vevent .summary { font-weight: bold; }
 .vevent abbr { cursor: auto; text-decoration: none; font-weight: bold; border: none; padding: 0 0.0625em; }
 
-@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > #content > .title, h4, h5, h6 { line-height: 1.2; }
+@media only screen and (min-width: 768px) { h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.2; }
     h1 { font-size: 2.75em; }
     h2 { font-size: 2.3125em; }
-    h3, #toctitle, .sidebarblock > #content > .title { font-size: 1.6875em; }
+    h3, #toctitle, .sidebarblock > .content > .title { font-size: 1.6875em; }
     h4 { font-size: 1.4375em; } }
 /* Tables */
 table { background: white; margin-bottom: 1.25em; border: solid 1px #dedede; }
@@ -316,8 +363,8 @@ table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoo
 
 body { -moz-osx-font-smoothing: grayscale; -webkit-font-smoothing: antialiased; tab-size: 4; }
 
-h1, h2, h3, #toctitle, .sidebarblock > #content > .title, h4, h5, h6 { line-height: 1.2; word-spacing: -0.05em; }
-h1 strong, h2 strong, h3 strong, #toctitle strong, .sidebarblock > #content > .title strong, h4 strong, h5 strong, h6 strong { font-weight: 400; }
+h1, h2, h3, #toctitle, .sidebarblock > .content > .title, h4, h5, h6 { line-height: 1.2; word-spacing: -0.05em; }
+h1 strong, h2 strong, h3 strong, #toctitle strong, .sidebarblock > .content > .title strong, h4 strong, h5 strong, h6 strong { font-weight: 400; }
 
 .clearfix:before, .clearfix:after, .float-group:before, .float-group:after { content: " "; display: table; }
 .clearfix:after, .float-group:after { clear: both; }
@@ -412,15 +459,15 @@ p a > code:hover { color: rgba(0, 0, 0, 0.9); }
 @media only screen and (min-width: 768px) { .sect1 { padding-bottom: 1.25em; } }
 .sect1 + .sect1 { border-top: 1px solid #efefed; }
 
-#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > #content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
-#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > #content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
-#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > #content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > #content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
-#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > #content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: #ba3925; text-decoration: none; }
-#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > #content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: #a53221; }
+#content h1 > a.anchor, h2 > a.anchor, h3 > a.anchor, #toctitle > a.anchor, .sidebarblock > .content > .title > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor { position: absolute; z-index: 1001; width: 1.5ex; margin-left: -1.5ex; display: block; text-decoration: none !important; visibility: hidden; text-align: center; font-weight: normal; }
+#content h1 > a.anchor:before, h2 > a.anchor:before, h3 > a.anchor:before, #toctitle > a.anchor:before, .sidebarblock > .content > .title > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before { content: "\00A7"; font-size: 0.85em; display: block; padding-top: 0.1em; }
+#content h1:hover > a.anchor, #content h1 > a.anchor:hover, h2:hover > a.anchor, h2 > a.anchor:hover, h3:hover > a.anchor, #toctitle:hover > a.anchor, .sidebarblock > .content > .title:hover > a.anchor, h3 > a.anchor:hover, #toctitle > a.anchor:hover, .sidebarblock > .content > .title > a.anchor:hover, h4:hover > a.anchor, h4 > a.anchor:hover, h5:hover > a.anchor, h5 > a.anchor:hover, h6:hover > a.anchor, h6 > a.anchor:hover { visibility: visible; }
+#content h1 > a.link, h2 > a.link, h3 > a.link, #toctitle > a.link, .sidebarblock > .content > .title > a.link, h4 > a.link, h5 > a.link, h6 > a.link { color: #ba3925; text-decoration: none; }
+#content h1 > a.link:hover, h2 > a.link:hover, h3 > a.link:hover, #toctitle > a.link:hover, .sidebarblock > .content > .title > a.link:hover, h4 > a.link:hover, h5 > a.link:hover, h6 > a.link:hover { color: #a53221; }
 
 .audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .videoblock { margin-bottom: 1.25em; }
 
-.admonitionblock td#content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; font-family: "Noto Serif", "DejaVu Serif", serif; font-size: 1rem; font-style: italic; }
+.admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title { text-rendering: optimizeLegibility; text-align: left; font-family: "Noto Serif", "DejaVu Serif", serif; font-size: 1rem; font-style: italic; }
 
 table.tableblock > caption.title { white-space: nowrap; overflow: visible; max-width: 0; }
 
@@ -432,19 +479,19 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 .admonitionblock > table td.icon { text-align: center; width: 80px; }
 .admonitionblock > table td.icon img { max-width: initial; }
 .admonitionblock > table td.icon .title { font-weight: bold; font-family: "Open Sans", "DejaVu Sans", sans-serif; text-transform: uppercase; }
-.admonitionblock > table td#content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #ddddd8; color: rgba(0, 0, 0, 0.6); }
-.admonitionblock > table td#content > :last-child > :last-child { margin-bottom: 0; }
+.admonitionblock > table td.content { padding-left: 1.125em; padding-right: 1.25em; border-left: 1px solid #ddddd8; color: rgba(0, 0, 0, 0.6); }
+.admonitionblock > table td.content > :last-child > :last-child { margin-bottom: 0; }
 
-.exampleblock > #content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 4px; border-radius: 4px; }
-.exampleblock > #content > :first-child { margin-top: 0; }
-.exampleblock > #content > :last-child { margin-bottom: 0; }
+.exampleblock > .content { border-style: solid; border-width: 1px; border-color: #e6e6e6; margin-bottom: 1.25em; padding: 1.25em; background: white; -webkit-border-radius: 4px; border-radius: 4px; }
+.exampleblock > .content > :first-child { margin-top: 0; }
+.exampleblock > .content > :last-child { margin-bottom: 0; }
 
 .sidebarblock { border-style: solid; border-width: 1px; border-color: #e0e0dc; margin-bottom: 1.25em; padding: 1.25em; background: #f8f8f7; -webkit-border-radius: 4px; border-radius: 4px; }
 .sidebarblock > :first-child { margin-top: 0; }
 .sidebarblock > :last-child { margin-bottom: 0; }
-.sidebarblock > #content > .title { color: #7a2518; margin-top: 0; text-align: center; }
+.sidebarblock > .content > .title { color: #7a2518; margin-top: 0; text-align: center; }
 
-.exampleblock > #content > :last-child > :last-child, .exampleblock > #content .olist > ol > li:last-child > :last-child, .exampleblock > #content .ulist > ul > li:last-child > :last-child, .exampleblock > #content .qlist > ol > li:last-child > :last-child, .sidebarblock > #content > :last-child > :last-child, .sidebarblock > #content .olist > ol > li:last-child > :last-child, .sidebarblock > #content .ulist > ul > li:last-child > :last-child, .sidebarblock > #content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
+.exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child { margin-bottom: 0; }
 
 .literalblock pre, .listingblock pre:not(.highlight), .listingblock pre[class="highlight"], .listingblock pre[class^="highlight "], .listingblock pre.CodeRay, .listingblock pre.prettyprint { background: #f7f7f8; }
 .sidebarblock .literalblock pre, .sidebarblock .listingblock pre:not(.highlight), .sidebarblock .listingblock pre[class="highlight"], .sidebarblock .listingblock pre[class^="highlight "], .sidebarblock .listingblock pre.CodeRay, .sidebarblock .listingblock pre.prettyprint { background: #f2f1f1; }
@@ -461,7 +508,7 @@ table.tableblock #preamble > .sectionbody > .paragraph:first-of-type p { font-si
 
 .listingblock pre.prettyprint { border-width: 0; }
 
-.listingblock > #content { position: relative; }
+.listingblock > .content { position: relative; }
 
 .listingblock code[data-lang]:before { display: none; content: attr(data-lang); position: absolute; font-size: 0.75em; top: 0.425rem; right: 0.5rem; line-height: 1; text-transform: uppercase; color: #999; }
 
@@ -731,19 +778,19 @@ b.conum * { color: inherit !important; }
 
 .conum:not([data-value]):empty { display: none; }
 
-dt, th.tableblock, td#content, div.footnote { text-rendering: optimizeLegibility; }
+dt, th.tableblock, td.content, div.footnote { text-rendering: optimizeLegibility; }
 
-h1, h2, p, td#content, span.alt { letter-spacing: -0.01em; }
+h1, h2, p, td.content, span.alt { letter-spacing: -0.01em; }
 
-p strong, td#content strong, div.footnote strong { letter-spacing: -0.005em; }
+p strong, td.content strong, div.footnote strong { letter-spacing: -0.005em; }
 
-p, blockquote, dt, td#content, span.alt { font-size: 1.0625rem; }
+p, blockquote, dt, td.content, span.alt { font-size: 1.0625rem; }
 
 p { margin-bottom: 1.25rem; }
 
-.sidebarblock p, .sidebarblock dt, .sidebarblock td#content, p.tableblock { font-size: 1em; }
+.sidebarblock p, .sidebarblock dt, .sidebarblock td.content, p.tableblock { font-size: 1em; }
 
-.exampleblock > #content { background-color: #fffef7; border-color: #e0e0dc; -webkit-box-shadow: 0 1px 4px #e0e0dc; box-shadow: 0 1px 4px #e0e0dc; }
+.exampleblock > .content { background-color: #fffef7; border-color: #e0e0dc; -webkit-box-shadow: 0 1px 4px #e0e0dc; box-shadow: 0 1px 4px #e0e0dc; }
 
 .print-only { display: none !important; }
 
@@ -756,9 +803,9 @@ p { margin-bottom: 1.25rem; }
     pre, blockquote, tr, img, object, svg { page-break-inside: avoid; }
     thead { display: table-header-group; }
     svg { max-width: 100%; }
-    p, blockquote, dt, td#content { font-size: 1em; orphans: 3; widows: 3; }
-    h2, h3, #toctitle, .sidebarblock > #content > .title, #toctitle, .sidebarblock > #content > .title { page-break-after: avoid; }
-    #toc, .sidebarblock, .exampleblock > #content { background: none !important; }
+    p, blockquote, dt, td.content { font-size: 1em; orphans: 3; widows: 3; }
+    h2, h3, #toctitle, .sidebarblock > .content > .title, #toctitle, .sidebarblock > .content > .title { page-break-after: avoid; }
+    #toc, .sidebarblock, .exampleblock > .content { background: none !important; }
     #toc { border-bottom: 1px solid #ddddd8 !important; padding-bottom: 0 !important; }
     .sect1 { padding-bottom: 0 !important; }
     .sect1 + .sect1 { border: 0 !important; }
@@ -816,9 +863,10 @@ a:focus {
 
 #content a[href^='../dsl/'],
 #content a[href^='../javadoc/'] {
-    font-family: monospace;
+    font-family: 'Inconsolata', monospace;
     font-style: normal;
-    border-bottom: 1px dotted #1DA2BD;
+    border-bottom: 1px dotted rgba(29, 162, 189, 0.5);
+    padding: 0 1px;
 }
 
 #content a[href^='../dsl/']:hover,
@@ -834,6 +882,10 @@ p {
     font-size: 1rem;
 }
 
+code {
+    font-family: 'Inconsolata', monospace;
+}
+
 h1,
 h2,
 h3,
@@ -841,7 +893,7 @@ h4,
 h5,
 h6,
 #toctitle,
-.sidebarblock > #content > .title {
+.sidebarblock > .content > .title {
     font-family: inherit;
     font-weight: 500;
     color: inherit;
@@ -922,7 +974,7 @@ p {
 }
 
 .subheader,
-.admonitionblock td#content > .title,
+.admonitionblock td.content > .title,
 .audioblock > .title,
 .exampleblock > .title,
 .imageblock > .title,

--- a/subprojects/docs/src/main/resources/head.html
+++ b/subprojects/docs/src/main/resources/head.html
@@ -1,3 +1,2 @@
 <link crossorigin href="//assets.gradle.com" rel="preconnect">
-<link href="https://fonts.googleapis.com/css?family=Lato:400,400i,700" rel="stylesheet"/>
 <script defer src="https://guides.gradle.org/js/guides-4.8.js"></script>


### PR DESCRIPTION
### Context
#6086 requests a nice font stack and code style rendering. This is one idea that uses Inconsolata for inline code but keeps Droid Sans Mono

Pros:
 * Consistent with Gradle Enterprise
 * Looks really nice IMO

Cons:
 * Loads 5 fonts from assets.gradle.com instead of fonts.google.com. Google Fonts is accelerated everywhere, and I'm not sure yet what the perf impact is in emerging markets. One big factor is our application to have downloads accelerated in China bypassing the great firewall. 
 * Probably too many fonts going on here, but I'm not sold yet on Inconsolata for the real real code font. 

#### Before & After

![screenshot 2018-07-26 12 05 21](https://user-images.githubusercontent.com/51534/43283421-ae44b3fc-90cd-11e8-823c-9177e02471b7.png)

WDYT?

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
