### PR TITLE
Improve file lock contention handling

### DIFF
--- a/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/locklistener/NoOpFileLockContentionHandler.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/cache/internal/locklistener/NoOpFileLockContentionHandler.java
@@ -16,9 +16,12 @@
 
 package org.gradle.cache.internal.locklistener;
 
+import org.gradle.api.Action;
+import org.gradle.cache.FileLockReleasedSignal;
+
 public class NoOpFileLockContentionHandler implements FileLockContentionHandler {
 
-    public void start(long lockId, Runnable whenContended) {}
+    public void start(long lockId, Action<FileLockReleasedSignal> whenContended) {}
 
     public void stop(long lockId) {}
 
@@ -26,7 +29,7 @@ public class NoOpFileLockContentionHandler implements FileLockContentionHandler 
         return -1;
     }
 
-    public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed) {
+    public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed, FileLockReleasedSignal signal) {
         return false;
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockManager.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.cache;
 
+import org.gradle.api.Action;
+
 import javax.annotation.Nullable;
 import java.io.File;
 
@@ -54,7 +56,7 @@ public interface FileLockManager {
      * @param whenContended will be called asynchronously by the thread that listens for cache access requests, when such request is received.
      * Note: currently, implementations are permitted to invoke the action <em>after</em> the lock as been closed.
      */
-    FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName, @Nullable Runnable whenContended) throws LockTimeoutException;
+    FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName, @Nullable Action<FileLockReleasedSignal> whenContended) throws LockTimeoutException;
 
     enum LockMode {
         /**

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockReleasedSignal.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockReleasedSignal.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache;
+
+public interface FileLockReleasedSignal {
+    void trigger();
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockReleasedSignal.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/FileLockReleasedSignal.java
@@ -16,6 +16,20 @@
 
 package org.gradle.cache;
 
+/**
+ * Signal that a file lock has been released.
+ *
+ * @see org.gradle.cache.internal.locklistener.FileLockContentionHandler
+ */
 public interface FileLockReleasedSignal {
+
+    /**
+     * Triggers this signal to notify the lock requesters that the file
+     * lock has been released.
+     *
+     * <p>Returns once the signal has been emitted but not necessarily
+     * received by the lock requesters.
+     */
     void trigger();
+
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -15,9 +15,12 @@
  */
 package org.gradle.cache.internal;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.gradle.api.Action;
 import org.gradle.cache.FileIntegrityViolationException;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
+import org.gradle.cache.FileLockReleasedSignal;
 import org.gradle.cache.InsufficientLockModeException;
 import org.gradle.cache.LockOptions;
 import org.gradle.cache.LockTimeoutException;
@@ -46,7 +49,11 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.gradle.internal.UncheckedException.throwAsUncheckedException;
 
 /**
@@ -87,7 +94,7 @@ public class DefaultFileLockManager implements FileLockManager {
         return lock(target, options, targetDisplayName, operationDisplayName, null);
     }
 
-    public FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName, Runnable whenContended) {
+    public FileLock lock(File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended) {
         if (options.getMode() == LockMode.None) {
             throw new UnsupportedOperationException(String.format("No %s mode lock implementation available.", options));
         }
@@ -124,7 +131,7 @@ public class DefaultFileLockManager implements FileLockManager {
         private int port;
         private final long lockId;
 
-        public DefaultFileLock(File target, LockOptions options, String displayName, String operationDisplayName, int port, Runnable whenContended) throws Throwable {
+        public DefaultFileLock(File target, LockOptions options, String displayName, String operationDisplayName, int port, Action<FileLockReleasedSignal> whenContended) throws Throwable {
             this.port = port;
             this.lockId = generator.generateId();
             if (options.getMode() == LockMode.None) {
@@ -352,7 +359,7 @@ public class DefaultFileLockManager implements FileLockManager {
                                 lastLockHolderPort = lockInfo.port;
                                 lastPingTime = 0;
                             }
-                            if (fileLockContentionHandler.maybePingOwner(lockInfo.port, lockInfo.lockId, displayName, backoff.timer.getElapsedMillis() - lastPingTime)) {
+                            if (fileLockContentionHandler.maybePingOwner(lockInfo.port, lockInfo.lockId, displayName, backoff.timer.getElapsedMillis() - lastPingTime, backoff.signal)) {
                                 lastPingTime = backoff.timer.getElapsedMillis();
                                 LOGGER.debug("The file lock is held by a different Gradle process (pid: {}, lockId: {}). Pinged owner at port {}", lockInfo.pid, lockInfo.lockId, lockInfo.port);
                             }
@@ -382,10 +389,10 @@ public class DefaultFileLockManager implements FileLockManager {
     private static class ExponentialBackoff {
 
         private static final int CAP_FACTOR = 100;
-
-        private static final long SLOT_TIME = 25L;
+        private static final long SLOT_TIME = 25;
 
         private final Random random = new Random();
+        private final AwaitableFileLockReleasedSignal signal = new AwaitableFileLockReleasedSignal();
 
         private final int timeoutMs;
         private CountdownTimer timer;
@@ -406,13 +413,57 @@ public class DefaultFileLockManager implements FileLockManager {
                 if (timer.hasExpired()) {
                     break;
                 }
-                Thread.sleep(backoffPeriodFor(++iteration));
+                boolean signaled = signal.await(backoffPeriodFor(++iteration));
+                if (signaled) {
+                    iteration = 0;
+                }
             }
             return result;
         }
 
         long backoffPeriodFor(int iteration) {
             return random.nextInt(Math.min(iteration, CAP_FACTOR)) * SLOT_TIME;
+        }
+    }
+
+    @VisibleForTesting
+    static class AwaitableFileLockReleasedSignal implements FileLockReleasedSignal {
+
+        private final Lock lock = new ReentrantLock();
+        private final Condition condition = lock.newCondition();
+        private int waiting;
+
+        public boolean await(long millis) throws InterruptedException {
+            lock.lock();
+            try {
+                waiting++;
+                return condition.await(millis, MILLISECONDS);
+            } finally {
+                waiting--;
+                lock.unlock();
+            }
+        }
+
+        @Override
+        public void trigger() {
+            lock.lock();
+            try {
+                if (waiting > 0) {
+                    condition.signalAll();
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        @VisibleForTesting
+        boolean isWaiting() {
+            lock.lock();
+            try {
+                return waiting > 0;
+            } finally {
+                lock.unlock();
+            }
         }
     }
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/FixedExclusiveModeCrossProcessCacheAccess.java
@@ -21,7 +21,9 @@ import org.gradle.api.Action;
 import org.gradle.cache.CrossProcessCacheAccess;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
+import org.gradle.cache.FileLockReleasedSignal;
 import org.gradle.cache.LockOptions;
+import org.gradle.internal.Actions;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 
@@ -33,10 +35,7 @@ import static org.gradle.cache.FileLockManager.LockMode.Exclusive;
  * A {@link CrossProcessCacheAccess} implementation used when a cache is opened with an exclusive lock that is held until the cache is closed. This implementation is simply a no-op for these methods.
  */
 public class FixedExclusiveModeCrossProcessCacheAccess extends AbstractCrossProcessCacheAccess {
-    private final static Runnable NO_OP_CONTENDED_ACTION = new Runnable() {
-        @Override
-        public void run() { }
-    };
+    private final static Action<FileLockReleasedSignal> NO_OP_CONTENDED_ACTION = Actions.doNothing();
 
     private final String cacheDisplayName;
     private final File lockTarget;

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
@@ -19,6 +19,7 @@ package org.gradle.cache.internal;
 import org.gradle.api.Action;
 import org.gradle.cache.FileLock;
 import org.gradle.cache.FileLockManager;
+import org.gradle.cache.FileLockReleasedSignal;
 import org.gradle.cache.LockOptions;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
@@ -38,11 +39,11 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
     private final Action<FileLock> onOpen;
     private final Action<FileLock> onClose;
     private final Runnable unlocker;
-    private final Runnable whenContended;
+    private final Action<FileLockReleasedSignal> whenContended;
     private int lockCount;
     private FileLock fileLock;
     private CacheInitializationAction initAction;
-    private boolean contended;
+    private FileLockReleasedSignal lockReleaseSignal;
 
     /**
      * Actions are notified when lock is opened or closed. Actions are called while holding state lock, so that no other threads are working with cache while these are running.
@@ -132,7 +133,7 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
                 throw new IllegalStateException("Mismatched lock count.");
             }
             lockCount--;
-            if (lockCount == 0 && contended) {
+            if (lockCount == 0 && lockReleaseSignal != null) {
                 releaseLockIfHeld();
             } // otherwise, keep lock open
         } finally {
@@ -152,7 +153,10 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
         } finally {
             fileLock.close();
             fileLock = null;
-            contended = false;
+            if (lockReleaseSignal != null) {
+                lockReleaseSignal.trigger();
+                lockReleaseSignal = null;
+            }
         }
     }
 
@@ -162,18 +166,19 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
         return unlocker;
     }
 
-    private class ContendedAction implements Runnable {
+    private class ContendedAction implements Action<FileLockReleasedSignal> {
         @Override
-        public void run() {
+        public void execute(FileLockReleasedSignal signal) {
             stateLock.lock();
             try {
                 if (lockCount == 0) {
                     LOGGER.debug("Lock on {} requested by another process - releasing lock.", cacheDisplayName);
                     releaseLockIfHeld();
+                    signal.trigger();
                 } else {
                     // Lock is in use - mark as contended
                     LOGGER.debug("Lock on {} requested by another process - lock is in use and will be released when operation completed.", cacheDisplayName);
-                    contended = true;
+                    lockReleaseSignal = signal;
                 }
             } finally {
                 stateLock.unlock();

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/DefaultFileLockContentionHandler.java
@@ -16,6 +16,8 @@
 
 package org.gradle.cache.internal.locklistener;
 
+import org.gradle.api.Action;
+import org.gradle.cache.FileLockReleasedSignal;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.Stoppable;
@@ -24,8 +26,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.DatagramPacket;
+import java.net.SocketAddress;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -39,11 +44,11 @@ import java.util.concurrent.locks.ReentrantLock;
  * The general strategy is that the Lock Holder keeps locks open as long as there is no Lock Requester. This is,
  * because each lock open/close action requires File I/O which is expensive.
  * <p>
- * The Lock Owner will inform this contention handler that it holds the lock via {@link #start(long, Runnable)}.
+ * The Lock Owner will inform this contention handler that it holds the lock via {@link #start(long, Action)}.
  * There it provides an action that this handler can call to release the lock, in case a release is requested.
  * <p>
  * A Lock Requester will notice that a lock is held by a Lock Holder by failing to lock the lock file.
- * It then turns to this contention via {@link #maybePingOwner(int, long, String, long)}.
+ * It then turns to this contention via {@link #maybePingOwner(int, long, String, long, FileLockReleasedSignal)}.
  * <p>
  * Both Lock Holder and Lock Requester listen on a socket using {@link FileLockCommunicator}. The messages they
  * exchange contain only the lock id. If this contention handler receives such a message it determines if it
@@ -55,11 +60,13 @@ import java.util.concurrent.locks.ReentrantLock;
  *     <li>the contended action to release the lock is started, if it is not running already. The action might already run
  *         if several Lock Requester compete for the same lock or if confirmation took too long and the same Requester retries.</li>
  *     <li>the message is sent back to the Lock Requester to confirm that the lock release is in progress</li>
+ *     <li>when the contended action finishes, i.e. the lock has been released, all Lock Requesters will get another message
+ *         to trigger an immediate retry</li>
  * </ul>
  * <p>
  * If this is the Lock Requester:
  *     <li>the message is interpreted as confirmation and stored. No further messages are sent to the Lock Owner via
- *    {@link #maybePingOwner(int, long, String, long)}.</li>
+ *    {@link #maybePingOwner(int, long, String, long, FileLockReleasedSignal)}.</li>
  * <p>
  * As Lock Requester, the state of the request is always stored per lock (lockId) and Lock Holder (port). The Lock Holder
  * for a lock might change without acquiring the lock if several Lock Requester compete for the same lock.
@@ -70,6 +77,7 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
     private final Lock lock = new ReentrantLock();
 
     private final Map<Long, ContendedAction> contendedActions = new HashMap<Long, ContendedAction>();
+    private final Map<Long, FileLockReleasedSignal> lockReleasedSignals = new HashMap<Long, FileLockReleasedSignal>();
     private final Map<Long, Integer> unlocksRequestedFrom = new HashMap<Long, Integer>();
     private final Map<Long, Integer> unlocksConfirmedFrom = new HashMap<Long, Integer>();
 
@@ -116,6 +124,7 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
                     if (contendedAction == null) {
                         acceptConfirmationAsLockRequester(lockId, packet.getPort());
                     } else {
+                        contendedAction.addRequester(packet.getSocketAddress());
                         if (!contendedAction.running) {
                             startLockReleaseAsLockHolder(contendedAction);
                         }
@@ -129,16 +138,26 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
 
     private void startLockReleaseAsLockHolder(ContendedAction contendedAction) {
         contendedAction.running = true;
-        unlockActionExecutor.execute(contendedAction.action);
+        unlockActionExecutor.execute(contendedAction);
     }
 
-    private void acceptConfirmationAsLockRequester(long lockId, int port) {
-        unlocksConfirmedFrom.put(lockId, port);
+    private void acceptConfirmationAsLockRequester(Long lockId, Integer port) {
         LOGGER.debug("Gradle process at port {} confirmed unlock request for lock with id {}.", port, lockId);
+        boolean isLockReleaseConfirmation = port.equals(unlocksConfirmedFrom.get(lockId));
+        if (isLockReleaseConfirmation) {
+            FileLockReleasedSignal signal = lockReleasedSignals.get(lockId);
+            if (signal != null) {
+                LOGGER.debug("Triggering lock release signal for lock with id {}.", lockId);
+                signal.trigger();
+            }
+        } else {
+            unlocksConfirmedFrom.put(lockId, port);
+        }
     }
 
-    public void start(long lockId, Runnable whenContended) {
+    public void start(long lockId, Action<FileLockReleasedSignal> whenContended) {
         lock.lock();
+        lockReleasedSignals.remove(lockId);
         unlocksRequestedFrom.remove(lockId);
         unlocksConfirmedFrom.remove(lockId);
         try {
@@ -156,13 +175,13 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
             if (contendedActions.containsKey(lockId)) {
                 throw new UnsupportedOperationException("Multiple contention actions for a given lock are currently not supported.");
             }
-            contendedActions.put(lockId, new ContendedAction(whenContended));
+            contendedActions.put(lockId, new ContendedAction(lockId, whenContended));
         } finally {
             lock.unlock();
         }
     }
 
-    public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed) {
+    public boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed, FileLockReleasedSignal signal) {
         if (Integer.valueOf(port).equals(unlocksConfirmedFrom.get(lockId))) {
             //the unlock was confirmed we are waiting
             return false;
@@ -176,6 +195,7 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
         if (pingSentSuccessfully) {
             lock.lock();
             unlocksRequestedFrom.put(lockId, port);
+            lockReleasedSignals.put(lockId, signal);
             lock.unlock();
         }
         return pingSentSuccessfully;
@@ -233,12 +253,52 @@ public class DefaultFileLockContentionHandler implements FileLockContentionHandl
         }
     }
 
-    private static class ContendedAction {
-        private final Runnable action;
+    private class ContendedAction implements Runnable {
+        private final Lock lock = new ReentrantLock();
+        private final long lockId;
+        private final Action<FileLockReleasedSignal> action;
+        private Set<SocketAddress> requesters = new LinkedHashSet<SocketAddress>();
         private boolean running;
 
-        private ContendedAction(Runnable action) {
+        private ContendedAction(long lockId, Action<FileLockReleasedSignal> action) {
+            this.lockId = lockId;
             this.action = action;
         }
+
+        @Override
+        public void run() {
+            action.execute(new FileLockReleasedSignal() {
+                @Override
+                public void trigger() {
+                    Set<SocketAddress> requesters = consumeRequesters();
+                    if (requesters == null) {
+                        throw new IllegalStateException("trigger() has already been called and must at most be called once");
+                    }
+                    communicator.confirmLockRelease(requesters, lockId);
+                }
+            });
+        }
+
+        private void addRequester(SocketAddress contender) {
+            lock.lock();
+            try {
+                if (requesters != null) {
+                    requesters.add(contender);
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        private Set<SocketAddress> consumeRequesters() {
+            lock.lock();
+            try {
+                return requesters;
+            } finally {
+                requesters = null;
+                lock.unlock();
+            }
+        }
     }
+
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockCommunicator.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockCommunicator.java
@@ -88,7 +88,7 @@ public class FileLockCommunicator {
 
     public FileLockPacketPayload decode(DatagramPacket receivedPacket) {
         try {
-            return FileLockPacketPayload.decode(receivedPacket.getData());
+            return FileLockPacketPayload.decode(receivedPacket.getData(), receivedPacket.getLength());
         } catch (IOException e) {
             if (!stopped) {
                 throw new RuntimeException(e);

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockContentionHandler.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockContentionHandler.java
@@ -16,8 +16,13 @@
 
 package org.gradle.cache.internal.locklistener;
 
+import org.gradle.api.Action;
+import org.gradle.cache.FileLockReleasedSignal;
+
+import javax.annotation.Nullable;
+
 public interface FileLockContentionHandler {
-    void start(long lockId, Runnable whenContended);
+    void start(long lockId, Action<FileLockReleasedSignal> whenContended);
 
     void stop(long lockId);
 
@@ -31,5 +36,5 @@ public interface FileLockContentionHandler {
      *
      * @return true if the owner was pinged in this call
      */
-    boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed);
+    boolean maybePingOwner(int port, long lockId, String displayName, long timeElapsed, @Nullable FileLockReleasedSignal signal);
 }

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockPacketPayload.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockPacketPayload.java
@@ -64,18 +64,21 @@ public class FileLockPacketPayload {
         return out.toByteArray();
     }
 
-    public static FileLockPacketPayload decode(byte[] bytes) throws IOException {
+    public static FileLockPacketPayload decode(byte[] bytes, int length) throws IOException {
         DataInputStream dataInput = new DataInputStream(new ByteArrayInputStream(bytes));
         byte version = dataInput.readByte();
         if (version != PROTOCOL_VERSION) {
             throw new IllegalArgumentException(String.format("Unexpected protocol version %s received in lock contention notification message", version));
         }
         long lockId = dataInput.readLong();
-        FileLockPacketType type = readType(dataInput);
+        FileLockPacketType type = readType(dataInput, length);
         return new FileLockPacketPayload(lockId, type);
     }
 
-    private static FileLockPacketType readType(DataInputStream dataInput) throws IOException {
+    private static FileLockPacketType readType(DataInputStream dataInput, int length) throws IOException {
+        if (length < MAX_BYTES) {
+            return UNKNOWN;
+        }
         try {
             int ordinal = dataInput.readByte();
             if (ordinal < TYPES.size()) {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockPacketPayload.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockPacketPayload.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.locklistener;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.UncheckedIOException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+
+import static org.gradle.cache.internal.locklistener.FileLockPacketType.UNKNOWN;
+
+public class FileLockPacketPayload {
+
+    public static final int MAX_BYTES = 1 + 8 + 1; // protocolVersion + lockId + type
+    private static final byte PROTOCOL_VERSION = 1;
+    private static final ImmutableList<FileLockPacketType> TYPES = ImmutableList.copyOf(FileLockPacketType.values());
+
+    private final long lockId;
+    private final FileLockPacketType type;
+
+    private FileLockPacketPayload(long lockId, FileLockPacketType type) {
+        this.lockId = lockId;
+        this.type = type;
+    }
+
+    public long getLockId() {
+        return lockId;
+    }
+
+    public FileLockPacketType getType() {
+        return type;
+    }
+
+    public static byte[] encode(long lockId, FileLockPacketType type) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        DataOutputStream dataOutput = new DataOutputStream(out);
+        try {
+            dataOutput.writeByte(PROTOCOL_VERSION);
+            dataOutput.writeLong(lockId);
+            dataOutput.writeByte(type.ordinal());
+            dataOutput.flush();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to encode lockId " + lockId + " and type " + type, e);
+        }
+        return out.toByteArray();
+    }
+
+    public static FileLockPacketPayload decode(byte[] bytes) throws IOException {
+        DataInputStream dataInput = new DataInputStream(new ByteArrayInputStream(bytes));
+        byte version = dataInput.readByte();
+        if (version != PROTOCOL_VERSION) {
+            throw new IllegalArgumentException(String.format("Unexpected protocol version %s received in lock contention notification message", version));
+        }
+        long lockId = dataInput.readLong();
+        FileLockPacketType type = readType(dataInput);
+        return new FileLockPacketPayload(lockId, type);
+    }
+
+    private static FileLockPacketType readType(DataInputStream dataInput) throws IOException {
+        try {
+            int ordinal = dataInput.readByte();
+            if (ordinal < TYPES.size()) {
+                return TYPES.get(ordinal);
+            }
+        } catch (EOFException ignore) {
+            // old versions don't send a type
+        }
+        return UNKNOWN;
+    }
+
+}

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockPacketType.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/locklistener/FileLockPacketType.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.locklistener;
+
+/**
+ * Packet type for communication about file locks.
+ *
+ * <p>For backward compatibility, enum constants must not be removed.
+ */
+public enum FileLockPacketType {
+    UNKNOWN,
+    UNLOCK_REQUEST,
+    UNLOCK_REQUEST_CONFIRMATION,
+    LOCK_RELEASE_CONFIRMATION
+}

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
@@ -15,11 +15,13 @@
  */
 package org.gradle.cache.internal
 
+import org.gradle.api.Action
 import org.gradle.cache.AsyncCacheAccess
 import org.gradle.cache.CacheDecorator
 import org.gradle.cache.CrossProcessCacheAccess
 import org.gradle.cache.FileLock
 import org.gradle.cache.FileLockManager
+import org.gradle.cache.FileLockReleasedSignal
 import org.gradle.cache.LockOptions
 import org.gradle.cache.MultiProcessSafePersistentIndexedCache
 import org.gradle.cache.PersistentIndexedCacheParameters
@@ -85,7 +87,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.open()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> false
         _ * lock.state
         0 * _._
@@ -150,7 +152,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.open()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> true
         1 * lock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initializationAction.initialize(lock)
@@ -166,7 +168,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.open()
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> { throw failure }
         1 * lock.close()
         0 * _._
@@ -218,8 +220,8 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> {
-            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Runnable whenContended -> contentionAction = whenContended; return lock }
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> {
+            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended -> contentionAction = whenContended; return lock }
         1 * initializationAction.requiresInitialization(lock) >> true
         1 * lock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initializationAction.initialize(lock)
@@ -229,7 +231,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         0 * _._
 
         when:
-        contentionAction.run()
+        contentionAction.execute({} as FileLockReleasedSignal)
 
         then:
         1 * lock.close()
@@ -238,8 +240,8 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> {
-            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Runnable whenContended -> contentionAction = whenContended; return lock }
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> {
+            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended -> contentionAction = whenContended; return lock }
         1 * initializationAction.requiresInitialization(lock) >> true
         1 * lock.writeFile(_) >> { Runnable r -> r.run() }
         1 * initializationAction.initialize(lock)
@@ -274,7 +276,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         if (lockMode == Shared) {
             lockManager.lock(lockFile, _, "<display-name>") >> lock
         } else {
-            lockManager.lock(lockFile, _, "<display-name>", "", _ as Runnable) >> lock
+            lockManager.lock(lockFile, _, "<display-name>", "", _) >> lock
         }
         def access = newAccess(lockMode)
 
@@ -298,7 +300,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.withFileLock(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> false
         _ * lock.getState()
 
@@ -321,7 +323,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.withFileLock(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> false
         _ * lock.getState()
         1 * action.create() >> "result"
@@ -347,7 +349,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.withFileLock(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> false
         _ * lock.getState()
 
@@ -372,7 +374,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * initializationAction.requiresInitialization(lock) >> false
         _ * lock.state
 
@@ -397,7 +399,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>","", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>","", _) >> lock
         1 * action.create() >> {
             access.useCache {
                 assert access.owner == Thread.currentThread()
@@ -417,7 +419,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * action.create() >> { assert access.owner == Thread.currentThread() }
 
         when:
@@ -467,11 +469,11 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache(action)
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> {
-            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Runnable whenContended -> contendedAction = whenContended; return lock }
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> {
+            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended -> contendedAction = whenContended; return lock }
 
         when:
-        contendedAction.run()
+        contendedAction.execute({} as FileLockReleasedSignal)
 
         then:
         1 * lock.close()
@@ -482,7 +484,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         def access = newAccess(mode)
 
         given:
-        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
 
         when:
         access.open()
@@ -504,7 +506,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         access.useCache { access.fileAccess.updateFile(runnable)}
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         1 * lock.updateFile(runnable)
 
         where:
@@ -516,7 +518,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         def access = newAccess(mode)
 
         given:
-        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         lockManager.lock(lockFile, mode(Exclusive), "<display-name>") >> lock
         access.open()
         access.useCache(runnable)
@@ -547,7 +549,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         def access = newAccess(None)
 
         given:
-        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         lock.writeFile(_) >> { Runnable r -> r.run() }
         access.open()
         def cache = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
@@ -565,13 +567,13 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         def contendedAction
 
         given:
-        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> {
-            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Runnable whenContended -> contendedAction = whenContended; return lock }
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> {
+            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended -> contendedAction = whenContended; return lock }
         lock.writeFile(_) >> { Runnable r -> r.run() }
         access.open()
         def cache = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class))
         access.useCache { cache.get("key") }
-        contendedAction.run()
+        contendedAction.execute({} as FileLockReleasedSignal)
         lock.close()
 
         when:
@@ -599,15 +601,15 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         def cache = access.newCache(new PersistentIndexedCacheParameters('cache', String.class, Integer.class).cacheDecorator(decorator))
 
         then:
-        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> {
-            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Runnable whenContended -> contendedAction = whenContended; return lock }
+        1 * lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> {
+            File target, LockOptions options, String targetDisplayName, String operationDisplayName, Action<FileLockReleasedSignal> whenContended -> contendedAction = whenContended; return lock }
 
         when:
         cpAccess.withFileLock {
             access.useCache {
                 cache.get("something")
             }
-            contendedAction.run()
+            contendedAction.execute({} as FileLockReleasedSignal)
             "result"
         }
 
@@ -682,7 +684,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
     def "returns the same cache object when cache decorator match"() {
         def access = newAccess(None)
         def decorator = Mock(CacheDecorator)
-        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _ as Runnable) >> lock
+        lockManager.lock(lockFile, mode(Exclusive), "<display-name>", "", _) >> lock
         decorator.decorate(_, _, _, _, _) >> { String cacheId, String cacheName, MultiProcessSafePersistentIndexedCache persistentCache, CrossProcessCacheAccess crossProcessCacheAccess, AsyncCacheAccess asyncCacheAccess ->
             persistentCache
         }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerAwaitableFileLockReleasedSignalTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultFileLockManagerAwaitableFileLockReleasedSignalTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal
+
+import org.gradle.util.ConcurrentSpecification
+import spock.lang.Subject
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
+
+class DefaultFileLockManagerAwaitableFileLockReleasedSignalTest extends ConcurrentSpecification {
+
+    @Subject def signal = new DefaultFileLockManager.AwaitableFileLockReleasedSignal()
+
+    def "can reuse signal"() {
+        given:
+        def signalCount = new AtomicInteger()
+
+        when:
+        start {
+            while (signalCount.get() < 2) {
+                def signaled = signal.await(10000)
+                if (signaled) {
+                    signalCount.incrementAndGet()
+                }
+            }
+        }
+
+        then:
+        poll {
+            assert signal.waiting
+        }
+
+        when:
+        signal.trigger()
+
+        then:
+        poll {
+            assert signalCount.get() == 1
+            assert signal.waiting
+        }
+
+        when:
+        signal.trigger()
+
+        then:
+        poll {
+            assert signalCount.get() == 2
+        }
+    }
+
+    def "can trigger signal without anyone waiting"() {
+        when:
+        signal.trigger()
+
+        then:
+        notThrown(Exception)
+    }
+}

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockCommunicatorTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockCommunicatorTest.groovy
@@ -25,7 +25,6 @@ import static org.gradle.test.fixtures.ConcurrentTestUtil.poll
 class FileLockCommunicatorTest extends ConcurrentSpecification {
 
     def communicator = new FileLockCommunicator(new InetAddressFactory())
-    Long receivedId
 
     def cleanup() {
         communicator.stop()
@@ -44,14 +43,16 @@ class FileLockCommunicatorTest extends ConcurrentSpecification {
         communicator.getPort() == -1
     }
 
-    def "can receive lock id"() {
+    def "can receive lock id and type"() {
+        FileLockPacketPayload receivedPayload
+
         start {
             def packet = communicator.receive()
-            receivedId = communicator.decodeLockId(packet)
+            receivedPayload = communicator.decode(packet)
         }
 
         poll {
-            assert communicator.getPort() != -1 && receivedId == null
+            assert communicator.getPort() != -1 && receivedPayload == null
         }
 
         when:
@@ -59,7 +60,8 @@ class FileLockCommunicatorTest extends ConcurrentSpecification {
 
         then:
         poll {
-            assert receivedId == 155
+            assert receivedPayload.lockId == 155
+            assert receivedPayload.type == FileLockPacketType.UNLOCK_REQUEST
         }
     }
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockPacketPayloadTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockPacketPayloadTest.groovy
@@ -35,7 +35,7 @@ class FileLockPacketPayloadTest extends Specification {
 
     def "decodes payloads without type"() {
         when:
-        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42] as byte[])
+        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, 1] as byte[], 9)
 
         then:
         payload.lockId == 42
@@ -45,7 +45,7 @@ class FileLockPacketPayloadTest extends Specification {
     @Unroll
     def "decodes payloads with type #type"() {
         when:
-        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, type.ordinal()] as byte[])
+        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, type.ordinal()] as byte[], 10)
 
         then:
         payload.lockId == 42
@@ -57,7 +57,7 @@ class FileLockPacketPayloadTest extends Specification {
 
     def "decodes payloads with unknown types that might be added in the future"() {
         when:
-        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, FileLockPacketType.values().length] as byte[])
+        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, FileLockPacketType.values().length] as byte[], 10)
 
         then:
         payload.lockId == 42

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockPacketPayloadTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockPacketPayloadTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.cache.internal.locklistener
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.cache.internal.locklistener.FileLockPacketType.LOCK_RELEASE_CONFIRMATION
+import static org.gradle.cache.internal.locklistener.FileLockPacketType.UNKNOWN
+
+class FileLockPacketPayloadTest extends Specification {
+
+    def "encodes lock id and type"() {
+        when:
+        def bytes = FileLockPacketPayload.encode(42, LOCK_RELEASE_CONFIRMATION)
+
+        then:
+        bytes.length == FileLockPacketPayload.MAX_BYTES
+        bytes == [1, 0, 0, 0, 0, 0, 0, 0, 42, 3] as byte[]
+    }
+
+    def "decodes payloads without type"() {
+        when:
+        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42] as byte[])
+
+        then:
+        payload.lockId == 42
+        payload.type == UNKNOWN
+    }
+
+    @Unroll
+    def "decodes payloads with type #type"() {
+        when:
+        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, type.ordinal()] as byte[])
+
+        then:
+        payload.lockId == 42
+        payload.type == type
+
+        where:
+        type << FileLockPacketType.values()
+    }
+
+    def "decodes payloads with unknown types that might be added in the future"() {
+        when:
+        def payload = FileLockPacketPayload.decode([1, 0, 0, 0, 0, 0, 0, 0, 42, FileLockPacketType.values().length] as byte[])
+
+        then:
+        payload.lockId == 42
+        payload.type == UNKNOWN
+    }
+}


### PR DESCRIPTION
This commit improves the likelihood for lock requesters to acquire a
file lock after it is released due to contention. After the lock has
been released, the former lock holder now sends a packet to the sockets
of all requesters. While old clients will simply ignore the additional
packet, new clients will interpret it as a signal that the file lock has
been released and will try to acquire it immediately.

Issue: gradle/gradle-private#1412.