### PR TITLE
Fix build logic to work with -Dorg.gradle.internal.tasks.eager=true

### DIFF
--- a/subprojects/distributions/distributions.gradle
+++ b/subprojects/distributions/distributions.gradle
@@ -54,16 +54,13 @@ gradlebuildJava {
 }
 
 apiMetadata {
-    sources = provider {
-        ProjectGroups.INSTANCE.getJavaProjects(project)
-            .collect { it.sourceSets.main.allJava.asFileTree }
-            .inject { acc, fileTree -> acc.plus(fileTree) }
-    }
+    sources.from(provider {
+        ProjectGroups.INSTANCE.getJavaProjects(project).collect { it.sourceSets.main.allJava }
+    })
     includes = PublicApi.includes
     excludes = PublicApi.excludes
-    classpath = provider {
-        rootProject.configurations.runtime + rootProject.configurations.gradlePlugins
-    }
+    classpath.from(rootProject.configurations.runtime)
+    classpath.from(rootProject.configurations.gradlePlugins)
 }
 
 evaluationDependsOn ":docs"


### PR DESCRIPTION
by simplifying extension/tasks properties,
removing `Provider<FileCollection>` and `Provider<FileTree>` properties

for the purpose of the eager vs. lazy performance comparison test
