### PR TITLE
Allow domain object collections to accept provider of Iterable

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -38,11 +38,22 @@ public interface DomainObjectCollection<T> extends Collection<T> {
      *
      * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
      *
-     * @param provider A {@link Provider} that can provider the element when required.
+     * @param provider A {@link Provider} that can provide the element when required.
      * @since 4.8
      */
     @Incubating
     void addLater(Provider<? extends T> provider);
+
+    /**
+     * Adds an element to this collection, given a {@link Provider} of {@link Iterable} that will provide the elements when required.
+     *
+     * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
+     *
+     * @param provider A {@link Provider} of {@link Iterable} that can provide the elements when required.
+     * @since 4.10
+     */
+    @Incubating
+    void addAllLater(Provider<? extends Iterable<T>> provider);
 
     /**
      * Returns a collection containing the objects in this collection of the given type.  The returned collection is

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -45,7 +45,7 @@ public interface DomainObjectCollection<T> extends Collection<T> {
     void addLater(Provider<? extends T> provider);
 
     /**
-     * Adds an element to this collection, given a {@link Provider} of {@link Iterable} that will provide the elements when required.
+     * Adds elements to this collection, given a {@link Provider} of {@link Iterable} that will provide the elements when required.
      *
      * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -50,7 +50,7 @@ public interface DomainObjectCollection<T> extends Collection<T> {
      * <strong>Note: this method currently has a placeholder name and will almost certainly be renamed.</strong>
      *
      * @param provider A {@link Provider} of {@link Iterable} that can provide the elements when required.
-     * @since 4.10
+     * @since 4.11
      */
     @Incubating
     void addAllLater(Provider<? extends Iterable<T>> provider);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.internal.collections.ElementSource;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.Actions;
@@ -283,6 +284,16 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
 
         @Override
         public boolean removePending(ProviderInternal<? extends T> provider) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean addPendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean removePendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.collections.CollectionEventRegister;
 import org.gradle.api.internal.collections.CollectionFilter;
 import org.gradle.api.internal.collections.ElementSource;
 import org.gradle.api.internal.collections.FilteredCollection;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
@@ -267,6 +268,19 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
             return;
         }
         store.addPending(providerInternal);
+    }
+
+    @Override
+    public void addAllLater(Provider<? extends Iterable<T>> provider) {
+        assertMutable();
+        CollectionProviderInternal<T, ? extends Iterable<T>> providerInternal = Cast.uncheckedCast(provider);
+        if (eventRegister.isSubscribed(providerInternal.getElementType())) {
+            for (T value : provider.get()) {
+                doAdd(value, eventRegister.getAddActions());
+            }
+            return;
+        }
+        store.addPendingCollection(providerInternal);
     }
 
     protected void didAdd(T toAdd) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DelegatingDomainObjectSet.java
@@ -89,6 +89,11 @@ public class DelegatingDomainObjectSet<T> implements DomainObjectSet<T> {
         backingSet.addLater(provider);
     }
 
+    @Override
+    public void addAllLater(Provider<? extends Iterable<T>> provider) {
+        backingSet.addAllLater(provider);
+    }
+
     public boolean add(T o) {
         return backingSet.add(o);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/TypedDomainObjectContainerWrapper.java
@@ -124,6 +124,11 @@ public class TypedDomainObjectContainerWrapper<U> implements NamedDomainObjectCo
         delegate.addLater(provider);
     }
 
