### PR TITLE
New navigation for user manual (revised)

### DIFF
--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1579,6 +1579,32 @@ div.screenshot {
     margin: 1.5em 0 0;
 }
 
+.docs-navigation li.main-link {
+    font-weight: 500;
+    margin-bottom: 0.2em;
+}
+
+.docs-navigation li.main-link a {
+    display: inline;
+}
+
+.docs-navigation ul.manual-formats {
+    display: inline-block;
+}
+
+.docs-navigation ul.manual-formats > li {
+    display: inline-block;
+    background-color: #EEEEEE;
+    padding: 0.1em 0.4em;
+    margin-right: 0.4em;
+}
+
+.docs-navigation ul.manual-formats > li a {
+    font-size: 0.8rem;
+    font-weight: normal;
+    color: #888;
+}
+
 @media screen and (min-width: 45rem) {
     .main-content {
         display: flex;

--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1579,32 +1579,6 @@ div.screenshot {
     margin: 1.5em 0 0;
 }
 
-.docs-navigation li.main-link {
-    font-weight: 500;
-    margin-bottom: 0.2em;
-}
-
-.docs-navigation li.main-link a {
-    display: inline;
-}
-
-.docs-navigation ul.manual-formats {
-    display: inline-block;
-}
-
-.docs-navigation ul.manual-formats > li {
-    display: inline-block;
-    background-color: #EEEEEE;
-    padding: 0.1em 0.4em;
-    margin-right: 0.4em;
-}
-
-.docs-navigation ul.manual-formats > li a {
-    font-size: 0.8rem;
-    font-weight: normal;
-    color: #888;
-}
-
 @media screen and (min-width: 45rem) {
     .main-content {
         display: flex;

--- a/subprojects/docs/src/docs/userguide/plugin_reference.adoc
+++ b/subprojects/docs/src/docs/userguide/plugin_reference.adoc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 [[plugin_reference]]
-= Gradle plugin reference
+= Gradle Plugin Reference
 
 This page contains links and short descriptions for all the core plugins provided by Gradle itself.
 
@@ -32,7 +32,7 @@ Provides support for building any type of http://groovy-lang.org/[Groovy] projec
 Provides support for building any type of https://www.scala-lang.org/[Scala] project.
 
 <<play_plugin.adoc#,Play>>::
-Proivdes support for building, testing and running https://www.playframework.com/[Play] applications. 
+Proivdes support for building, testing and running https://www.playframework.com/[Play] applications.
 
 <<antlr_plugin.adoc#,ANTLR>>::
 Provides support for generating parsers using http://www.antlr.org/[ANTLR].

--- a/subprojects/docs/src/docs/userguide/plugin_reference.adoc
+++ b/subprojects/docs/src/docs/userguide/plugin_reference.adoc
@@ -1,0 +1,109 @@
+// Copyright 2018 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[plugin_reference]]
+= Gradle plugin reference
+
+This page contains links and short descriptions for all the core plugins provided by Gradle itself.
+
+== JVM languages and frameworks
+
+<<java_plugin.adoc#,Java>>::
+Provides support for building any type of Java project.
+
+<<java_library_plugin.adoc#,Java Library>>::
+Provides support for building a Java library.
+
+<<groovy_plugin.adoc#,Groovy>>::
+Provides support for building any type of http://groovy-lang.org/[Groovy] project.
+
+<<scala_plugin.adoc#,Scala>>::
+Provides support for building any type of https://www.scala-lang.org/[Scala] project.
+
+<<play_plugin.adoc#,Play>>::
+Proivdes support for building, testing and running https://www.playframework.com/[Play] applications. 
+
+<<antlr_plugin.adoc#,ANTLR>>::
+Provides support for generating parsers using http://www.antlr.org/[ANTLR].
+
+== Packaging and distribution
+
+<<application_plugin.adoc#,Application>>::
+Provides support for building JVM-based, runnable applications.
+
+<<war_plugin.adoc#,WAR>>::
+Provides support for building and packaging WAR-based Java web applications.
+
+<<ear_plugin.adoc#,EAR>>::
+Provides support for building and packaging Java EE applications.
+
+<<osgi_plugin.adoc#,OSGi>>::
+Provides support for creating https://www.osgi.org/[OSGi] packages.
+
+<<publishing_maven.adoc#,Maven Publish>>::
+Provides support for <<publishing_overview.adoc#,publishing artifacts>> to Maven-compatible repositories.
+
+<<publishing_ivy.adoc#,Ivy Publish>>::
+Provides support for <<publishing_overview.adoc#,publishing artifacts>> to Ivy-compatible repositories.
+
+<<maven_plugin.adoc#,Legacy Maven Plugin>>::
+Provides support for publishing artifacts using the <<artifact_management.adoc#,legacy mechanism>> to Maven-compatible repositories.
+
+<<distribution_plugin.adoc#,Distribution>>::
+Makes it easy to create ZIP and tarball distributions of your project.
+
+<<java_library_distribution_plugin.adoc#,Java Library Distribution>>::
+Provides support for creating a ZIP distribution of a Java library project that includes its runtime dependencies.
+
+== Code analysis
+
+<<checkstyle_plugin.adoc#,Checkstyle>>::
+Performs quality checks on your project’s Java source files using http://checkstyle.sourceforge.net/index.html[Checkstyle] and generates associated reports.
+
+<<findbugs_plugin.adoc#,FindBugs>>::
+Performs quality checks on your project’s Java source files using http://findbugs.sourceforge.net/[FindBugs] and generates associated reports.
+
+<<pmd_plugin.adoc#,PMD>>::
+Performs quality checks on your project’s Java source files using http://pmd.github.io/[PMD] and generates associated reports.
+
+<<jdepend_plugin.adoc#,JDepend>>::
+Performs quality checks on your project’s Java source files using http://clarkware.com/software/JDepend.html[JDepend] and generates associated reports.
+
+<<jacoco_plugin.adoc#,JaCoCo>>::
+Provides code coverage metrics for your Java project using http://www.eclemma.org/jacoco/[JaCoCo].
+
+<<codenarc_plugin.adoc#,CodeNarc>>::
+Performs quality checks on your Groovy source files using http://codenarc.sourceforge.net/index.html[CodeNarc] and generates associated reports.
+
+== IDE integration
+
+<<eclipse_plugin.adoc#,Eclipse>>::
+Generates Eclipse project files for the build that can be opened by the IDE. This set of plugins can also be used to fine tune http://projects.eclipse.org/projects/tools.buildship[Buildship's] import process for Gradle builds.
+
+<<idea_plugin.adoc#, IntelliJ IDEA>>::
+Generates IDEA project files for the build that can be opened by the IDE. It can also be used to fine tune IDEA's import process for Gradle builds.
+
+== Utility
+
+<<base_plugin.adoc#,Base>>::
+Provides common lifecycle tasks, such as `clean`, and other features common to most builds.
+
+<<build_init_plugin.adoc#,Build Init>>::
+Generates a new Gradle build of a specified type, such as a Java library. It can also generate a build script from a Maven POM — see https://guides.gradle.org/migrating-from-maven/[_Migrating from Maven to Gradle_] for more details.
+
+<<signing_plugin.adoc#,Signing>>::
+Provides support for digitally signing generated files and artifacts.
+
+<<java_gradle_plugin.adoc#,Plugin Development>>::
+Makes it easier to develop and publish a Gradle plugin.

--- a/subprojects/docs/src/docs/userguide/third_party_integration.adoc
+++ b/subprojects/docs/src/docs/userguide/third_party_integration.adoc
@@ -1,0 +1,54 @@
+// Copyright 2018 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[third_party_integration]]
+= Gradle & Third-party Tools
+
+Gradle can be integrated with many different third-party tools such as IDEs and continuous integration platforms. Here we look at some of the more common ones as well as how to integrate your own tool with Gradle.
+
+== IDEs
+
+Android Studio::
+This is a variant of IntelliJ IDEA, so the same integration features apply. It has built-in support for importing and building Gradle projects. You can also use the <<idea_plugin.adoc#,IDEA Plugin for Gradle>> to fine-tune the import process if that's necessary.
+
+Eclipse::
+If you want to work on a project within Eclipse that has a Gradle build, you should use the https://projects.eclipse.org/projects/tools.buildship[Eclipse Buildship plugin]. This will allow you to import and run Gradle builds. If you need to fine tune the import process so that the project loads correctly, you can use the <<eclipse_plugin.adoc#,Eclipse Plugins for Gradle>>. See https://discuss.gradle.org/t/buildship-1-0-18-is-now-available/19012[the associated release announcement] for details on what fine tuning you can do.
+
+IntelliJ IDEA::
+IDEA has built-in support for importing Gradle projects. If you need to fine tune the import process so that the project loads correctly, you can use the <<idea_plugin.adoc#,IDEA Plugin for Gradle>>.
+
+NetBeans::
+Add the http://plugins.netbeans.org/plugin/44510/gradle-support[Gradle Support] plugin to NetBeans in order to import and run projects with Gradle builds.
+
+Visual Studio::
+Gradle comes with a <<native_software.adoc#native_binaries:visual_studio,Visual Studio plugin>> that will generate link:{groovyDslPath}/org.gradle.ide.visualstudio.VisualStudioProject.html[VisualStudioProject] and link:{groovyDslPath}/org.gradle.ide.visualstudio.VisualStudioSolution.html[VisualStudioSolution] files for your native projects.
+
+== Continuous integration
+
+We have dedicated guides showing you how to integrate a Gradle project with the following CI platforms:
+
+ * https://guides.gradle.org/executing-gradle-builds-on-jenkins[Jenkins]
+ * https://guides.gradle.org/executing-gradle-builds-on-teamcity[TeamCity]
+ * https://guides.gradle.org/executing-gradle-builds-on-travisci[Travis CI]
+
+Even if you don't use one of the above, you can almost certainly configure your CI platform to use the <<gradle_wrapper.adoc#,Gradle Wrapper>> scripts.
+
+== How to integrate with Gradle
+
+There are two main ways to integrate a tool with Gradle:
+
+ * The Gradle build uses the tool
+ * The tool executes the Gradle build
+
+The former case is typically <<custom_plugins.adoc#,implemented as a Gradle plugin>>. The latter can be accomplished by embedding Gradle through <<embedding.adoc#,the Tooling API>>.

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -71,25 +71,39 @@
     <!-- Primary Navigation -->
     <nav class="docs-navigation">
         <ul>
-            <li><a href="/userguide/userguide.html">User Manual Home</a></li>
-            <li><a href="/release-notes.html">Release Notes</a></li>
+            <li class="main-link"><a href="/userguide/userguide.html">User Manual</a>
+                <ul class="manual-formats">
+                    <li><a href="/userguide/userguide_single.html">1 page</a></li>
+                    <li><a href="/userguide/userguide.pdf">PDF</a></li>
+                </ul>
+            </li>
+            
+            <li class="main-link"><a href="/release-notes.html">Release Notes</a></li>
+            <li class="main-link"><a href="/userguide/installation.html">Installing Gradle</a></li>
+            <li class="main-link" id="tutorials"><a href="https://guides.gradle.org/">Tutorials</a></li>
+        </ul>
+        <h3 id="reference">Reference</h3>
+        <ul>
+            <li><a href="/dsl/">Groovy DSL Reference</a></li>
+            <li><a href="/javadoc/">Gradle API Javadoc</a></li>
+            <li><a href="/userguide/plugin_reference.html">Core Plugins</a></li>
+            <li id="third-party-integration"><a href="/userguide/third_party_integration.html">Gradle &amp; Third-party Tools</a></li>
         </ul>
 
         <h3 id="getting-started">Getting Started</h3>
         <ul>
-            <li><a href="/userguide/installation.html">Installing Gradle</a></li>
             <li><a href="https://guides.gradle.org/creating-new-gradle-builds/">Creating New Gradle Builds</a></li>
             <li><a href="https://guides.gradle.org/creating-build-scans/">Creating Build Scans</a></li>
             <li><a href="https://guides.gradle.org/migrating-from-maven/">Migrating From Maven</a></li>
         </ul>
 
-        <h3 id="using-gradle-builds">Using Gradle Builds</h3>
+        <h3 id="using-gradle-builds">Running Gradle Builds</h3>
         <ul>
             <li><a href="/userguide/command_line_interface.html">Command-Line Interface</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#customizing-execution" aria-expanded="false" aria-controls="customizing-execution">Customizing Execution</a>
                 <ul id="customizing-execution">
-                    <li><a href="/userguide/build_environment.html">Configuring Build Environment</a></li>
-                    <li><a href="/userguide/gradle_daemon.html">Configuring Gradle Daemon</a></li>
+                    <li><a href="/userguide/build_environment.html">Configuring the Build Environment</a></li>
+                    <li><a href="/userguide/gradle_daemon.html">Configuring the Gradle Daemon</a></li>
                     <li><a href="/userguide/init_scripts.html">Initialization Scripts</a></li>
                 </ul>
             </li>
@@ -97,81 +111,32 @@
             <li><a href="/userguide/gradle_wrapper.html">Gradle Wrapper</a></li>
             <li><a href="/userguide/troubleshooting.html">Troubleshooting</a></li>
             <li><a href="https://docs.gradle.com/build-scan-plugin">Using Build Scans</a></li>
-        </ul>
-
-        <h3 id="tutorials">Project Tutorials</h3>
-        <ul>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-android-projects" aria-expanded="false" aria-controls="building-android-projects">Android</a>
-                <ul id="building-android-projects">
-                    <li><a href="https://guides.gradle.org/building-android-apps/">Building Android Apps</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-cpp-projects" aria-expanded="false" aria-controls="building-cpp-projects">C++</a>
-                <ul id="building-cpp-projects">
-                    <li><a href="https://guides.gradle.org/building-cpp-executables/">Building C++ Executables</a></li>
-                    <li><a href="https://guides.gradle.org/building-cpp-libraries/">Building C++ Libraries</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-groovy-projects" aria-expanded="false" aria-controls="building-groovy-projects">Groovy</a>
-                <ul id="building-groovy-projects">
-                    <li><a href="https://guides.gradle.org/building-groovy-libraries/">Building Groovy Libraries</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-java-projects" aria-expanded="false" aria-controls="building-java-projects">Java</a>
-                <ul id="building-java-projects">
-                    <li><a href="https://guides.gradle.org/building-java-applications/">Building Java Applications</a></li>
-                    <li><a href="https://guides.gradle.org/building-java-libraries/">Building Java Libraries</a></li>
-                    <li><a href="https://guides.gradle.org/building-java-9-modules/">Building Java 9 Modules</a></li>
-                    <li><a href="https://guides.gradle.org/building-java-web-applications/">Building Java Web Applications</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-javascript-projects" aria-expanded="false" aria-controls="building-javascript-projects">JavaScript</a>
-                <ul id="building-javascript-projects">
-                    <li><a href="https://guides.gradle.org/running-webpack-with-gradle/">Running Webpack with Gradle</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-kotlin-projects" aria-expanded="false" aria-controls="building-kotlin-projects">Kotlin</a>
-                <ul id="building-kotlin-projects">
-                    <li><a href="https://guides.gradle.org/building-kotlin-jvm-libraries/">Building Kotlin JVM Libraries</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#building-scala-projects" aria-expanded="false" aria-controls="building-scala-projects">Scala</a>
-                <ul id="building-scala-projects">
-                    <li><a href="https://guides.gradle.org/building-scala-libraries/">Building Scala Libraries</a></li>
-                </ul>
-            </li>
+            <li><a href="/userguide/build_cache.html">Enabling and Configuring the Build Cache</a></li>
+            <li><a href="/userguide/composite_builds.html">Integrating Separate Gradle Builds (Composite Builds)</a></li>
         </ul>
 
         <h3 id="authoring-gradle-builds">Authoring Gradle Builds</h3>
         <ul>
-            <li><a href="/dsl/">Groovy DSL Reference</a></li>
-            <li><a href="/javadoc/">Gradle API Javadoc</a></li>
-            <li><a href="/userguide/feature_lifecycle.html">Gradle Feature Lifecycle</a></li>
-            <li><p></p></li>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#authoring-build-scripts" aria-expanded="false" aria-controls="authoring-build-scripts">Fundamentals</a>
+                <ul id="authoring-build-scripts">
+                    <li><a href="/userguide/tutorial_using_tasks.html">Introducing the Basics of Build Scripts</a></li>
+                    <li><a href="/userguide/more_about_tasks.html">Working with Tasks</a></li>
+                    <li><a href="/userguide/writing_build_scripts.html">Learning More About Build Scripts</a></li>
+                    <li><a href="/userguide/working_with_files.html">Working with Files</a></li>
+                    <li><a href="/userguide/custom_tasks.html">Creating Custom Task Types</a></li>
+                    <li><a href="/userguide/plugins.html">Using Gradle Plugins</a></li>
+                    <li><a href="/userguide/standard_plugins.html">The Standard Gradle Plugins</a></li>
+                    <li><a href="/userguide/build_lifecycle.html">Understanding the Build Lifecycle</a></li>
+                    <li><a href="/userguide/logging.html">Working with Logging</a></li>
+                    <li><a href="/userguide/multi_project_builds.html">Configuring Multi-Project Builds</a></li>
+                </ul>
+            </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#best-practices" aria-expanded="false" aria-controls="best-practices">Best Practices</a>
                 <ul id="best-practices">
                     <li><a href="/userguide/authoring_maintainable_build_scripts.html">Authoring Maintainable Build Scripts</a></li>
                     <li><a href="/userguide/organizing_gradle_projects.html">Organizing Gradle Projects</a></li>
                     <li><a href="https://guides.gradle.org/performance/">Optimizing Build Performance</a></li>
                     <li><a href="https://guides.gradle.org/using-build-cache/">Using the Build Cache</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#authoring-build-scripts" aria-expanded="false" aria-controls="authoring-build-scripts">Build Configuration Scripts</a>
-                <ul id="authoring-build-scripts">
-                    <li><a href="/userguide/build_cache.html">Build Cache Basics</a></li>
-                    <li><a href="/userguide/build_init_plugin.html">Build Initialization</a></li>
-                    <li><a href="/userguide/build_lifecycle.html">Build Lifecycle</a></li>
-                    <li><a href="/userguide/tutorial_using_tasks.html">Build Script Basics</a></li>
-                    <li><a href="/userguide/composite_builds.html">Composite Builds</a></li>
-                    <li><a href="/userguide/multi_project_builds.html">Configuring Multi-Project Builds</a></li>
-                    <li><a href="/userguide/more_about_tasks.html">Declaring Tasks</a></li>
-                    <li><a href="/userguide/logging.html">Logging</a></li>
-                    <li><a href="/userguide/standard_plugins.html">Standard Gradle Plugins</a></li>
-                    <li><a href="/userguide/test_kit.html">Testing with TestKit</a></li>
-                    <li><a href="/userguide/plugins.html">Using Gradle Plugins</a></li>
-                    <li><a href="/userguide/working_with_files.html">Working with Files</a></li>
-                    <li><a href="/userguide/writing_build_scripts.html">Writing Build Scripts</a></li>
-                    <li><a href="/userguide/custom_tasks.html">Writing Custom Task Classes</a></li>
                 </ul>
             </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#dependency-management" aria-expanded="false" aria-controls="dependency-management">Dependency Management</a>
@@ -194,24 +159,8 @@
                     <li><a href="/userguide/working_with_dependencies.html">Working with Dependencies</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#publishing-artifacts" aria-expanded="false" aria-controls="publishing-artifacts">Publishing Artifacts</a>
-                <ul id="publishing-artifacts">
-                    <li><a href="/userguide/publishing_maven.html">Maven Publish Plugin</a></li>
-                    <li><a href="/userguide/publishing_ivy.html">Ivy Publish Plugin</a></li>
-                    <li><a href="/userguide/artifact_management.html">Publishing Artifacts Overview</a></li>
-                    <li><a href="/userguide/maven_plugin.html">Old Maven Plugin</a></li>
-                    <li><a href="/userguide/signing_plugin.html">Signing Plugin</a></li>
-                    <li><a href="/userguide/distribution_plugin.html">Distribution Plugin</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#sample-gradle-builds" aria-expanded="false" aria-controls="sample-gradle-builds">Sample Gradle Builds</a>
-                <ul id="sample-gradle-builds">
-                    <li><a href="https://github.com/gradle/gradle/tree/master/subprojects/docs/src/samples">Groovy DSL Samples</a></li>
-                    <li><a href="https://github.com/gradle/kotlin-dsl/tree/master/samples">Kotlin DSL Samples</a></li>
-                </ul>
-            </li>
             <li><p></p></li>
-            <li><a href="/userguide/base_plugin.html">Base Plugin</a></li>
+            <li><a href="/userguide/artifact_management.html">Publishing Artifacts</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#cpp-projects" aria-expanded="false" aria-controls="cpp-projects">C++ Projects</a>
                 <ul id="cpp-projects">
                     <li><a href="/userguide/native_software.html">Building Native Software</a></li>
@@ -221,83 +170,40 @@
                     <li><a href="/userguide/software_model_extend.html">Extending the Software Model</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#groovy-projects" aria-expanded="false" aria-controls="groovy-projects">Groovy Projects</a>
-                <ul id="groovy-projects">
-                    <li><a href="/userguide/tutorial_groovy_projects.html">Groovy Quickstart</a></li>
-                    <li><a href="/userguide/groovy_plugin.html">Groovy Plugin</a></li>
-                    <li><a href="/userguide/codenarc_plugin.html">CodeNarc Plugin</a></li>
-                </ul>
-            </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#java-projects" aria-expanded="false" aria-controls="java-projects">Java Projects</a>
                 <ul id="java-projects">
-                    <li><a href="/userguide/tutorial_java_projects.html">Java Quickstart</a></li>
-                    <li><a href="/userguide/building_java_projects.html">Building Java &amp; JVM Projects</a></li>
-                    <li><a href="/userguide/java_testing.html">Testing Java &amp; JVM Projects</a></li>
-                    <li><a href="/userguide/java_plugin.html">Java Plugin</a></li>
-                    <li><a href="/userguide/java_library_plugin.html">Java Library Plugin</a></li>
-                    <li><a href="/userguide/java_library_distribution_plugin.html">Java Library Distribution Plugin</a></li>
-                    <li><a href="/userguide/dependency_management_for_java_projects.html">Java Dependency Management</a></li>
+                    <li><a href="/userguide/building_java_projects.html">Building Java &amp; JVM projects</a></li>
+                    <li><a href="/userguide/java_testing.html">Testing Java &amp; JVM projects</a></li>
+                </ul>
+            </li>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#advanced-techniques" aria-expanded="false" aria-controls="advanced-techniques">Advanced techniques</a>
+                <ul id="advanced-techniques">
+                    <li><a href="/userguide/lazy_configuration.html">Configuring Tasks Lazily</a></li>
+                    <li><a href="https://guides.gradle.org/using-the-worker-api/">Developing Parallel Tasks</a></li>
+                    <li><a href="/userguide/test_kit.html">Testing Your Build with TestKit</a></li>
                     <li><a href="/userguide/ant.html">Using Ant from Gradle</a></li>
-                    <li><p></p></li>
-                    <li><a href="/userguide/antlr_plugin.html">ANTLR Plugin</a></li>
-                    <li><a href="/userguide/application_plugin.html">Application Plugin</a></li>
-                    <li><a class="nav-dropdown" data-toggle="collapse" href="#jvm-plugins-reference" aria-expanded="false" aria-controls="jvm-plugins-reference">Code Quality Plugins</a>
-                        <ul id="jvm-plugins-reference">
-                            <li><a href="/userguide/checkstyle_plugin.html">Checkstyle Plugin</a></li>
-                            <li><a href="/userguide/findbugs_plugin.html">FindBugs Plugin</a></li>
-                            <li><a href="/userguide/jacoco_plugin.html">JaCoCo Plugin</a></li>
-                            <li><a href="/userguide/jdepend_plugin.html">JDepend Plugin</a></li>
-                            <li><a href="/userguide/pmd_plugin.html">PMD Plugin</a></li>
-                        </ul>
-                    </li>
-                    <li><a href="/userguide/osgi_plugin.html">OSGi Plugin</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#java-web-projects" aria-expanded="false" aria-controls="java-web-projects">Java Web Projects</a>
-                <ul id="java-web-projects">
-                    <li><a href="/userguide/ear_plugin.html">EAR Plugin</a></li>
-                    <li><a href="/userguide/play_plugin.html">Play Plugin</a></li>
-                    <li><a href="/userguide/war_plugin.html">WAR Plugin</a></li>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#best-practices" aria-expanded="false" aria-controls="best-practices">Best Practices</a>
+                <ul id="best-practices">
+                    <li><a href="/userguide/authoring_maintainable_build_scripts.html">Authoring Maintainable Build Scripts</a></li>
+                    <li><a href="/userguide/organizing_gradle_projects.html">Organizing Gradle Projects</a></li>
+                    <li><a href="https://guides.gradle.org/performance/">Optimizing Build Performance</a></li>
+                    <li><a href="https://guides.gradle.org/using-build-cache/">Using the Build Cache</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#scala-projects" aria-expanded="false" aria-controls="scala-projects">Scala Projects</a>
-                <ul id="scala-projects">
-                    <li><a href="/userguide/scala_plugin.html">Scala Plugin</a></li>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#sample-gradle-builds" aria-expanded="false" aria-controls="sample-gradle-builds">Sample Gradle builds</a>
+                <ul id="sample-gradle-builds">
+                    <li><a href="https://github.com/gradle/gradle/tree/master/subprojects/docs/src/samples">Groovy DSL Samples</a></li>
+                    <li><a href="https://github.com/gradle/kotlin-dsl/tree/master/samples">Kotlin DSL Samples</a></li>
                 </ul>
             </li>
-        </ul>
-
-        <h3 id="integrating-gradle">Integrating Gradle</h3>
-        <ul>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#ci-integration" aria-expanded="false" aria-controls="ci-integration">Continuous Integration</a>
-                <ul id="ci-integration">
-                    <li><a href="https://guides.gradle.org/executing-gradle-builds-on-jenkins">Using Gradle with Jenkins</a></li>
-                    <li><a href="https://guides.gradle.org/executing-gradle-builds-on-travisci">Using Gradle with Travis CI</a></li>
-                </ul>
-            </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#ide-integration" aria-expanded="false" aria-controls="ide-integration">IDE Integration</a>
-                <ul id="ide-integration">
-                    <li><a href="/userguide/eclipse_plugin.html">Eclipse Plugin</a></li>
-                    <li><a href="/userguide/idea_plugin.html">IDEA Plugin</a></li>
-                </ul>
-            </li>
-            <li><a href="/userguide/embedding.html">Tooling API</a></li>
         </ul>
 
         <h3 id="developing-gradle-plugins">Extending Gradle</h3>
         <ul>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#plugins-tutorials" aria-expanded="false" aria-controls="plugins-tutorials">Plugin Development Guides</a>
-                <ul id="plugins-tutorials">
-                    <li><a href="https://guides.gradle.org/designing-gradle-plugins/">Designing Gradle Plugins</a></li>
-                    <li><a href="https://guides.gradle.org/implementing-gradle-plugins/">Implementing Gradle Plugins</a></li>
-                    <li><a href="https://guides.gradle.org/testing-gradle-plugins/">Testing Gradle Plugins</a></li>
-                    <li><a href="https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/">Publishing Gradle Plugins</a></li>
-                </ul>
-            </li>
-            <li><a href="https://guides.gradle.org/using-the-worker-api/">Developing Parallel Tasks</a></li>
-            <li><a href="/userguide/lazy_configuration.html">Lazy Task Configuration</a></li>
-            <li><a href="/userguide/java_gradle_plugin.html">Plugin Development Plugin</a></li>
             <li><a href="/userguide/custom_plugins.html">Writing Custom Plugins</a></li>
+            <li><a href="https://gradle.org/guides/?q=Plugin%20Development">Plugin Development Guides</a></li>
         </ul>
     </nav>
     <!-- End Primary Navigation -->

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -71,16 +71,10 @@
     <!-- Primary Navigation -->
     <nav class="docs-navigation">
         <ul>
-            <li class="main-link"><a href="/userguide/userguide.html">User Manual</a>
-                <ul class="manual-formats">
-                    <li><a href="/userguide/userguide_single.html">1 page</a></li>
-                    <li><a href="/userguide/userguide.pdf">PDF</a></li>
-                </ul>
-            </li>
-            
-            <li class="main-link"><a href="/release-notes.html">Release Notes</a></li>
-            <li class="main-link"><a href="/userguide/installation.html">Installing Gradle</a></li>
-            <li class="main-link" id="tutorials"><a href="https://guides.gradle.org/">Tutorials</a></li>
+            <li><a href="/userguide/userguide.html">User Manual Home</a></li>
+            <li><a href="/release-notes.html">Release Notes</a></li>
+            <li><a href="/userguide/installation.html">Installing Gradle</a></li>
+            <li id="tutorials"><a href="https://guides.gradle.org/">Tutorials</a></li>
         </ul>
         <h3 id="reference">Reference</h3>
         <ul>

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -178,14 +178,6 @@
                     <li><a href="/userguide/ant.html">Using Ant from Gradle</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#best-practices" aria-expanded="false" aria-controls="best-practices">Best Practices</a>
-                <ul id="best-practices">
-                    <li><a href="/userguide/authoring_maintainable_build_scripts.html">Authoring Maintainable Build Scripts</a></li>
-                    <li><a href="/userguide/organizing_gradle_projects.html">Organizing Gradle Projects</a></li>
-                    <li><a href="https://guides.gradle.org/performance/">Optimizing Build Performance</a></li>
-                    <li><a href="https://guides.gradle.org/using-build-cache/">Using the Build Cache</a></li>
-                </ul>
-            </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#sample-gradle-builds" aria-expanded="false" aria-controls="sample-gradle-builds">Sample Gradle builds</a>
                 <ul id="sample-gradle-builds">
                     <li><a href="https://github.com/gradle/gradle/tree/master/subprojects/docs/src/samples">Groovy DSL Samples</a></li>

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -170,7 +170,7 @@
                     <li><a href="/userguide/java_testing.html">Testing Java &amp; JVM projects</a></li>
                 </ul>
             </li>
-            <li><a class="nav-dropdown" data-toggle="collapse" href="#advanced-techniques" aria-expanded="false" aria-controls="advanced-techniques">Advanced techniques</a>
+            <li><a class="nav-dropdown" data-toggle="collapse" href="#advanced-techniques" aria-expanded="false" aria-controls="advanced-techniques">Advanced Techniques</a>
                 <ul id="advanced-techniques">
                     <li><a href="/userguide/lazy_configuration.html">Configuring Tasks Lazily</a></li>
                     <li><a href="https://guides.gradle.org/using-the-worker-api/">Developing Parallel Tasks</a></li>


### PR DESCRIPTION
### Context
This is revised #5783 with a few changes:
 * single-page/PDF links removed — @aweida and I have a good idea to put these in the top navigation in a way that allows users to choose Gradle version (4.10, 4.9, 3.5, etc) + format (multi-page, single-page HTML, PDF). 
 * Removed a duplicated nav subsection
 * Use of title case until we convert everything to sentence case later

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
