### PR TITLE
Disable daemon conditionally

### DIFF
--- a/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
+++ b/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
@@ -10,7 +10,7 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildTyp
     name = "Build Distributions"
     description = "Creation and verification of the distribution and documentation"
 
-    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=%linux.java8.oracle.64bit%")
+    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=%linux.java8.oracle.64bit%", daemon = false)
 
     artifactRules = """$artifactRules
         build/distributions/*.zip => distributions

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,7 +7,7 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", requiresDaemon: Boolean = true, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
+class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", useDaemon: Boolean = true, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
     uuid = testCoverage.asConfigurationId(model, subProject)
     id = AbsoluteId(uuid)
     name = testCoverage.asName() + if (!subProject.isEmpty()) " ($subProject)" else ""
@@ -30,7 +30,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
                             + buildScanValues.map { buildScanCustomValue(it.key, it.value) }
                     ).joinToString(separator = " "),
             timeout = testCoverage.testType.timeout,
-            daemon = requiresDaemon)
+            daemon = useDaemon)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.oracle.64bit%")

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,7 +7,7 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
+class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", requiresDaemon: Boolean = true, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
     uuid = testCoverage.asConfigurationId(model, subProject)
     id = AbsoluteId(uuid)
     name = testCoverage.asName() + if (!subProject.isEmpty()) " ($subProject)" else ""
@@ -29,7 +29,8 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
                             + buildScanTags.map { buildScanTag(it) }
                             + buildScanValues.map { buildScanCustomValue(it.key, it.value) }
                     ).joinToString(separator = " "),
-            timeout = testCoverage.testType.timeout)
+            timeout = testCoverage.testType.timeout,
+            daemon = requiresDaemon)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.oracle.64bit%")

--- a/.teamcity/Gradle_Check/configurations/Gradleception.kt
+++ b/.teamcity/Gradle_Check/configurations/Gradleception.kt
@@ -17,7 +17,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(mod
     }
 
     val buildScanTagForType = buildScanTag("Gradleception")
-    val defaultParameters = (gradleParameters + listOf(buildScanTagForType)).joinToString(separator = " ")
+    val defaultParameters = (gradleParameters() + listOf(buildScanTagForType)).joinToString(separator = " ")
 
     applyDefaults(model, this, ":install", notQuick = true, extraParameters = "-Pgradle_installPath=dogfood-first $buildScanTagForType", extraSteps = {
         localGradle {

--- a/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
+++ b/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
@@ -40,7 +40,7 @@ class IndividualPerformanceScenarioWorkers(model: CIBuildModel) : BaseGradleBuil
             name = "GRADLE_RUNNER"
             tasks = ""
             gradleParams = (
-                    gradleParameters.map { if (it == "--daemon") "--no-daemon" else it }
+                    gradleParameters(daemon = false)
                     + listOf("""clean %templates% fullPerformanceTests --scenarios "%scenario%" --baselines %baselines% --warmups %warmups% --runs %runs% --checks %checks% --channel %channel% -x prepareSamples -x performanceReport -Porg.gradle.performance.db.url=%performance.db.url% -Porg.gradle.performance.db.username=%performance.db.username% -Porg.gradle.performance.db.password=%performance.db.password.tcagent% -PtimestampedVersion""",
                             buildScanTag("IndividualPerformanceScenarioWorkers"))
                             + model.parentBuildCache.gradleParameters(OS.linux)

--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -39,7 +39,7 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Sta
             name = "GRADLE_RUNNER"
             tasks = ""
             gradleParams = (
-                    gradleParameters
+                    gradleParameters(daemon = false)
                     + listOf("clean distributed${type.taskId}s -x prepareSamples --baselines %performance.baselines% ${type.extraParameters} -PtimestampedVersion -Porg.gradle.performance.branchName=%teamcity.build.branch% -Porg.gradle.performance.db.url=%performance.db.url% -Porg.gradle.performance.db.username=%performance.db.username% -PteamCityUsername=%TC_USERNAME% -PteamCityPassword=%teamcity.password.restbot% -Porg.gradle.performance.buildTypeId=${IndividualPerformanceScenarioWorkers(model).id} -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id% -Porg.gradle.performance.db.password=%performance.db.password.tcagent%",
                             buildScanTag("PerformanceTest"))
                             + model.parentBuildCache.gradleParameters(OS.linux)

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -133,11 +133,11 @@ data class CIBuildModel (
             GradleSubproject("testingJvm"),
             GradleSubproject("testingJunitPlatform"),
             GradleSubproject("testingNative"),
-            GradleSubproject("toolingApi", crossVersionTests = true, requiresDaemon = false),
+            GradleSubproject("toolingApi", crossVersionTests = true, useDaemon = false),
             GradleSubproject("toolingApiBuilders", functionalTests = false),
             GradleSubproject("versionControl"),
             GradleSubproject("workers"),
-            GradleSubproject("wrapper", crossVersionTests = true, requiresDaemon = false),
+            GradleSubproject("wrapper", crossVersionTests = true, useDaemon = false),
 
             GradleSubproject("soak", unitTests = false, functionalTests = false),
 
@@ -152,7 +152,7 @@ data class CIBuildModel (
             GradleSubproject("smokeTest", unitTests = false, functionalTests = false))
         )
 
-data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false, val requiresDaemon: Boolean = true) {
+data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false, val useDaemon: Boolean = true) {
     fun asDirectoryName(): String {
         return name.replace(Regex("([A-Z])"), { "-" + it.groups[1]!!.value.toLowerCase()})
     }

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -133,11 +133,11 @@ data class CIBuildModel (
             GradleSubproject("testingJvm"),
             GradleSubproject("testingJunitPlatform"),
             GradleSubproject("testingNative"),
-            GradleSubproject("toolingApi", crossVersionTests = true),
+            GradleSubproject("toolingApi", crossVersionTests = true, requiresDaemon = false),
             GradleSubproject("toolingApiBuilders", functionalTests = false),
             GradleSubproject("versionControl"),
             GradleSubproject("workers"),
-            GradleSubproject("wrapper", crossVersionTests = true),
+            GradleSubproject("wrapper", crossVersionTests = true, requiresDaemon = false),
 
             GradleSubproject("soak", unitTests = false, functionalTests = false),
 
@@ -152,7 +152,7 @@ data class CIBuildModel (
             GradleSubproject("smokeTest", unitTests = false, functionalTests = false))
         )
 
-data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false) {
+data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false, val requiresDaemon: Boolean = true) {
     fun asDirectoryName(): String {
         return name.replace(Regex("([A-Z])"), { "-" + it.groups[1]!!.value.toLowerCase()})
     }

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -23,11 +23,11 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
         }
 
         if (subProject.unitTests && testConfig.testType.unitTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
         } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
         } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
         }
     }
 }){

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -23,11 +23,11 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
         }
 
         if (subProject.unitTests && testConfig.testType.unitTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
         } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
         } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
         }
     }
 }){

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -70,11 +70,11 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
                 if (subProject.containsSlowTests) {
                     FunctionalTestProject.missingTestCoverage.forEach { testConfig ->
                         if (subProject.unitTests && testConfig.testType.unitTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
                         } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
                         } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
                         }
                     }
                 }

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -70,11 +70,11 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
                 if (subProject.containsSlowTests) {
                     FunctionalTestProject.missingTestCoverage.forEach { testConfig ->
                         if (subProject.unitTests && testConfig.testType.unitTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
                         } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
                         } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.requiresDaemon, stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
                         }
                     }
                 }


### PR DESCRIPTION
This is a follow-up of https://github.com/gradle/gradle-private/issues/1352. The asciidoctor plugin
we're using has a serious issue that its native library sometimes cause the daemon JVM crash.
As a workaround, we identify the following builds need to run `docs:docs` task because they depend on
`binZip` task:

- wrapper
- toolingApi
- distributions
- performance test coordinators because they're running in the default pool

This commit disables daemon by removing `--daemon` from build parameter list. (TeamCity would automatically
add `-Dorg.gradle.daemon=false` at the end of the parameter list.)

Of course this is not a final solution but we need this to verify it actually works and to get rid of lots of `daemon disappear` issues.