### PR TITLE
Allow `getTasksByName` from lazy configuration action

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -1057,4 +1057,20 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         where:
         [description, code] << INVALID_CALL_FROM_LAZY_CONFIGURATION
     }
+
+    def "can query all task for given name of subprojects"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        buildFile << """
+            subprojects {
+                tasks.register('foo')
+            }
+            tasks.register('allFoo') {
+                dependsOn getTasksByName('foo', true)
+            }
+        """
+
+        expect:
+        succeeds "allFoo"
+        result.assertTasksExecuted(":allFoo", ":a:foo", ":b:foo", ":c:foo")
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -1073,4 +1073,20 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         succeeds "allFoo"
         result.assertTasksExecuted(":allFoo", ":a:foo", ":b:foo", ":c:foo")
     }
+
+    def "can query all task"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        buildFile << """
+            subprojects {
+                tasks.register('foo')
+            }
+            tasks.register('allFoo') {
+                dependsOn getAllTasks(true).values()*.findAll { !(it.project == rootProject) }
+            }
+        """
+
+        expect:
+        succeeds "allFoo"
+        result.assertTasksExecuted(":allFoo", ":a:foo", ":b:foo", ":c:foo")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -797,7 +797,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
             }
         };
         if (recursive) {
-            allprojects(action);
+            doAllprojects(action);
         } else {
             action.execute(this);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -647,6 +647,10 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public void allprojects(Action<? super Project> action) {
         assertMethodExecutionAllowed("Project#allprojects(Action)");
+        doAllprojects(action);
+    }
+
+    private void doAllprojects(Action<? super Project> action) {
         getProjectConfigurator().allprojects(getAllprojects(), action);
     }
 
@@ -818,7 +822,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
             }
         };
         if (recursive) {
-            allprojects(action);
+            doAllprojects(action);
         } else {
             action.execute(this);
         }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle/issues/6124

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fissue-6124)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
