### PR TITLE
Issue 142: C++ to leverage library path for GCC linker and loader.

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccLinker.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccLinker.java
@@ -74,7 +74,17 @@ class GccLinker extends AbstractCompiler<LinkerSpec> {
                 args.add(file.getAbsolutePath());
             }
             for (File file : spec.getLibraries()) {
-                args.add(file.getAbsolutePath());
+                // Link against libraries leveraging the library path.
+                if (file.getName().startsWith ("lib")) {
+                    args.add("-L" + file.getParent());
+                    String library = file.getName().replaceFirst("lib", "-l");
+                    args.add(library.substring(0, library.lastIndexOf('.')));
+                }
+                // Link against direct objects with the full path.
+                else {
+                    args.add(file.getAbsolutePath());
+                }
+
             }
             if (!spec.getLibraryPath().isEmpty()) {
                 throw new UnsupportedOperationException("Library Path not yet supported on GCC");


### PR DESCRIPTION
Signed-off-by: jb020370 <john.bennewitz@cerner.com>

### Context
Addresses issue 142 for GCC: https://github.com/gradle/gradle-native/issues/142. 

Current State: C++ built binaries rely on dependent binaries (libraries) being in the same absolute file path as was built against. This makes installation (moving the binaries to a different machine) difficult because other machines must mirror the build file system structure in order to execute the binary. 

Proposed State: C++ built binaries rely on the library path (LD_LIBRARY_PATH on GCC Linux) to find dependent libraries to link against and load. This is similar to leveraging the java CLASSPATH for loading JARs as opposed to forcing the loader to load from an absolute path.
 
Notes: 
- There are existing integration test which cover the code changed (CppLibraryIntegrationTest, CppCachingIntegrationTest, CppDependenciesIntegrationTest, etc.). Let me know if there is a more specific automated test we would want to see here. 
- Validated gradle build / existing automated test run successfully as does the existing samples: https://github.com/gradle/native-samples/tree/master/cpp/library-with-tests


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
