### PR TITLE
Only restrict afterEvaluate in lazy configuration actions

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -1050,4 +1050,20 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         where:
         [description, code] << INVALID_CALL_FROM_LAZY_CONFIGURATION
     }
+
+    @Unroll
+    def "can execute #description during eager configuration action with registered task"() {
+        buildFile << """
+            tasks.withType(SomeTask) {
+                ${code}
+            }
+            tasks.register("foo", SomeTask)
+        """
+
+        expect:
+        succeeds "foo"
+
+        where:
+        [description, code] << INVALID_CALL_FROM_LAZY_CONFIGURATION
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -611,13 +611,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
 
         @Override
         public void configure(final Action<? super I> action) {
+            Action<? super I> wrappedAction = crossProjectConfigurator.withCrossProjectConfigurationDisabled(action);
             if (task != null) {
                 // Already realized, just run the action now
-                crossProjectConfigurator.withCrossProjectConfigurationDisabled(action).execute(task);
+                wrappedAction.execute(task);
                 return;
             }
             // Collect any container level add actions then add the task specific action
-            onCreate = onCreate.mergeFrom(getEventRegister().getAddActions()).add(action);
+            onCreate = onCreate.mergeFrom(getEventRegister().getAddActions()).add(wrappedAction);
         }
 
         @Override
@@ -641,7 +642,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                                 statistics.lazyTaskRealized(getType());
 
                                 // Register the task
-                                add(task, crossProjectConfigurator.withCrossProjectConfigurationDisabled(onCreate));
+                                add(task, onCreate);
                                 // TODO removing this stuff from the store should be handled through some sort of decoration
                                 context.setResult(REALIZE_RESULT);
                             } catch (Throwable ex) {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
