### PR TITLE
Let the distributions contain a gradle-api-metadata jar

### DIFF
--- a/buildSrc/subprojects/packaging/packaging.gradle.kts
+++ b/buildSrc/subprojects/packaging/packaging.gradle.kts
@@ -6,11 +6,13 @@ apply(plugin = "org.gradle.kotlin.kotlin-dsl")
 
 dependencies {
     implementation(project(":configuration"))
+    implementation(project(":build"))
     implementation(project(":kotlinDsl"))
     implementation("com.google.guava:guava-jdk5:14.0.1")
     implementation("org.ow2.asm:asm:6.0")
     implementation("org.ow2.asm:asm-commons:6.0")
     implementation("com.google.code.gson:gson:2.7")
+    implementation("com.thoughtworks.qdox:qdox:2.0-M9")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.1.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.1.0")
@@ -29,6 +31,10 @@ gradlePlugin {
         "shadedJar" {
             id = "gradlebuild.shaded-jar"
             implementationClass = "org.gradle.gradlebuild.packaging.ShadedJarPlugin"
+        }
+        "apiMetadata" {
+            id = "gradlebuild.api-metadata"
+            implementationClass = "org.gradle.gradlebuild.packaging.ApiMetadataPlugin"
         }
     }
 }

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataPlugin.kt
@@ -1,0 +1,181 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.packaging
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileTree
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.WriteProperties
+import org.gradle.api.tasks.bundling.Jar
+
+import org.gradle.internal.classloader.ClassLoaderFactory
+import org.gradle.internal.classpath.DefaultClassPath
+
+import accessors.base
+import org.gradle.build.ReproduciblePropertiesWriter
+
+import com.thoughtworks.qdox.JavaProjectBuilder
+import com.thoughtworks.qdox.library.SortedClassLibraryBuilder
+import com.thoughtworks.qdox.model.JavaMethod
+
+import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.serviceOf
+
+
+open class ApiMetadataExtension(project: Project, val jarTask: Provider<Jar>) {
+
+    val sources = project.objects.property<FileTree>()
+    val includes = project.objects.listProperty<String>()
+    val excludes = project.objects.listProperty<String>()
+    val classpath = project.objects.property<FileCollection>()
+}
+
+
+/**
+ * Generates a JAR with Gradle API metadata resources.
+ *
+ * Include and exclude patterns for the Gradle API.
+ * Parameter names for the Gradle API.
+ */
+open class ApiMetadataPlugin : Plugin<Project> {
+
+    override fun apply(project: Project): Unit = project.run {
+
+        val jarTask =
+            tasks.register("apiMetadataJar", Jar::class.java)
+
+        val extension =
+            extensions.create("apiMetadata", ApiMetadataExtension::class.java, project, jarTask)
+
+        val apiDeclarationTask =
+            tasks.register("apiDeclarationResource", WriteProperties::class.java) {
+                property("includes", extension.includes.get().joinToString(":"))
+                property("excludes", extension.excludes.get().joinToString(":"))
+                outputFile = generatedPropertiesFileFor("gradle-api-declaration").get().asFile
+            }
+
+        val apiParameterNamesTask =
+            tasks.register("apiParameterNamesResource", ParameterNamesResourceTask::class.java) {
+                sources = extension.sources.get().matching {
+                    include(extension.includes.get())
+                    exclude(extension.excludes.get())
+                }
+                classpath = extension.classpath.get()
+                destinationFile.set(generatedPropertiesFileFor("gradle-api-parameter-names"))
+            }
+
+        jarTask.configure {
+            description = "Assembles the API metadata jar."
+            group = "build"
+            from(apiDeclarationTask)
+            from(apiParameterNamesTask)
+            destinationDir = layout.buildDirectory.file("$name").get().asFile
+            archiveName = "gradle-api-metadata-$version.jar"
+        }
+
+        // Required as this is overridden by :distributions build script
+        afterEvaluate {
+            jarTask.configure {
+                destinationDir = base.libsDir
+            }
+        }
+    }
+
+    private
+    fun Project.generatedPropertiesFileFor(name: String) =
+        layout.buildDirectory.file("generated-resources/$name/$name.properties")
+}
+
+
+@CacheableTask
+open class ParameterNamesResourceTask : DefaultTask() {
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    lateinit var sources: FileTree
+
+    @InputFiles
+    @Classpath
+    lateinit var classpath: FileCollection
+
+    @OutputFile
+    @PathSensitive(PathSensitivity.NONE)
+    val destinationFile = project.layout.fileProperty()
+
+    @TaskAction
+    fun generate() {
+
+        val qdoxBuilder = JavaProjectBuilder(sortedClassLibraryBuilderWithClassLoaderFor(classpath))
+        val qdoxSources = sources.asSequence().mapNotNull { qdoxBuilder.addSource(it) }
+
+        val properties = qdoxSources
+            .flatMap { it.classes.asSequence().filter { it.isPublic } }
+            .flatMap { it.methods.asSequence().filter { it.isPublic && it.parameterTypes.isNotEmpty() } }
+            .map { method ->
+                fullyQualifiedSignatureOf(method) to commaSeparatedParameterNamesOf(method)
+            }.toMap(linkedMapOf())
+
+        write(properties)
+    }
+
+    private
+    fun write(properties: LinkedHashMap<String, String>) {
+        destinationFile.get().asFile.let { file ->
+            file.parentFile.mkdirs()
+            ReproduciblePropertiesWriter.store(properties, file)
+        }
+    }
+
+    private
+    fun fullyQualifiedSignatureOf(method: JavaMethod): String =
+        "${method.declaringClass.binaryName}.${method.name}(${signatureOf(method)})"
+
+    private
+    fun signatureOf(method: JavaMethod): String =
+        method.parameters.joinToString(separator = ",") { p ->
+            if (p.isVarArgs || p.javaClass.isArray) "${p.type.binaryName}[]"
+            else p.type.binaryName
+        }
+
+    private
+    fun commaSeparatedParameterNamesOf(method: JavaMethod) =
+        method.parameters.joinToString(separator = ",") { it.name }
+
+    private
+    fun sortedClassLibraryBuilderWithClassLoaderFor(classpath: FileCollection): SortedClassLibraryBuilder =
+        SortedClassLibraryBuilder().apply {
+            appendClassLoader(isolatedClassLoaderFor(classpath))
+        }
+
+    private
+    fun isolatedClassLoaderFor(classpath: FileCollection) =
+        classLoaderFactory.createIsolatedClassLoader(DefaultClassPath.of(classpath.files))
+
+    private
+    val classLoaderFactory
+        get() = project.serviceOf<ClassLoaderFactory>()
+}

