### PR TITLE
Add plugin portal mirror system property to startup parameters

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -45,7 +45,8 @@ fun gradleParameters(os: OS = OS.linux, daemon: Boolean = true): List<String> =
         """-I "%teamcity.build.checkoutDir%/gradle/init-scripts/build-scan.init.gradle.kts"""",
         java7Homes[os]!!,
         java9Homes[os]!!,
-        "-Dorg.gradle.internal.tasks.createops")
+        "-Dorg.gradle.internal.tasks.createops",
+        "-Dorg.gradle.internal.plugins.portal.url.override=http://dev12.gradle.org:8081/artifactory/gradle-plugins/")
 
 
 val m2CleanScriptUnixLike = """


### PR DESCRIPTION
### Context

Previously we set `org.gradle.internal.plugins.portal.url.override` system property in TeamCity configuration page, but somehow it doesn't work. I've confirmed we can't fetch this property in the build, so this PR moves it into start parameter list. A bonus would be that it's version-controlled now.