### PR TITLE
Retain full declared version constraints in dependency model

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -37,12 +37,22 @@ public interface VersionConstraint {
     String getBranch();
 
     /**
-     * The preferred version of a module. The preferred version of a module can typically be upgraded during dependency resolution,
-     * unless further constraints are added.
+     * The preferred version of a module (which may be an exact version or a version range).
+     *
+     * The preferred version of a module can typically be upgraded during dependency resolution, unless further constraints are added.
      *
      * @return the preferred version, or empty string if no preferred version specified. Never null.
      */
     String getPreferredVersion();
+
+    /**
+     * The strictly required version of a module (which may be an exact version or a version range).
+     *
+     * The required version of a module is strictly enforced and cannot be upgraded or downgraded during dependency resolution.
+     *
+     * @return the strict version, or empty string if no required version specified. Never null.
+     */
+    String getStrictVersion();
 
     /**
      * Returns the list of versions that this module rejects  (which may be exact versions, or ranges, anything that fits into a version string).

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -37,9 +37,19 @@ public interface VersionConstraint {
     String getBranch();
 
     /**
+     * The required version of a module (which may be an exact version or a version range).
+     *
+     * The required version of a module can typically be upgraded during dependency resolution, but not downgraded.
+     *
+     * @return the required version, or empty string if no required version specified. Never null.
+     */
+    String getRequiredVersion();
+
+    /**
      * The preferred version of a module (which may be an exact version or a version range).
      *
-     * The preferred version of a module can typically be upgraded during dependency resolution, unless further constraints are added.
+     * The preferred version of a module provides a hint when resolving the version,
+     * but will not be honored in the presence of conflicting constraints.
      *
      * @return the preferred version, or empty string if no preferred version specified. Never null.
      */

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependencySpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependencySpec.groovy
@@ -49,7 +49,9 @@ abstract class AbstractModuleDependencySpec extends Specification {
         dependency.group == "org.gradle"
         dependency.name == "gradle-core"
         dependency.version == "4.4-beta2"
-        dependency.versionConstraint.preferredVersion == "4.4-beta2"
+        dependency.versionConstraint.requiredVersion == "4.4-beta2"
+        dependency.versionConstraint.preferredVersion == ""
+        dependency.versionConstraint.strictVersion == ""
         dependency.versionConstraint.rejectedVersions == []
         dependency.transitive
         dependency.artifacts.isEmpty()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraintTest.groovy
@@ -27,7 +27,9 @@ class DefaultDependencyConstraintTest extends Specification {
         dependencyConstraint.group == "org.gradle"
         dependencyConstraint.name == "gradle-core"
         dependencyConstraint.version == "4.4-beta2"
-        dependencyConstraint.versionConstraint.preferredVersion == "4.4-beta2"
+        dependencyConstraint.versionConstraint.requiredVersion == "4.4-beta2"
+        dependencyConstraint.versionConstraint.preferredVersion == ""
+        dependencyConstraint.versionConstraint.strictVersion == ""
         dependencyConstraint.versionConstraint.rejectedVersions == []
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -108,7 +108,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '1.1'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'
    Constraint path ':test:unspecified' --> 'org:foo' rejects all versions""")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -771,7 +771,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org.test:moduleB' prefers '1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB' prefers '1.0', rejects '(1.0,)'"""
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB' strictly '1.0'"""
 
         where:
         thing                    | defineAsConstraint

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -770,7 +770,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         then:
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org.test:moduleB' prefers '1.1'
+   Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
    ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB' strictly '1.0'"""
 
         where:
@@ -837,8 +837,8 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         then:
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org.test:moduleB' prefers '1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB' prefers '1.0', rejects any of "'1.1', '1.2'\""""
+   Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB' prefers '1.0' rejects any of "'1.1', '1.2'\""""
 
         where:
         thing                    | defineAsConstraint

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -181,7 +181,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 void execute(ComponentMetadataContext context) {
                     context.details.withVariant("$variantToTest") {
                         withDependencies {
-                            removeAll { it.versionConstraint.preferredVersion == '1.0' }
+                            removeAll { it.versionConstraint.requiredVersion == '1.0' }
                         }
                     }
                 }
@@ -224,7 +224,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 void execute(ComponentMetadataContext context) {
                     context.details.withVariant("$variantToTest") {
                         withDependencyConstraints {
-                            removeAll { it.versionConstraint.preferredVersion == '2.0' }
+                            removeAll { it.versionConstraint.requiredVersion == '2.0' }
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -103,7 +103,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '1.0', rejects '(1.0,)'
+   Dependency path ':test:unspecified' --> 'org:foo' strictly '1.0'
    Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '1.1'""")
 
     }
@@ -312,7 +312,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo' prefers '17'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' prefers '15', rejects '(15,)'""")
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '15'""")
 
     }
 
@@ -364,8 +364,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '17', rejects '(17,)'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' prefers '15', rejects '(15,)'""")
+   Dependency path ':test:unspecified' --> 'org:foo' strictly '17'
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '15'""")
 
     }
 
@@ -420,8 +420,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '[15,16]', rejects '(16,)'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' prefers '[17,18]', rejects '(18,)'""")
+   Dependency path ':test:unspecified' --> 'org:foo' strictly '[15,16]'
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '[17,18]'""")
 
     }
 
@@ -836,7 +836,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:bar' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:bar' prefers '1'
-   Constraint path ':test:unspecified' --> 'org:bar' prefers '1', rejects '(1,)'
+   Constraint path ':test:unspecified' --> 'org:bar' strictly '1'
    Dependency path ':test:unspecified' --> 'org:foo:2' --> 'org:bar' prefers '2'""")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -62,6 +62,56 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         }
     }
 
+    @Issue("gradle/gradle#4186")
+    def "should choose highest when multiple prefer versions disagree"() {
+        repository {
+            'org:foo' {
+                '1.0.0'()
+                '1.1.0'()
+                '1.2.0'()
+                '2.0.0'()
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                constraints {
+                    conf('org:foo') {
+                        version { prefer '1.1.0' }
+                    }
+                    conf('org:foo') {
+                        version { prefer '1.0.0' }
+                    }
+                }
+                conf 'org:foo:[1.0.0,2.0.0)'
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo' {
+                expectVersionListing()
+                '1.1.0' {
+                    expectGetMetadata()
+                    expectGetArtifact()
+                }
+                '1.2.0' {
+                    expectGetMetadata()
+                }
+            }
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:foo:1.0.0", "org:foo:1.1.0")
+                edge("org:foo:1.1.0", "org:foo:1.1.0")
+                edge("org:foo:[1.0.0,2.0.0)", "org:foo:1.1.0")
+            }
+        }
+    }
+
     void "should fail if transitive dependency version is not compatible with the strict dependency version"() {
         given:
         repository {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -154,7 +154,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo' strictly '1.0'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '1.1'""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'""")
 
     }
 
@@ -361,7 +361,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '17'
+   Dependency path ':test:unspecified' --> 'org:foo:17'
    Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '15'""")
 
     }
@@ -670,8 +670,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '1.0', rejects '1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '1.1'""")
+   Dependency path ':test:unspecified' --> 'org:foo:1.0' rejects '1.1'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'""")
     }
 
     def "can reject a version range"() {
@@ -885,9 +885,9 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:bar' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:bar' prefers '1'
+   Dependency path ':test:unspecified' --> 'org:bar:1'
    Constraint path ':test:unspecified' --> 'org:bar' strictly '1'
-   Dependency path ':test:unspecified' --> 'org:foo:2' --> 'org:bar' prefers '2'""")
+   Dependency path ':test:unspecified' --> 'org:foo:2' --> 'org:bar:2'""")
     }
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsResolveIntegrationTest.groovy
@@ -59,7 +59,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo' prefers '17'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '15', rejects '(15,)' because of the following reason: what not""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' strictly '15' because of the following reason: what not""")
 
     }
 
@@ -199,8 +199,8 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '17', rejects '(17,)'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '15', rejects '(15,)'""")
+   Dependency path ':test:unspecified' --> 'org:foo' strictly '17'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' strictly '15'""")
 
     }
 
@@ -370,7 +370,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' prefers '1.0', rejects '(1.0,)' because of the following reason: Not following semantic versioning
+   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' strictly '1.0' because of the following reason: Not following semantic versioning
    Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b' prefers '1.1'""")
 
         and:
@@ -429,7 +429,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' prefers '1.0', rejects '(1.0,)' because of the following reason: Not following semantic versioning
+   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' strictly '1.0' because of the following reason: Not following semantic versioning
    Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b' prefers '1.1'""")
 
         and:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsResolveIntegrationTest.groovy
@@ -34,7 +34,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
                 '17'()
             }
             'org:bar:1.0' {
-                dependsOn(group: 'org', artifact: 'foo', version: '15', rejects: ['(15,)'], reason: 'what not')
+                dependsOn(group: 'org', artifact: 'foo', version: '15', strictly: '15', reason: 'what not')
             }
         }
 
@@ -73,7 +73,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
                 '1.3'()
             }
             'org:bar:1.0' {
-                dependsOn(group: 'org', artifact: 'foo', version: '[1.1,1.3]', rejects: [']1.3,)'])
+                dependsOn(group: 'org', artifact: 'foo', version: '[1.1,1.3]', strictly: '[1.1,1.3]')
             }
         }
 
@@ -170,7 +170,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
             'org:foo:15'()
             'org:foo:17'()
             'org:bar:1.0' {
-                dependsOn(group: 'org', artifact: 'foo', version: '15', rejects: ['(15,)'])
+                dependsOn(group: 'org', artifact: 'foo', version: '15', strictly: '15')
             }
         }
 
