### PR TITLE
Ignore artifact transforms when resolving Task.getTaskDependencies()

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformDependency.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+/**
+ * Empty interface for now to signal a dependency on an artifact transformation.
+ */
+public interface ArtifactTransformDependency {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/transform/package-info.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/internal/artifacts/transform/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.NonNullApi;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 @NonNullApi
 public abstract class AbstractTaskDependency implements TaskDependencyInternal {
-    private static WorkDependencyResolver<Task> IGNORE_ARTIFACT_TRANSFORM_RESOLVER = new WorkDependencyResolver<Task>() {
+    private static final WorkDependencyResolver<Task> IGNORE_ARTIFACT_TRANSFORM_RESOLVER = new WorkDependencyResolver<Task>() {
         @Override
         public boolean resolve(Task task, Object node, Action<? super Task> resolveAction) {
             // Ignore artifact transforms

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
@@ -16,18 +16,29 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.Action;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Task;
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformDependency;
 
 import javax.annotation.Nullable;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.Set;
 
 @NonNullApi
 public abstract class AbstractTaskDependency implements TaskDependencyInternal {
+    private static WorkDependencyResolver<Task> ARTIFACT_TRANSFORM_RESOLVER = new WorkDependencyResolver<Task>() {
+        @Override
+        public boolean resolve(Task task, Object node, Action<? super Task> resolveAction) {
+            // Ignore artifact transforms
+            return node instanceof ArtifactTransformDependency;
+        }
+    };
+
+    @Override
     public Set<? extends Task> getDependencies(@Nullable Task task) {
         CachingTaskDependencyResolveContext<Task> context = new CachingTaskDependencyResolveContext<Task>(
-            Collections.singleton(WorkDependencyResolver.TASK_AS_TASK));
+            Arrays.asList(WorkDependencyResolver.TASK_AS_TASK, ARTIFACT_TRANSFORM_RESOLVER));
         return context.getDependencies(task, this);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
@@ -27,7 +27,7 @@ import java.util.Set;
 
 @NonNullApi
 public abstract class AbstractTaskDependency implements TaskDependencyInternal {
-    private static WorkDependencyResolver<Task> ARTIFACT_TRANSFORM_RESOLVER = new WorkDependencyResolver<Task>() {
+    private static WorkDependencyResolver<Task> IGNORE_ARTIFACT_TRANSFORM_RESOLVER = new WorkDependencyResolver<Task>() {
         @Override
         public boolean resolve(Task task, Object node, Action<? super Task> resolveAction) {
             // Ignore artifact transforms
@@ -38,7 +38,7 @@ public abstract class AbstractTaskDependency implements TaskDependencyInternal {
     @Override
     public Set<? extends Task> getDependencies(@Nullable Task task) {
         CachingTaskDependencyResolveContext<Task> context = new CachingTaskDependencyResolveContext<Task>(
-            Arrays.asList(WorkDependencyResolver.TASK_AS_TASK, ARTIFACT_TRANSFORM_RESOLVER));
+            Arrays.asList(WorkDependencyResolver.TASK_AS_TASK, IGNORE_ARTIFACT_TRANSFORM_RESOLVER));
         return context.getDependencies(task, this);
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1749,7 +1749,7 @@ Found the following transforms:
             gradle.taskGraph.whenReady { taskGraph ->
                 taskGraph.allTasks.each { task ->
                     task.taskDependencies.getDependencies(task).each { dependency ->
-                        println "> Dependency: \${dependency}"
+                        println "> Dependency: \${task} -> \${dependency}"
                     }
                 }
             }
@@ -1760,7 +1760,7 @@ Found the following transforms:
 
         then:
         output.count("> Dependency:") == 1
-        output.contains("> Dependency: task ':app:resolve'")
+        output.contains("> Dependency: task ':app:dependent' -> task ':app:resolve'")
     }
 
     def declareTransform(String transformImplementation) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import spock.lang.Issue
 
 class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
@@ -1717,6 +1718,51 @@ Found the following transforms:
         output.count("Transforming") == 1
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/6156")
+    def "stops resolving dependencies of task when artifact transforms are encountered"() {
+        given:
+        buildFile << """
+            project(':lib') {
+                task jar(type: Jar) {
+                    destinationDir = buildDir
+                    archiveName = 'lib1.jar'
+                }
+
+                artifacts {
+                    compile jar
+                }
+            }
+
+            project(':app') {
+
+                dependencies {
+                    compile project(':lib')
+                }
+
+                ${configurationAndTransform()}
+
+                task dependent {
+                    dependsOn resolve
+                }
+            }
+
+            gradle.taskGraph.whenReady { taskGraph ->
+                taskGraph.allTasks.each { task ->
+                    task.taskDependencies.getDependencies(task).each { dependency ->
+                        println "> Dependency: \${dependency}"
+                    }
+                }
+            }
+        """
+
+        when:
+        run "dependent"
+
+        then:
+        output.count("> Dependency:") == 1
+        output.contains("> Dependency: task ':app:resolve'")
+    }
+
     def declareTransform(String transformImplementation) {
         """
             dependencies {
@@ -1729,7 +1775,7 @@ Found the following transforms:
         """
     }
 
-    def configurationAndTransform(String transformImplementation) {
+    def configurationAndTransform(String transformImplementation = "FileSizer") {
         """
             ${declareTransform(transformImplementation)}
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1761,6 +1761,8 @@ Found the following transforms:
         then:
         output.count("> Dependency:") == 1
         output.contains("> Dependency: task ':app:dependent' -> task ':app:resolve'")
+        output.contains("> Transform lib1.jar (project :lib) with FileSizer")
+        output.contains("> Task :app:resolve")
     }
 
     def declareTransform(String transformImplementation) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -51,6 +51,6 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
 
     @Override
     public void collectBuildDependencies(BuildDependenciesVisitor visitor) {
-        visitor.visitDependency(new ArtifactTransformDependency(transform, delegate));
+        visitor.visitDependency(new DefaultArtifactTransformDependency(transform, delegate));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependency.java
@@ -20,11 +20,11 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 
 @NonNullApi
-public class ArtifactTransformDependency {
+public class DefaultArtifactTransformDependency implements ArtifactTransformDependency {
     private final ArtifactTransformer transform;
     private final ResolvedArtifactSet artifacts;
 
-    public ArtifactTransformDependency(ArtifactTransformer transform, ResolvedArtifactSet artifacts) {
+    public DefaultArtifactTransformDependency(ArtifactTransformer transform, ResolvedArtifactSet artifacts) {
         this.transform = transform;
         this.artifacts = artifacts;
     }
@@ -46,7 +46,7 @@ public class ArtifactTransformDependency {
             return false;
         }
 
-        ArtifactTransformDependency that = (ArtifactTransformDependency) o;
+        DefaultArtifactTransformDependency that = (DefaultArtifactTransformDependency) o;
 
         if (!transform.equals(that.transform)) {
             return false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInfoDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInfoDependencyResolver.java
@@ -35,8 +35,8 @@ public class TransformInfoDependencyResolver implements WorkInfoDependencyResolv
 
     @Override
     public boolean resolve(Task task, Object node, Action<? super WorkInfo> resolveAction) {
-        if (node instanceof ArtifactTransformDependency) {
-            ArtifactTransformDependency transformation = (ArtifactTransformDependency) node;
+        if (node instanceof DefaultArtifactTransformDependency) {
+            DefaultArtifactTransformDependency transformation = (DefaultArtifactTransformDependency) node;
             Collection<TransformInfo> transforms = transformInfoFactory.getOrCreate(transformation.getArtifacts(), transformation.getTransform());
             for (TransformInfo transformInfo : transforms) {
                 resolveAction.execute(transformInfo);


### PR DESCRIPTION
The TaskDependency API will be deprecated, because it has numerous shortcomings, including the inability to express dependencies that are not tasks. Until then we need a way to handle artifact transform dependencies. This commit introduces a change that allows ignoring these dependencies when resolving via TaskDependency.

Fixes #6156.