### PR TITLE
Make environment variable mutation work on Java9+

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -158,6 +158,10 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
                 // enable class unloading
                 jvmArgs("-XX:+UseConcMarkSweepGC", "-XX:+CMSClassUnloadingEnabled")
             }
+            if (javaInstallationForTest.javaVersion.isJava9Compatible) {
+                //allow embedded executer to modify environment variables
+                jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
+            }
             // Includes JVM vendor and major version
             inputs.property("javaInstallation", javaInstallationForTest.displayName)
             doFirst {

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/PropertiesLoaderIntegrationTest.groovy
@@ -141,4 +141,33 @@ task printSystemProp {
         then:
         succeeds ':help'
     }
+
+    def "Gradle properties can be derived from environment variables"() {
+        given:
+        buildFile << """
+            task printProperty() {
+                doLast {
+                    println "myProp=\${project.ext.myProp}"
+                }
+            }
+        """
+
+        when:
+        executer.withEnvironmentVars(ORG_GRADLE_PROJECT_myProp: 'fromEnv')
+
+        then:
+        succeeds 'printProperty'
+
+        and:
+        outputContains("myProp=fromEnv")
+
+        when:
+        executer.withEnvironmentVars(ORG_GRADLE_PROJECT_myProp: 'fromEnv2')
+
+        then:
+        succeeds 'printProperty'
+
+        and:
+        outputContains("myProp=fromEnv2")
+    }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/util/TestPrecondition.groovy
@@ -44,7 +44,7 @@ enum TestPrecondition implements org.gradle.internal.Factory<Boolean> {
         !FILE_PERMISSIONS.fulfilled
     }),
     SET_ENV_VARIABLE({
-        !UNKNOWN_OS.fulfilled && JavaVersion.current() < JavaVersion.VERSION_1_9
+        !UNKNOWN_OS.fulfilled
     }),
     WORKING_DIR({
         !UNKNOWN_OS.fulfilled && JavaVersion.current() < JavaVersion.VERSION_11

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -37,6 +37,7 @@ public class DaemonParameters {
 
     public static final List<String> DEFAULT_JVM_ARGS = ImmutableList.of("-Xmx1024m", "-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError");
     public static final List<String> DEFAULT_JVM_8_ARGS = ImmutableList.of("-Xmx1024m", "-XX:+HeapDumpOnOutOfMemoryError");
+    public static final ImmutableList<String> ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE = ImmutableList.of("--add-opens", "java.base/java.util=ALL-UNNAMED");
 
     private final File gradleUserHomeDir;
 
@@ -126,6 +127,9 @@ public class DaemonParameters {
     }
 
     public void applyDefaultsFor(JavaVersion javaVersion) {
+        if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
+            jvmOptions.jvmArgs(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
+        }
         if (hasJvmArgs) {
             return;
         }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/EstablishBuildEnvironment.java
@@ -56,7 +56,7 @@ public class EstablishBuildEnvironment extends BuildCommandOnly {
                 continue;
             }
             if (entry.getKey().startsWith("sun.") || entry.getKey().startsWith("awt.")
-                    || entry.getKey().contains(".awt.")) {
+                || entry.getKey().contains(".awt.")) {
                 continue;
             }
             System.setProperty(entry.getKey(), entry.getValue());

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/EnvironmentModificationResult.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/EnvironmentModificationResult.java
@@ -21,7 +21,6 @@ package org.gradle.internal.nativeintegration;
  */
 public enum EnvironmentModificationResult {
     SUCCESS(null),
-    JAVA_9_IMMUTABLE_ENVIRONMENT("Java 9 does not support modifying environment variables."),
     UNSUPPORTED_ENVIRONMENT("There is no native integration with this operating environment.");
 
     private final String reason;

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/processenvironment/AbstractProcessEnvironment.java
@@ -17,7 +17,6 @@ package org.gradle.internal.nativeintegration.processenvironment;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.gradle.api.JavaVersion;
 import org.gradle.internal.nativeintegration.EnvironmentModificationResult;
 import org.gradle.internal.nativeintegration.NativeIntegrationException;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
@@ -33,9 +32,6 @@ public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
 
     @Override
     public EnvironmentModificationResult maybeSetEnvironment(Map<String, String> source) {
-        if (JavaVersion.current().isJava9Compatible()) {
-            return EnvironmentModificationResult.JAVA_9_IMMUTABLE_ENVIRONMENT;
-        }
         // need to take copy to prevent ConcurrentModificationException
         List<String> keysToRemove = Lists.newArrayList(Sets.difference(System.getenv().keySet(), source.keySet()));
         for (String key : keysToRemove) {
@@ -57,9 +53,6 @@ public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
 
     @Override
     public EnvironmentModificationResult maybeRemoveEnvironmentVariable(String name) {
-        if (JavaVersion.current().isJava9Compatible()) {
-            return EnvironmentModificationResult.JAVA_9_IMMUTABLE_ENVIRONMENT;
-        }
         removeEnvironmentVariable(name);
         return EnvironmentModificationResult.SUCCESS;
     }
@@ -79,9 +72,6 @@ public abstract class AbstractProcessEnvironment implements ProcessEnvironment {
 
     @Override
     public EnvironmentModificationResult maybeSetEnvironmentVariable(String name, String value) {
-        if (JavaVersion.current().isJava9Compatible()) {
-            return EnvironmentModificationResult.JAVA_9_IMMUTABLE_ENVIRONMENT;
-        }
         setEnvironmentVariable(name, value);
         return EnvironmentModificationResult.SUCCESS;
     }


### PR DESCRIPTION
Mutating the environment requires reflection on the
java.util package, so we need to open that package
up to Gradle. Since Gradle is not modularized, this
means opening it up to the whole classpath. This is
less than desirable, but the only way to restore the
behavior we had on Java 8 and below.

We should start limiting access to environment variables
going forward so users don't depend on arbitrary values.
However, this change allows us to unblock users who are
currently either not using Java 9 or running Gradle in
no-daemon mode, both of which are terrible solutions.

Fixes #3468