### PR TITLE
Let all performance tests require a settings script

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/TestProjectLocator.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/TestProjectLocator.groovy
@@ -23,6 +23,9 @@ class TestProjectLocator {
         if (!dir.directory) {
             throw new IllegalArgumentException("Did not find test project at: '$dir.absolutePath'. Please run 'gradlew $name' to generate the test project.")
         }
+        if (!new File(dir, "settings.gradle").file && !new File(dir, "settings.gradle.kts").file) {
+            throw new IllegalArgumentException("Test project at '$dir.absolutePath' does not have a settings script. Please add one.")
+        }
         dir
     }
 }


### PR DESCRIPTION
Otherwise they use the root one and include buildSrc.
