### PR TITLE
Avoid requesting JARs when POM for a plugin is missing

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories;
 
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
@@ -121,6 +122,13 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     public ArtifactRepository createGradlePluginPortal() {
         MavenArtifactRepository mavenRepository = createMavenRepository(new NamedMavenRepositoryDescriber(PLUGIN_PORTAL_DEFAULT_URL));
         mavenRepository.setUrl(System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, PLUGIN_PORTAL_DEFAULT_URL));
+        mavenRepository.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+            @Override
+            public void execute(MavenArtifactRepository.MetadataSources metadataSources) {
+                metadataSources.mavenPom();
+                metadataSources.gradleMetadata();
+            }
+        });
         return mavenRepository;
     }
 


### PR DESCRIPTION
This deactivates the legacy Maven fallback of just trying
to find the JAR when no POM file is present. We don't need
this fallback for Gradle plugins, as all of them should be
published with a POM file. This avoids unnecessary network
traffic.

@bigdaz assigning you since you just proposed this in the 
discussion on bintray timeouts often failing on these.