### PR TITLE
Disable daemon in noDaemonTest

### DIFF
--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -30,7 +30,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
                             + buildScanValues.map { buildScanCustomValue(it.key, it.value) }
                     ).joinToString(separator = " "),
             timeout = testCoverage.testType.timeout,
-            daemon = useDaemon)
+            daemon = useDaemon && testCoverage.testType != TestType.noDaemon)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.oracle.64bit%")

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -30,7 +30,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
                             + buildScanValues.map { buildScanCustomValue(it.key, it.value) }
                     ).joinToString(separator = " "),
             timeout = testCoverage.testType.timeout,
-            daemon = useDaemon && testCoverage.testType != TestType.noDaemon)
+            daemon = useDaemon)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.oracle.64bit%")

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -154,8 +154,12 @@ data class CIBuildModel (
 
 data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false, val useDaemon: Boolean = true) {
     fun asDirectoryName(): String {
-        return name.replace(Regex("([A-Z])"), { "-" + it.groups[1]!!.value.toLowerCase()})
+        return name.replace(Regex("([A-Z])"), { "-" + it.groups[1]!!.value.toLowerCase() })
     }
+
+    fun hasTestsOf(type: TestType) = (unitTests && type.unitTests) || (functionalTests && type.functionalTests) || (crossVersionTests && type.crossVersionTests)
+
+    fun useDaemonFor(type: TestType) = useDaemon && type != TestType.noDaemon
 }
 
 interface BuildCache {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -4,9 +4,7 @@ import configurations.FunctionalTest
 import configurations.shouldBeSkipped
 import jetbrains.buildServer.configs.kotlin.v2018_1.AbsoluteId
 import jetbrains.buildServer.configs.kotlin.v2018_1.Project
-import model.CIBuildModel
-import model.Stage
-import model.TestCoverage
+import model.*
 
 class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage: Stage) : Project({
     this.uuid = testConfig.asId(model)
@@ -22,13 +20,7 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
             return@forEach
         }
 
-        if (subProject.unitTests && testConfig.testType.unitTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
-        } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
-        } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
-        }
+        configureBuildType(model, testConfig, stage, subProject)
     }
 }){
     companion object {
@@ -37,5 +29,17 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
         private fun addMissingTestCoverage(coverage: TestCoverage) {
             this.missingTestCoverage.add(coverage)
         }
+    }
+}
+
+fun Project.configureBuildType(model: CIBuildModel, testConfig: TestCoverage, stage: Stage, subProject: GradleSubproject) {
+    val useDaemon = subProject.useDaemon && testConfig.testType != TestType.noDaemon
+
+    if (subProject.unitTests && testConfig.testType.unitTests) {
+        buildType(FunctionalTest(model, testConfig, subProject.name, useDaemon, stage))
+    } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
+        buildType(FunctionalTest(model, testConfig, subProject.name, useDaemon, stage))
+    } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
+        buildType(FunctionalTest(model, testConfig, subProject.name, useDaemon, stage))
     }
 }

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -69,13 +69,7 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
             model.subProjects.forEach { subProject ->
                 if (subProject.containsSlowTests) {
                     FunctionalTestProject.missingTestCoverage.forEach { testConfig ->
-                        if (subProject.unitTests && testConfig.testType.unitTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
-                        } else if (subProject.functionalTests && testConfig.testType.functionalTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
-                        } else if (subProject.crossVersionTests && testConfig.testType.crossVersionTests) {
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemon, stage))
-                        }
+                        configureBuildType(model, testConfig, stage, subProject)
                     }
                 }
             }


### PR DESCRIPTION
### Context

In https://github.com/gradle/gradle/pull/6106 we disabled daemon for some certain
subprojects, however, all subprojects' `noDaemonTest` requires allDistribution, which
in turn invokes userguide task. This PR disabled daemon for `noDaemonTest`, given that
noDaemonTest is excuted once a day.