### PR TITLE
Pass mirror init script down to smoke test builds

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -28,6 +28,7 @@ import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.*
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.*
 
 abstract class AbstractSmokeTest extends Specification {
+    private static final String MIRROR_INIT_SCRIPT_LOCATION = "org.gradle.smoketests.mirror.init.script"
 
     @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
     File buildFile
@@ -53,7 +54,12 @@ abstract class AbstractSmokeTest extends Specification {
             .withGradleInstallation(IntegrationTestBuildContext.INSTANCE.gradleHomeDir)
             .withTestKitDir(IntegrationTestBuildContext.INSTANCE.gradleUserHomeDir)
             .withProjectDir(testProjectDir.root)
-            .withArguments(tasks.toList() + ['-s', '-I', createMirrorInitScript().absolutePath, "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}".toString()])
+            .withArguments(tasks.toList() + ['-s'] + repoMirrorParameters())
+    }
+
+    private List<String> repoMirrorParameters() {
+        String mirrorInitScriptPath = createMirrorInitScript().absolutePath
+        return ['-I', mirrorInitScriptPath, "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}".toString(), "-D${MIRROR_INIT_SCRIPT_LOCATION}=${mirrorInitScriptPath}".toString()]
     }
 
     protected void useSample(String sampleDirectory) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -28,7 +28,7 @@ import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.*
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.*
 
 abstract class AbstractSmokeTest extends Specification {
-    private static final String MIRROR_INIT_SCRIPT_LOCATION = "org.gradle.smoketests.mirror.init.script"
+    private static final String INIT_SCRIPT_LOCATION = "org.gradle.smoketests.init.script"
 
     @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
     File buildFile
@@ -59,7 +59,7 @@ abstract class AbstractSmokeTest extends Specification {
 
     private List<String> repoMirrorParameters() {
         String mirrorInitScriptPath = createMirrorInitScript().absolutePath
-        return ['-I', mirrorInitScriptPath, "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}".toString(), "-D${MIRROR_INIT_SCRIPT_LOCATION}=${mirrorInitScriptPath}".toString()]
+        return ['-I', mirrorInitScriptPath, "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}".toString(), "-D${INIT_SCRIPT_LOCATION}=${mirrorInitScriptPath}".toString()]
     }
 
     protected void useSample(String sampleDirectory) {


### PR DESCRIPTION
### Context

Some of our smoke tests need to clone external repositories and run builds inside
them, which can't benefit from main build's init script. This PR passes the mirror init script
to these builds as an system property so that they can read and use it.

Also see https://github.com/gradle/android-relocation-test/pull/4 and https://github.com/gradle/kotlin-relocation-test/pull/9

This fixes https://github.com/gradle/gradle-private/issues/1402