+    @Override
+    public void addAllLater(Provider<? extends Iterable<U>> provider) {
+        delegate.addAllLater(provider);
+    }
+
     public boolean addAll(Collection<? extends U> c) {
         return delegate.addAll(c);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -18,18 +18,21 @@ package org.gradle.api.internal.collections;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
+import org.gradle.api.internal.provider.Collectors.*;
 import org.gradle.api.internal.provider.ProviderInternal;
 
+import java.util.Iterator;
 import java.util.List;
 
 public class DefaultPendingSource<T> implements PendingSource<T> {
-    private final List<ProviderInternal<? extends T>> pending = Lists.newArrayList();
+    private final List<TypedCollector<T>> pending = Lists.newArrayList();
     private Action<T> flushAction;
 
     @Override
     public void realizePending() {
         if (!pending.isEmpty()) {
-            List<ProviderInternal<? extends T>> copied = Lists.newArrayList(pending);
+            List<TypedCollector<T>> copied = Lists.newArrayList(pending);
             realize(copied);
         }
     }
@@ -37,21 +40,25 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
     @Override
     public void realizePending(Class<?> type) {
         if (!pending.isEmpty()) {
-            List<ProviderInternal<? extends T>> copied = Lists.newArrayList();
-            for (ProviderInternal<? extends T> provider : pending) {
-                if (provider.getType() == null || type.isAssignableFrom(provider.getType())) {
-                    copied.add(provider);
+            List<TypedCollector<T>> copied = Lists.newArrayList();
+            for (TypedCollector<T> collector : pending) {
+                if (collector.getType() == null || type.isAssignableFrom(collector.getType())) {
+                    copied.add(collector);
                 }
             }
             realize(copied);
         }
     }
 
-    private void realize(Iterable<ProviderInternal<? extends T>> elements) {
-        for (ProviderInternal<? extends T> provider : elements) {
+    private void realize(Iterable<TypedCollector<T>> collectors) {
+        for (TypedCollector<T> collector : collectors) {
             if (flushAction != null) {
-                pending.remove(provider);
-                flushAction.execute(provider.get());
+                pending.remove(collector);
+                List<T> realized = Lists.newArrayList();
+                collector.collectInto(realized);
+                for (T element : realized) {
+                    flushAction.execute(element);
+                }
             } else {
                 throw new IllegalStateException("Cannot realize pending elements when realize action is not set");
             }
@@ -60,12 +67,34 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
 
     @Override
     public boolean addPending(ProviderInternal<? extends T> provider) {
-        return pending.add(provider);
+        return pending.add(new TypedCollector<T>(provider.getType(), new ElementFromProvider<T>(provider)));
     }
 
     @Override
     public boolean removePending(ProviderInternal<? extends T> provider) {
-        return pending.remove(provider);
+        return removeByProvider(provider);
+    }
+
+    private boolean removeByProvider(ProviderInternal<?> provider) {
+        Iterator<TypedCollector<T>> iterator = pending.iterator();
+        while (iterator.hasNext()) {
+            TypedCollector<T> collector = iterator.next();
+            if (collector.isProvidedBy(provider)) {
+                iterator.remove();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean addPendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider) {
+        return pending.add(new TypedCollector<T>(provider.getElementType(), new ElementsFromCollectionProvider<T>(provider)));
+    }
+
+    @Override
+    public boolean removePendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider) {
+        return removeByProvider(provider);
     }
 
     @Override
@@ -85,7 +114,11 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
 
     @Override
     public int size() {
-        return pending.size();
+        int count = 0;
+        for (TypedCollector<T> collector : pending) {
+            count += collector.size();
+        }
+        return count;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -17,7 +17,9 @@ package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
 import org.gradle.api.internal.WithEstimatedSize;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
+import org.gradle.internal.Cast;
 
 import java.util.Collection;
 import java.util.Iterator;
@@ -193,6 +195,18 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     @Override
     public boolean removePending(ProviderInternal<? extends S> provider) {
         return collection.removePending(provider);
+    }
+
+    @Override
+    public boolean addPendingCollection(CollectionProviderInternal<S, ? extends Iterable<S>> provider) {
+        CollectionProviderInternal<T, ? extends Iterable<T>> providerOfT = Cast.uncheckedCast(provider);
+        return collection.addPendingCollection(providerOfT);
+    }
+
+    @Override
+    public boolean removePendingCollection(CollectionProviderInternal<S, ? extends Iterable<S>> provider) {
+        CollectionProviderInternal<T, ? extends Iterable<T>> providerOfT = Cast.uncheckedCast(provider);
+        return collection.removePendingCollection(providerOfT);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSource.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.collections;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.specs.Spec;
@@ -65,8 +64,7 @@ public class IterationOrderRetainingSetElementSource<T> extends AbstractIteratio
         boolean seen = false;
         for (Element<T> element : getInserted()) {
             if (element.isRealized()) {
-                List<T> collected = Lists.newArrayList();
-                element.collectInto(collected);
+                List<T> collected = element.getValues();
                 for (int index = 0; index < collected.size(); index++) {
                     if (Objects.equal(collected.get(index), value)) {
                         if (seen) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/ListElementSource.java
@@ -160,7 +160,7 @@ public class ListElementSource<T> extends AbstractIterationOrderRetainingElement
             while (i >= 0) {
                 Element<T> candidate = backingList.get(i);
                 if (candidate.isRealized()) {
-                    List<T> collected = collectFrom(candidate);
+                    List<T> collected = candidate.getValues();
                     if (previousSubIndex == -1) {
                         previousSubIndex = collected.size();
                     }
@@ -186,7 +186,7 @@ public class ListElementSource<T> extends AbstractIterationOrderRetainingElement
         @Override
         public T next() {
             T value = super.next();
-            previous = collectFrom(backingList.get(previousIndex)).get(previousSubIndex);
+            previous = backingList.get(previousIndex).getValues().get(previousSubIndex);
             listNextIndex++;
             listPreviousIndex++;
             return value;
@@ -229,7 +229,7 @@ public class ListElementSource<T> extends AbstractIterationOrderRetainingElement
             Element<T> element = new Element<T>(t);
             backingList.add(nextIndex, element);
             nextIndex++;
-            previous = collectFrom(element).get(0);
+            previous = element.getValues().get(0);
             previousIndex = nextIndex;
             previousSubIndex = 0;
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 
 public interface PendingSource<T> {
@@ -27,6 +28,10 @@ public interface PendingSource<T> {
     boolean addPending(ProviderInternal<? extends T> provider);
 
     boolean removePending(ProviderInternal<? extends T> provider);
+
+    boolean addPendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider);
+
+    boolean removePendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider);
 
     void realizeExternal(ProviderInternal<? extends T> provider);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.collections;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
 import org.gradle.api.internal.provider.ProviderInternal;
 
 import java.util.Collection;
@@ -114,6 +115,16 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     @Override
     public boolean removePending(ProviderInternal<? extends T> provider) {
         return pending.removePending(provider);
+    }
+
+    @Override
+    public boolean addPendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider) {
+        return pending.addPendingCollection(provider);
+    }
+
+    @Override
+    public boolean removePendingCollection(CollectionProviderInternal<T, ? extends Iterable<T>> provider) {
+        return pending.removePendingCollection(provider);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/CollectionProviderInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/CollectionProviderInternal.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+public interface CollectionProviderInternal<T, C extends Iterable<T>> extends ProviderInternal<C> {
+    Class<? extends T> getElementType();
+
+    int size();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/Collector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/Collector.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import java.util.Collection;
+
+/**
+ * This could move to the public API.
+ */
+public interface Collector<T> {
+    boolean present();
+
+    void collectInto(ValueCollector<T> collector, Collection<T> dest);
+
+    boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> dest);
+
+    int size();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.Iterables;
+import groovy.lang.GString;
+import org.gradle.api.provider.Provider;
+import org.gradle.util.CollectionUtils;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+public class Collectors {
+    public static final IdentityValueCollector IDENTITY_VALUE_COLLECTOR = new IdentityValueCollector();
+    public static final StringValueCollector STRING_VALUE_COLLECTOR = new StringValueCollector();
+
+    public interface ProvidedCollector<T> extends Collector<T> {
+        boolean isProvidedBy(Provider<?> provider);
+    }
+
+    public static class EmptyCollection implements Collector<Object> {
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<Object> collector, Collection<Object> collection) {
+            return true;
+        }
+
+        @Override
+        public void collectInto(ValueCollector<Object> collector, Collection<Object> collection) {
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+    }
+
+    public static class SingleElement<T> implements Collector<T> {
+        private final T element;
+
+        public SingleElement(T element) {
+            this.element = element;
+        }
+
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public void collectInto(ValueCollector<T> collector, Collection<T> collection) {
+            collector.add(element, collection);
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
+            collector.add(element, collection);
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            SingleElement<?> that = (SingleElement<?>) o;
+            return Objects.equal(element, that.element);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(element);
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+    }
+
+    public static class ElementFromProvider<T> implements ProvidedCollector<T> {
+        private final Provider<? extends T> providerOfElement;
+
+        public ElementFromProvider(Provider<? extends T> providerOfElement) {
+            this.providerOfElement = providerOfElement;
+        }
+
+        @Override
+        public boolean present() {
+            return providerOfElement.isPresent();
+        }
+
+        @Override
+        public void collectInto(ValueCollector<T> collector, Collection<T> collection) {
+            T value = providerOfElement.get();
+            collector.add(value, collection);
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
+            T value = providerOfElement.getOrNull();
+            if (value == null) {
+                return false;
+            }
+            collector.add(value, collection);
+            return true;
+        }
+
+        @Override
+        public boolean isProvidedBy(Provider<?> provider) {
+            return Objects.equal(provider, providerOfElement);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ElementFromProvider<?> that = (ElementFromProvider<?>) o;
+            return Objects.equal(providerOfElement, that.providerOfElement);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(providerOfElement);
+        }
+
+        @Override
+        public int size() {
+            return 1;
+        }
+    }
+
+    public static class ElementsFromCollection<T> implements Collector<T> {
+        private final Iterable<? extends T> value;
+
+        public ElementsFromCollection(Iterable<? extends T> value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public void collectInto(ValueCollector<T> collector, Collection<T> collection) {
+            collector.addAll(value, collection);
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
+            collector.addAll(value, collection);
+            return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ElementsFromCollection<?> that = (ElementsFromCollection<?>) o;
+            return Objects.equal(value, that.value);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(value);
+        }
+
+        @Override
+        public int size() {
+            return Iterables.size(value);
+        }
+    }
+
+    public static class ElementsFromCollectionProvider<T> implements ProvidedCollector<T> {
+        private final Provider<? extends Iterable<? extends T>> provider;
+
+        public ElementsFromCollectionProvider(Provider<? extends Iterable<? extends T>> provider) {
+            this.provider = provider;
+        }
+
+        @Override
+        public boolean present() {
+            return provider.isPresent();
+        }
+
+        @Override
+        public void collectInto(ValueCollector<T> collector, Collection<T> collection) {
+            Iterable<? extends T> value = provider.get();
+            collector.addAll(value, collection);
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
+            Iterable<? extends T> value = provider.getOrNull();
+            if (value == null) {
+                return false;
+            }
+            collector.addAll(value, collection);
+            return true;
+        }
+
+        @Override
+        public boolean isProvidedBy(Provider<?> provider) {
+            return Objects.equal(provider, provider);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ElementsFromCollectionProvider<?> that = (ElementsFromCollectionProvider<?>) o;
+            return Objects.equal(provider, that.provider);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(provider);
+        }
+
+        @Override
+        public int size() {
+            if (provider instanceof CollectionProviderInternal) {
+                return ((CollectionProviderInternal)provider).size();
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    public static class NoValueCollector implements Collector<Object> {
+        @Override
+        public boolean present() {
+            return false;
+        }
+
+        @Override
+        public void collectInto(ValueCollector<Object> collector, Collection<Object> collection) {
+            throw new IllegalStateException(Providers.NULL_VALUE);
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<Object> collector, Collection<Object> collection) {
+            return false;
+        }
+
+        @Override
+        public int size() {
+            return 0;
+        }
+    }
+
+    public static class ElementsFromArray<T> implements Collector<T> {
+        private final T[] value;
+
+        ElementsFromArray(T[] value) {
+            this.value = value;
+        }
+
+        @Override
+        public boolean present() {
+            return true;
+        }
+
+        @Override
+        public void collectInto(ValueCollector<T> collector, Collection<T> dest) {
+            for (T t : value) {
+                collector.add(t, dest);
+            }
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> dest) {
+            collectInto(collector, dest);
+            return true;
+        }
+
+        @Override
+        public int size() {
+            return value.length;
+        }
+    }
+
+    public static class TypedCollector<T> implements ProvidedCollector<T> {
+        private final Class<? extends T> type;
+        protected final Collector<T> delegate;
+        private final ValueCollector<T> valueCollector;
+
+        public TypedCollector(@Nullable Class<? extends T> type, Collector<T> delegate) {
+            this.type = type;
+            this.delegate = delegate;
+            this.valueCollector = (ValueCollector<T>) (type == String.class ? STRING_VALUE_COLLECTOR : IDENTITY_VALUE_COLLECTOR);
+        }
+
+        @Nullable
+        public Class<? extends T> getType() {
+            return type;
+        }
+
+        @Override
+        public boolean present() {
+            return delegate.present();
+        }
+
+        public void collectInto(Collection<T> collection) {
+            delegate.collectInto(valueCollector, collection);
+        }
+
+        public boolean maybeCollectInto(Collection<T> collection) {
+            return delegate.maybeCollectInto(valueCollector, collection);
+        }
+
+        @Override
+        public void collectInto(ValueCollector<T> collector, Collection<T> dest) {
+            delegate.collectInto(collector, dest);
+        }
+
+        @Override
+        public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> dest) {
+            return delegate.maybeCollectInto(collector, dest);
+        }
+
+        @Override
+        public boolean isProvidedBy(Provider<?> provider) {
+            return delegate instanceof ProvidedCollector && ((ProvidedCollector<T>)delegate).isProvidedBy(provider);
+        }
+
+        @Override
+        public int size() {
+            return delegate.size();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TypedCollector<?> that = (TypedCollector<?>) o;
+            return Objects.equal(type, that.type) &&
+                Objects.equal(delegate, that.delegate);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(type, delegate);
+        }
+    }
+
+    public static class IdentityValueCollector implements ValueCollector<Object> {
+        @Override
+        public void add(Object value, Collection<Object> dest) {
+            dest.add(value);
+        }
+
+        @Override
+        public void addAll(Iterable<?> values, Collection<Object> dest) {
+            CollectionUtils.addAll(dest, values);
+        }
+    }
+
+    public static class StringValueCollector implements ValueCollector<Object> {
+        @Override
+        public void add(Object value, Collection<Object> dest) {
+            if (value instanceof GString) {
+                dest.add(value.toString());
+            } else {
+                dest.add(value);
+            }
+        }
+
+        @Override
+        public void addAll(Iterable<?> values, Collection<Object> dest) {
+            for (Object value : values) {
+                add(value, dest);
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/provider/ValueCollector.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/provider/ValueCollector.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.provider;
+
+import java.util.Collection;
+
+public interface ValueCollector<T> {
+    void add(T value, Collection<T> dest);
+
+    void addAll(Iterable<? extends T> values, Collection<T> dest);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -703,6 +703,11 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     }
 
     @Override
+    public void addAllLater(Provider<? extends Iterable<Task>> provider) {
+        throw new UnsupportedOperationException("Adding a task provider directly to the task container is not supported.  Use the register() method instead.");
+    }
+
+    @Override
     public boolean addInternal(Task task) {
         return super.add(task);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RealizableTaskCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/RealizableTaskCollection.java
@@ -136,6 +136,11 @@ public class RealizableTaskCollection<T extends Task> implements TaskCollection<
     }
 
     @Override
+    public void addAllLater(Provider<? extends Iterable<T>> provider) {
+        delegate.addAllLater(provider);
+    }
+
+    @Override
     public boolean addAll(Collection<? extends T> c) {
         return delegate.addAll(c);
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal
 
 import org.gradle.api.Action
 import org.gradle.api.DomainObjectCollection
+import org.gradle.api.internal.provider.CollectionProviderInternal
 import org.gradle.api.internal.provider.ProviderInternal
 import spock.lang.Specification
 
@@ -72,7 +73,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.addLater(provider)
 
         then:
-        1 * provider.type >> type
+        _ * provider.type >> type
         0 * provider._
 
         and:
@@ -80,21 +81,41 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !container.empty
     }
 
-    def "provider for element is not queried when another element added"() {
+    def "elements added using provider of iterable are not realized when added"() {
+        def provider = Mock(CollectionProviderInternal)
+        _ * provider.size() >> 2
+
+        when:
+        container.addAllLater(provider)
+
+        then:
+        _ * provider.elementType >> type
+        0 * provider._
+
+        and:
+        container.size() == 2
+        !container.empty
+    }
+
+    def "provider of elements are not queried when another element added"() {
         def provider = Mock(ProviderInternal)
+        def providerOfIterable = Mock(CollectionProviderInternal)
+        _ * providerOfIterable.size() >> 2
 
         given:
         container.add(a)
         container.addLater(provider)
+        container.addAllLater(providerOfIterable)
 
         when:
         container.add(b)
 
         then:
         0 * provider._
+        0 * providerOfIterable._
 
         and:
-        container.size() == 3
+        container.size() == 5
         !container.empty
     }
 
@@ -125,6 +146,23 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         1 * provider.get() >> a
     }
 
+    def "provider for iterable of elements is queried when membership checked"() {
+        def provider = Mock(CollectionProviderInternal)
+
+        given:
+        container.add(b)
+        container.addAllLater(provider)
+
+        when:
+        def result = container.contains(c)
+
+        then:
+        !result
+
+        and:
+        1 * provider.get() >> [a, d]
+    }
+
     def "can get all domain objects ordered by order added"() {
         given:
         container.add(b)
@@ -150,7 +188,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         seen == iterationOrder(b, a, c)
     }
 
-    def "provider for element is queried when elements iterated but insertion order is not retained"() {
+    def "provider for element is queried when elements iterated and insertion order is retained"() {
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
 
@@ -169,6 +207,25 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         and:
         1 * provider1.get() >> a
         1 * provider2.get() >> d
+        0 * _
+    }
+
+    def "provider for iterable of elements is queried when elements iterated and insertion order is retained"() {
+        def provider1 = Mock(CollectionProviderInternal)
+
+        given:
+        container.add(b)
+        container.addAllLater(provider1)
+        container.add(c)
+
+        when:
+        def result = toList(container)
+
+        then:
+        result == iterationOrder(b, a, d, c)
+
+        and:
+        1 * provider1.get() >> [a, d]
         0 * _
     }
 
@@ -220,6 +277,34 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
+    def "queries provider for iterable of elements when registering action for all elements in a collection"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+
+        container.addAllLater(provider1)
+
+        when:
+        container.all(action)
+
+        then:
+        1 * action.execute(c)
+        _ * provider1.elementType >> type
+        1 * provider1.get() >> [c]
+        _ * provider1.size() >> 1
+        0 * _
+
+        when:
+        container.addAllLater(provider2)
+
+        then:
+        1 * action.execute(a)
+        1 * action.execute(b)
+        _ * provider2.elementType >> type
+        1 * provider2.get() >> [a, b]
+        0 * _
+    }
+
     def "can get filtered collection containing all objects which have type"() {
         container.add(c)
         container.add(a)
@@ -260,8 +345,40 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * provider._
     }
 
+    def "provider for iterable of elements is queried when filtered collection with matching type created"() {
+        def provider = Mock(CollectionProviderInternal)
+        _ * provider.elementType >> type
+
+        container.add(c)
+        container.addAllLater(provider)
+        container.add(d)
+
+        when:
+        def filtered = container.withType(type)
+
+        then:
+        0 * provider._
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        result == iterationOrder(c, a, b)
+        _ * provider.size() >> 2
+        1 * provider.get() >> [a, b]
+        0 * provider._
+
+        when:
+        def result2 = toList(container)
+
+        then:
+        result2 == iterationOrder(c, a, b, d)
+        0 * provider._
+    }
+
     def "provider for element is not queried when filtered collection with non matching type created"() {
         def provider = Mock(ProviderInternal)
+        _ * provider.type >> type
 
         container.add(c)
         container.addLater(provider)
@@ -278,7 +395,6 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         result == iterationOrder(d)
-        _ * provider.type >> type
         0 * provider._
 
         when:
@@ -287,6 +403,38 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         result2 == iterationOrder(c, a, d)
         1 * provider.get() >> a
+        0 * provider._
+    }
+
+    def "provider for iterable of elements is not queried when filtered collection with non matching type created"() {
+        def provider = Mock(CollectionProviderInternal)
+        _ * provider.elementType >> type
+
+        container.add(c)
+        container.addAllLater(provider)
+        container.add(d)
+
+        when:
+        def filtered = container.withType(otherType)
+
+        then:
+        0 * provider._
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        result == iterationOrder(d)
+        _ * provider.size() >> 2
+        0 * provider._
+
+        when:
+        def result2 = toList(container)
+
+        then:
+        result2 == iterationOrder(c, a, b, d)
+        _ * provider.size() >> 2
+        1 * provider.get() >> [a, b]
         0 * provider._
     }
 
@@ -375,10 +523,40 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
+    def "provider for iterable of elements is queried and action executed for filtered collection with matching type"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+
+        container.addAllLater(provider1)
+        container.add(d)
+
+        when:
+        container.withType(type, action)
+
+        then:
+        _ * provider1.elementType >> type
+        _ * provider1.size() >> 1
+        1 * provider1.get() >> [c]
+        1 * action.execute(c)
+        0 * _
+
+        when:
+        container.addAllLater(provider2)
+
+        then:
+        _ * provider2.elementType >> type
+        1 * provider2.get() >> [a, b]
+        1 * action.execute(a)
+        1 * action.execute(b)
+        0 * _
+    }
+
     def "provider for element is not queried and action executed for filtered collection with non matching type"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
+        _ * provider1.type >> type
 
         container.addLater(provider1)
         container.add(d)
@@ -387,7 +565,6 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.withType(otherType, action)
 
         then:
-        _ * provider1.type >> type
         1 * action.execute(d)
         0 * _
 
@@ -399,10 +576,36 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
+    def "provider for iterable of elements is not queried and action executed for filtered collection with non matching type"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+        _ * provider1.elementType >> type
+
+        container.addAllLater(provider1)
+        container.add(d)
+
+        when:
+        container.withType(otherType, action)
+
+        then:
+        1 * action.execute(d)
+        _ * provider1.size() >> 1
+        0 * _
+
+        when:
+        container.addAllLater(provider2)
+
+        then:
+        _ * provider2.elementType >> type
+        0 * _
+    }
+
     def "can execute action to configure element when element is realized"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
         def provider2 = Mock(ProviderInternal)
+        def provider3 = Mock(CollectionProviderInternal)
 
         given:
         container.addLater(provider1)
@@ -425,7 +628,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.addLater(provider2)
 
         then:
-        1 * provider2.type >> type
+        _ * provider2.type >> type
         0 * _
 
         when:
@@ -435,15 +638,34 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         1 * provider2.get() >> c
         1 * action.execute(c)
         0 * _
+
+        when:
+        container.addAllLater(provider3)
+
+        then:
+        _ * provider3.elementType >> type
+        0 * _
+
+        when:
+        toList(container)
+
+        then:
+        1 * provider3.get() >> [b, d]
+        1 * action.execute(b)
+        1 * action.execute(d)
+        0 * _
     }
 
     def "runs configure element action immediately when element already realized"() {
         def action = Mock(Action)
         def provider = Mock(ProviderInternal)
+        def providerOfIterable = Mock(CollectionProviderInternal)
 
         given:
         _ * provider.get() >> a
+        _ * providerOfIterable.get() >> [b, c]
         container.addLater(provider)
+        container.addAllLater(providerOfIterable)
         toList(container)
 
         when:
@@ -451,6 +673,8 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         1 * action.execute(a)
+        1 * action.execute(b)
+        1 * action.execute(c)
         0 * _
     }
 
@@ -501,6 +725,42 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         0 * _
     }
 
+    def "can execute action to configure elements of given type when iterable of elements is realized"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+
+        given:
+        container.addAllLater(provider1)
+        container.addAllLater(provider2)
+
+        when:
+        container.withType(type).configureEach(action)
+
+        then:
+        _ * provider1.size() >> 2
+        _ * provider2.size() >> 1
+        0 * _
+
+        when:
+        toList(container)
+
+        then:
+        _ * provider1.elementType >> type
+        1 * provider1.get() >> [a, c]
+        1 * action.execute(a)
+        1 * action.execute(c)
+        _ * provider2.elementType >> otherType
+        1 * provider2.get() >> [d]
+        0 * _
+
+        when:
+        toList(container)
+
+        then:
+        0 * _
+    }
+
     def "provider is not queried or element configured until collection is realized when lazy action is registered on type-filtered collection"() {
         def action = Mock(Action)
         def provider1 = Mock(ProviderInternal)
@@ -531,6 +791,42 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         and:
         1 * action.execute(a)
+        1 * action.execute(b)
+    }
+
+    def "provider of iterable is not queried or elements configured until collection is realized when lazy action is registered on type-filtered collection"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+
+        given:
+        _ * provider1.elementType >> type
+        _ * provider2.elementType >> type
+        container.addAllLater(provider1)
+        container.addAllLater(provider2)
+        def filtered = container.withType(type)
+
+        when:
+        filtered.configureEach(action)
+
+        then:
+        0 * provider1.get()
+        0 * provider2.get()
+        0 * action.execute(_)
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        _ * provider1.size() >> 1
+        _ * provider2.size() >> 2
+        1 * provider1.get() >> [a]
+        1 * provider2.get() >> [c, b]
+        result == iterationOrder(a, c, b)
+
+        and:
+        1 * action.execute(a)
+        1 * action.execute(c)
         1 * action.execute(b)
     }
 
@@ -565,6 +861,42 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         and:
         0 * action.execute(a)
         1 * action.execute(b)
+    }
+
+    def "only realized elements of iterable with given type are configured when lazy action is registered on type-filtered collection"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+
+        given:
+        _ * provider1.elementType >> otherType
+        _ * provider2.type >> type
+        container.addAllLater(provider1)
+        container.addAllLater(provider2)
+        def filtered = container.withType(type)
+
+        when:
+        filtered.configureEach(action)
+
+        then:
+        0 * provider1.get()
+        0 * provider2.get()
+        0 * action.execute(_)
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        _ * provider1.size() >> 1
+        _ * provider2.size() >> 2
+        0 * provider1.get() >> [a]
+        1 * provider2.get() >> [b, c]
+        result == iterationOrder(b, c)
+
+        and:
+        0 * action.execute(a)
+        1 * action.execute(b)
+        1 * action.execute(c)
     }
 
     def "provider is queried but element not configured when lazy action is registered on non-matching filter"() {
@@ -612,5 +944,40 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         toList(container) == [a, b, c, d]
+    }
+
+    def "provider of iterable is queried but elements not configured when lazy action is registered on non-matching filter"() {
+        def action = Mock(Action)
+        def provider1 = Mock(CollectionProviderInternal)
+        def provider2 = Mock(CollectionProviderInternal)
+
+        given:
+        _ * provider1.elementType >> type
+        _ * provider2.elementType >> type
+        container.addAllLater(provider1)
+        container.addAllLater(provider2)
+        def filtered = container.matching { it == b }
+
+        when:
+        filtered.configureEach(action)
+
+        then:
+        0 * provider1.get()
+        0 * provider2.get()
+
+        when:
+        def result = toList(filtered)
+
+        then:
+        _ * provider1.size() >> 1
+        _ * provider2.size() >> 2
+        1 * provider1.get() >> [a]
+        1 * provider2.get() >> [b, c]
+        result == iterationOrder(b)
+
+        and:
+        0 * action.execute(a)
+        0 * action.execute(c)
+        1 * action.execute(b)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -225,6 +225,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         result == iterationOrder(b, a, d, c)
 
         and:
+        _ * provider1.size() >> 2
         1 * provider1.get() >> [a, d]
         0 * _
     }
@@ -650,6 +651,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         toList(container)
 
         then:
+        _ * provider3.size() >> 2
         1 * provider3.get() >> [b, d]
         1 * action.execute(b)
         1 * action.execute(d)
@@ -672,6 +674,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.configureEach(action)
 
         then:
+        _ * providerOfIterable.size() >> 2
         1 * action.execute(a)
         1 * action.execute(b)
         1 * action.execute(c)
@@ -747,10 +750,12 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         then:
         _ * provider1.elementType >> type
+        _ * provider1.size() >> 2
         1 * provider1.get() >> [a, c]
         1 * action.execute(a)
         1 * action.execute(c)
         _ * provider2.elementType >> otherType
+        _ * provider2.size() >> 1
         1 * provider2.get() >> [d]
         0 * _
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -640,4 +640,20 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds("help")
     }
+
+    def "cannot add a pre-created provider of tasks to the task container"() {
+        given:
+        buildFile << """
+            Task foo = tasks.create("foo")
+            Task bar = tasks.create("bar")
+            
+            tasks.addAllLater(provider { [foo, bar] })
+        """
+
+        when:
+        fails("help")
+
+        then:
+        failure.assertHasCause("Adding a task provider directly to the task container is not supported.")
+    }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/BinaryTasksCollectionWrapper.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/BinaryTasksCollectionWrapper.java
@@ -185,6 +185,11 @@ public class BinaryTasksCollectionWrapper implements BinaryTasksCollection {
     }
 
     @Override
+    public void addAllLater(Provider<? extends Iterable<Task>> provider) {
+        delegate.addAllLater(provider);
+    }
+
+    @Override
     public boolean remove(Object o) {
         return delegate.remove(o);
     }


### PR DESCRIPTION
This adds a `addAllLater` method to domain object collections which accepts a `Provider<? extends Iterable<T>>`