### PR TITLE
Capture URL in UrlRepositoryDescriptor as File if the scheme is 'file'

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -53,7 +53,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
         def repos = op.details.repositories
         repos.size() == 1
         repos.first() == augmentMapWithProperties(expectedRepo, [
-            URL: expectedRepo.name == 'MavenLocal' ? m2.mavenRepo().uri.toString() : mavenHttpRepo.uri.toString(),
+            URL: expectedRepo.name == 'MavenLocal' ? new File(m2.mavenRepo().uri).absolutePath : mavenHttpRepo.uri.toString(),
             DIRS: [buildFile.parentFile.file('fooDir').absolutePath]
         ])
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -171,8 +171,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
             m2Compatible = false;
         }
 
-        URI url = getUrl();
-        return new IvyRepositoryDescriptor.Builder(getName(), url == null ? null : url.toASCIIString())
+        return new IvyRepositoryDescriptor.Builder(getName(), getUrl())
             .setAuthenticated(getConfiguredCredentials() != null)
             .setAuthenticationSchemes(getAuthenticationSchemes())
             .setMetadataSources(metadataSources.asList())

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.repositories;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Transformer;
@@ -57,7 +58,6 @@ import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
-import org.gradle.util.CollectionUtils;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -196,17 +196,11 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     @Override
     protected RepositoryDescriptor createDescriptor() {
-        URI url = getUrl();
-        return new MavenRepositoryDescriptor.Builder(getName(), url == null ? null : url.toASCIIString())
+        return new MavenRepositoryDescriptor.Builder(getName(), getUrl())
             .setAuthenticated(getConfiguredCredentials() != null)
             .setAuthenticationSchemes(getAuthenticationSchemes())
             .setMetadataSources(metadataSources.asList())
-            .setArtifactUrls(CollectionUtils.collect(getArtifactUrls(), new Transformer<String, URI>() {
-                @Override
-                public String transform(URI uri) {
-                    return uri.toASCIIString();
-                }
-            }))
+            .setArtifactUrls(Sets.newHashSet(getArtifactUrls()))
             .create();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/IvyRepositoryDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/IvyRepositoryDescriptor.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
+import java.net.URI;
 import java.util.Collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -41,7 +42,7 @@ public final class IvyRepositoryDescriptor extends UrlRepositoryDescriptor {
 
     private IvyRepositoryDescriptor(
         String name,
-        String url,
+        URI url,
         ImmutableList<String> metadataSources,
         boolean authenticated,
         ImmutableList<String> authenticationSchemes,
@@ -78,7 +79,7 @@ public final class IvyRepositoryDescriptor extends UrlRepositoryDescriptor {
         private String layoutType;
         private Boolean m2Compatible;
 
-        public Builder(String name, String url) {
+        public Builder(String name, URI url) {
             super(name, url);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/MavenRepositoryDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/MavenRepositoryDescriptor.java
@@ -18,8 +18,11 @@ package org.gradle.api.internal.artifacts.repositories.descriptor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.api.Transformer;
 import org.gradle.internal.scan.UsedByScanPlugin;
+import org.gradle.util.CollectionUtils;
 
+import java.net.URI;
 import java.util.Collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -31,15 +34,15 @@ public final class MavenRepositoryDescriptor extends UrlRepositoryDescriptor {
         ARTIFACT_URLS,
     }
 
-    public final ImmutableList<String> artifactUrls;
+    public final ImmutableList<URI> artifactUrls;
 
     private MavenRepositoryDescriptor(
         String name,
-        String url,
+        URI url,
         ImmutableList<String> metadataSources,
         boolean authenticated,
         ImmutableList<String> authenticationSchemes,
-        ImmutableList<String> artifactUrls
+        ImmutableList<URI> artifactUrls
     ) {
         super(name, url, metadataSources, authenticated, authenticationSchemes);
         this.artifactUrls = artifactUrls;
@@ -53,18 +56,23 @@ public final class MavenRepositoryDescriptor extends UrlRepositoryDescriptor {
     @Override
     protected void addProperties(ImmutableSortedMap.Builder<String, Object> builder) {
         super.addProperties(builder);
-        builder.put(Property.ARTIFACT_URLS.name(), artifactUrls);
+        builder.put(Property.ARTIFACT_URLS.name(), CollectionUtils.collect(artifactUrls, new Transformer<Object, URI>() {
+            @Override
+            public Object transform(URI uri) {
+                return maybeFileFromUrl(uri);
+            }
+        }));
     }
 
     public static class Builder extends UrlRepositoryDescriptor.Builder<Builder> {
 
-        private ImmutableList<String> artifactUrls;
+        private ImmutableList<URI> artifactUrls;
 
-        public Builder(String name, String url) {
+        public Builder(String name, URI url) {
             super(name, url);
         }
 
-        public Builder setArtifactUrls(Collection<String> artifactUrls) {
+        public Builder setArtifactUrls(Collection<URI> artifactUrls) {
             this.artifactUrls = ImmutableList.copyOf(artifactUrls);
             return this;
         }


### PR DESCRIPTION
This allows the build scan plugin to relativize the URL to known 'roots' as other captured files.
It looks nicer, dedupes better, and is more consistent.

### Context
This information is used by the build scan plugin. In case of File properties, we do our best to relativize them to known 'roots', such as the root build directory, Gradle User Home, or any included build directory. This allows to represent most files with a more succinct graphical representation, without losing context.