### PR TITLE
Allow initializing nested builds

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/BuildInitPluginIntegrationTest.groovy
@@ -257,6 +257,19 @@ include("child")
                      scala-library""")
     }
 
+    def "does not warn or fail when initializing a project inside another project"() {
+        given:
+        def sub = file("sub")
+        sub.mkdirs()
+        executer.inDirectory(sub)
+
+        when:
+        file("settings.gradle") << "rootProject.name = 'root'"
+
+        then:
+        succeeds "init"
+    }
+
     private ExecutionResult runInitWith(BuildInitDsl dsl) {
         run 'init', '--dsl', dsl.id
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/layout/BuildLayoutConfiguration.java
@@ -16,6 +16,7 @@
 package org.gradle.initialization.layout;
 
 import org.gradle.StartParameter;
+import org.gradle.TaskExecutionRequest;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import java.io.File;
@@ -32,9 +33,21 @@ public class BuildLayoutConfiguration {
 
     public BuildLayoutConfiguration(StartParameter startParameter) {
         currentDir = startParameter.getCurrentDir();
-        searchUpwards = startParameter.isSearchUpwards();
+        searchUpwards = startParameter.isSearchUpwards() && !isInitTaskRequested(startParameter);
         settingsFile = startParameter.getSettingsFile();
         useEmptySettings = startParameter.isUseEmptySettings();
+    }
+
+    private boolean isInitTaskRequested(StartParameter startParameter) {
+        if (startParameter.getTaskNames().contains("init")) {
+            return true;
+        }
+        for (TaskExecutionRequest request : startParameter.getTaskRequests()) {
+            if (request.getArgs().contains("init")) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public File getCurrentDir() {


### PR DESCRIPTION
We deprecated nested builds without a settings file.
However, when calling `gradle init` there is no settings
file yet, so users would get a warning (and it would fail
in 5.0). We now detect this special case and treat it just
as if the user had specified `--no-search-upwards`.

Fixes https://github.com/gradle/gradle/issues/5371