### PR TITLE
Introduce DomainObjectProvider

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectProvider.java
@@ -14,26 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.api.tasks;
+package org.gradle.api;
 
-import org.gradle.api.Action;
-import org.gradle.api.DomainObjectProvider;
-import org.gradle.api.Incubating;
-import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
 
 /**
- * Providers a task of the given type.
+ * Provides a domain object of the given type.
  *
- * @param <T> Task type
- * @since 4.8
+ * @param <T> type of domain object
+ * @since 4.10
  */
 @Incubating
-public interface TaskProvider<T extends Task> extends DomainObjectProvider<T> {
+public interface DomainObjectProvider<T> extends Provider<T> {
     /**
-     * Configures the task with the given action. Actions are run in the order added.
+     * Configures the domain object with the given action. Actions are run in the order added.
      *
-     * @param action A {@link Action} that can configure the task when required.
-     * @since 4.8
+     * @param action A {@link Action} that can configure the domain object when required.
+     * @since 4.10
      */
     void configure(Action<? super T> action);
 
@@ -43,7 +40,7 @@ public interface TaskProvider<T extends Task> extends DomainObjectProvider<T> {
      * Must be constant for the life of the object.
      *
      * @return The task name. Never null.
-     * @since 4.9
+     * @since 4.10
      */
     String getName();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
@@ -227,6 +227,6 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @since 4.10
      */
     @Incubating
-    Provider<T> named(String name) throws UnknownDomainObjectException;
+    DomainObjectProvider<T> named(String name) throws UnknownDomainObjectException;
 
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
@@ -92,7 +92,7 @@ public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, 
      * @since 4.10
      */
     @Incubating
-    Provider<T> register(String name, Action<? super T> configurationAction) throws InvalidUserDataException;
+    DomainObjectProvider<T> register(String name, Action<? super T> configurationAction) throws InvalidUserDataException;
 
     /**
      * Defines a new object, which will be created when it is required. A object is 'required' when the object is located using query methods such as {@link NamedDomainObjectCollection#getByName(java.lang.String)} or when {@link Provider#get()} is called on the return value of this method.
@@ -105,6 +105,5 @@ public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, 
      * @since 4.10
      */
     @Incubating
-    Provider<T> register(String name) throws InvalidUserDataException;
-
+    DomainObjectProvider<T> register(String name) throws InvalidUserDataException;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/PolymorphicDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/PolymorphicDomainObjectContainer.java
@@ -98,7 +98,7 @@ public interface PolymorphicDomainObjectContainer<T> extends NamedDomainObjectCo
      * @since 4.10
      */
     @Incubating
-    <U extends T> Provider<U> register(String name, Class<U> type, Action<? super U> configurationAction) throws InvalidUserDataException;
+    <U extends T> DomainObjectProvider<U> register(String name, Class<U> type, Action<? super U> configurationAction) throws InvalidUserDataException;
 
     /**
      * Defines a new object, which will be created when it is required. A object is 'required' when the object is located using query methods such as {@link #getByName(String)} or when {@link Provider#get()} is called on the return value of this method.
@@ -113,5 +113,5 @@ public interface PolymorphicDomainObjectContainer<T> extends NamedDomainObjectCo
      * @since 4.10
      */
     @Incubating
-    <U extends T> Provider<U> register(String name, Class<U> type) throws InvalidUserDataException;
+    <U extends T> DomainObjectProvider<U> register(String name, Class<U> type) throws InvalidUserDataException;
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -17,11 +17,11 @@ package org.gradle.api.internal;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.DomainObjectProvider;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Namer;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.internal.Actions;
@@ -95,18 +95,18 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
     }
 
     @Override
-    public Provider<T> register(String name) throws InvalidUserDataException {
+    public DomainObjectProvider<T> register(String name) throws InvalidUserDataException {
         return createDomainObjectProvider(name, null);
     }
 
     @Override
-    public Provider<T> register(String name, Action<? super T> configurationAction) throws InvalidUserDataException {
+    public DomainObjectProvider<T> register(String name, Action<? super T> configurationAction) throws InvalidUserDataException {
         return createDomainObjectProvider(name, configurationAction);
     }
 
-    protected Provider<T> createDomainObjectProvider(String name, @Nullable Action<? super T> configurationAction) {
+    protected DomainObjectProvider<T> createDomainObjectProvider(String name, @Nullable Action<? super T> configurationAction) {
         assertCanAdd(name);
-        Provider<T> provider = Cast.uncheckedCast(
+        DomainObjectProvider<T> provider = Cast.uncheckedCast(
             getInstantiator().newInstance(DomainObjectCreatingProvider.class, AbstractNamedDomainObjectContainer.this, name, configurationAction)
         );
         addLater(provider);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
@@ -17,10 +17,10 @@ package org.gradle.api.internal;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.DomainObjectProvider;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Namer;
-import org.gradle.api.provider.Provider;
 import org.gradle.internal.Cast;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.Transformers;
@@ -68,18 +68,18 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
     }
 
     @Override
-    public <U extends T> Provider<U> register(String name, Class<U> type) throws InvalidUserDataException {
+    public <U extends T> DomainObjectProvider<U> register(String name, Class<U> type) throws InvalidUserDataException {
         return createDomainObjectProvider(name, type, null);
     }
 
     @Override
-    public <U extends T> Provider<U> register(String name, Class<U> type, Action<? super U> configurationAction) throws InvalidUserDataException {
+    public <U extends T> DomainObjectProvider<U> register(String name, Class<U> type, Action<? super U> configurationAction) throws InvalidUserDataException {
         return createDomainObjectProvider(name, type, configurationAction);
     }
 
-    protected <U extends T> Provider<U> createDomainObjectProvider(String name, Class<U> type, @Nullable Action<? super U> configurationAction) {
+    protected <U extends T> DomainObjectProvider<U> createDomainObjectProvider(String name, Class<U> type, @Nullable Action<? super U> configurationAction) {
         assertCanAdd(name);
-        Provider<U> provider = Cast.uncheckedCast(
+        DomainObjectProvider<U> provider = Cast.uncheckedCast(
             getInstantiator().newInstance(DomainObjectCreatingProvider.class, AbstractPolymorphicDomainObjectContainer.this, name, type, configurationAction)
         );
         addLater(provider);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal;
 import com.google.common.collect.Maps;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.DomainObjectProvider;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectCollection;
@@ -335,8 +336,8 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
     }
 
     @Override
-    public Provider<T> named(String name) throws UnknownTaskException {
-        Provider<? extends T> provider = findDomainObject(name);
+    public DomainObjectProvider<T> named(String name) throws UnknownTaskException {
+        DomainObjectProvider<? extends T> provider = findDomainObject(name);
         if (provider == null) {
             throw createNotFoundException(name);
         }
@@ -696,16 +697,17 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
     }
 
     @Nullable
-    protected Provider<? extends T> findDomainObject(String name) {
+    protected DomainObjectProvider<? extends T> findDomainObject(String name) {
         T object = findByNameWithoutRules(name);
         if (object == null) {
-            return findByNameLaterWithoutRules(name);
+            // TODO: Need to check for proper type/cast
+            return Cast.uncheckedCast(findByNameLaterWithoutRules(name));
         }
 
         return Cast.uncheckedCast(getInstantiator().newInstance(ExistingDomainObjectProvider.class, this, object, name));
     }
 
-    protected abstract class AbstractDomainObjectProvider<I extends T> extends AbstractProvider<I> implements Named {
+    protected abstract class AbstractDomainObjectProvider<I extends T> extends AbstractProvider<I> implements Named, DomainObjectProvider<I> {
         private final String name;
 
         protected AbstractDomainObjectProvider(String name) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
+import org.gradle.api.DomainObjectProvider;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectSet;
@@ -83,12 +84,12 @@ public class TypedDomainObjectContainerWrapper<U> implements NamedDomainObjectCo
     }
 
     @Override
-    public Provider<U> register(String name, Action<? super U> configurationAction) throws InvalidUserDataException {
+    public DomainObjectProvider<U> register(String name, Action<? super U> configurationAction) throws InvalidUserDataException {
         return parent.register(name, type, configurationAction);
     }
 
     @Override
-    public Provider<U> register(String name) throws InvalidUserDataException {
+    public DomainObjectProvider<U> register(String name) throws InvalidUserDataException {
         return parent.register(name, type);
     }
 
@@ -101,7 +102,7 @@ public class TypedDomainObjectContainerWrapper<U> implements NamedDomainObjectCo
     }
 
     @Override
-    public Provider<U> named(String name) throws UnknownDomainObjectException {
+    public DomainObjectProvider<U> named(String name) throws UnknownDomainObjectException {
         return delegate.named(name);
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectCollectionTest.groovy
@@ -141,8 +141,21 @@ class DefaultNamedDomainObjectCollectionTest extends AbstractNamedDomainObjectCo
         0 * rule._
     }
 
+    def "can configure domain objects through provider"() {
+        container.add(a)
+        when:
+        def result = container.named("a")
+        result.configure {
+            it.value = "changed"
+        }
+        then:
+        result.get().value == "changed"
+    }
+
     static class Bean {
         public final String name
+
+        String value = "original"
 
         Bean(String name) {
             this.name = name

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -293,4 +293,26 @@ class DefaultPolymorphicDomainObjectContainerTest extends Specification {
         bob.present
         bob.get().name == "bob"
     }
+
+    def "can configure objects via provider"() {
+        given:
+        container.registerFactory(AgeAwarePerson, { new DefaultAgeAwarePerson(name: it) } as NamedDomainObjectFactory)
+
+        when:
+        container.register("fred", AgeAwarePerson).configure {
+            it.age = 50
+        }
+        container.create("bob", AgeAwarePerson)
+
+        def fred = container.named("fred")
+        def bob = container.named("bob")
+        bob.configure {
+            it.age = 50
+        }
+        then:
+        fred.present
+        fred.get().age == 50
+        bob.present
+        bob.get().age == 50
+    }
 }


### PR DESCRIPTION
Domain object containers return a DomainObjectProvider instead of a plain Provider
so users can configure domain objects

This is similar to the previously introduced TaskProvider