--- a/subprojects/distributions/distributions.gradle
+++ b/subprojects/distributions/distributions.gradle
@@ -18,6 +18,10 @@ import org.gradle.gradlebuild.unittestandcompile.ModuleType
  * limitations under the License.
  */
 
+plugins {
+    id("gradlebuild.api-metadata")
+}
+
 // This is a groovy project because we have int tests.
 // Remove any pre-configured archives
 configurations.all {
@@ -49,6 +53,18 @@ gradlebuildJava {
     moduleType = ModuleType.INTERNAL
 }
 
+apiMetadata {
+    sources = provider {
+        ProjectGroups.INSTANCE.getJavaProjects(project)
+            .collect { it.sourceSets.main.allJava.asFileTree }
+            .inject { acc, fileTree -> acc.plus(fileTree) }
+    }
+    includes = PublicApi.includes
+    excludes = PublicApi.excludes
+    classpath = provider {
+        rootProject.configurations.runtime + rootProject.configurations.gradlePlugins
+    }
+}
 
 evaluationDependsOn ":docs"
 
@@ -64,6 +80,7 @@ ext {
         }
         into('lib') {
             from rootProject.configurations.runtime
+            from apiMetadata.jarTask
             into('plugins') {
                 from rootProject.configurations.gradlePlugins - rootProject.configurations.runtime
             }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -16,8 +16,11 @@
 
 package org.gradle
 
+import org.apache.commons.io.IOUtils
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.archive.JarTestFixture
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.GUtil
 import org.gradle.util.GradleVersion
 import org.gradle.util.PreconditionVerifier
 import org.junit.Rule
@@ -38,7 +41,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
     abstract String getDistributionLabel()
 
     int getLibJarsCount() {
-        195
+        196
     }
 
     def "no duplicate entries"() {
@@ -110,7 +113,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
 
         // Core libs
         def coreLibs = contentsDir.file("lib").listFiles().findAll {
-            it.name.startsWith("gradle-") && !it.name.startsWith("gradle-kotlin-dsl")
+            it.name.startsWith("gradle-") && !it.name.startsWith("gradle-api-metadata") && !it.name.startsWith("gradle-kotlin-dsl")
         }
         assert coreLibs.size() == 22
         coreLibs.each { assertIsGradleJar(it) }
@@ -143,6 +146,9 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         // Docs
         contentsDir.file('getting-started.html').assertIsFile()
 
+        // Others
+        assertIsGradleApiMetadataJar(contentsDir.file("lib/gradle-api-metadata-${baseVersion}.jar"))
+
         // Jars that must not be shipped
         assert !contentsDir.file("lib/tools.jar").exists()
         assert !contentsDir.file("lib/plugins/tools.jar").exists()
@@ -152,5 +158,17 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
         jar.assertIsFile()
         assertThat(jar.manifest.mainAttributes.getValue('Implementation-Version'), equalTo(baseVersion))
         assertThat(jar.manifest.mainAttributes.getValue('Implementation-Title'), equalTo('Gradle'))
+    }
+
+    private static void assertIsGradleApiMetadataJar(TestFile jar) {
+        new JarTestFixture(jar.canonicalFile).with {
+            def apiDeclaration = GUtil.loadProperties(IOUtils.toInputStream(content("gradle-api-declaration.properties")))
+            assert apiDeclaration.size() == 2
+            assert apiDeclaration.getProperty("includes").contains(":org/gradle/api/**:")
+            assert apiDeclaration.getProperty("excludes").split(":").size() == 1
+            def parameterNames = GUtil.loadProperties(IOUtils.toInputStream(content("gradle-api-parameter-names.properties")))
+            assert parameterNames.size() > 2900
+            assert parameterNames["org.gradle.api.DomainObjectCollection.withType(java.lang.Class,org.gradle.api.Action)"] == "type,configureAction"
+        }
     }
 }


### PR DESCRIPTION
which contains resources defining the Gradle API
- includes/excludes declaring the API packages
- API members parameter names absent from Java 7 bytecode

Required by https://github.com/gradle/kotlin-dsl/issues/221