### PR TITLE
Make recommendation against `new File(relativePath)` stronger

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -64,7 +64,7 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         hasArtifact(moduleA)
     }
 
-    @Requires(TestPrecondition.JDK8_OR_EARLIER) //modifies environment variables
+    @Requires(TestPrecondition.SET_ENV_VARIABLE)
     def "can resolve artifacts from local m2 with custom local repository defined in global settings.xml"() {
         given:
         def sysPropRepo = mavenLocal("artifactrepo")

--- a/subprojects/docs/src/docs/userguide/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_files.adoc
@@ -334,14 +334,17 @@ See how we're using the `compileJava` task as the source of the files to package
 Using a task directly as an argument like this relies on it having <<more_about_tasks.adoc#sec:task_inputs_outputs,defined outputs>>, so it won't always be possible. In addition, this example could be improved further by relying on the Java plugin's convention for `destinationDir` rather than overriding it, but it does demonstrate the use of project properties.
 
 [[sec:single_file_paths]]
-=== Single file paths
+=== Single file
 
-One of the great quandaries when developing a build is how to specify file locations when the build may be executed from an arbitrary directory — not necessarily in the project — and may be run on any number of different systems with incompatible directory layouts. The standard Java mechanism for specifying a file path runs into trouble in these situations:
+Gradle provides the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(java.lang.Object)] method for specifying the location of a single file or directory.
+Relative paths are resolved relative to the project directory, absolute paths remain unchanged.
 
- * `new File(relative path)` generates a path relative to the current working directory, which could be anywhere
- * `new File(absolute path)` will fail if the file system doesn't have the requisite path.
+[CAUTION]
+====
+Never use `new File(relative path)`, as this creates a path relative to the current working directory, which could be anywhere.
+====
 
-Gradle solves this problem by providing the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(java.lang.Object)] method, which generates a path relative to the _project_ directory (unless the given path is absolute, in which case it is used as is). Here are some examples of using the `file()` method with different types of argument:
+Here are some examples of using the `file()` method with different types of argument:
 
 === Example: Locating files
 

--- a/subprojects/docs/src/docs/userguide/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_files.adoc
@@ -334,10 +334,10 @@ See how we're using the `compileJava` task as the source of the files to package
 Using a task directly as an argument like this relies on it having <<more_about_tasks.adoc#sec:task_inputs_outputs,defined outputs>>, so it won't always be possible. In addition, this example could be improved further by relying on the Java plugin's convention for `destinationDir` rather than overriding it, but it does demonstrate the use of project properties.
 
 [[sec:single_file_paths]]
-=== Single file
+=== Single files and directories
 
 Gradle provides the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(java.lang.Object)] method for specifying the location of a single file or directory.
-Relative paths are resolved relative to the project directory, absolute paths remain unchanged.
+Relative paths are resolved relative to the project directory, while absolute paths remain unchanged.
 
 [CAUTION]
 ====

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseClasspathFixture.groovy
@@ -125,7 +125,7 @@ class EclipseClasspathFixture {
         }
 
         void assertHasJar(File jar) {
-            assert entry.@path == jar.absolutePath.replace(File.separator, '/')
+            assert entry.@path == jar.path.replace(File.separator, '/')
         }
 
         void assertHasJar(String jar) {
@@ -137,7 +137,7 @@ class EclipseClasspathFixture {
         }
 
         void assertHasSource(File jar) {
-            assert entry.@sourcepath == jar.absolutePath.replace(File.separator, '/')
+            assert entry.@sourcepath == jar.path.replace(File.separator, '/')
         }
 
         String getSourcePath() {
@@ -153,7 +153,7 @@ class EclipseClasspathFixture {
         }
 
         private String cachePath(String group, String module, String version) {
-            return Pattern.quote("${userHomeDir.absolutePath.replace(File.separator, '/')}") + "/caches/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}/" + Pattern.quote("${group}/${module}/${version}/") + "\\w+/"
+            return Pattern.quote("${userHomeDir.path.replace(File.separator, '/')}") + "/caches/${CacheLayout.ROOT.getKey()}/${CacheLayout.FILE_STORE.getKey()}/" + Pattern.quote("${group}/${module}/${version}/") + "\\w+/"
         }
 
         void assertHasNoSource() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/environment/BuildEnvironmentIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/environment/BuildEnvironmentIntegrationTest.groovy
@@ -69,7 +69,7 @@ class BuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("GRADLE-1762")
-    @Requires(TestPrecondition.JDK8_OR_EARLIER) //modifies environment variables
+    @Requires(TestPrecondition.SET_ENV_VARIABLE)
     def "build uses environment variables from where the build was launched"() {
         file('build.gradle') << "println System.getenv('foo')"
 
@@ -86,6 +86,7 @@ class BuildEnvironmentIntegrationTest extends AbstractIntegrationSpec {
         out.contains("and will be even better")
     }
 
+    @Requires(TestPrecondition.WORKING_DIR)
     def "build is executed with working directory set to where the build was launched from"() {
         def project1 = file("project1")
         def project2 = file("project2")

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -47,7 +47,7 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
         !UNKNOWN_OS.fulfilled && JavaVersion.current() < JavaVersion.VERSION_1_9
     }),
     WORKING_DIR({
-        !UNKNOWN_OS.fulfilled
+        !UNKNOWN_OS.fulfilled && JavaVersion.current() < JavaVersion.VERSION_11
     }),
     PROCESS_ID({
         !UNKNOWN_OS.fulfilled

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildEnvironmentCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildEnvironmentCrossVersionSpec.groovy
@@ -29,7 +29,7 @@ class BuildEnvironmentCrossVersionSpec extends ToolingApiSpecification {
 
     @ToolingApiVersion(">=3.5")
     @TargetGradleVersion(">=3.5")
-    @Requires(TestPrecondition.JDK8_OR_EARLIER) //modifies environment variables
+    @Requires(TestPrecondition.SET_ENV_VARIABLE)
     def "provide setEnvironmentVariables on LongRunningOperation"() {
         given:
         toolingApi.requireDaemons() //cannot be run in embedded mode

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -60,6 +60,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         GradleContextualExecuter.isLongLivingProcess() || gradle.standardOutput.contains("Shutdown working dir: " + executer.gradleUserHomeDir.file("workers").getAbsolutePath())
     }
 
+    @Requires(TestPrecondition.WORKING_DIR)
     def "sets the working directory to the specified directory during worker execution"() {
         withRunnableClassInBuildScript()
         buildFile << """


### PR DESCRIPTION
This doesn't work in a lot of cases and must never be used.
Users need to use `Project.file` instead.

I found the original wording verbose and burying the important information.

I also adjusted the tests for changing the user.dir to be ignored on Java 11+,
because it no longer supports mutating it. In Gradle 5.0 we may want to stop
doing this entirely to be consistent in all Java versions.

Fixes https://github.com/gradle/gradle/issues/5187