### PR TITLE
Deprecate any task dependency removal on `Task` instance

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyIntegrationTest.groovy
@@ -36,11 +36,15 @@ class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         when:
+        executer.expectDeprecationWarning()
         succeeds "foo"
 
         then:
         result.assertTasksExecuted(":foo")
         result.assertTaskNotExecuted(":bar")
+
+        and:
+        outputContains("Do not remove a task dependency from a Task instance. This behaviour has been deprecated and is scheduled to become an error in Gradle 6.0.")
     }
 
     def "can remove a Task instance from task dependencies containing a Provider to the Task instance"() {
@@ -66,6 +70,9 @@ class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.assertTasksExecuted(":foo")
         result.assertTaskNotExecuted(":bar")
+
+        and:
+        outputContains("Do not remove a task dependency from a Task instance. This behaviour has been deprecated and is scheduled to become an error in Gradle 6.0.")
     }
 
     def "can remove a Provider instance from task dependencies containing the Provider"() {
@@ -85,10 +92,14 @@ class TaskDependencyIntegrationTest extends AbstractIntegrationSpec {
         '''
 
         when:
+        executer.expectDeprecationWarning()
         succeeds "foo"
 
         then:
         result.assertTasksExecuted(":foo")
         result.assertTaskNotExecuted(":bar")
+
+        and:
+        outputContains("Do not remove a task dependency from a Task instance. This behaviour has been deprecated and is scheduled to become an error in Gradle 6.0.")
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -235,6 +235,7 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
 
         @Override
         public boolean remove(Object o) {
+            DeprecationLogger.nagUserWith("Do not remove a task dependency from a Task instance.", "This behaviour has been deprecated and is scheduled to become an error in Gradle 6.0.", "", "");
             if (delegate.remove(o)) {
                 return true;
             }
@@ -242,7 +243,6 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
             for (Iterator<Object> it = delegate.iterator(); it.hasNext();) {
                 Object obj = it.next();
                 if (isTaskProvider(obj) && o instanceof Task && isTaskProviderOfTask((TaskProvider) obj, (Task) o)) {
-                    DeprecationLogger.nagUserOfDeprecatedBehaviour("Do not remove a Task instance from a task dependency set when it contains a Provider to the Task instance.");
                     it.remove();
                     return true;
                 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -56,6 +56,13 @@ Removing tasks from the `TaskContainer` using the following methods has been dep
 With the deprecation of every method removing a task, registering a callback when an object is removed is also deprecated (`whenObjectRemoved(Closure/Action)`)
 
 
+### Removing task dependencies from a Task instance
+
+Code such as `foo.dependsOn.remove(bar)` is prone to errors and rely on the internal implementation details of how tasks were wired together.
+Removing task dependencies from a Task instance will become an error.
+At the moment, we aren't providing an alternative as this is considered as bad practice and sensitive to configuration ordering issues.
+Please open an issue to express use cases for the Gradle team to consider for a replacement.
+
 ## Potential breaking changes
 
 <!--


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native/issues/790

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fremoving-task-dependencies)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
