### PR TITLE
Remove verbose logging of downloads and JAR generation

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -32,7 +32,6 @@ import org.gradle.internal.operations.OperationIdentifier
 import org.gradle.internal.operations.OperationProgressEvent
 import org.gradle.internal.operations.OperationStartEvent
 import org.gradle.internal.operations.trace.BuildOperationRecord
-import org.gradle.internal.resource.transfer.ProgressLoggingExternalResourceAccessor
 import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
@@ -140,11 +139,6 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         operations.parentsOf(downloadEvent).find {
             it.hasDetailsOfType(ExecuteTaskBuildOperationType.Details) && it.details.taskPath == ":resolve"
         }
-        def downloadProgress = downloadEvent.progress
-        downloadProgress.size() == 1
-        downloadProgress[0].details.logLevel == 'LIFECYCLE'
-        downloadProgress[0].details.category == ProgressLoggingExternalResourceAccessor.ProgressLoggingExternalResource.name
-        downloadProgress[0].details.description == "Download http://localhost:${server.port}/repo/org/foo/1.0/foo-1.0.jar"
     }
 
     def "captures output from buildSrc"() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/NoOpProgressLoggerFactory.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/progress/NoOpProgressLoggerFactory.groovy
@@ -58,8 +58,8 @@ class NoOpProgressLoggerFactory implements ProgressLoggerFactory {
 
         String getLoggingHeader() { loggingHeader }
 
-        ProgressLogger setLoggingHeader(String header) {
-            this.loggingHeader = header
+        ProgressLogger setLoggingHeader(String loggingHeader) {
+            this.loggingHeader = loggingHeader
             this
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreator.java
@@ -69,7 +69,7 @@ import java.util.zip.ZipOutputStream;
 
 class RuntimeShadedJarCreator {
 
-    public static final int ADDITIONAL_PROGRESS_STEPS = 2;
+    private static final int ADDITIONAL_PROGRESS_STEPS = 2;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RuntimeShadedJarCreator.class);
 
@@ -88,10 +88,9 @@ class RuntimeShadedJarCreator {
     }
 
     public void create(final File outputJar, final Iterable<? extends File> files) {
-        LOGGER.info("Generating JAR file: " + outputJar.getAbsolutePath());
+        LOGGER.info("Generating " + outputJar.getAbsolutePath());
         ProgressLogger progressLogger = progressLoggerFactory.newOperation(RuntimeShadedJarCreator.class);
-        progressLogger.setDescription("Gradle JARs generation");
-        progressLogger.setLoggingHeader("Generating JAR file '" + outputJar.getName() + "'");
+        progressLogger.setDescription("Generating " + outputJar.getName());
         progressLogger.started();
 
         try {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarFactory.java
@@ -63,8 +63,9 @@ public class RuntimeShadedJarFactory {
 
                     @Override
                     public BuildOperationDescriptor.Builder description() {
-                        String displayName = "Generating Jar " + file;
-                        return BuildOperationDescriptor.displayName(displayName).progressDisplayName(displayName);
+                        return BuildOperationDescriptor
+                            .displayName("Generate " + file)
+                            .progressDisplayName("Generating " + file.getName());
                     }
                 });
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/AbstractProgressLoggingHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resource/transfer/AbstractProgressLoggingHandler.java
@@ -34,7 +34,6 @@ public class AbstractProgressLoggingHandler {
         ProgressLogger progressLogger = progressLoggerFactory.newOperation(loggingClazz != null ? loggingClazz : getClass());
         String description = createDescription(operationType, resource);
         progressLogger.setDescription(description);
-        progressLogger.setLoggingHeader(description);
         progressLogger.started();
         String resourceName = createShortDescription(resource);
         return new ResourceOperation(progressLogger, operationType, contentLength, resourceName);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/runtimeshaded/RuntimeShadedJarCreatorTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.Action
 import org.gradle.api.internal.file.collections.DefaultDirectoryFileTreeFactory
 import org.gradle.internal.IoActions
 import org.gradle.internal.installation.GradleRuntimeShadedJarDetector
-import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestFile
@@ -41,8 +40,6 @@ import spock.lang.Specification
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 
-import static org.gradle.api.internal.runtimeshaded.RuntimeShadedJarCreator.ADDITIONAL_PROGRESS_STEPS
-
 @UsesNativeServices
 @CleanupTestDirectory(fieldName = "tmpDir")
 class RuntimeShadedJarCreatorTest extends Specification {
@@ -50,8 +47,7 @@ class RuntimeShadedJarCreatorTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
 
-    def progressLoggerFactory = Mock(ProgressLoggerFactory)
-    def progressLogger = Mock(ProgressLogger)
+    def progressLoggerFactory = Stub(ProgressLoggerFactory)
     def relocatedJarCreator
     def outputJar = tmpDir.testDirectory.file('gradle-api.jar')
 
@@ -68,12 +64,6 @@ class RuntimeShadedJarCreatorTest extends Specification {
         relocatedJarCreator.create(outputJar, [inputFilesDir])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
-        1 * progressLogger.setDescription('Gradle JARs generation')
-        1 * progressLogger.setLoggingHeader("Generating JAR file '$outputJar.name'")
-        1 * progressLogger.started()
-        (1 + ADDITIONAL_PROGRESS_STEPS) * progressLogger.progress(_)
-        1 * progressLogger.completed()
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
         contents[0] == outputJar
@@ -92,12 +82,6 @@ class RuntimeShadedJarCreatorTest extends Specification {
         relocatedJarCreator.create(outputJar, [jarFile1, jarFile2])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
-        1 * progressLogger.setDescription('Gradle JARs generation')
-        1 * progressLogger.setLoggingHeader("Generating JAR file '$outputJar.name'")
-        1 * progressLogger.started()
-        (2 + ADDITIONAL_PROGRESS_STEPS) * progressLogger.progress(_)
-        1 * progressLogger.completed()
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
         contents[0] == outputJar
@@ -137,7 +121,6 @@ org.gradle.api.internal.tasks.CompileServices
         relocatedJarCreator.create(outputJar, [jarFile1, jarFile2, jarFile3, jarFile4, jarFile5, jarFile6, inputDirectory])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
 
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
@@ -178,7 +161,6 @@ org.gradle.api.internal.tasks.CompileServices
         relocatedJarCreator.create(outputJar, [jarFile1, jarFile2, inputDirectory])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
 
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
@@ -216,12 +198,6 @@ org.gradle.api.internal.tasks.CompileServices
         relocatedJarCreator.create(outputJar, [jarFile1, jarFile2, jarFile3])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
-        1 * progressLogger.setDescription('Gradle JARs generation')
-        1 * progressLogger.setLoggingHeader("Generating JAR file '$outputJar.name'")
-        1 * progressLogger.started()
-        (3 + ADDITIONAL_PROGRESS_STEPS) * progressLogger.progress(_)
-        1 * progressLogger.completed()
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
         def relocatedJar = contents[0]
@@ -266,12 +242,6 @@ org.gradle.api.internal.tasks.CompileServices"""
         relocatedJarCreator.create(outputJar, [jarFile])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
-        1 * progressLogger.setDescription('Gradle JARs generation')
-        1 * progressLogger.setLoggingHeader("Generating JAR file '$outputJar.name'")
-        1 * progressLogger.started()
-        (1 + ADDITIONAL_PROGRESS_STEPS) * progressLogger.progress(_)
-        1 * progressLogger.completed()
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
         def relocatedJar = contents[0]
@@ -358,7 +328,6 @@ org.gradle.api.internal.tasks.CompileServices"""
         def inputFilesDir = tmpDir.createDir('inputFiles')
         def jarFile = inputFilesDir.file('lib.jar')
         createJarFileWithClassFiles(jarFile, ["org.slf4j.impl.StaticLoggerBinder"])
-        progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
 
         when:
         relocatedJarCreator.create(outputJar, [jarFile])
@@ -386,8 +355,6 @@ org.gradle.api.internal.tasks.CompileServices"""
         relocatedJarCreator.create(outputJar, [jarFile])
 
         then:
-        1 * progressLoggerFactory.newOperation(RuntimeShadedJarCreator) >> progressLogger
-        1 * progressLogger.completed()
         TestFile[] contents = tmpDir.testDirectory.listFiles().findAll { it.isFile() }
         contents.length == 1
         def relocatedJar = contents[0]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceUploaderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resource/transfer/ProgressLoggingExternalResourceUploaderTest.groovy
@@ -67,7 +67,6 @@ class ProgressLoggingExternalResourceUploaderTest extends Specification {
     def startsProgress() {
         1 * progressLoggerFactory.newOperation(ProgressLoggingExternalResourceUploader.class) >> progressLogger;
         1 * progressLogger.setDescription("Upload http://a/remote/path")
-        1 * progressLogger.setLoggingHeader("Upload http://a/remote/path")
         1 * progressLogger.started()
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
@@ -20,9 +20,6 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec {
 
-    public static final String API_JAR_GENERATION_OUTPUT_REGEX = "Generating JAR file 'gradle-api-(.*)\\.jar"
-    public static final String TESTKIT_GENERATION_OUTPUT_REGEX = "Generating JAR file 'gradle-test-kit-(.*)\\.jar"
-
     def setup() {
         executer.requireGradleDistribution()
     }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsGenerationIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsGenerationIntegrationTest.groovy
@@ -27,7 +27,7 @@ class GradleImplDepsGenerationIntegrationTest extends BaseGradleImplDepsIntegrat
         succeeds 'build'
 
         then:
-        assertNoGenerationOutput(output, API_JAR_GENERATION_OUTPUT_REGEX)
+        file("user-home/caches/${distribution.version.version}/generated-gradle-jars").assertIsEmptyDir()
     }
 
     def "buildSrc project implicitly forces generation of Gradle API JAR"() {
@@ -40,7 +40,7 @@ class GradleImplDepsGenerationIntegrationTest extends BaseGradleImplDepsIntegrat
         succeeds 'build'
 
         then:
-        assertSingleGenerationOutput(output, API_JAR_GENERATION_OUTPUT_REGEX)
+        file("user-home/caches/${distribution.version.version}/generated-gradle-jars/gradle-api-${distribution.version.version}.jar").assertExists()
     }
 
     def "Gradle API dependency resolves the expected JAR files"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsLoggingIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/GradleImplDepsLoggingIntegrationTest.groovy
@@ -23,16 +23,16 @@ class GradleImplDepsLoggingIntegrationTest extends BaseGradleImplDepsIntegration
         requireOwnGradleUserHomeDir()
     }
 
-    def "Generating shaded JARs is logged with console #console"() {
+    def "Generating Gradle API jar is logged with rich console"() {
         given:
-        executer.withArgument("--console=$console")
+        executer.withArgument("--console=rich")
         buildFile << """
             configurations {
                 gradleImplDeps
             }
 
             dependencies {
-                gradleImplDeps gradleApi(), gradleTestKit()
+                gradleImplDeps gradleApi()
             }
 
             task resolveDependencies {
@@ -47,12 +47,6 @@ class GradleImplDepsLoggingIntegrationTest extends BaseGradleImplDepsIntegration
 
         then:
         def gradleVersion = GradleVersion.current().version
-        output.contains("Generating JAR file 'gradle-api-${gradleVersion}.jar'")
-        output.contains("Generating JAR file 'gradle-test-kit-${gradleVersion}.jar'")
-
-        where:
-        console  | placeholder
-        "plain"  | _
-        "rich"   | _
+        output.contains("Generating gradle-api-${gradleVersion}.jar")
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/ResolvedGeneratedJarsIntegrationTest.groovy
@@ -40,7 +40,6 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegration
 
         then:
         file("user-home/caches/${distribution.version.version}/generated-gradle-jars/gradle-api-${distribution.version.version}.jar").assertExists()
-        assertSingleGenerationOutput(output, API_JAR_GENERATION_OUTPUT_REGEX)
 
     }
 
@@ -59,7 +58,6 @@ class ResolvedGeneratedJarsIntegrationTest extends BaseGradleImplDepsIntegration
 
         then:
         file("user-home/caches/${distribution.version.version}/generated-gradle-jars/gradle-test-kit-${distribution.version.version}.jar").assertExists()
-        assertSingleGenerationOutput(output, TESTKIT_GENERATION_OUTPUT_REGEX)
     }
 
     private TestFile productionCode() {


### PR DESCRIPTION
Artifact downloads and Gradle JAR generation were emitting
logging headers, flooding the console on builds with cold
caches. Headers should only be used by operations that group
some other progress, like tasks and project configuration.

Fixes https://github.com/gradle/gradle/issues/6098