@@ -324,7 +324,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
         repository {
             'org' {
                 'a:1.0' {
-                    dependsOn (group: 'org', artifact: 'b', version: '1.0', rejects: ['(1.0,)'], reason: 'Not following semantic versioning')
+                    dependsOn (group: 'org', artifact: 'b', version: '1.0', strictly: '1.0', reason: 'Not following semantic versioning')
                 }
                 'b' {
                     '1.0'()
@@ -382,7 +382,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
         repository {
             'org' {
                 'a:1.0' {
-                    dependsOn (group: 'org', artifact: 'b', version: '1.0', rejects: ['(1.0,)'], reason: 'Not following semantic versioning')
+                    dependsOn (group: 'org', artifact: 'b', version: '1.0', strictly: '1.0', reason: 'Not following semantic versioning')
                 }
                 'b' {
                     '1.0'()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsResolveIntegrationTest.groovy
@@ -58,7 +58,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '17'
+   Dependency path ':test:unspecified' --> 'org:foo:17'
    Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' strictly '15' because of the following reason: what not""")
 
     }
@@ -246,8 +246,8 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '1.0', rejects '1.1'""")
+   Dependency path ':test:unspecified' --> 'org:foo:1.1'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.0' rejects '1.1'""")
     }
 
     @Unroll
@@ -282,8 +282,8 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' prefers '1.0', rejects any of "${rejects.collect {"'$it'"}.join(', ')}\"""")
+   Dependency path ':test:unspecified' --> 'org:foo:1.1'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.0' rejects any of "${rejects.collect {"'$it'"}.join(', ')}\"""")
 
         where:
         rejects << [
@@ -324,7 +324,7 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
 
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
-   Dependency path ':test:unspecified' --> 'org:foo' prefers '1.0'
+   Dependency path ':test:unspecified' --> 'org:foo:1.0'
    Constraint path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' rejects all versions""")
 
     }
@@ -381,10 +381,10 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' strictly '1.0' because of the following reason: Not following semantic versioning
-   Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b' prefers '1.1'""")
+   Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b:1.1'""")
 
         and:
-        failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b' prefers '1.1'")
+        failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
     def "handles dependency cycles"() {
@@ -440,10 +440,10 @@ class RichVersionConstraintsResolveIntegrationTest extends AbstractModuleDepende
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' strictly '1.0' because of the following reason: Not following semantic versioning
-   Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b' prefers '1.1'""")
+   Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b:1.1'""")
 
         and:
-        failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b' prefers '1.1'")
+        failure.assertHasNoCause("Dependency path ':test:unspecified' --> 'org:d:1.0' --> 'org:c:1.0' --> 'org:b:1.1'")
     }
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
@@ -331,45 +331,6 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         permutation << VersionRangeResolveTestScenarios.SCENARIOS_DEPENDENCY_WITH_REJECT
     }
 
-    @Unroll
-    def "resolve three #permutation"() {
-        given:
-        def candidates = permutation.candidates
-        def expected = permutation.expected
-
-        expect:
-        checkScenarioResolution(expected, candidates)
-
-        where:
-        permutation << VersionRangeResolveTestScenarios.SCENARIOS_THREE_DEPENDENCIES
-    }
-
-    @Unroll
-    def "resolve deps with reject #permutation"() {
-        given:
-        def candidates = permutation.candidates
-        def expected = permutation.expected
-
-        expect:
-        checkScenarioResolution(expected, candidates)
-
-        where:
-        permutation << VersionRangeResolveTestScenarios.SCENARIOS_WITH_REJECT
-    }
-
-    @Unroll
-    def "resolve four #permutation"() {
-        given:
-        def candidates = permutation.candidates
-        def expected = permutation.expected
-
-        expect:
-        checkScenarioResolution(expected, candidates)
-
-        where:
-        permutation << VersionRangeResolveTestScenarios.SCENARIOS_FOUR_DEPENDENCIES
-    }
-
     void checkScenarioResolution(String expected, VersionRangeResolveTestScenarios.RenderableVersion... versions) {
         checkScenarioResolution(expected, versions as List)
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
@@ -423,7 +423,7 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
 
     def parseFailureType(ExecutionFailure failure) {
         if (failure.error.contains("Cannot find a version of 'org:foo' that satisfies the version constraints")
-            && failure.error.contains("rejects")) {
+            && (failure.error.contains("rejects") || failure.error.contains("strictly"))) {
             return VersionRangeResolveTestScenarios.REJECTED
         }
         return VersionRangeResolveTestScenarios.FAILED

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -106,7 +106,7 @@ dependencies {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':depLock:unspecified' --> 'org:foo' prefers '1.+'
+   Dependency path ':depLock:unspecified' --> 'org:foo:1.+'
    Dependency path ':depLock:unspecified' --> 'org:foo' strictly '1.1'
    Constraint path ':depLock:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'"""
     }
@@ -143,8 +143,8 @@ dependencies {
 
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':depLock:unspecified' --> 'org:foo' prefers '1.+'
-   Dependency path ':depLock:unspecified' --> 'org:foo' prefers '1.1'
+   Dependency path ':depLock:unspecified' --> 'org:foo:1.+'
+   Dependency path ':depLock:unspecified' --> 'org:foo:1.1'
    Constraint path ':depLock:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'"""
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -49,12 +49,13 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
 
     public VersionConstraint readVersionConstraint(Decoder decoder) throws IOException {
         String preferred = decoder.readString();
+        String strictly = decoder.readString();
         int cpt = decoder.readSmallInt();
         List<String> rejects = Lists.newArrayListWithCapacity(cpt);
         for (int i = 0; i < cpt; i++) {
             rejects.add(decoder.readString());
         }
-        return new DefaultImmutableVersionConstraint(preferred, rejects);
+        return new DefaultImmutableVersionConstraint(preferred, strictly, rejects);
     }
 
     public void write(Encoder encoder, ModuleComponentSelector value) throws IOException {
@@ -73,6 +74,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
 
     public void writeVersionConstraint(Encoder encoder, VersionConstraint cst) throws IOException {
         encoder.writeString(cst.getPreferredVersion());
+        encoder.writeString(cst.getStrictVersion());
         List<String> rejectedVersions = cst.getRejectedVersions();
         encoder.writeSmallInt(rejectedVersions.size());
         for (String rejectedVersion : rejectedVersions) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializer.java
@@ -48,6 +48,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
     }
 
     public VersionConstraint readVersionConstraint(Decoder decoder) throws IOException {
+        String required = decoder.readString();
         String preferred = decoder.readString();
         String strictly = decoder.readString();
         int cpt = decoder.readSmallInt();
@@ -55,7 +56,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
         for (int i = 0; i < cpt; i++) {
             rejects.add(decoder.readString());
         }
-        return new DefaultImmutableVersionConstraint(preferred, strictly, rejects);
+        return new DefaultImmutableVersionConstraint(required, preferred, strictly, rejects);
     }
 
     public void write(Encoder encoder, ModuleComponentSelector value) throws IOException {
@@ -73,6 +74,7 @@ public class ModuleComponentSelectorSerializer implements Serializer<ModuleCompo
     }
 
     public void writeVersionConstraint(Encoder encoder, VersionConstraint cst) throws IOException {
+        encoder.writeString(cst.getRequiredVersion());
         encoder.writeString(cst.getPreferredVersion());
         encoder.writeString(cst.getStrictVersion());
         List<String> rejectedVersions = cst.getRejectedVersions();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
@@ -17,7 +17,7 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 
-public interface ResolvedVersionConstraint extends ImmutableVersionConstraint {
+public interface ResolvedVersionConstraint {
     VersionSelector getPreferredSelector();
     VersionSelector getRejectedSelector();
     boolean isRejectAll();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
@@ -21,4 +21,5 @@ public interface ResolvedVersionConstraint {
     VersionSelector getPreferredSelector();
     VersionSelector getRejectedSelector();
     boolean isRejectAll();
+    boolean isPrefer();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -67,7 +67,7 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     }
 
     public String getVersion() {
-        return Strings.emptyToNull(versionConstraint.getPreferredVersion());
+        return Strings.emptyToNull(versionConstraint.getRequiredVersion());
     }
 
     public boolean isForce() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -31,20 +31,15 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
 
         AbstractVersionConstraint that = (AbstractVersionConstraint) o;
 
-        if (!Objects.equal(getPreferredVersion(), that.getPreferredVersion())) {
-            return false;
-        }
-        if (!Objects.equal(getBranch(), that.getBranch())) {
-            return false;
-        }
-        return getRejectedVersions().equals(that.getRejectedVersions());
+        return Objects.equal(getPreferredVersion(), that.getPreferredVersion())
+            && Objects.equal(getStrictVersion(), that.getStrictVersion())
+            && Objects.equal(getBranch(), that.getBranch())
+            && Objects.equal(getRejectedVersions(), that.getRejectedVersions());
     }
 
     @Override
     public int hashCode() {
-        int result = getPreferredVersion().hashCode();
-        result = 31 * result + getRejectedVersions().hashCode();
-        return result;
+        return Objects.hashCode(getPreferredVersion(), getStrictVersion(), getRejectedVersions());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -31,7 +31,8 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
 
         AbstractVersionConstraint that = (AbstractVersionConstraint) o;
 
-        return Objects.equal(getPreferredVersion(), that.getPreferredVersion())
+        return Objects.equal(getRequiredVersion(), that.getRequiredVersion())
+            && Objects.equal(getPreferredVersion(), that.getPreferredVersion())
             && Objects.equal(getStrictVersion(), that.getStrictVersion())
             && Objects.equal(getBranch(), that.getBranch())
             && Objects.equal(getRejectedVersions(), that.getRejectedVersions());
@@ -39,11 +40,15 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getPreferredVersion(), getStrictVersion(), getRejectedVersions());
+        return Objects.hashCode(getRequiredVersion(), getPreferredVersion(), getStrictVersion(), getRejectedVersions());
     }
 
     @Override
     public String toString() {
-        return getPreferredVersion() + (getRejectedVersions().isEmpty() ? "" : " {rejects: " + Joiner.on(" & ").join(getRejectedVersions()) + "}") + (getBranch() == null ? "" : " {branch: " + getBranch() + "}");
+        return getRequiredVersion()
+            + (getPreferredVersion().isEmpty() ? "" : " {prefers: " + getPreferredVersion() + "}")
+            + (getStrictVersion().isEmpty() ? "" : " {strictly: " + getStrictVersion() + "}")
+            + (getRejectedVersions().isEmpty() ? "" : " {rejects: " + Joiner.on(" & ").join(getRejectedVersions()) + "}")
+            + (getBranch() == null ? "" : " {branch: " + getBranch() + "}");
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -69,7 +69,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
 
     @Override
     public String getVersion() {
-        return Strings.emptyToNull(versionConstraint.getPreferredVersion());
+        return Strings.emptyToNull(versionConstraint.getRequiredVersion());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -26,6 +26,7 @@ import java.util.List;
 public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint implements ImmutableVersionConstraint {
     private static final DefaultImmutableVersionConstraint EMPTY = new DefaultImmutableVersionConstraint("");
     private final String preferredVersion;
+    private final String strictVersion;
     private final ImmutableList<String> rejectedVersions;
     @Nullable
     private final String requiredBranch;
@@ -33,16 +34,21 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
     private final int hashCode;
 
     public DefaultImmutableVersionConstraint(String preferredVersion,
+                                             String strictVersion,
                                              List<String> rejectedVersions) {
-        this(preferredVersion, rejectedVersions, null);
+        this(preferredVersion, strictVersion, rejectedVersions, null);
     }
 
     public DefaultImmutableVersionConstraint(String preferredVersion,
+                                             String strictVersion,
                                              List<String> rejectedVersions,
                                              @Nullable
                                              String requiredBranch) {
         if (preferredVersion == null) {
             throw new IllegalArgumentException("Preferred version must not be null");
+        }
+        if (strictVersion == null) {
+            throw new IllegalArgumentException("Strict version must not be null");
         }
         if (rejectedVersions == null) {
             throw new IllegalArgumentException("Rejected versions must not be null");
@@ -53,6 +59,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
             }
         }
         this.preferredVersion = preferredVersion;
+        this.strictVersion = strictVersion;
         this.rejectedVersions = ImmutableList.copyOf(rejectedVersions);
         this.requiredBranch = requiredBranch;
         this.hashCode = super.hashCode();
@@ -63,6 +70,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
             throw new IllegalArgumentException("Preferred version must not be null");
         }
         this.preferredVersion = preferredVersion;
+        this.strictVersion = "";
         this.rejectedVersions = ImmutableList.of();
         this.requiredBranch = null;
         this.hashCode = super.hashCode();
@@ -85,6 +93,11 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
     }
 
     @Override
+    public String getStrictVersion() {
+        return strictVersion;
+    }
+
+    @Override
     public List<String> getRejectedVersions() {
         return rejectedVersions;
     }
@@ -93,7 +106,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         if (versionConstraint instanceof ImmutableVersionConstraint) {
             return (ImmutableVersionConstraint) versionConstraint;
         }
-        return new DefaultImmutableVersionConstraint(versionConstraint.getPreferredVersion(), versionConstraint.getRejectedVersions());
+        return new DefaultImmutableVersionConstraint(versionConstraint.getPreferredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions());
     }
 
     public static ImmutableVersionConstraint of(String preferredVersion) {
@@ -103,8 +116,8 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         return new DefaultImmutableVersionConstraint(preferredVersion);
     }
 
-    public static ImmutableVersionConstraint of(String preferredVersion, List<String> rejects) {
-        return new DefaultImmutableVersionConstraint(preferredVersion, rejects);
+    public static ImmutableVersionConstraint of(String preferredVersion, String requiredVersion, List<String> rejects) {
+        return new DefaultImmutableVersionConstraint(preferredVersion, requiredVersion, rejects);
     }
 
     public static ImmutableVersionConstraint of() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -25,6 +25,7 @@ import java.util.List;
 
 public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint implements ImmutableVersionConstraint {
     private static final DefaultImmutableVersionConstraint EMPTY = new DefaultImmutableVersionConstraint("");
+    private final String requiredVersion;
     private final String preferredVersion;
     private final String strictVersion;
     private final ImmutableList<String> rejectedVersions;
@@ -33,17 +34,22 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
 
     private final int hashCode;
 
-    public DefaultImmutableVersionConstraint(String preferredVersion,
+    public DefaultImmutableVersionConstraint(String requiredVersion,
+                                             String preferredVersion,
                                              String strictVersion,
                                              List<String> rejectedVersions) {
-        this(preferredVersion, strictVersion, rejectedVersions, null);
+        this(requiredVersion, preferredVersion, strictVersion, rejectedVersions, null);
     }
 
-    public DefaultImmutableVersionConstraint(String preferredVersion,
+    public DefaultImmutableVersionConstraint(String requiredVersion,
+                                             String preferredVersion,
                                              String strictVersion,
                                              List<String> rejectedVersions,
                                              @Nullable
                                              String requiredBranch) {
+        if (requiredVersion == null) {
+            throw new IllegalArgumentException("Required version must not be null");
+        }
         if (preferredVersion == null) {
             throw new IllegalArgumentException("Preferred version must not be null");
         }
@@ -58,6 +64,7 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
                 throw new IllegalArgumentException("Rejected version must not be empty");
             }
         }
+        this.requiredVersion = requiredVersion;
         this.preferredVersion = preferredVersion;
         this.strictVersion = strictVersion;
         this.rejectedVersions = ImmutableList.copyOf(rejectedVersions);
@@ -65,11 +72,12 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         this.hashCode = super.hashCode();
     }
 
-    public DefaultImmutableVersionConstraint(String preferredVersion) {
-        if (preferredVersion == null) {
-            throw new IllegalArgumentException("Preferred version must not be null");
+    public DefaultImmutableVersionConstraint(String requiredVersion) {
+        if (requiredVersion == null) {
+            throw new IllegalArgumentException("Required version must not be null");
         }
-        this.preferredVersion = preferredVersion;
+        this.requiredVersion = requiredVersion;
+        this.preferredVersion = "";
         this.strictVersion = "";
         this.rejectedVersions = ImmutableList.of();
         this.requiredBranch = null;
@@ -85,6 +93,11 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
     @Override
     public String getBranch() {
         return requiredBranch;
+    }
+
+    @Override
+    public String getRequiredVersion() {
+        return requiredVersion;
     }
 
     @Override
@@ -106,18 +119,18 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
         if (versionConstraint instanceof ImmutableVersionConstraint) {
             return (ImmutableVersionConstraint) versionConstraint;
         }
-        return new DefaultImmutableVersionConstraint(versionConstraint.getPreferredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions());
+        return new DefaultImmutableVersionConstraint(versionConstraint.getRequiredVersion(), versionConstraint.getPreferredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions());
     }
 
-    public static ImmutableVersionConstraint of(String preferredVersion) {
-        if (preferredVersion == null) {
+    public static ImmutableVersionConstraint of(String version) {
+        if (version == null) {
             return of();
         }
-        return new DefaultImmutableVersionConstraint(preferredVersion);
+        return new DefaultImmutableVersionConstraint(version);
     }
 
-    public static ImmutableVersionConstraint of(String preferredVersion, String requiredVersion, List<String> rejects) {
-        return new DefaultImmutableVersionConstraint(preferredVersion, requiredVersion, rejects);
+    public static ImmutableVersionConstraint of(String requiredVersion, String preferredVersion, String strictVersion, List<String> rejects) {
+        return new DefaultImmutableVersionConstraint(requiredVersion, preferredVersion, strictVersion, rejects);
     }
 
     public static ImmutableVersionConstraint of() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -31,28 +31,39 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     private String preferredVersion;
     private String strictVersion;
     private String branch;
-    private final List<String> rejectedVersions = Lists.newArrayListWithExpectedSize(1);
+    private final List<String> rejectedVersions;
 
     public DefaultMutableVersionConstraint(VersionConstraint versionConstraint) {
-        this.preferredVersion = nullToEmpty(versionConstraint.getPreferredVersion());
-        this.strictVersion = nullToEmpty(versionConstraint.getStrictVersion());
-        this.rejectedVersions.addAll(versionConstraint.getRejectedVersions());
+        this(versionConstraint.getPreferredVersion(), versionConstraint.getStrictVersion(), versionConstraint.getRejectedVersions());
     }
 
     public DefaultMutableVersionConstraint(String version) {
-        prefer(version);
+        this(version, null);
     }
 
-    public DefaultMutableVersionConstraint(String version, boolean strict) {
-        prefer(version);
-        if (strict) {
-            strictly(version);
+    private DefaultMutableVersionConstraint(String preferredVersion, String strictVersion) {
+        this(preferredVersion, strictVersion, Collections.<String>emptyList());
+    }
+
+    private DefaultMutableVersionConstraint(String preferredVersion, String strictVersion, List<String> rejects) {
+        this.preferredVersion = nullToEmpty(preferredVersion);
+        this.strictVersion = nullToEmpty(strictVersion);
+        this.rejectedVersions = Lists.newArrayListWithCapacity(rejects.size());
+        for (String reject : rejects) {
+            this.rejectedVersions.add(nullToEmpty(reject));
         }
     }
 
-    public DefaultMutableVersionConstraint(String version, List<String> rejects) {
-        prefer(version);
-        this.rejectedVersions.addAll(rejects);
+    public static DefaultMutableVersionConstraint withVersion(String version) {
+        return new DefaultMutableVersionConstraint(version, null);
+    }
+
+    public static DefaultMutableVersionConstraint withPreferredVersion(String version) {
+        return new DefaultMutableVersionConstraint(version, null);
+    }
+
+    public static DefaultMutableVersionConstraint withStrictVersion(String version) {
+        return new DefaultMutableVersionConstraint(version, version);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
@@ -23,23 +23,23 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionS
 
 import java.util.List;
 
-public class DefaultResolvedVersionConstraint extends DefaultImmutableVersionConstraint implements ResolvedVersionConstraint {
+public class DefaultResolvedVersionConstraint implements ResolvedVersionConstraint {
     private final VersionSelector preferredVersionSelector;
     private final VersionSelector rejectedVersionsSelector;
+    private final boolean rejectAll;
 
     public DefaultResolvedVersionConstraint(VersionSelector preferredVersionSelector, VersionSelector rejectedVersionsSelector) {
-        super(preferredVersionSelector.getSelector());
         this.preferredVersionSelector = preferredVersionSelector;
         this.rejectedVersionsSelector = rejectedVersionsSelector;
+        rejectAll = false;
     }
 
     public DefaultResolvedVersionConstraint(VersionConstraint parent, VersionSelectorScheme scheme) {
-        super(parent.getPreferredVersion(), parent.getRejectedVersions());
-
         String preferredVersion = parent.getPreferredVersion();
         List<String> rejectedVersions = parent.getRejectedVersions();
         this.preferredVersionSelector = scheme.parseSelector(preferredVersion);
         this.rejectedVersionsSelector = toRejectSelector(scheme, rejectedVersions);
+        rejectAll = isRejectAll(preferredVersion, rejectedVersions);
     }
 
     private static VersionSelector toRejectSelector(VersionSelectorScheme scheme, List<String> rejectedVersions) {
@@ -61,8 +61,12 @@ public class DefaultResolvedVersionConstraint extends DefaultImmutableVersionCon
 
     @Override
     public boolean isRejectAll() {
-        return "".equals(getPreferredVersion())
-            && hasMatchAllSelector(getRejectedVersions());
+        return rejectAll;
+    }
+
+    private static boolean isRejectAll(String preferredVersion, List<String> rejectedVersions) {
+        return "".equals(preferredVersion)
+            && hasMatchAllSelector(rejectedVersions);
     }
 
     private static boolean hasMatchAllSelector(List<String> rejectedVersions) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.UnionVersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.util.GUtil;
 
 import java.util.List;
 
@@ -36,13 +37,15 @@ public class DefaultResolvedVersionConstraint implements ResolvedVersionConstrai
     }
 
     public DefaultResolvedVersionConstraint(VersionConstraint parent, VersionSelectorScheme scheme) {
-        this(parent.getPreferredVersion(), parent.getStrictVersion(), parent.getRejectedVersions(), scheme);
+        this(parent.getRequiredVersion(), parent.getPreferredVersion(), parent.getStrictVersion(), parent.getRejectedVersions(), scheme);
     }
 
     @VisibleForTesting
-    public DefaultResolvedVersionConstraint(String preferredVersion, String strictVersion, List<String> rejectedVersions, VersionSelectorScheme scheme) {
+    public DefaultResolvedVersionConstraint(String requiredVersion, String preferredVersion, String strictVersion, List<String> rejectedVersions, VersionSelectorScheme scheme) {
+        // For now, required and preferred are treated the same
+
         boolean strict = !strictVersion.isEmpty();
-        String version = strict ? strictVersion : preferredVersion;
+        String version = strict ? strictVersion : GUtil.elvis(preferredVersion, requiredVersion);
         this.preferredVersionSelector = scheme.parseSelector(version);
 
         if (strict) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -50,7 +50,7 @@ public enum CacheLayout {
         .changedTo(53, "4.6-rc-1")
         .changedTo(56, "4.7-rc-1")
         .changedTo(58, "4.8-rc-1")
-        .changedTo(61, "4.10-rc-1")),
+        .changedTo(63, "4.10-rc-1")),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainDependencyToComponentIdResolver.java
@@ -71,7 +71,7 @@ public class RepositoryChainDependencyToComponentIdResolver implements Dependenc
             if (preferredSelector.isDynamic()) {
                 dynamicRevisionResolver.resolve(toModuleDependencyMetadata(dependency), preferredSelector, rejectSelector, consumerAttributes, result);
             } else {
-                String version = resolvedVersionConstraint.getPreferredVersion();
+                String version = preferredSelector.getSelector();
                 ModuleIdentifier moduleId = module.getModuleIdentifier();
                 ModuleComponentIdentifier id = DefaultModuleComponentIdentifier.newId(moduleId, version);
                 ModuleVersionIdentifier mvId = DefaultModuleVersionIdentifier.newId(moduleId, version);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -286,12 +286,15 @@ public class ModuleMetadataParser {
 
     private ImmutableVersionConstraint consumeVersion(JsonReader reader) throws IOException {
         reader.beginObject();
-        String preferred = "";
+        String preferredVersion = "";
+        String strictVersion = "";
         List<String> rejects = Lists.newArrayList();
         while (reader.peek() != END_OBJECT) {
             String cst = reader.nextName();
             if ("prefers".equals(cst)) {
-                preferred = reader.nextString();
+                preferredVersion = reader.nextString();
+            } else if ("strictly".equals(cst)) {
+                strictVersion = reader.nextString();
             } else if ("rejects".equals(cst)) {
                 reader.beginArray();
                 while (reader.peek() != END_ARRAY) {
@@ -301,7 +304,7 @@ public class ModuleMetadataParser {
             }
         }
         reader.endObject();
-        return DefaultImmutableVersionConstraint.of(preferred, rejects);
+        return DefaultImmutableVersionConstraint.of(preferredVersion, strictVersion, rejects);
     }
 
     private ImmutableList<ExcludeMetadata> consumeExcludes(JsonReader reader) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -286,12 +286,15 @@ public class ModuleMetadataParser {
 
     private ImmutableVersionConstraint consumeVersion(JsonReader reader) throws IOException {
         reader.beginObject();
+        String requiredVersion = "";
         String preferredVersion = "";
         String strictVersion = "";
         List<String> rejects = Lists.newArrayList();
         while (reader.peek() != END_OBJECT) {
             String cst = reader.nextName();
-            if ("prefers".equals(cst)) {
+            if ("requires".equals(cst)) {
+                requiredVersion = reader.nextString();
+            } else if ("prefers".equals(cst)) {
                 preferredVersion = reader.nextString();
             } else if ("strictly".equals(cst)) {
                 strictVersion = reader.nextString();
@@ -304,7 +307,7 @@ public class ModuleMetadataParser {
             }
         }
         reader.endObject();
-        return DefaultImmutableVersionConstraint.of(preferredVersion, strictVersion, rejects);
+        return DefaultImmutableVersionConstraint.of(requiredVersion, preferredVersion, strictVersion, rejects);
     }
 
     private ImmutableList<ExcludeMetadata> consumeExcludes(JsonReader reader) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorScheme.java
@@ -56,15 +56,10 @@ public class DefaultVersionSelectorScheme implements VersionSelectorScheme {
 
     @Override
     public VersionSelector complementForRejection(VersionSelector selector) {
-        if (selector instanceof ExactVersionSelector) {
-            return new VersionRangeSelector("(" + selector.getSelector() + ",)", versionComparator.asVersionComparator(), versionParser);
-        }
-        if (selector instanceof VersionRangeSelector) {
-            VersionRangeSelector vrs = (VersionRangeSelector) selector;
-            if (vrs.getUpperBound() != null) {
-                String lowerBoundInclusion = vrs.isUpperInclusive() ? "(" : "[";
-                return new VersionRangeSelector(lowerBoundInclusion + vrs.getUpperBound() + ",)", versionComparator.asVersionComparator(), versionParser);
-            }
+        // TODO:DAZ We can probably now support more versions with `strictly` but we'll need more test coverage
+        if ((selector instanceof ExactVersionSelector)
+            || (selector instanceof VersionRangeSelector && ((VersionRangeSelector) selector).getUpperBound() != null)) {
+            return new InverseVersionSelector(selector);
         }
         throw new IllegalArgumentException("Version '" + renderSelector(selector) + "' cannot be converted to a strict version constraint.");
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/InverseVersionSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/InverseVersionSelector.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy;
+
+import org.gradle.api.artifacts.ComponentMetadata;
+
+public class InverseVersionSelector implements VersionSelector {
+    private final VersionSelector versionSelector;
+
+    public InverseVersionSelector(VersionSelector versionSelector) {
+        this.versionSelector = versionSelector;
+    }
+
+    @Override
+    public String getSelector() {
+        return "!(" + versionSelector.getSelector() + ")";
+    }
+
+    @Override
+    public boolean isDynamic() {
+        return versionSelector.isDynamic();
+    }
+
+    @Override
+    public boolean requiresMetadata() {
+        return versionSelector.requiresMetadata();
+    }
+
+    @Override
+    public boolean accept(String candidate) {
+        return !versionSelector.accept(candidate);
+    }
+
+    @Override
+    public boolean accept(Version candidate) {
+        return !versionSelector.accept(candidate);
+    }
+
+    @Override
+    public boolean accept(ComponentMetadata candidate) {
+        return !versionSelector.accept(candidate);
+    }
+
+    @Override
+    public boolean matchesUniqueVersion() {
+        return false;
+    }
+
+    @Override
+    public boolean canShortCircuitWhenVersionAlreadyPreselected() {
+        return false;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -20,10 +20,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.CompositeVersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.InverseVersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 
 import java.util.Collection;
 import java.util.List;
@@ -76,41 +72,5 @@ abstract class MessageBuilderHelper {
                 accumulator.add(currentPath);
             }
         }
-    }
-
-    static String renderVersionConstraint(ResolvedVersionConstraint constraint) {
-        if (constraint.isRejectAll()) {
-            return "rejects all versions";
-        }
-        VersionSelector preferredSelector = constraint.getPreferredSelector();
-        VersionSelector rejectedSelector = constraint.getRejectedSelector();
-        if (rejectedSelector == null) {
-            return "prefers '" + preferredSelector.getSelector() + "'";
-        }
-        if (rejectedSelector instanceof InverseVersionSelector) {
-            return "strictly '" + preferredSelector.getSelector() + "'";
-        }
-
-        StringBuilder sb = new StringBuilder("prefers '");
-        sb.append(preferredSelector.getSelector());
-        sb.append("', rejects ");
-        if (rejectedSelector instanceof CompositeVersionSelector) {
-            sb.append("any of \"");
-            int i = 0;
-            for (VersionSelector selector : ((CompositeVersionSelector) rejectedSelector).getSelectors()) {
-                if (i++ > 0) {
-                    sb.append(", ");
-                }
-                sb.append('\'');
-                sb.append(selector.getSelector());
-                sb.append('\'');
-            }
-            sb.append("\"");
-        } else {
-            sb.append('\'');
-            sb.append(rejectedSelector.getSelector());
-            sb.append('\'');
-        }
-        return sb.toString();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
 import java.util.List;
+import java.util.Set;
 
 public class RejectedModuleMessageBuilder {
     public String buildFailureMessage(ModuleResolveState module) {
@@ -35,7 +36,12 @@ public class RejectedModuleMessageBuilder {
         } else {
             sb.append("Cannot find a version of '").append(module.getId()).append("' that satisfies the version constraints: \n");
         }
-        for (EdgeState incomingEdge : module.getIncomingEdges()) {
+        renderEdges(module.getIncomingEdges(), sb);
+        return sb.toString();
+    }
+
+    private void renderEdges(Set<EdgeState> incomingEdges, StringBuilder sb) {
+        for (EdgeState incomingEdge : incomingEdges) {
             SelectorState selector = incomingEdge.getSelector();
             for (String path : MessageBuilderHelper.pathTo(incomingEdge)) {
                 sb.append("   ").append(path);
@@ -44,7 +50,6 @@ public class RejectedModuleMessageBuilder {
                 sb.append("\n");
             }
         }
-        return sb.toString();
     }
 
     private static void renderReason(StringBuilder sb, SelectorState selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -17,7 +17,12 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.CompositeVersionSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.InverseVersionSelector;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
@@ -36,19 +41,70 @@ public class RejectedModuleMessageBuilder {
         } else {
             sb.append("Cannot find a version of '").append(module.getId()).append("' that satisfies the version constraints: \n");
         }
-        renderEdges(module.getIncomingEdges(), sb);
+        renderEdges(sb, module.getIncomingEdges());
         return sb.toString();
     }
 
-    private void renderEdges(Set<EdgeState> incomingEdges, StringBuilder sb) {
+    private void renderEdges(StringBuilder sb, Set<EdgeState> incomingEdges) {
         for (EdgeState incomingEdge : incomingEdges) {
             SelectorState selector = incomingEdge.getSelector();
-            for (String path : MessageBuilderHelper.pathTo(incomingEdge)) {
+            for (String path : MessageBuilderHelper.pathTo(incomingEdge, false)) {
                 sb.append("   ").append(path);
-                sb.append(" ").append(MessageBuilderHelper.renderVersionConstraint(selector.getVersionConstraint()));
+                sb.append(" --> ");
+                renderSelector(sb, selector);
                 renderReason(sb, selector);
                 sb.append("\n");
             }
+        }
+    }
+
+    static void renderSelector(StringBuilder sb, SelectorState selectorState) {
+        ResolvedVersionConstraint constraint = selectorState.getVersionConstraint();
+        ModuleIdentifier moduleId = selectorState.getTargetModule().getId();
+
+        sb.append('\'').append(moduleId.getGroup()).append(':').append(moduleId.getName());
+
+        if (constraint.isRejectAll()) {
+            sb.append("' rejects all versions");
+            return;
+        }
+
+        VersionSelector preferredSelector = constraint.getPreferredSelector();
+        VersionSelector rejectedSelector = constraint.getRejectedSelector();
+
+        if (rejectedSelector instanceof InverseVersionSelector) {
+            sb.append("' strictly '").append(preferredSelector.getSelector()).append("'");
+            return;
+        }
+
+        if (!constraint.isPrefer()) {
+            sb.append(':');
+        } else {
+            sb.append("' prefers '");
+        }
+        sb.append(preferredSelector.getSelector()).append("'");
+
+        if (rejectedSelector == null) {
+            return;
+        }
+
+        sb.append(" rejects ");
+        if (rejectedSelector instanceof CompositeVersionSelector) {
+            sb.append("any of \"");
+            int i = 0;
+            for (VersionSelector selector : ((CompositeVersionSelector) rejectedSelector).getSelectors()) {
+                if (i++ > 0) {
+                    sb.append(", ");
+                }
+                sb.append('\'');
+                sb.append(selector.getSelector());
+                sb.append('\'');
+            }
+            sb.append("\"");
+        } else {
+            sb.append('\'');
+            sb.append(rejectedSelector.getSelector());
+            sb.append('\'');
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -65,7 +65,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private final DependencyState dependencyState;
     private final DependencyMetadata firstSeenDependency;
     private final DependencyToComponentIdResolver resolver;
-    private final ResolvedVersionConstraint versionConstraint;
+    private final DefaultResolvedVersionConstraint versionConstraint;
     private final VersionSelectorScheme versionSelectorScheme;
     private final ImmutableAttributesFactory attributesFactory;
     private final Set<ComponentSelectionDescriptorInternal> dependencyReasons = Sets.newLinkedHashSet();
@@ -121,7 +121,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         dependencyReasons.add(dependencyDescriptor);
     }
 
-    private ResolvedVersionConstraint resolveVersionConstraint(ComponentSelector selector) {
+    private DefaultResolvedVersionConstraint resolveVersionConstraint(ComponentSelector selector) {
         if (selector instanceof ModuleComponentSelector) {
             return new DefaultResolvedVersionConstraint(((ModuleComponentSelector) selector).getVersionConstraint(), versionSelectorScheme);
         }
@@ -166,7 +166,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         if (dependencyState.failure != null) {
             idResolveResult.failed(dependencyState.failure);
         } else {
-            ResolvedVersionConstraint mergedConstraint = versionConstraint == null ? null : new DefaultResolvedVersionConstraint(versionConstraint.getPreferredSelector(), allRejects);
+            ResolvedVersionConstraint mergedConstraint = versionConstraint == null ? null : versionConstraint.withRejectSelector(allRejects);
             resolver.resolve(firstSeenDependency, mergedConstraint, idResolveResult);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -82,12 +82,13 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
 
     ImmutableVersionConstraint readVersionConstraint(Decoder decoder) throws IOException {
         String prefers = decoder.readString();
+        String strictly = decoder.readString();
         int rejectCount = decoder.readSmallInt();
         List<String> rejects = Lists.newArrayListWithCapacity(rejectCount);
         for (int i = 0; i < rejectCount; i++) {
             rejects.add(decoder.readString());
         }
-        return new DefaultImmutableVersionConstraint(prefers, rejects);
+        return new DefaultImmutableVersionConstraint(prefers, strictly, rejects);
     }
 
     public void write(Encoder encoder, ComponentSelector value) throws IOException {
@@ -143,6 +144,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
 
     private void writeVersionConstraint(Encoder encoder, VersionConstraint versionConstraint) throws IOException {
         encoder.writeString(versionConstraint.getPreferredVersion());
+        encoder.writeString(versionConstraint.getStrictVersion());
         List<String> rejectedVersions = versionConstraint.getRejectedVersions();
         encoder.writeSmallInt(rejectedVersions.size());
         for (String rejectedVersion : rejectedVersions) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -81,6 +81,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
     }
 
     ImmutableVersionConstraint readVersionConstraint(Decoder decoder) throws IOException {
+        String requires = decoder.readString();
         String prefers = decoder.readString();
         String strictly = decoder.readString();
         int rejectCount = decoder.readSmallInt();
@@ -88,7 +89,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         for (int i = 0; i < rejectCount; i++) {
             rejects.add(decoder.readString());
         }
-        return new DefaultImmutableVersionConstraint(prefers, strictly, rejects);
+        return new DefaultImmutableVersionConstraint(requires, prefers, strictly, rejects);
     }
 
     public void write(Encoder encoder, ComponentSelector value) throws IOException {
@@ -143,6 +144,7 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
     }
 
     private void writeVersionConstraint(Encoder encoder, VersionConstraint versionConstraint) throws IOException {
+        encoder.writeString(versionConstraint.getRequiredVersion());
         encoder.writeString(versionConstraint.getPreferredVersion());
         encoder.writeString(versionConstraint.getStrictVersion());
         List<String> rejectedVersions = versionConstraint.getRejectedVersions();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/vcs/VcsDependencyResolver.java
@@ -150,7 +150,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
             return versionControlSystem.getBranch(spec, constraint.getBranch());
         }
 
-        String version = constraint.getPreferredVersion();
+        String version = constraint.getRequiredVersion();
         VersionSelector versionSelector = versionSelectorScheme.parseSelector(version);
         if (versionSelector instanceof LatestVersionSelector && ((LatestVersionSelector)versionSelector).getSelectorStatus().equals("integration")) {
             return versionControlSystem.getDefaultBranch(spec);
@@ -181,7 +181,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
         if (constraint.getBranch() != null) {
             return spec.getUniqueId() + ":b:" + constraint.getBranch();
         }
-        return spec.getUniqueId() + ":v:" + constraint.getPreferredVersion();
+        return spec.getUniqueId() + ":v:" + constraint.getRequiredVersion();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
@@ -101,6 +101,7 @@ public class DefaultIvyModulePublishMetadata implements IvyModulePublishMetadata
             DefaultImmutableVersionConstraint transformedConstraint =
                 new DefaultImmutableVersionConstraint(
                     VERSION_TRANSFORMER.transform(versionConstraint.getPreferredVersion()),
+                    VERSION_TRANSFORMER.transform(versionConstraint.getStrictVersion()),
                     CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER));
             ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), transformedConstraint, selector.getAttributes());
             return dependency.withTarget(newSelector);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
@@ -100,6 +100,7 @@ public class DefaultIvyModulePublishMetadata implements IvyModulePublishMetadata
             VersionConstraint versionConstraint = selector.getVersionConstraint();
             DefaultImmutableVersionConstraint transformedConstraint =
                 new DefaultImmutableVersionConstraint(
+                    VERSION_TRANSFORMER.transform(versionConstraint.getRequiredVersion()),
                     VERSION_TRANSFORMER.transform(versionConstraint.getPreferredVersion()),
                     VERSION_TRANSFORMER.transform(versionConstraint.getStrictVersion()),
                     CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -99,7 +99,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
             ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier) identifier;
             return moduleIdentifier.getName().equals(moduleComponentIdentifier.getModule())
                 && moduleIdentifier.getGroup().equals(moduleComponentIdentifier.getGroup())
-                && versionConstraint.getPreferredVersion().equals(moduleComponentIdentifier.getVersion());
+                && getVersion().equals(moduleComponentIdentifier.getVersion());
         }
 
         return false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -49,13 +49,13 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     public String getDisplayName() {
         String group = moduleIdentifier.getGroup();
         String module = moduleIdentifier.getName();
-        StringBuilder builder = new StringBuilder(group.length() + module.length() + versionConstraint.getPreferredVersion().length() + 2);
+        StringBuilder builder = new StringBuilder(group.length() + module.length() + versionConstraint.getRequiredVersion().length() + 2);
         builder.append(group);
         builder.append(":");
         builder.append(module);
-        if (versionConstraint.getPreferredVersion().length() > 0) {
+        if (versionConstraint.getRequiredVersion().length() > 0) {
             builder.append(":");
-            builder.append(versionConstraint.getPreferredVersion());
+            builder.append(versionConstraint.getRequiredVersion());
         }
         if (versionConstraint.getBranch() != null) {
             builder.append(" (branch: ");
@@ -74,7 +74,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     }
 
     public String getVersion() {
-        return versionConstraint.getPreferredVersion();
+        return versionConstraint.getRequiredVersion();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
@@ -65,7 +65,7 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
     }
 
     public IvyDependencyDescriptor(ModuleComponentSelector requested, ListMultimap<String, String> confMappings) {
-        this(requested, requested.getVersionConstraint().getPreferredVersion(), false, true, false, confMappings, Collections.<Artifact>emptyList(), Collections.<Exclude>emptyList());
+        this(requested, requested.getVersion(), false, true, false, confMappings, Collections.<Artifact>emptyList(), Collections.<Exclude>emptyList());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -82,7 +82,9 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                 boolean strict = dependencyLockingState.mustValidateLockState();
                 for (ModuleComponentIdentifier lockedDependency : dependencyLockingState.getLockedDependencies()) {
                     String lockedVersion = lockedDependency.getVersion();
-                    VersionConstraint versionConstraint = new DefaultMutableVersionConstraint(lockedVersion, strict);
+                    VersionConstraint versionConstraint = strict
+                        ? DefaultMutableVersionConstraint.withStrictVersion(lockedVersion)
+                        : DefaultMutableVersionConstraint.withVersion(lockedVersion);
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(lockedDependency.getGroup(), lockedDependency.getModule()), versionConstraint);
                     result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
                         Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, getLockReason(strict, lockedVersion)));

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.artifacts.MutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DesugaredAttributeContainerSerializer
 import org.gradle.api.internal.model.NamedObjectInstantiator
@@ -35,16 +36,27 @@ class ModuleComponentSelectorSerializerTest extends SerializerSpec {
     @Unroll
     def "serializes"() {
         when:
-        def result = serialize(newSelector(UTIL, new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar')), serializer)
+        def result = serialize(newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar')), serializer)
 
         then:
-        result == newSelector(UTIL, new DefaultMutableVersionConstraint(version, rejects), attributes(foo: 'bar'))
+        result == newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar'))
 
         where:
-        version | rejects
-        '5.0'   | []
-        '5.0'   | ['1.0']
-        '5.0'   | ['1.0', '2.0']
+        version | strict   | rejects
+        '5.0'   | ''       | []
+        '5.0'   | ''       | ['1.0']
+        '5.0'   | ''       | ['1.0', '2.0']
+        '5.0'   | '[1.0,)' | []
+    }
 
+    private static MutableVersionConstraint constraint(String version, String strictVersion, List<String> rejectedVersions) {
+        MutableVersionConstraint constraint = new DefaultMutableVersionConstraint(version)
+        if (strictVersion != null) {
+            constraint.strictly(strictVersion)
+        }
+        for (String reject : rejectedVersions) {
+            constraint.reject(reject)
+        }
+        return constraint
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
@@ -31,16 +31,17 @@ class DefaultImmutableVersionConstraintTest extends Specification {
 
     def "can create an immutable version constraint with rejects"() {
         given:
-        def v = new DefaultImmutableVersionConstraint('1.0', ['1.1','2.0'])
+        def v = new DefaultImmutableVersionConstraint('1.0', '1.1', ['1.2','2.0'])
 
         expect:
         v.preferredVersion == '1.0'
-        v.rejectedVersions == ['1.1','2.0']
+        v.strictVersion == '1.1'
+        v.rejectedVersions == ['1.2','2.0']
     }
 
     def "cannot mutate rejection list"() {
         given:
-        def v = new DefaultImmutableVersionConstraint('1.0', ['1.1','2.0'])
+        def v = new DefaultImmutableVersionConstraint('1.0', '1.1', ['1.2','2.0'])
 
         when:
         v.rejectedVersions.add('3.0')
@@ -49,58 +50,60 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         def e = thrown(UnsupportedOperationException)
     }
 
-    def "cannot use null as preferred version"() {
+    def "cannot use null as preferred or required version"() {
         when:
-        new DefaultImmutableVersionConstraint(null)
+        new DefaultImmutableVersionConstraint(null, '1.1', ['1.2','2.0'])
 
         then:
         def e = thrown(IllegalArgumentException)
         e.message == 'Preferred version must not be null'
 
         when:
-        new DefaultImmutableVersionConstraint(null, [])
+        new DefaultImmutableVersionConstraint('1.0', null, ['1.2','2.0'])
 
         then:
         e = thrown(IllegalArgumentException)
-        e.message == 'Preferred version must not be null'
+        e.message == 'Strict version must not be null'
     }
 
     def "cannot use empty or null as rejected version"() {
 
         when:
-        new DefaultImmutableVersionConstraint('', [null])
+        new DefaultImmutableVersionConstraint('', '', [null])
 
         then:
         def e = thrown(IllegalArgumentException)
         e.message == 'Rejected version must not be empty'
 
         when:
-        new DefaultImmutableVersionConstraint('', [''])
+        new DefaultImmutableVersionConstraint('', '', [''])
 
         then:
         e = thrown(IllegalArgumentException)
         e.message == 'Rejected version must not be empty'
     }
 
-    def "can use empty as preferred version"() {
+    def "can use empty as preferred and strict version"() {
         when:
         def v = new DefaultImmutableVersionConstraint('')
 
         then:
         v.preferredVersion == ''
+        v.strictVersion == ''
         v.rejectedVersions.empty
 
         when:
-        v = new DefaultImmutableVersionConstraint('', ['1.1','2.0'])
+        v = new DefaultImmutableVersionConstraint('', '', ['1.1','2.0'])
 
         then:
         v.preferredVersion == ''
+        v.strictVersion == ''
         v.rejectedVersions == ['1.1', '2.0']
     }
 
     def "cannot use null as rejected versions"() {
         when:
-        def v = new DefaultImmutableVersionConstraint('1.0', null)
+        def v = new DefaultImmutableVersionConstraint('1.0', '', null)
 
         then:
         def e = thrown(IllegalArgumentException)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
@@ -123,7 +123,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
 
     def "can convert mutable version constraint to immutable version constraint"() {
         given:
-        def v = new DefaultMutableVersionConstraint('1.0', ['1.1', '2.0'])
+        def v = new DefaultMutableVersionConstraint('1.0', '2.0', ['1.1', '2.0'])
 
         when:
         def c = DefaultImmutableVersionConstraint.of(v)
@@ -132,6 +132,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         !v.is(c)
         c instanceof ImmutableVersionConstraint
         c.preferredVersion == v.preferredVersion
+        c.strictVersion == v.strictVersion
         c.rejectedVersions == v.rejectedVersions
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.dependencies
 
 import org.gradle.api.InvalidUserDataException
 import spock.lang.Specification
-import spock.lang.Unroll
 
 class DefaultMutableVersionConstraintTest extends Specification {
     def "defaults to an empty reject list"() {
@@ -27,38 +26,8 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
         then:
         e.preferredVersion == '1.0'
+        e.strictVersion == ''
         e.rejectedVersions == []
-    }
-
-    @Unroll
-    def "computes the complement of preferred version #preferred"() {
-        when:
-        def e = new DefaultMutableVersionConstraint(preferred, true)
-
-        then:
-        e.preferredVersion == preferred
-        e.rejectedVersions == [complement]
-
-        where:
-        preferred    | complement
-        '1.0'        | '(1.0,)'
-        '[1.0, 2.0]' | '(2.0,)'
-        '[1.0, 2.0)' | '[2.0,)'
-        '(, 2.0)'    | '[2.0,)'
-        '(, 2.0]'    | '(2.0,)'
-    }
-
-    @Unroll
-    def "fails converting version #preferred to a strict dependency"() {
-        when:
-        def e = new DefaultMutableVersionConstraint(preferred, true)
-
-        then:
-        IllegalArgumentException ex = thrown()
-        ex.message == "Version '$preferred' cannot be converted to a strict version constraint."
-
-        where:
-        preferred << ['[1.0,)', '1.+', '1+']
     }
 
     def "can override preferred version with another preferred version"() {
@@ -70,6 +39,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
         then:
         version.preferredVersion == '2.0'
+        version.strictVersion == ''
         version.rejectedVersions == []
     }
 
@@ -82,6 +52,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
         then:
         version.preferredVersion == '2.0'
+        version.strictVersion == ''
         version.rejectedVersions == []
     }
 
@@ -94,7 +65,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
         then:
         version.preferredVersion == '2.0'
-        version.rejectedVersions == ['(2.0,)']
+        version.strictVersion == '2.0'
     }
 
     def "can declare rejected versions"() {
@@ -126,6 +97,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
         then:
         version.preferredVersion == '1.1'
+        version.strictVersion == ''
         version.rejectedVersions == []
     }
 
@@ -139,7 +111,8 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
         then:
         version.preferredVersion == '1.1'
-        version.rejectedVersions == ['(1.1,)']
+        version.strictVersion == '1.1'
+        version.rejectedVersions == []
     }
 
     def "cannot use an empty list of rejections"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -25,7 +25,8 @@ class DefaultMutableVersionConstraintTest extends Specification {
         def e = new DefaultMutableVersionConstraint('1.0')
 
         then:
-        e.preferredVersion == '1.0'
+        e.requiredVersion == '1.0'
+        e.preferredVersion == ''
         e.strictVersion == ''
         e.rejectedVersions == []
     }
@@ -33,11 +34,27 @@ class DefaultMutableVersionConstraintTest extends Specification {
     def "can override preferred version with another preferred version"() {
         given:
         def version = new DefaultMutableVersionConstraint('1.0')
+        version.prefer('1.0')
 
         when:
         version.prefer('2.0')
 
         then:
+        version.requiredVersion == '2.0'
+        version.preferredVersion == '2.0'
+        version.strictVersion == ''
+        version.rejectedVersions == []
+    }
+
+    def "can override version with preferred version"() {
+        given:
+        def version = new DefaultMutableVersionConstraint('1.0')
+
+        when:
+        version.prefer('2.0')
+
+        then:
+        version.requiredVersion == '2.0'
         version.preferredVersion == '2.0'
         version.strictVersion == ''
         version.rejectedVersions == []
@@ -51,6 +68,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.prefer('2.0')
 
         then:
+        version.requiredVersion == '2.0'
         version.preferredVersion == '2.0'
         version.strictVersion == ''
         version.rejectedVersions == []
@@ -64,6 +82,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.strictly('2.0')
 
         then:
+        version.requiredVersion == '2.0'
         version.preferredVersion == '2.0'
         version.strictVersion == '2.0'
     }
@@ -76,14 +95,14 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.reject('1.0.1')
 
         then:
-        version.preferredVersion == '1.0'
+        version.requiredVersion == '1.0'
         version.rejectedVersions == ['1.0.1']
 
         when:
         version.reject('1.0.2')
 
         then:
-        version.preferredVersion == '1.0'
+        version.requiredVersion == '1.0'
         version.rejectedVersions == ['1.0.1', '1.0.2']
     }
 
@@ -96,6 +115,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.prefer('1.1')
 
         then:
+        version.requiredVersion == '1.1'
         version.preferredVersion == '1.1'
         version.strictVersion == ''
         version.rejectedVersions == []
@@ -110,6 +130,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.strictly('1.1')
 
         then:
+        version.requiredVersion == '1.1'
         version.preferredVersion == '1.1'
         version.strictVersion == '1.1'
         version.rejectedVersions == []

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -45,7 +45,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
 
     def "can override strict version with preferred version"() {
         given:
-        def version = new DefaultMutableVersionConstraint('1.0', true)
+        def version = DefaultMutableVersionConstraint.withStrictVersion('1.0')
 
         when:
         version.prefer('2.0')

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.dependencies
+
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class DefaultResolvedVersionConstraintTest extends Specification {
+    private final VersionParser versionParser = new VersionParser()
+    private final DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
+
+    @Unroll
+    def "computes the complement of strict version #strictVersion"() {
+        when:
+        def e = new DefaultResolvedVersionConstraint('', strictVersion, [], versionSelectorScheme)
+
+        then:
+        e.preferredSelector.selector == strictVersion
+        e.rejectedSelector.selector == complement
+        !e.rejectAll
+
+        where:
+        strictVersion | complement
+        '1.0'         | '(1.0,)'
+        '[1.0, 2.0]'  | '(2.0,)'
+        '[1.0, 2.0)'  | '[2.0,)'
+        '(, 2.0)'     | '[2.0,)'
+        '(, 2.0]'     | '(2.0,)'
+    }
+
+    @Unroll
+    def "fails converting version #version to a strict dependency"() {
+        when:
+        new DefaultResolvedVersionConstraint('', version, [], versionSelectorScheme)
+
+        then:
+        IllegalArgumentException ex = thrown()
+        ex.message == "Version '$version' cannot be converted to a strict version constraint."
+
+        where:
+        version << ['[1.0,)', '1.+', '1+']
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dependencies
 
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.InverseVersionSelector
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -33,16 +34,17 @@ class DefaultResolvedVersionConstraintTest extends Specification {
 
         then:
         e.preferredSelector.selector == strictVersion
+        e.rejectedSelector instanceof InverseVersionSelector
         e.rejectedSelector.selector == complement
         !e.rejectAll
 
         where:
         strictVersion | complement
-        '1.0'         | '(1.0,)'
-        '[1.0, 2.0]'  | '(2.0,)'
-        '[1.0, 2.0)'  | '[2.0,)'
-        '(, 2.0)'     | '[2.0,)'
-        '(, 2.0]'     | '(2.0,)'
+        '1.0'         | '!(1.0)'
+        '[1.0, 2.0]'  | '!([1.0, 2.0])'
+        '[1.0, 2.0)'  | '!([1.0, 2.0))'
+        '(, 2.0)'     | '!((, 2.0))'
+        '(, 2.0]'     | '!((, 2.0])'
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
@@ -30,7 +30,7 @@ class DefaultResolvedVersionConstraintTest extends Specification {
     @Unroll
     def "computes the complement of strict version #strictVersion"() {
         when:
-        def e = new DefaultResolvedVersionConstraint('', strictVersion, [], versionSelectorScheme)
+        def e = new DefaultResolvedVersionConstraint('', '', strictVersion, [], versionSelectorScheme)
 
         then:
         e.preferredSelector.selector == strictVersion
@@ -50,7 +50,7 @@ class DefaultResolvedVersionConstraintTest extends Specification {
     @Unroll
     def "fails converting version #version to a strict dependency"() {
         when:
-        new DefaultResolvedVersionConstraint('', version, [], versionSelectorScheme)
+        new DefaultResolvedVersionConstraint('', '', version, [], versionSelectorScheme)
 
         then:
         IllegalArgumentException ex = thrown()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/ComponentSelectorParsersTest.groovy
@@ -45,7 +45,9 @@ class ComponentSelectorParsersTest extends Specification {
         v[0].group == 'org.foo'
         v[0].module  == 'bar'
         v[0].version  == '1.0'
-        v[0].versionConstraint.preferredVersion == '1.0'
+        v[0].versionConstraint.requiredVersion == '1.0'
+        v[0].versionConstraint.preferredVersion == ''
+        v[0].versionConstraint.strictVersion == ''
         v[0].versionConstraint.rejectedVersions == []
     }
 
@@ -73,7 +75,9 @@ class ComponentSelectorParsersTest extends Specification {
         v[0].group == 'org.foo'
         v[0].module == 'bar'
         v[0].version  == '2.0'
-        v[0].versionConstraint.preferredVersion == '2.0'
+        v[0].versionConstraint.requiredVersion == '2.0'
+        v[0].versionConstraint.preferredVersion == ''
+        v[0].versionConstraint.strictVersion == ''
         v[0].versionConstraint.rejectedVersions == []
     }
 
@@ -101,7 +105,9 @@ class ComponentSelectorParsersTest extends Specification {
         v[0].group == 'org.foo'
         v[0].module  == 'bar'
         v[0].version  == '1.0'
-        v[0].versionConstraint.preferredVersion == '1.0'
+        v[0].versionConstraint.requiredVersion == '1.0'
+        v[0].versionConstraint.preferredVersion == ''
+        v[0].versionConstraint.strictVersion == ''
         v[0].versionConstraint.rejectedVersions == []
     }
 
@@ -193,7 +199,9 @@ class ComponentSelectorParsersTest extends Specification {
         v.group == 'org.foo'
         v.module  == 'bar'
         v.version  == '1.0'
-        v.versionConstraint.preferredVersion == '1.0'
+        v.versionConstraint.requiredVersion == '1.0'
+        v.versionConstraint.preferredVersion == ''
+        v.versionConstraint.strictVersion == ''
         v.versionConstraint.rejectedVersions == []
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,10 +54,10 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.61'
-        cacheLayout.version == CacheVersion.parse("2.61")
-        cacheLayout.version.toString() == '2.61'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.61')
+        cacheLayout.key == 'metadata-2.63'
+        cacheLayout.version == CacheVersion.parse("2.63")
+        cacheLayout.version.toString() == '2.63'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.63')
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -44,8 +44,16 @@ class ModuleMetadataParserTest extends Specification {
         DefaultImmutableVersionConstraint.of((String) version)
     }
 
+    VersionConstraint strictly(String version) {
+        DefaultImmutableVersionConstraint.of('', version, [])
+    }
+
+    VersionConstraint prefersAndStrictly(String prefers, String strictly) {
+        DefaultImmutableVersionConstraint.of(prefers, strictly, [])
+    }
+
     VersionConstraint prefersAndRejects(String version, List<String> rejects) {
-        DefaultImmutableVersionConstraint.of(version, rejects)
+        DefaultImmutableVersionConstraint.of(version, "", rejects)
     }
 
     List<Exclude> excludes(String... input) {
@@ -224,9 +232,9 @@ class ModuleMetadataParserTest extends Specification {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencies": [ 
                     { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
-                    { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
+                    { "module": "m4", "version": { "prefers": "v4", "strictly": "v5" }, "group": "g4"},
                     { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
-                    { "module": "m6", "group": "g6", "version": { "prefers": "v6" }, "reason": "v5 is buggy"}
+                    { "module": "m6", "group": "g6", "version": { "strictly": "v6" }, "reason": "v5 is buggy"}
                 ],
                 "name": "runtime"
             }
@@ -242,9 +250,9 @@ class ModuleMetadataParserTest extends Specification {
         1 * variant1.addDependency("g3", "m3", prefers("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY)
-        1 * variant2.addDependency("g4", "m4", prefersAndRejects("v4", ["v5"]), [], null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g4", "m4", prefersAndStrictly("v4", "v5"), [], null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY)
-        1 * variant2.addDependency("g6", "m6", prefers("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g6", "m6", strictly("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY)
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -40,20 +40,24 @@ class ModuleMetadataParserTest extends Specification {
         DefaultImmutableVersionConstraint.of()
     }
 
-    VersionConstraint prefers(String version) {
+    VersionConstraint requires(String version) {
         DefaultImmutableVersionConstraint.of((String) version)
     }
 
+    VersionConstraint prefers(String version) {
+        DefaultImmutableVersionConstraint.of('', version, '', [])
+    }
+
     VersionConstraint strictly(String version) {
-        DefaultImmutableVersionConstraint.of('', version, [])
+        DefaultImmutableVersionConstraint.of('', '', version, [])
     }
 
     VersionConstraint prefersAndStrictly(String prefers, String strictly) {
-        DefaultImmutableVersionConstraint.of(prefers, strictly, [])
+        DefaultImmutableVersionConstraint.of('', prefers, strictly, [])
     }
 
     VersionConstraint prefersAndRejects(String version, List<String> rejects) {
-        DefaultImmutableVersionConstraint.of(version, "", rejects)
+        DefaultImmutableVersionConstraint.of('', version, "", rejects)
     }
 
     List<Exclude> excludes(String... input) {
@@ -214,12 +218,12 @@ class ModuleMetadataParserTest extends Specification {
                 "name": "api",
                 "dependencies": [ 
                     { "group": "g0", "module": "m0" },
-                    { "group": "g1", "module": "m1", "version": { "prefers": "v1" } },
+                    { "group": "g1", "module": "m1", "version": { "requires": "v1" } },
                     { "version": { "prefers": "v2" }, "group": "g2", "module": "m2" },
                     { 
                         "group": "g3", 
                         "module": "m3", 
-                        "version": { "prefers": "v3" },
+                        "version": { "requires": "v3" },
                         "excludes": [
                             {"group": "gx", "module": "mx" },
                             {"group": "*", "module": "*" }
@@ -245,9 +249,9 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
         1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY)
         1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependency("g3", "m3", prefers("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g3", "m3", requires("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependency("g4", "m4", prefersAndStrictly("v4", "v5"), [], null, ImmutableAttributes.EMPTY)
@@ -269,12 +273,12 @@ class ModuleMetadataParserTest extends Specification {
             {
                 "name": "api",
                 "dependencyConstraints": [ 
-                    { "group": "g1", "module": "m1", "version": { "prefers": "v1" } },
+                    { "group": "g1", "module": "m1", "version": { "requires": "v1" } },
                     { "version": { "prefers": "v2" }, "group": "g2", "module": "m2" },
                     { 
                         "group": "g3", 
                         "module": "m3", 
-                        "version": { "prefers": "v3" }
+                        "version": { "requires": "v3" }
                     }
                 ],
                 "attributes": { "usage": "compile" }
@@ -295,9 +299,9 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependencyConstraint("g1", "m1", prefers("v1"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependencyConstraint("g1", "m1", requires("v1"), null, ImmutableAttributes.EMPTY)
         1 * variant1.addDependencyConstraint("g2", "m2", prefers("v2"), null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependencyConstraint("g3", "m3", prefers("v3"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependencyConstraint("g3", "m3", requires("v3"), null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependencyConstraint("g3", "m3", prefers("v3"), null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]), null, ImmutableAttributes.EMPTY)
@@ -319,7 +323,7 @@ class ModuleMetadataParserTest extends Specification {
             {
                 "name": "api",
                 "dependencies": [ 
-                    { "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
+                    { "group": "g1", "module": "m1", "version": { "requires": "v1" }, "attributes": {"custom": "foo"} },
                     { "version": { "prefers": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
                 ],
                 "attributes": { "usage": "compile" }
@@ -328,7 +332,7 @@ class ModuleMetadataParserTest extends Specification {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencyConstraints": [ 
                     { "group": "g1", "module": "m1", "version": { "prefers": "v1" }, "attributes": {"custom": "foo"} },
-                    { "version": { "prefers": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
+                    { "version": { "requires": "v2" }, "group": "g2", "module": "m2", "attributes": {"custom": "foo", "other": "bar"} }
                 ],
                 "name": "runtime"
             }
@@ -338,11 +342,11 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null, attributes(custom: 'foo'))
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, attributes(custom: 'foo'))
         1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, attributes(custom: 'foo', other:'bar'))
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependencyConstraint("g1", "m1", prefers("v1"), null, attributes(custom: 'foo'))
-        1 * variant2.addDependencyConstraint("g2", "m2", prefers("v2"), null, attributes(custom: 'foo', other: 'bar'))
+        1 * variant2.addDependencyConstraint("g2", "m2", requires("v2"), null, attributes(custom: 'foo', other: 'bar'))
         0 * _
     }
 
@@ -474,9 +478,9 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g2", "m2", requires("v2"), [], null, ImmutableAttributes.EMPTY)
         0 * _
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionSelectorSchemeTest.groovy
@@ -81,7 +81,7 @@ class DefaultVersionSelectorSchemeTest extends Specification {
     }
 
     @Unroll
-    def "can compute rejection selector for strict dependency versions"() {
+    def "computes rejection selector for strict dependency version"() {
         given:
         def normal = matcher.parseSelector(selector)
 
@@ -89,18 +89,14 @@ class DefaultVersionSelectorSchemeTest extends Specification {
         def reject = matcher.complementForRejection(normal)
 
         then:
+        reject instanceof InverseVersionSelector
         reject.selector == complement
 
         where:
-        selector | complement
-        '20'     | '(20,)'
-        '[3,10]' | '(10,)'
-        '[3,10)' | '[10,)'
-        '(3,10]' | '(10,)'
-        '(3,10)' | '[10,)'
-        '(,10]'  | '(10,)'
-        '(,10)'  | '[10,)'
-
+        selector         | complement
+        '20'             | '!(20)'
+        '[3,10]'         | '!([3,10])'
+        '(,10)'          | '!((,10))'
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -36,7 +36,7 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
     private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR, VERSION_PARSER);
 
     private final DependencyToComponentIdResolver resolver;
-    private ResolvedVersionConstraint versionConstraint;
+    private DefaultResolvedVersionConstraint versionConstraint;
     public ComponentIdResolveResult resolved;
 
     public TestModuleSelectorState(DependencyToComponentIdResolver resolver, VersionConstraint versionConstraint) {
@@ -71,7 +71,7 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
             return resolved;
         }
 
-        ResolvedVersionConstraint mergedConstraint = new DefaultResolvedVersionConstraint(versionConstraint.getPreferredSelector(), allRejects);
+        ResolvedVersionConstraint mergedConstraint = versionConstraint.withRejectSelector(allRejects);
         resolved = resolveVersion(mergedConstraint);
         return resolved;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -24,9 +24,6 @@ import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -41,16 +38,13 @@ import spock.lang.Unroll
 import static org.gradle.util.Path.path
 
 class ComponentSelectorSerializerTest extends SerializerSpec {
-    private final VersionParser versionParser = new VersionParser()
-    private final DefaultVersionSelectorScheme versionSelectorScheme = new DefaultVersionSelectorScheme(new DefaultVersionComparator(), versionParser)
     private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
-    private ImmutableVersionConstraint constraint(String version, boolean strict = false) {
-        def reject = strict ? versionSelectorScheme.complementForRejection(versionSelectorScheme.parseSelector(version)) : null
-        List<String> rejects = strict ? [reject.selector] : []
+    private ImmutableVersionConstraint constraint(String version, String strictVersion = '', List<String> rejectVersions = []) {
         return new DefaultImmutableVersionConstraint(
             version,
-            rejects
+            strictVersion,
+            rejectVersions
         )
     }
 
@@ -189,9 +183,9 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
         ':myPath'   | 'myLib'
     }
 
-    def "serializes strict constraint"() {
+    def "serializes version constraint"() {
         given:
-        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('group-one', 'name-one'), constraint('version-one', true))
+        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('group-one', 'name-one'), constraint('pref', 'req', ['rej']))
 
         when:
         ModuleComponentSelector result = serialize(selection, serializer)
@@ -199,8 +193,9 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
         then:
         result.group == 'group-one'
         result.module == 'name-one'
-        result.version == 'version-one'
-        result.versionConstraint.preferredVersion == 'version-one'
-        result.versionConstraint.rejectedVersions == ['(version-one,)']
+        result.version == 'pref'
+        result.versionConstraint.preferredVersion == 'pref'
+        result.versionConstraint.strictVersion == 'req'
+        result.versionConstraint.rejectedVersions == ['rej']
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializerTest.groovy
@@ -40,9 +40,10 @@ import static org.gradle.util.Path.path
 class ComponentSelectorSerializerTest extends SerializerSpec {
     private final ComponentSelectorSerializer serializer = new ComponentSelectorSerializer(new DesugaredAttributeContainerSerializer(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE))
 
-    private ImmutableVersionConstraint constraint(String version, String strictVersion = '', List<String> rejectVersions = []) {
+    private static ImmutableVersionConstraint constraint(String version, String preferredVersion = '', String strictVersion = '', List<String> rejectVersions = []) {
         return new DefaultImmutableVersionConstraint(
             version,
+            preferredVersion,
             strictVersion,
             rejectVersions
         )
@@ -148,7 +149,9 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
         result.group == 'group-one'
         result.module == 'name-one'
         result.version == 'version-one'
-        result.versionConstraint.preferredVersion == 'version-one'
+        result.versionConstraint.requiredVersion == 'version-one'
+        result.versionConstraint.preferredVersion == ''
+        result.versionConstraint.strictVersion == ''
         result.versionConstraint.rejectedVersions == []
     }
 
@@ -185,7 +188,7 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
 
     def "serializes version constraint"() {
         given:
-        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('group-one', 'name-one'), constraint('pref', 'req', ['rej']))
+        ModuleComponentSelector selection = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('group-one', 'name-one'), constraint('req', 'pref', 'strict', ['rej']))
 
         when:
         ModuleComponentSelector result = serialize(selection, serializer)
@@ -193,9 +196,10 @@ class ComponentSelectorSerializerTest extends SerializerSpec {
         then:
         result.group == 'group-one'
         result.module == 'name-one'
-        result.version == 'pref'
+        result.version == 'req'
+        result.versionConstraint.requiredVersion == 'req'
         result.versionConstraint.preferredVersion == 'pref'
-        result.versionConstraint.strictVersion == 'req'
+        result.versionConstraint.strictVersion == 'strict'
         result.versionConstraint.rejectedVersions == ['rej']
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializerTest.groovy
@@ -34,7 +34,7 @@ class DependencyResultSerializerTest extends Specification {
     def serializer = new DependencyResultSerializer()
 
     def "serializes successful dependency result"() {
-        def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org", "foo"), new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
+        def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("org", "foo"), new DefaultMutableVersionConstraint("1.0"))
         def successful = Mock(DependencyGraphEdge) {
             getSelector() >> Stub(DependencyGraphSelector) {
                 getResultId() >> 4L
@@ -60,7 +60,7 @@ class DependencyResultSerializerTest extends Specification {
 
     def "serializes failed dependency result"() {
         def mid = DefaultModuleIdentifier.newId("x", "y")
-        def requested = DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0", ['2.0', '3.0']))
+        def requested = DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
         def failure = new ModuleVersionResolveException(newSelector(mid, "1.2"), new RuntimeException("Boo!"))
 
         def failed = Mock(DependencyGraphEdge) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyMapNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyMapNotationConverterTest.groovy
@@ -35,7 +35,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '4.4-beta2'
-        d.versionConstraint.preferredVersion == '4.4-beta2'
+        d.versionConstraint.requiredVersion == '4.4-beta2'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
 
         !d.force
@@ -54,7 +56,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '10'
-        d.versionConstraint.preferredVersion == '10'
+        d.versionConstraint.requiredVersion == '10'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
 
         !d.force
@@ -73,7 +77,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '10'
-        d.versionConstraint.preferredVersion == '10'
+        d.versionConstraint.requiredVersion == '10'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -93,7 +99,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.group == 'org.gradle'
         d.name == 'gradle-core'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -109,7 +117,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.group == 'org.gradle'
         d.name == 'gradle-core'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.targetConfiguration == 'compile'
         d.transitive
@@ -126,7 +136,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.group == 'org.gradle'
         d.name == 'gradle-core'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.targetConfiguration == 'default'
         d.transitive
@@ -143,7 +155,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.group == 'org.gradle'
         d.name == 'gradle-core'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.targetConfiguration == null
         d.transitive
@@ -160,7 +174,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.group == 'org.gradle'
         d.name == 'gradle-core'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
 
         !d.transitive
@@ -177,7 +193,9 @@ class DependencyMapNotationConverterTest extends Specification {
         d.group == null
         d.name == 'foo'
         d.version == null
+        d.versionConstraint.requiredVersion == ''
         d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/DependencyStringNotationConverterTest.groovy
@@ -36,7 +36,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '4.4-beta2'
-        d.versionConstraint.preferredVersion == '4.4-beta2'
+        d.versionConstraint.requiredVersion == '4.4-beta2'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
 
         !d.force
@@ -55,7 +57,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '10'
-        d.versionConstraint.preferredVersion == '10'
+        d.versionConstraint.requiredVersion == '10'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
 
         !d.force
@@ -74,7 +78,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '10'
-        d.versionConstraint.preferredVersion == '10'
+        d.versionConstraint.requiredVersion == '10'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -96,7 +102,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.group == 'org.gradle'
         d.name == 'gradle-core'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -112,7 +120,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.group == null
         d.name == 'foo'
         d.version == '1.0'
-        d.versionConstraint.preferredVersion == '1.0'
+        d.versionConstraint.requiredVersion == '1.0'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -128,7 +138,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.group == 'hey'
         d.name == 'foo'
         d.version == null
+        d.versionConstraint.requiredVersion == ''
         d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -144,7 +156,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.group == null
         d.name == 'foo'
         d.version == null
+        d.versionConstraint.requiredVersion == ''
         d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -163,7 +177,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '10'
-        d.versionConstraint.preferredVersion == '10'
+        d.versionConstraint.requiredVersion == '10'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 
@@ -181,7 +197,9 @@ class DependencyStringNotationConverterTest extends Specification {
         d.name == 'gradle-core'
         d.group == 'org.gradle'
         d.version == '10@jar'
-        d.versionConstraint.preferredVersion == '10@jar'
+        d.versionConstraint.requiredVersion == '10@jar'
+        d.versionConstraint.preferredVersion == ''
+        d.versionConstraint.strictVersion == ''
         d.versionConstraint.rejectedVersions == []
         d.transitive
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -198,6 +198,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
                 assert dependencies.size() == 1
                 dependencies[0].version {
                     it.strictly "2.0"
+                    it.reject "[3.0,)"
                 }
             } else {
                 assert dependencies.empty
@@ -211,7 +212,8 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         then:
         if (supportedInMetadata(metadataType)) {
             assert dependencies[0].selector.version == "2.0"
-            assert dependencies[0].selector.versionConstraint.rejectedVersions[0] == "(2.0,)"
+            assert dependencies[0].selector.versionConstraint.strictVersion == "2.0"
+            assert dependencies[0].selector.versionConstraint.rejectedVersions[0] == "[3.0,)"
             assert dependencies[0].pending == addAllDependenciesAsConstraints()
         } else {
             assert dependencies.empty

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -244,15 +244,15 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         metadata.variants[0].dependencies.size() == 2
         metadata.variants[0].dependencies[0].group == "g1"
         metadata.variants[0].dependencies[0].module == "m1"
-        metadata.variants[0].dependencies[0].versionConstraint.preferredVersion == "v1"
+        metadata.variants[0].dependencies[0].versionConstraint.requiredVersion == "v1"
         metadata.variants[0].dependencies[1].group == "g2"
         metadata.variants[0].dependencies[1].module == "m2"
-        metadata.variants[0].dependencies[1].versionConstraint.preferredVersion == "v2"
+        metadata.variants[0].dependencies[1].versionConstraint.requiredVersion == "v2"
         metadata.variants[0].dependencies[1].reason == "v2 is tested"
         metadata.variants[1].dependencies.size() == 1
         metadata.variants[1].dependencies[0].group == "g1"
         metadata.variants[1].dependencies[0].module == "m1"
-        metadata.variants[1].dependencies[0].versionConstraint.preferredVersion == "v1"
+        metadata.variants[1].dependencies[0].versionConstraint.requiredVersion == "v1"
 
         def immutable = metadata.asImmutable()
         immutable.variants.size() == 2

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -60,10 +60,10 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractLazyModuleComponentRes
         def compile = md.getConfiguration("compile")
 
         then:
-        runtime.dependencies*.selector*.versionConstraint.preferredVersion == ["1.1", "1.2", "1.3", "1.5"]
+        runtime.dependencies*.selector*.version == ["1.1", "1.2", "1.3", "1.5"]
         runtime.dependencies.is(runtime.dependencies)
 
-        compile.dependencies*.selector*.versionConstraint.preferredVersion == ["1.2", "1.3", "1.5"]
+        compile.dependencies*.selector*.version == ["1.2", "1.3", "1.5"]
         compile.dependencies.is(compile.dependencies)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -61,10 +61,10 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         def compile = md.getConfiguration("compile")
 
         then:
-        runtime.dependencies*.selector*.versionConstraint.preferredVersion == ["1.1", "1.2"]
+        runtime.dependencies*.selector*.version == ["1.1", "1.2"]
         runtime.dependencies.is(runtime.dependencies)
 
-        compile.dependencies*.selector*.versionConstraint.preferredVersion == ["1.1"]
+        compile.dependencies*.selector*.version == ["1.1"]
         compile.dependencies.is(compile.dependencies)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
@@ -33,11 +33,11 @@ class DefaultModuleComponentSelectorTest extends Specification {
     }
 
     private static ImmutableVersionConstraint v(String version, String branch) {
-        return new DefaultImmutableVersionConstraint(version, [], branch)
+        return new DefaultImmutableVersionConstraint(version, "", [], branch)
     }
 
     private static ImmutableVersionConstraint b(String branch) {
-        return new DefaultImmutableVersionConstraint("", [], branch)
+        return new DefaultImmutableVersionConstraint("", "", [], branch)
     }
 
     def "is instantiated with non-null constructor parameter values"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
@@ -33,11 +33,11 @@ class DefaultModuleComponentSelectorTest extends Specification {
     }
 
     private static ImmutableVersionConstraint v(String version, String branch) {
-        return new DefaultImmutableVersionConstraint(version, "", [], branch)
+        return new DefaultImmutableVersionConstraint(version, "", "", [], branch)
     }
 
     private static ImmutableVersionConstraint b(String branch) {
-        return new DefaultImmutableVersionConstraint("", "", [], branch)
+        return new DefaultImmutableVersionConstraint("", "", "", [], branch)
     }
 
     def "is instantiated with non-null constructor parameter values"() {
@@ -48,7 +48,9 @@ class DefaultModuleComponentSelectorTest extends Specification {
         selector.group == 'some-group'
         selector.module == 'some-name'
         selector.version == '1.0'
-        selector.versionConstraint.preferredVersion == '1.0'
+        selector.versionConstraint.requiredVersion == '1.0'
+        selector.versionConstraint.preferredVersion == ''
+        selector.versionConstraint.strictVersion == ''
         selector.versionConstraint.rejectedVersions == []
         selector.displayName == 'some-group:some-name:1.0'
         selector.attributes.empty
@@ -116,7 +118,9 @@ class DefaultModuleComponentSelectorTest extends Specification {
         selector.group == 'some-group'
         selector.module == 'some-name'
         selector.version == '1.0'
-        selector.versionConstraint.preferredVersion == '1.0'
+        selector.versionConstraint.requiredVersion == '1.0'
+        selector.versionConstraint.preferredVersion == ''
+        selector.versionConstraint.strictVersion == ''
         selector.versionConstraint.rejectedVersions == []
         selector.displayName == 'some-group:some-name:1.0'
         selector.toString() == 'some-group:some-name:1.0'
@@ -133,7 +137,9 @@ class DefaultModuleComponentSelectorTest extends Specification {
         selector.group == 'some-group'
         selector.module == 'some-name'
         selector.version == '1.0'
-        selector.versionConstraint.preferredVersion == '1.0'
+        selector.versionConstraint.requiredVersion == '1.0'
+        selector.versionConstraint.preferredVersion == ''
+        selector.versionConstraint.strictVersion == ''
         selector.versionConstraint.rejectedVersions == []
         selector.attributes.keySet() == [customAttr, otherAttr] as Set
         selector.attributes.getAttribute(customAttr) == 'foo'

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
@@ -18,10 +18,11 @@
             "attributes": { "usage": "runtime", "packaging": "zip" },
             "dependencyConstraints": [
                 { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
-                { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
+                { "module": "m4", "version": { "prefers": "v4", "strictly": "v4a", "rejects": ["v5"] }, "group": "g4"},
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                 { "module": "m6", "version": { "rejects": ["+"] }, "group": "g6"},
-                { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"}
+                { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"},
+                { "module": "m8", "version": { "strictly": "v8" }, "group": "g8"}
             ],
             "name": "runtime"
         }

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
@@ -4,12 +4,12 @@
         {
             "name": "api",
             "dependencyConstraints": [
-                { "group": "g1", "module": "m1", "version": { "prefers": "v1" } },
+                { "group": "g1", "module": "m1", "version": { "requires": "v1" } },
                 { "version": { "prefers": "v2" }, "group": "g2", "module": "m2" },
                 {
                     "group": "g3",
                     "module": "m3",
-                    "version": { "prefers": "v3" }
+                    "version": { "requires": "v3" }
                 }
             ],
             "attributes": { "usage": "compile" }
@@ -18,7 +18,7 @@
             "attributes": { "usage": "runtime", "packaging": "zip" },
             "dependencyConstraints": [
                 { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
-                { "module": "m4", "version": { "prefers": "v4", "strictly": "v4a", "rejects": ["v5"] }, "group": "g4"},
+                { "module": "m4", "version": { "requires": "v4", "strictly": "v4a", "rejects": ["v5"] }, "group": "g4"},
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                 { "module": "m6", "version": { "rejects": ["+"] }, "group": "g6"},
                 { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"},

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -26,7 +26,8 @@
                 { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                 { "module": "m6", "version": { "rejects": ["v8"] }, "group": "g6"},
-                { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"}
+                { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"},
+                { "module": "m8", "version": { "strictly": "v8" }, "group": "g7"}
             ],
             "name": "runtime"
         }

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -5,12 +5,12 @@
             "name": "api",
             "dependencies": [
                 { "group": "g0", "module": "m0" },
-                { "group": "g1", "module": "m1", "version": { "prefers": "v1" } },
+                { "group": "g1", "module": "m1", "version": { "requires": "v1" } },
                 { "version": { "prefers": "v2" }, "group": "g2", "module": "m2" },
                 {
                     "group": "g3",
                     "module": "m3",
-                    "version": { "prefers": "v3" },
+                    "version": { "requires": "v3" },
                     "excludes": [
                         {"group": "gx", "module": "mx" },
                         {"group": "*", "module": "*" }
@@ -23,7 +23,7 @@
             "attributes": { "usage": "runtime", "packaging": "zip" },
             "dependencies": [
                 { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
-                { "module": "m4", "version": { "prefers": "v4", "rejects": ["v5"] }, "group": "g4"},
+                { "module": "m4", "version": { "requires": "v4", "rejects": ["v5"] }, "group": "g4"},
                 { "module": "m5", "version": { "prefers": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                 { "module": "m6", "version": { "rejects": ["v8"] }, "group": "g6"},
                 { "module": "m7", "version": { "rejects": ["v7"] }, "group": "g7", "reason": "v7 is buggy"},

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -207,16 +207,19 @@ class VersionRangeResolveTestScenarios {
     public static final StrictPermutationsProvider SCENARIOS_WITH_REJECT = StrictPermutationsProvider.check(
         versions: [FIXED_11, FIXED_12, REJECT_11],
         expectedNoStrict: "12",
+        expectedStrict: [REJECTED, "12", IGNORE]
     ).and(
         versions: [FIXED_11, FIXED_12, REJECT_12],
         expectedNoStrict: REJECTED,
+        expectedStrict: [REJECTED, REJECTED, IGNORE]
     ).and(
         versions: [FIXED_11, FIXED_12, REJECT_13],
         expectedNoStrict: "12",
-
+        expectedStrict: [REJECTED, "12", IGNORE]
     ).and(
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_11],
         expectedNoStrict: "12",
+        expectedStrict: ["12", "12", "12", IGNORE]
     ).and(
         ignore: true, // This will require resolving RANGE_10_14 with the knowledge that FIXED_12 rejects < "12".
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_12],
@@ -224,38 +227,49 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_13],
         expectedNoStrict: "12",
+        expectedStrict: ["12", "12", "12", IGNORE]
     ).and(
         versions: [RANGE_10_12, RANGE_13_14, REJECT_11],
         expectedNoStrict: "13",
+        expectedStrict: [REJECTED, "13", IGNORE]
     ).and(
         versions: [RANGE_10_12, RANGE_13_14, REJECT_12],
         expectedNoStrict: "13",
+        expectedStrict: [REJECTED, "13", IGNORE]
     ).and(
         versions: [RANGE_10_12, RANGE_13_14, REJECT_13],
         expectedNoStrict: REJECTED,
+        expectedStrict: [REJECTED, REJECTED, IGNORE]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_11],
         expectedNoStrict: "10",
+        expectedStrict: [REJECTED, "10", "10", IGNORE]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_12],
         expectedNoStrict: "11",
+        expectedStrict: [REJECTED, "11", "11", IGNORE]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_13],
         expectedNoStrict: "11",
+        expectedStrict: [REJECTED, "11", "11", IGNORE]
     )
 
     public static final StrictPermutationsProvider SCENARIOS_FOUR_DEPENDENCIES = StrictPermutationsProvider.check(
         versions: [FIXED_9, FIXED_10, FIXED_11, FIXED_12],
-        expectedNoStrict: "12"
+        expectedNoStrict: "12",
+        expectedStrict: [REJECTED, REJECTED, REJECTED, "12"]
     ).and(
         versions: [FIXED_10, RANGE_10_11, FIXED_12, RANGE_12_14],
-        expectedNoStrict: "12"
+        expectedNoStrict: "12",
+        expectedStrict: [REJECTED, REJECTED, "12", "12"]
     ).and(
         versions: [FIXED_10, RANGE_10_11, RANGE_10_12, RANGE_13_14],
-        expectedNoStrict: "13"
+        expectedNoStrict: "13",
+        expectedStrict: [REJECTED, REJECTED, REJECTED, "13"]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, RANGE_10_14],
-        expectedNoStrict: "11"
+        expectedNoStrict: "11",
+        expectedStrict: [REJECTED, "11", "11", "11"]
     )
     private static RenderableVersion fixed(int version) {
         def vs = new SimpleVersion()

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -363,7 +363,7 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            DefaultImmutableVersionConstraint.of("", [version])
+            DefaultImmutableVersionConstraint.of("", "", [version])
         }
 
         @Override

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -14,6 +14,20 @@
  * limitations under the License.
  */
 
+/**
+ * Tuesday:
+ * - Differentiate between `prefer` and `require` in `VersionConstraint`:
+ *     - Push all the way into `.module` files
+ *     - No difference in behaviour at this stage.
+ *     - Display differently in exceptions (and insight report?)
+ * - Merge improvements to `strictly`, `require` and `prefer` into master. No change in behaviour: better reporting.
+ *     - Single update to metadata cache layout
+ * - Provide different resolution of `prefer` vs `require`
+ *     - Come up with a matrix of combinations
+ *     - Add more test coverage to VersionRangeResolveTestScenarios (maybe similar to prefer vs strictly)
+ *     - Implement a hacky solution
+ *     - Consider what to do about `require 4.+ && strictly 4` : Do we have a reject constraint for `require` or special treatment of `prefer`?
+ */
 package org.gradle.resolve.scenarios
 
 import groovy.transform.Canonical
@@ -339,7 +353,9 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            DefaultMutableVersionConstraint.withStrictVersion(version)
+            def vc = new DefaultMutableVersionConstraint(version)
+            vc.strictly(version)
+            return vc
         }
 
         @Override
@@ -358,7 +374,9 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            DefaultImmutableVersionConstraint.of(version)
+            def vc = new DefaultMutableVersionConstraint(version)
+            vc.prefer(version)
+            return vc
         }
 
         @Override
@@ -377,7 +395,7 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            DefaultImmutableVersionConstraint.of("", "", [version])
+            DefaultImmutableVersionConstraint.of("", "", "", [version])
         }
 
         @Override

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -320,7 +320,7 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            new DefaultMutableVersionConstraint(version, false)
+            DefaultMutableVersionConstraint.withVersion(version)
         }
 
         @Override
@@ -339,7 +339,7 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         VersionConstraint getVersionConstraint() {
-            new DefaultMutableVersionConstraint(version, true)
+            DefaultMutableVersionConstraint.withStrictVersion(version)
         }
 
         @Override

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -442,7 +442,7 @@ org:foo:1.0 FAILED
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
                Dependency path ':insight-test:unspecified' --> 'org:foo' prefers '1.+'
                Constraint path ':insight-test:unspecified' --> 'org:foo' prefers '1.1'
-               Constraint path ':insight-test:unspecified' --> 'org:foo' prefers '1.0', rejects '(1.0,)' because of the following reason: dependency was locked to version '1.0'
+               Constraint path ':insight-test:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'
 
 org:foo:1.0 FAILED
 \\--- lockedConf

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -440,7 +440,7 @@ org:foo:1.0 FAILED
    Failures:
       - Could not resolve org:foo:1.0.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
-               Dependency path ':insight-test:unspecified' --> 'org:foo' prefers '1.+'
+               Dependency path ':insight-test:unspecified' --> 'org:foo:1.+'
                Constraint path ':insight-test:unspecified' --> 'org:foo' prefers '1.1'
                Constraint path ':insight-test:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'
 
@@ -2292,7 +2292,7 @@ org:bar: FAILED
    Failures:
       - Could not resolve org:bar.:
           - Module 'org:bar' has been rejected:
-               Dependency path ':insight-test:unspecified' --> 'org:bar' prefers '[1.0,)'
+               Dependency path ':insight-test:unspecified' --> 'org:bar:[1.0,)'
                Constraint path ':insight-test:unspecified' --> 'org:bar' rejects all versions because of the following reason: Nope, you won't use this
 
 org:bar FAILED
@@ -2309,8 +2309,8 @@ org:foo: (via constraint) FAILED
    Failures:
       - Could not resolve org:foo.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
-               Dependency path ':insight-test:unspecified' --> 'org:foo' prefers '[1.0,)'
-               Constraint path ':insight-test:unspecified' --> 'org:foo' prefers '', rejects any of "'1.0', '1.1', '1.2'"
+               Dependency path ':insight-test:unspecified' --> 'org:foo:[1.0,)'
+               Constraint path ':insight-test:unspecified' --> 'org:foo:' rejects any of "'1.0', '1.1', '1.2'"
 
 org:foo FAILED
 \\--- compileClasspath

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpec.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/dsl/DependencyResultSpec.java
@@ -46,7 +46,7 @@ class DependencyResultSpec implements Spec<DependencyResult> {
 
         if(requested instanceof ModuleComponentSelector) {
             ModuleComponentSelector requestedModule = (ModuleComponentSelector)requested;
-            String requestedCandidate = requestedModule.getGroup() + ":" + requestedModule.getModule() + ":" + requestedModule.getVersionConstraint().getPreferredVersion();
+            String requestedCandidate = requestedModule.getGroup() + ":" + requestedModule.getModule() + ":" + requestedModule.getVersion();
             return requestedCandidate.contains(stringNotation);
         }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
@@ -56,7 +56,7 @@ public abstract class AbstractRenderableDependencyResult extends AbstractRendera
      */
     private boolean isSameGroupAndModuleButDifferentVersion(ModuleComponentSelector requested, ModuleComponentIdentifier selected) {
         return requested.getModuleIdentifier().equals(selected.getModuleIdentifier())
-            && !requested.getVersionConstraint().getPreferredVersion().equals(selected.getVersion());
+            && !requested.getVersion().equals(selected.getVersion());
     }
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
@@ -53,8 +53,8 @@ public class RenderableUnresolvedDependencyResult extends AbstractRenderableDepe
             if(requestedSelector.getGroup().equals(attemptedSelector.getGroup())
                 && requestedSelector.getModule().equals(attemptedSelector.getModule())) {
 
-                String requestedVersion = requestedSelector.getVersionConstraint().getPreferredVersion();
-                String attemptedVersion = attemptedSelector.getVersionConstraint().getPreferredVersion();
+                String requestedVersion = requestedSelector.getVersion();
+                String attemptedVersion = attemptedSelector.getVersion();
                 if (attemptedVersion.equals(requestedVersion)) {
                     return requested.getDisplayName();
                 } else {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -36,7 +36,7 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
         this.dependency = dependency;
         // TODO:Prezi Is this cast safe? Can't this be a LibraryComponentSelector, say?
         ModuleComponentSelector attempted = (ModuleComponentSelector)dependency.getAttempted();
-        actual = DefaultModuleComponentIdentifier.newId(attempted.getModuleIdentifier(), attempted.getVersionConstraint().getPreferredVersion());
+        actual = DefaultModuleComponentIdentifier.newId(attempted.getModuleIdentifier(), attempted.getVersion());
     }
 
     public Throwable getFailure() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyResultSorter.java
@@ -132,8 +132,8 @@ public abstract class DependencyResultSorter {
             }
 
             //order dynamic selectors after static selectors
-            boolean leftDynamic = versionSelectorScheme.parseSelector(leftRequested.getVersionConstraint().getPreferredVersion()).isDynamic();
-            boolean rightDynamic = versionSelectorScheme.parseSelector(rightRequested.getVersionConstraint().getPreferredVersion()).isDynamic();
+            boolean leftDynamic = versionSelectorScheme.parseSelector(leftRequested.getVersion()).isDynamic();
+            boolean rightDynamic = versionSelectorScheme.parseSelector(rightRequested.getVersion()).isDynamic();
             if (leftDynamic && !rightDynamic) {
                 return 1;
             } else if (!leftDynamic && rightDynamic) {
@@ -143,10 +143,10 @@ public abstract class DependencyResultSorter {
             int byVersion;
             if (leftDynamic && rightDynamic) {
                 // order dynamic selectors lexicographically
-                byVersion = leftRequested.getVersionConstraint().getPreferredVersion().compareTo(rightRequested.getVersionConstraint().getPreferredVersion());
+                byVersion = leftRequested.getVersion().compareTo(rightRequested.getVersion());
             } else {
                 // order static selectors semantically
-                byVersion = compareVersions(leftRequested.getVersionConstraint().getPreferredVersion(), rightRequested.getVersionConstraint().getPreferredVersion());
+                byVersion = compareVersions(leftRequested.getVersion(), rightRequested.getVersion());
             }
             if (byVersion != 0) {
                 return byVersion;

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -15,6 +15,22 @@
             "changes": [
                 "Method added to interface"
             ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.VersionConstraint",
+            "member": "Method org.gradle.api.artifacts.VersionConstraint.getStrictVersion()",
+            "acceptation": "New method on incubating interface",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.VersionConstraint",
+            "member": "Method org.gradle.api.artifacts.VersionConstraint.getRequiredVersion()",
+            "acceptation": "New method on incubating interface",
+            "changes": [
+                "Method added to interface"
+            ]
         }
     ]
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -158,7 +158,7 @@ class GradleModuleMetadata {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {
                     def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
-                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
+                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.strictly, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencies
@@ -175,7 +175,7 @@ class GradleModuleMetadata {
         List<DependencyConstraint> getDependencyConstraints() {
             if (dependencyConstraints == null) {
                 dependencyConstraints = (values.dependencyConstraints ?: []).collect {
-                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
+                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.strictly, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencyConstraints
@@ -275,6 +275,12 @@ class GradleModuleMetadata {
                 noMoreExcludes()
             }
 
+            DependencyView strictly(String version) {
+                String actualStrictly = find()?.strictly
+                assert actualStrictly == version
+                this
+            }
+
             DependencyView rejects(String... rejections) {
                 Set<String> actualRejects = find()?.rejectsVersion
                 Set<String> expectedRejects = rejections as Set
@@ -328,6 +334,12 @@ class GradleModuleMetadata {
                 this
             }
 
+            DependencyConstraintView strictly(String version) {
+                String actualStrictly = find()?.strictly
+                assert actualStrictly == version
+                this
+            }
+
             DependencyConstraintView rejects(String... rejections) {
                 Set<String> actualRejects = find()?.rejectsVersion
                 Set<String> expectedRejects = rejections as Set
@@ -365,14 +377,16 @@ class GradleModuleMetadata {
         final String group
         final String module
         final String version
+        final String strictly
         final List<String> rejectsVersion
         final String reason
         final Map<String, String> attributes
 
-        Coords(String group, String module, String version, List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
+        Coords(String group, String module, String prefers, String strictly = '', List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
             this.group = group
             this.module = module
-            this.version = version
+            this.version = prefers
+            this.strictly = strictly
             this.rejectsVersion = rejectsVersion
             this.reason = reason
             this.attributes = attributes
@@ -391,7 +405,7 @@ class GradleModuleMetadata {
         final String url
 
         ModuleReference(String group, String module, String version, String url) {
-            super(group, module, version)
+            super(group, module, version, version)
             this.url = url
         }
 
@@ -402,8 +416,9 @@ class GradleModuleMetadata {
 
     static class Dependency extends Coords {
         final List<String> excludes
-        Dependency(String group, String module, String version, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
-            super(group, module, version, rejectedVersions, reason, attributes)
+
+        Dependency(String group, String module, String prefers, String strictly, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
+            super(group, module, prefers, strictly, rejectedVersions, reason, attributes)
             this.excludes = excludes*.toString()
         }
 
@@ -417,8 +432,8 @@ class GradleModuleMetadata {
     }
 
     static class DependencyConstraint extends Coords {
-        DependencyConstraint(String group, String module, String version, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
-            super(group, module, version, rejectedVersions, reason, attributes)
+        DependencyConstraint(String group, String module, String prefers, String strictly, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
+            super(group, module, prefers, strictly, rejectedVersions, reason, attributes)
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -158,7 +158,7 @@ class GradleModuleMetadata {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {
                     def exclusions = it.excludes ? it.excludes.collect { "${it.group}:${it.module}" } : []
-                    new Dependency(it.group, it.module, it.version?.prefers, it.version?.strictly, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
+                    new Dependency(it.group, it.module, it.version?.requires, it.version?.prefers, it.version?.strictly, it.version?.rejects ?: [], exclusions, it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencies
@@ -175,7 +175,7 @@ class GradleModuleMetadata {
         List<DependencyConstraint> getDependencyConstraints() {
             if (dependencyConstraints == null) {
                 dependencyConstraints = (values.dependencyConstraints ?: []).collect {
-                    new DependencyConstraint(it.group, it.module, it.version.prefers, it.version.strictly, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
+                    new DependencyConstraint(it.group, it.module, it.version.requires, it.version.prefers, it.version.strictly, it.version.rejects ?: [], it.reason, normalizeForTests(it.attributes))
                 }
             }
             dependencyConstraints
@@ -275,7 +275,13 @@ class GradleModuleMetadata {
                 noMoreExcludes()
             }
 
-            DependencyView strictly(String version) {
+            DependencyView prefers(String version = null) {
+                String actualPrefers = find()?.prefers
+                assert actualPrefers == version
+                this
+            }
+
+            DependencyView strictly(String version = null) {
                 String actualStrictly = find()?.strictly
                 assert actualStrictly == version
                 this
@@ -334,6 +340,12 @@ class GradleModuleMetadata {
                 this
             }
 
+            DependencyConstraintView prefers(String version) {
+                String actualPrefers = find()?.prefers
+                assert actualPrefers == version
+                this
+            }
+
             DependencyConstraintView strictly(String version) {
                 String actualStrictly = find()?.strictly
                 assert actualStrictly == version
@@ -377,15 +389,17 @@ class GradleModuleMetadata {
         final String group
         final String module
         final String version
+        final String prefers
         final String strictly
         final List<String> rejectsVersion
         final String reason
         final Map<String, String> attributes
 
-        Coords(String group, String module, String prefers, String strictly = '', List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
+        Coords(String group, String module, String version, String prefers = '', String strictly = '', List<String> rejectsVersion = [], String reason = null, Map<String, String> attributes = [:]) {
             this.group = group
             this.module = module
-            this.version = prefers
+            this.version = version
+            this.prefers = prefers
             this.strictly = strictly
             this.rejectsVersion = rejectsVersion
             this.reason = reason
@@ -405,7 +419,7 @@ class GradleModuleMetadata {
         final String url
 
         ModuleReference(String group, String module, String version, String url) {
-            super(group, module, version, version)
+            super(group, module, version)
             this.url = url
         }
 
@@ -417,8 +431,8 @@ class GradleModuleMetadata {
     static class Dependency extends Coords {
         final List<String> excludes
 
-        Dependency(String group, String module, String prefers, String strictly, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
-            super(group, module, prefers, strictly, rejectedVersions, reason, attributes)
+        Dependency(String group, String module, String requires, String prefers, String strictly, List<String> rejectedVersions, List<String> excludes, String reason, Map<String, String> attributes) {
+            super(group, module, requires, prefers, strictly, rejectedVersions, reason, attributes)
             this.excludes = excludes*.toString()
         }
 
@@ -432,8 +446,8 @@ class GradleModuleMetadata {
     }
 
     static class DependencyConstraint extends Coords {
-        DependencyConstraint(String group, String module, String prefers, String strictly, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
-            super(group, module, prefers, strictly, rejectedVersions, reason, attributes)
+        DependencyConstraint(String group, String module, String version, String prefers, String strictly, List<String> rejectedVersions, String reason, Map<String, String> attributes) {
+            super(group, module, version, prefers, strictly, rejectedVersions, reason, attributes)
         }
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
@@ -23,14 +23,16 @@ class DependencyConstraintSpec {
     String group
     String module
     String prefers
+    String strictVersion
     List<String> rejects
     String reason
     Map<String, ?> attributes
 
-    DependencyConstraintSpec(String g, String m, String version, List<String> r, String desc, Map<String, ?> attrs) {
+    DependencyConstraintSpec(String g, String m, String version, String strictVersion, List<String> r, String desc, Map<String, ?> attrs) {
         group = g
         module = m
         prefers = version
+        this.strictVersion = strictVersion
         rejects = r?:Collections.<String>emptyList()
         reason = desc
         attributes = attrs

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencyConstraintSpec.groovy
@@ -22,16 +22,18 @@ import groovy.transform.CompileStatic
 class DependencyConstraintSpec {
     String group
     String module
-    String prefers
+    String version
+    String preferredVersion
     String strictVersion
     List<String> rejects
     String reason
     Map<String, ?> attributes
 
-    DependencyConstraintSpec(String g, String m, String version, String strictVersion, List<String> r, String desc, Map<String, ?> attrs) {
+    DependencyConstraintSpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> r, String desc, Map<String, ?> attrs) {
         group = g
         module = m
-        prefers = version
+        version = v
+        this.preferredVersion = preferredVersion
         this.strictVersion = strictVersion
         rejects = r?:Collections.<String>emptyList()
         reason = desc

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -25,18 +25,20 @@ class DependencySpec {
     String group
     String module
     String prefers
+    String strictVersion
     List<String> rejects
     List<ExcludeSpec> exclusions = []
     String reason
     Map<String, ?> attributes
 
-    DependencySpec(String g, String m, String version, List<String> r, Collection<Map> e, String reason, Map<String, ?> attributes) {
+    DependencySpec(String g, String m, String prefers, String strictVersion, List<String> rejects, Collection<Map> excludes, String reason, Map<String, ?> attributes) {
         group = g
         module = m
-        prefers = version
-        rejects = r?:Collections.<String>emptyList()
-        if (e) {
-            exclusions = e.collect { Map exclusion ->
+        this.prefers = prefers
+        this.strictVersion = strictVersion
+        this.rejects = rejects?:Collections.<String>emptyList()
+        if (excludes) {
+            exclusions = excludes.collect { Map exclusion ->
                 String group = exclusion.get('group')?.toString()
                 String module = exclusion.get('module')?.toString()
                 new ExcludeSpec(group, module)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -24,17 +24,19 @@ import groovy.transform.EqualsAndHashCode
 class DependencySpec {
     String group
     String module
-    String prefers
+    String version
+    String preferredVersion
     String strictVersion
     List<String> rejects
     List<ExcludeSpec> exclusions = []
     String reason
     Map<String, ?> attributes
 
-    DependencySpec(String g, String m, String prefers, String strictVersion, List<String> rejects, Collection<Map> excludes, String reason, Map<String, ?> attributes) {
+    DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> rejects, Collection<Map> excludes, String reason, Map<String, ?> attributes) {
         group = g
         module = m
-        this.prefers = prefers
+        version = v
+        this.preferredVersion = preferredVersion
         this.strictVersion = strictVersion
         this.rejects = rejects?:Collections.<String>emptyList()
         if (excludes) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -74,6 +74,9 @@ class GradleFileModuleAdapter {
                             module d.module
                             version {
                                 prefers d.prefers
+                                if (d.strictVersion) {
+                                    strictly d.strictVersion
+                                }
                                 rejects d.rejects
                             }
                             if (d.reason) {
@@ -103,6 +106,9 @@ class GradleFileModuleAdapter {
                             version {
                                 if (dc.prefers) {
                                     prefers dc.prefers
+                                }
+                                if (dc.strictVersion) {
+                                    strictly dc.strictVersion
                                 }
                                 if (dc.rejects) {
                                     rejects dc.rejects

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -73,6 +73,7 @@ class GradleFileModuleAdapter {
                             group d.group
                             module d.module
                             version {
+                                requires d.prefers
                                 prefers d.prefers
                                 if (d.strictVersion) {
                                     strictly d.strictVersion
@@ -105,6 +106,7 @@ class GradleFileModuleAdapter {
                             module dc.module
                             version {
                                 if (dc.prefers) {
+                                    requires dc.prefers
                                     prefers dc.prefers
                                 }
                                 if (dc.strictVersion) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -73,8 +73,12 @@ class GradleFileModuleAdapter {
                             group d.group
                             module d.module
                             version {
-                                requires d.prefers
-                                prefers d.prefers
+                                if (d.version) {
+                                    requires d.version
+                                }
+                                if (d.preferredVersion) {
+                                    prefers d.preferredVersion
+                                }
                                 if (d.strictVersion) {
                                     strictly d.strictVersion
                                 }
@@ -105,9 +109,11 @@ class GradleFileModuleAdapter {
                             group dc.group
                             module dc.module
                             version {
-                                if (dc.prefers) {
-                                    requires dc.prefers
-                                    prefers dc.prefers
+                                if (dc.version) {
+                                    requires dc.version
+                                }
+                                if (dc.preferredVersion) {
+                                    prefers dc.preferredVersion
                                 }
                                 if (dc.strictVersion) {
                                     strictly dc.strictVersion

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -49,11 +49,11 @@ class VariantMetadataSpec {
     }
 
     void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes=[:]) {
-        dependencies += new DependencySpec(group, module, version, null, null, reason, attributes)
+        dependencies += new DependencySpec(group, module, version, null, null, null, reason, attributes)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
-        def spec = new DependencySpec(group, module, version, null, null, null, [:])
+        def spec = new DependencySpec(group, module, version, null, null, null, null, [:])
         config.delegate = spec
         config.resolveStrategy = Closure.DELEGATE_FIRST
         config()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -49,11 +49,11 @@ class VariantMetadataSpec {
     }
 
     void dependsOn(String group, String module, String version, String reason = null, Map<String, ?> attributes=[:]) {
-        dependencies += new DependencySpec(group, module, version, null, null, null, reason, attributes)
+        dependencies += new DependencySpec(group, module, version, null, null, null, null, reason, attributes)
     }
 
     void dependsOn(String group, String module, String version, @DelegatesTo(value=DependencySpec, strategy=Closure.DELEGATE_FIRST) Closure<?> config) {
-        def spec = new DependencySpec(group, module, version, null, null, null, null, [:])
+        def spec = new DependencySpec(group, module, version, null, null, null, null, null, [:])
         config.delegate = spec
         config.resolveStrategy = Closure.DELEGATE_FIRST
         config()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -397,10 +397,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
-                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.rejects, d.reason, d.attributes)
+                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.strictly, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts ?: defaultArtifacts,
                     v.capabilities

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -397,10 +397,10 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.collect { d ->
-                        new DependencySpec(d.organisation, d.module, d.revision, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencyConstraints.collect { d ->
-                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.strictly, d.rejects, d.reason, d.attributes)
+                        new DependencyConstraintSpec(d.organisation, d.module, d.revision, d.prefers, d.strictly, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts ?: defaultArtifacts,
                     v.capabilities

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -486,13 +486,13 @@ class IvyFileModule extends AbstractModule implements IvyModule {
             def runtimeDependencies = variants.find{ it.name == 'runtime' }?.dependencies
             if (compileDependencies) {
                 compileDependencies.each { dep ->
-                    def depAttrs = [org: dep.group, name: dep.module, rev: dep.prefers, conf: 'compile->default']
+                    def depAttrs = [org: dep.group, name: dep.module, rev: dep.version, conf: 'compile->default']
                     builder.dependency(depAttrs)
                 }
             }
             if (runtimeDependencies) {
                 (runtimeDependencies - compileDependencies).each { dep ->
-                    def depAttrs = [org: dep.group, name: dep.module, rev: dep.prefers, conf: 'runtime->default']
+                    def depAttrs = [org: dep.group, name: dep.module, rev: dep.version, conf: 'runtime->default']
                     builder.dependency(depAttrs)
                 }
             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -127,7 +127,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         this.dependencies << [groupId: target.group, artifactId: target.module, version: target.version,
                               type: attributes.type, scope: attributes.scope, classifier: attributes.classifier,
                               optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects,
-                              reason: attributes.reason
+                              strictly: attributes.strictly, reason: attributes.reason
         ]
         return this
     }
@@ -437,10 +437,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
-                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.rejects, d.reason, d.attributes)
+                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.strictly, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts?:defaultArtifacts,
                     v.capabilities

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -558,7 +558,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                                 dependency {
                                     groupId(dep.group)
                                     artifactId(dep.module)
-                                    if (dep.prefers) { version(dep.prefers) }
+                                    if (dep.version) { version(dep.version) }
                                     scope('compile')
                                 }
                             }
@@ -568,7 +568,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                                 dependency {
                                     groupId(dep.group)
                                     artifactId(dep.module)
-                                    if (dep.prefers) { version(dep.prefers) }
+                                    if (dep.version) { version(dep.version) }
                                     scope('runtime')
                                 }
                             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -127,7 +127,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         this.dependencies << [groupId: target.group, artifactId: target.module, version: target.version,
                               type: attributes.type, scope: attributes.scope, classifier: attributes.classifier,
                               optional: attributes.optional, exclusions: attributes.exclusions, rejects: attributes.rejects,
-                              strictly: attributes.strictly, reason: attributes.reason
+                              prefers: attributes.prefers, strictly: attributes.strictly, reason: attributes.reason
         ]
         return this
     }
@@ -437,10 +437,10 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.name,
                     v.attributes,
                     v.dependencies + dependencies.findAll { !it.optional }.collect { d ->
-                        new DependencySpec(d.groupId, d.artifactId, d.version, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
+                        new DependencySpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.rejects, d.exclusions, d.reason, d.attributes)
                     },
                     v.dependencyConstraints + dependencies.findAll { it.optional }.collect { d ->
-                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.strictly, d.rejects, d.reason, d.attributes)
+                        new DependencyConstraintSpec(d.groupId, d.artifactId, d.version, d.prefers, d.strictly, d.rejects, d.reason, d.attributes)
                     },
                     v.artifacts?:defaultArtifacts,
                     v.capabilities

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -249,11 +249,13 @@ class TestCapability implements Capability {
         variant.dependencies[0].group == 'org'
         variant.dependencies[0].module == 'foo'
         variant.dependencies[0].version == '1.0'
-        variant.dependencies[0].rejectsVersion == ['(1.0,)']
+        variant.dependencies[0].strictly == '1.0'
+        variant.dependencies[0].rejectsVersion == []
 
         variant.dependencies[1].group == 'org'
         variant.dependencies[1].module == 'bar'
         variant.dependencies[1].version == '2.0'
+        variant.dependencies[1].strictly == null
         variant.dependencies[1].rejectsVersion == []
     }
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyGradleModuleMetadataPublishIntegrationTest.groovy
@@ -200,7 +200,7 @@ class TestCapability implements Capability {
         api.dependencies[1].coords == 'group.b:utils:0.01'
     }
 
-    def "publishes component with strict dependencies"() {
+    def "publishes component with strict and prefer dependencies"() {
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
             apply plugin: 'ivy-publish'
@@ -221,7 +221,12 @@ class TestCapability implements Capability {
                         strictly '1.0'
                     }
                 }
-                implementation("org:bar:2.0")
+                implementation("org:bar") {
+                    version {
+                        prefer '1.0'
+                    }
+                }
+                implementation("org:baz:2.0")
             }
 
             publishing {
@@ -244,19 +249,28 @@ class TestCapability implements Capability {
         module.assertPublished()
         module.parsedModuleMetadata.variants.size() == 1
         def variant = module.parsedModuleMetadata.variants[0]
-        variant.dependencies.size() == 2
+        variant.dependencies.size() == 3
 
         variant.dependencies[0].group == 'org'
         variant.dependencies[0].module == 'foo'
         variant.dependencies[0].version == '1.0'
+        variant.dependencies[0].prefers == '1.0'
         variant.dependencies[0].strictly == '1.0'
         variant.dependencies[0].rejectsVersion == []
 
         variant.dependencies[1].group == 'org'
         variant.dependencies[1].module == 'bar'
-        variant.dependencies[1].version == '2.0'
+        variant.dependencies[1].version == '1.0'
+        variant.dependencies[1].prefers == '1.0'
         variant.dependencies[1].strictly == null
         variant.dependencies[1].rejectsVersion == []
+
+        variant.dependencies[2].group == 'org'
+        variant.dependencies[2].module == 'baz'
+        variant.dependencies[2].version == '2.0'
+        variant.dependencies[2].prefers == null
+        variant.dependencies[2].strictly == null
+        variant.dependencies[2].rejectsVersion == []
     }
 
     def "publishes component with dependency constraints"() {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -525,8 +525,10 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         javaLibrary.parsedModuleMetadata.variant('runtime') {
             dependency('commons-collections:commons-collections:3.2.2') {
+                // TODO:DAZ Validate the 'required' version
                 noMoreExcludes()
-                rejects '(3.2.2,)'
+                strictly('3.2.2')
+                rejects()
             }
             dependency('org.springframework:spring-core:2.5.6') {
                 noMoreExcludes()
@@ -600,7 +602,10 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 rejects()
                 noMoreExcludes()
             }
-            constraint('org.tukaani:xz:1.6') { rejects('(1.6,)') }
+            constraint('org.tukaani:xz:1.6') {
+                strictly('1.6')
+                rejects()
+            }
 
             noMoreDependencies()
         }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -483,14 +483,16 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         javaLibrary.assertApiDependencies('org.test:dep1:X', 'org.test:dep2:X')
     }
 
-    def "can publish java-library with strict dependencies"() {
+    def "can publish java-library with strict and prefer dependencies"() {
         requiresExternalDependencies = true
 
         given:
         createBuildScripts("""
 
             dependencies {
-                api "org.springframework:spring-core:2.5.6"
+                api("org.springframework:spring-core") {
+                    version { prefer '2.5.6' }
+                }
                 implementation("commons-collections:commons-collections") {
                     version { strictly '3.2.2' }
                 }
@@ -518,6 +520,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         javaLibrary.parsedModuleMetadata.variant('api') {
             dependency('org.springframework:spring-core:2.5.6') {
                 noMoreExcludes()
+                prefers('2.5.6')
+                strictly(null)
                 rejects()
             }
             noMoreDependencies()
@@ -527,11 +531,14 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
             dependency('commons-collections:commons-collections:3.2.2') {
                 // TODO:DAZ Validate the 'required' version
                 noMoreExcludes()
+                prefers('3.2.2')
                 strictly('3.2.2')
                 rejects()
             }
             dependency('org.springframework:spring-core:2.5.6') {
                 noMoreExcludes()
+                prefers('2.5.6')
+                strictly(null)
                 rejects()
             }
             noMoreDependencies()
@@ -553,7 +560,9 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 implementation "org.apache.commons:commons-compress:1.5"
                 constraints {
                     api "commons-logging:commons-logging:1.1"
-                    implementation "commons-logging:commons-logging:1.2"
+                    implementation("commons-logging:commons-logging") {
+                        version { prefer "1.2" }
+                    }
                     implementation("org.tukaani:xz") {
                         version { strictly "1.6" }
                     }
@@ -596,7 +605,10 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 noMoreExcludes()
             }
             constraint('commons-logging:commons-logging:1.1') { rejects() }
-            constraint('commons-logging:commons-logging:1.2') { rejects() }
+            constraint('commons-logging:commons-logging:1.2') {
+                prefers('1.2')
+                rejects()
+            }
 
             dependency('org.apache.commons:commons-compress:1.5') {
                 rejects()

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.publish.ivy.internal.dependency;
 
+import com.google.common.base.Strings;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ExternalDependency;
@@ -36,7 +37,7 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
     public DefaultIvyDependency(String organisation, String module, String revision, String confMapping, boolean transitive) {
         this.organisation = organisation;
         this.module = module;
-        this.revision = revision;
+        this.revision = Strings.nullToEmpty(revision);
         this.confMapping = confMapping;
         this.transitive = transitive;
     }
@@ -52,7 +53,7 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
     }
 
     public DefaultIvyDependency(ExternalDependency dependency, String confMapping) {
-        this(dependency.getGroup(), dependency.getName(), dependency.getVersionConstraint().getPreferredVersion(), confMapping, dependency.isTransitive(), dependency.getArtifacts(), dependency.getExcludeRules());
+        this(dependency.getGroup(), dependency.getName(), dependency.getVersion(), confMapping, dependency.isTransitive(), dependency.getArtifacts(), dependency.getExcludeRules());
     }
 
     public String getOrganisation() {

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -32,7 +32,6 @@ import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.ClassGeneratorBackedInstantiator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -134,7 +134,7 @@ class DefaultIvyPublicationTest extends Specification {
         when:
         moduleDependency.group >> "org"
         moduleDependency.name >> "name"
-        moduleDependency.versionConstraint >> DefaultImmutableVersionConstraint.of("version")
+        moduleDependency.version >> "version"
         moduleDependency.targetConfiguration >> "dep-configuration"
         moduleDependency.artifacts >> [artifact]
         moduleDependency.excludeRules >> [exclude]

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -212,11 +212,13 @@ class TestCapability implements Capability {
         variant.dependencies[0].group == 'org'
         variant.dependencies[0].module == 'foo'
         variant.dependencies[0].version == '1.0'
-        variant.dependencies[0].rejectsVersion == ['(1.0,)']
+        variant.dependencies[0].strictly == '1.0'
+        variant.dependencies[0].rejectsVersion == []
 
         variant.dependencies[1].group == 'org'
         variant.dependencies[1].module == 'bar'
         variant.dependencies[1].version == '2.0'
+        variant.dependencies[1].strictly == null
         variant.dependencies[1].rejectsVersion == []
     }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenGradleModuleMetadataPublishIntegrationTest.groovy
@@ -163,7 +163,7 @@ class TestCapability implements Capability {
         api.dependencies[1].coords == 'group.b:utils:0.01'
     }
 
-    def "publishes component with strict dependencies"() {
+    def "publishes component with strict and prefer dependencies"() {
         settingsFile << "rootProject.name = 'root'"
         buildFile << """
             apply plugin: 'maven-publish'
@@ -184,7 +184,12 @@ class TestCapability implements Capability {
                         strictly '1.0'
                     }
                 }
-                implementation("org:bar:2.0")
+                implementation("org:bar") {
+                    version {
+                        prefer '2.0'
+                    }
+                }
+                implementation("org:baz:3.0")
             }
 
             publishing {
@@ -207,7 +212,7 @@ class TestCapability implements Capability {
         module.assertPublished()
         module.parsedModuleMetadata.variants.size() == 1
         def variant = module.parsedModuleMetadata.variants[0]
-        variant.dependencies.size() == 2
+        variant.dependencies.size() == 3
 
         variant.dependencies[0].group == 'org'
         variant.dependencies[0].module == 'foo'
@@ -218,8 +223,16 @@ class TestCapability implements Capability {
         variant.dependencies[1].group == 'org'
         variant.dependencies[1].module == 'bar'
         variant.dependencies[1].version == '2.0'
+        variant.dependencies[1].prefers == '2.0'
         variant.dependencies[1].strictly == null
         variant.dependencies[1].rejectsVersion == []
+
+        variant.dependencies[2].group == 'org'
+        variant.dependencies[2].module == 'baz'
+        variant.dependencies[2].version == '3.0'
+        variant.dependencies[2].prefers == null
+        variant.dependencies[2].strictly == null
+        variant.dependencies[2].rejectsVersion == []
     }
 
     def "publishes component with dependency constraints"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -200,6 +200,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.parsedModuleMetadata.variant('api') {
             dependency('org.springframework:spring-core:2.5.6') {
                 noMoreExcludes()
+                strictly(null)
                 rejects()
             }
             noMoreDependencies()
@@ -208,10 +209,12 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.parsedModuleMetadata.variant('runtime') {
             dependency('commons-collections:commons-collections:3.2.2') {
                 noMoreExcludes()
-                rejects '(3.2.2,)'
+                strictly('3.2.2')
+                rejects()
             }
             dependency('org.springframework:spring-core:2.5.6') {
                 noMoreExcludes()
+                strictly(null)
                 rejects()
             }
             noMoreDependencies()
@@ -289,7 +292,10 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 rejects()
                 noMoreExcludes()
             }
-            constraint('org.tukaani:xz:1.6') { rejects('(1.6,)') }
+            constraint('org.tukaani:xz:1.6') {
+                strictly('1.6')
+                rejects()
+            }
 
             noMoreDependencies()
         }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -257,8 +257,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             }
             Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(usageContext.getUsage());
             for (DependencyConstraint dependency : usageContext.getDependencyConstraints()) {
-                if (seenConstraints.add(dependency)
-                    && !dependency.getVersionConstraint().getPreferredVersion().isEmpty()) {
+                if (seenConstraints.add(dependency) && dependency.getVersion() != null) {
                     addDependencyConstraint(dependency, dependencyConstraints);
                 }
             }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ExternalDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
-import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.VersionConstraint;
@@ -140,6 +139,10 @@ public class ModuleMetadataFileGenerator {
         if (!versionConstraint.getPreferredVersion().isEmpty()) {
             jsonWriter.name("prefers");
             jsonWriter.value(versionConstraint.getPreferredVersion());
+        }
+        if (!versionConstraint.getStrictVersion().isEmpty()) {
+            jsonWriter.name("strictly");
+            jsonWriter.value(versionConstraint.getStrictVersion());
         }
         List<String> rejectedVersions = versionConstraint.getRejectedVersions();
         if (!rejectedVersions.isEmpty()) {
@@ -383,7 +386,7 @@ public class ModuleMetadataFileGenerator {
             jsonWriter.name("module");
             jsonWriter.value(dependency.getName());
             VersionConstraint vc;
-            if (dependency instanceof ModuleVersionSelector) {
+            if (dependency instanceof ExternalDependency) {
                 vc = ((ExternalDependency) dependency).getVersionConstraint();
             } else {
                 vc = DefaultImmutableVersionConstraint.of(Strings.nullToEmpty(dependency.getVersion()));

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -136,6 +136,10 @@ public class ModuleMetadataFileGenerator {
 
         jsonWriter.name("version");
         jsonWriter.beginObject();
+        if (!versionConstraint.getRequiredVersion().isEmpty()) {
+            jsonWriter.name("requires");
+            jsonWriter.value(versionConstraint.getRequiredVersion());
+        }
         if (!versionConstraint.getPreferredVersion().isEmpty()) {
             jsonWriter.name("prefers");
             jsonWriter.value(versionConstraint.getPreferredVersion());

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -51,7 +51,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     }
 
     VersionConstraint prefersAndRejects(String version, List<String> rejects) {
-        DefaultImmutableVersionConstraint.of(version, rejects)
+        DefaultImmutableVersionConstraint.of(version, "", rejects)
     }
 
     @Rule

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -46,12 +46,16 @@ import static org.gradle.util.TestUtil.attributes
 
 class ModuleMetadataFileGeneratorTest extends Specification {
 
-    VersionConstraint prefers(String version) {
+    VersionConstraint requires(String version) {
         DefaultImmutableVersionConstraint.of(version)
     }
 
+    VersionConstraint strictly(String version) {
+        DefaultImmutableVersionConstraint.of("", "", version, [])
+    }
+
     VersionConstraint prefersAndRejects(String version, List<String> rejects) {
-        DefaultImmutableVersionConstraint.of(version, "", rejects)
+        DefaultImmutableVersionConstraint.of(version, version, "", rejects)
     }
 
     @Rule
@@ -228,7 +232,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def d3 = Stub(ExternalDependency)
         d3.group >> "g3"
         d3.name >> "m3"
-        d3.versionConstraint >> prefers("v3")
+        d3.versionConstraint >> requires("v3")
         d3.transitive >> true
         d3.excludeRules >> [new DefaultExcludeRule("g4", "m4"), new DefaultExcludeRule(null, "m5"), new DefaultExcludeRule("g5", null)]
         d3.attributes >> ImmutableAttributes.EMPTY
@@ -236,7 +240,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def d4 = Stub(ExternalDependency)
         d4.group >> "g4"
         d4.name >> "m4"
-        d4.versionConstraint >> prefers('')
+        d4.versionConstraint >> requires('')
         d4.transitive >> true
         d4.attributes >> ImmutableAttributes.EMPTY
 
@@ -250,7 +254,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def d6 = Stub(ExternalDependency)
         d6.group >> "g6"
         d6.name >> "m6"
-        d6.versionConstraint >> prefers('1.0')
+        d6.versionConstraint >> strictly('1.0')
         d6.transitive >> true
         d6.reason >> 'custom reason'
         d6.attributes >> ImmutableAttributes.EMPTY
@@ -258,7 +262,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def d7 = Stub(ExternalDependency)
         d7.group >> "g7"
         d7.name >> "m7"
-        d7.versionConstraint >> prefers('1.0')
+        d7.versionConstraint >> requires('1.0')
         d7.transitive >> true
         d7.attributes >> attributes(foo: 'foo', bar: 'baz')
 
@@ -303,7 +307,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g1",
           "module": "m1",
           "version": {
-            "prefers": "v1"
+            "requires": "v1"
           }
         }
       ]
@@ -318,6 +322,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g2",
           "module": "m2",
           "version": {
+            "requires": "v2",
             "prefers": "v2",
             "rejects": [
               "v3",
@@ -335,7 +340,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g3",
           "module": "m3",
           "version": {
-            "prefers": "v3"
+            "requires": "v3"
           },
           "excludes": [
             {
@@ -369,7 +374,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g6",
           "module": "m6",
           "version": {
-            "prefers": "1.0"
+            "strictly": "1.0"
           },
           "reason": "custom reason"
         },
@@ -377,7 +382,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g7",
           "module": "m7",
           "version": {
-            "prefers": "1.0"
+            "requires": "1.0"
           },
           "attributes": {
             "bar": "baz",
@@ -399,7 +404,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def dc1 = Stub(DependencyConstraint)
         dc1.group >> "g1"
         dc1.name >> "m1"
-        dc1.versionConstraint >> prefers("v1")
+        dc1.versionConstraint >> requires("v1")
         dc1.attributes >> ImmutableAttributes.EMPTY
 
         def dc2 = Stub(DependencyConstraint)
@@ -411,13 +416,13 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         def dc3 = Stub(DependencyConstraint)
         dc3.group >> "g3"
         dc3.name >> "m3"
-        dc3.versionConstraint >> prefers("v3")
+        dc3.versionConstraint >> requires("v3")
         dc3.attributes >> ImmutableAttributes.EMPTY
 
         def dc4 = Stub(DependencyConstraint)
         dc4.group >> "g4"
         dc4.name >> "m4"
-        dc4.versionConstraint >> prefers("v4")
+        dc4.versionConstraint >> strictly("v4")
         dc4.attributes >> attributes(quality: 'awesome', channel: 'canary')
 
         def v1 = Stub(UsageContext)
@@ -460,7 +465,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g1",
           "module": "m1",
           "version": {
-            "prefers": "v1"
+            "requires": "v1"
           }
         }
       ]
@@ -475,6 +480,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g2",
           "module": "m2",
           "version": {
+            "requires": "v2",
             "prefers": "v2",
             "rejects": [
               "v3",
@@ -486,14 +492,14 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "group": "g3",
           "module": "m3",
           "version": {
-            "prefers": "v3"
+            "requires": "v3"
           }
         },
         {
           "group": "g4",
           "module": "m4",
           "version": {
-            "prefers": "v4"
+            "strictly": "v4"
           },
           "attributes": {
             "channel": "canary",


### PR DESCRIPTION
Previously, declared version constraints were mapped to a single `prefer` and set of `reject` constraints. This mapping was problematic and lossy:
- Dependency reports didn't match the user input for `strictly` version constraints
- Generating a `reject` constraint for a declared `strict` constraint was not always possible
- A dependency like `org:foo:1.0` was considered identical to `org:foo { prefer '1.0' }`, making it impossible to provide different behaviours for these.

This PR ensures that the full set of declared version constraints is retained in the internal dependency model, and is correctly published and consumed in Gradle `.module` metadata files.