### PR TITLE
Treat 'prefer' version constraints as recommendations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/MutableVersionConstraint.java
@@ -46,14 +46,21 @@ public interface MutableVersionConstraint extends VersionConstraint {
     void setBranch(@Nullable String branch);
 
     /**
-     * Sets the preferred version of this module. Any other rejection/strict constraint will be overriden.
+     * Sets the required version of this module. Any other version constraints will be overriden.
+     * @param version the preferred version of this module
+     * @since 4.11
+     */
+    void require(String version);
+
+    /**
+     * Sets the preferred version of this module. Any other version constraints will be overriden.
      * @param version the preferred version of this module
      */
     void prefer(String version);
 
     /**
      * Sets the version as strict, meaning that if any other dependency version for this module disagrees with
-     * this version, resolution will fail.
+     * this version, resolution will fail. Any other version constraints will be overriden.
      *
      * @param version the strict version to be used for this module
      */

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationMutationIntegrationTest.groovy
@@ -151,7 +151,7 @@ configurations.compile.withDependencies { deps ->
 configurations.compile.withDependencies { deps ->
     def bar = deps.find { it.name == 'bar' }
     assert bar.version == null
-    bar.version { prefer '1.0' }
+    bar.version { require '1.0' }
 }
 """
 
@@ -239,7 +239,7 @@ project(":producer") {
             withDependencies { deps ->
                 deps.each {
                     it.version {
-                       prefer '3.4'
+                       require '3.4'
                     }
                 }
                 deps.add(project.dependencies.create("org:added-dependency:3.4"))

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -925,7 +925,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                         }
                         withDependencyConstraints {
                             it.each {
-                                it.version { prefer '1.1' }
+                                it.version { strictly '1.1' }
                                 it.because '1.0 is buggy'
                             }
                         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -328,7 +328,8 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         "dependency constraints" | _
     }
 
-    def "can set version on dependency"() {
+    @Unroll
+    def "can set version on dependency using #keyword"() {
         given:
         repository {
             'org.test:moduleA:1.0'() {
@@ -343,7 +344,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                     context.details.withVariant("$variantToTest") { 
                         withDependencies {
                             it.each {
-                                it.version { prefer '1.0' }
+                                it.version { ${keyword} '1.0' }
                             }
                         }
                     }
@@ -377,6 +378,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 }
             }
         }
+
+        where:
+        keyword << ["prefer", "require", "strictly"]
     }
 
     @RequiredFeatures(

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
@@ -321,6 +321,19 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
     }
 
     @Unroll
+    def "resolve prefer pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        checkScenarioResolution(expected, candidates)
+
+        where:
+        permutation << VersionRangeResolveTestScenarios.SCENARIOS_PREFER
+    }
+
+    @Unroll
     def "resolve reject pair #permutation"() {
         given:
         def candidates = permutation.candidates

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraint.java
@@ -90,6 +90,11 @@ public class DefaultMutableVersionConstraint extends AbstractVersionConstraint i
     }
 
     @Override
+    public void require(String version) {
+        updateVersions(version, version, null);
+    }
+
+    @Override
     public String getPreferredVersion() {
         return preferredVersion;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -71,12 +71,21 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
     private List<T> resolveSelectors(List<? extends ResolvableSelectorState> selectors, VersionSelector allRejects) {
         if (selectors.size() == 1) {
             ResolvableSelectorState selectorState = selectors.get(0);
-            ComponentIdResolveResult resolved = selectorState.resolve(allRejects);
-            T selected = SelectorStateResolverResults.componentForIdResolveResult(componentFactory, resolved, selectorState);
-            return Collections.singletonList(selected);
+            return resolveSingleSelector(selectorState, allRejects);
         }
 
-        return buildResolveResults(selectors, allRejects);
+        List<T> results = buildResolveResults(selectors, allRejects);
+        if (results.isEmpty()) {
+            // Every selector was empty: simply 'resolve' one of them
+            return resolveSingleSelector(selectors.get(0), allRejects);
+        }
+        return results;
+    }
+
+    private List<T> resolveSingleSelector(ResolvableSelectorState selectorState, VersionSelector allRejects) {
+        ComponentIdResolveResult resolved = selectorState.resolve(allRejects);
+        T selected = SelectorStateResolverResults.componentForIdResolveResult(componentFactory, resolved, selectorState);
+        return Collections.singletonList(selected);
     }
 
     /**
@@ -87,11 +96,12 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
     private List<T> buildResolveResults(List<? extends ResolvableSelectorState> selectors, VersionSelector allRejects) {
         SelectorStateResolverResults results = new SelectorStateResolverResults(selectors.size());
         for (ResolvableSelectorState selector : selectors) {
-
-            // For a 'reject-only' selector, don't need to resolve
-//            if (isRejectOnly(dep)) {
-//                continue;
-//            }
+            // If this selector doesn't specify a prefer/require version, then ignore it here.
+            // This will avoid resolving 'reject' selectors, too.
+            if (isEmpty(selector)) {
+                selector.markResolved();
+                continue;
+            }
 
             // Check already resolved results for a compatible version, and use it for this dependency rather than re-resolving.
             if (results.alreadyHaveResolution(selector)) {
@@ -104,7 +114,16 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
 
             results.registerResolution(selector, resolved);
         }
+
         return results.getResolved(componentFactory);
+    }
+
+    private boolean isEmpty(ResolvableSelectorState selector) {
+        ResolvedVersionConstraint versionConstraint = selector.getVersionConstraint();
+        if (versionConstraint != null) {
+            return versionConstraint.getPreferredSelector().getSelector().isEmpty();
+        }
+        return false;
     }
 
     private VersionSelector createAllRejects(List<? extends ResolvableSelectorState> selectors) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -46,6 +46,21 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.rejectedVersions == []
     }
 
+    def "can override preferred version with required version"() {
+        given:
+        def version = new DefaultMutableVersionConstraint('1.0')
+        version.prefer('1.0')
+
+        when:
+        version.require('2.0')
+
+        then:
+        version.requiredVersion == '2.0'
+        version.preferredVersion == '2.0'
+        version.strictVersion == ''
+        version.rejectedVersions == []
+    }
+
     def "can override version with preferred version"() {
         given:
         def version = new DefaultMutableVersionConstraint('1.0')
@@ -74,7 +89,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.rejectedVersions == []
     }
 
-    def "can override preferred version with strict version"() {
+    def "can override required version with strict version"() {
         given:
         def version = new DefaultMutableVersionConstraint('1.0')
 
@@ -85,6 +100,19 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.requiredVersion == '2.0'
         version.preferredVersion == '2.0'
         version.strictVersion == '2.0'
+    }
+
+    def "can override strict version with required version"() {
+        given:
+        def version = DefaultMutableVersionConstraint.withStrictVersion('1.0')
+
+        when:
+        version.require('2.0')
+
+        then:
+        version.requiredVersion == '2.0'
+        version.preferredVersion == '2.0'
+        version.strictVersion == ''
     }
 
     def "can declare rejected versions"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -47,7 +47,6 @@ import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult
 import org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios
 import org.gradle.util.Path
-import spock.lang.Ignore
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -58,11 +57,10 @@ import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.RANG
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.RANGE_7_8
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_DEPENDENCY_WITH_REJECT
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_FOUR_DEPENDENCIES
+import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_PREFER
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_THREE_DEPENDENCIES
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_TWO_DEPENDENCIES
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_WITH_REJECT
-import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_PREFER
-
 /**
  * Unit test coverage of dependency resolution of a single module version, given a set of input selectors.
  */
@@ -88,7 +86,6 @@ class SelectorStateResolverTest extends Specification {
         permutation << SCENARIOS_TWO_DEPENDENCIES
     }
 
-    @Ignore // Not yet implemented
     @Unroll
     def "resolve prefer pair #permutation"() {
         given:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -56,6 +56,7 @@ import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.RANG
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.RANGE_14_16
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.RANGE_7_8
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_DEPENDENCY_WITH_REJECT
+import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_EMPTY
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_FOUR_DEPENDENCIES
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_PREFER
 import static org.gradle.resolve.scenarios.VersionRangeResolveTestScenarios.SCENARIOS_THREE_DEPENDENCIES
@@ -84,6 +85,19 @@ class SelectorStateResolverTest extends Specification {
 
         where:
         permutation << SCENARIOS_TWO_DEPENDENCIES
+    }
+
+    @Unroll
+    def "resolve empty pair #permutation"() {
+        given:
+        def candidates = permutation.candidates
+        def expected = permutation.expected
+
+        expect:
+        resolve(candidates) == expected
+
+        where:
+        permutation << SCENARIOS_EMPTY
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -36,17 +36,19 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
     private static final VersionSelectorScheme VERSION_SELECTOR_SCHEME = new DefaultVersionSelectorScheme(VERSION_COMPARATOR, VERSION_PARSER);
 
     private final DependencyToComponentIdResolver resolver;
-    private DefaultResolvedVersionConstraint versionConstraint;
+    private final DefaultResolvedVersionConstraint resolvedVersionConstraint;
+    private final VersionConstraint versionConstraint;
     public ComponentIdResolveResult resolved;
 
     public TestModuleSelectorState(DependencyToComponentIdResolver resolver, VersionConstraint versionConstraint) {
         this.resolver = resolver;
-        this.versionConstraint = new DefaultResolvedVersionConstraint(versionConstraint, VERSION_SELECTOR_SCHEME);
+        this.resolvedVersionConstraint = new DefaultResolvedVersionConstraint(versionConstraint, VERSION_SELECTOR_SCHEME);
+        this.versionConstraint = versionConstraint;
     }
 
     @Override
     public ResolvedVersionConstraint getVersionConstraint() {
-        return versionConstraint;
+        return resolvedVersionConstraint;
     }
 
     @Override
@@ -71,7 +73,7 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
             return resolved;
         }
 
-        ResolvedVersionConstraint mergedConstraint = versionConstraint.withRejectSelector(allRejects);
+        ResolvedVersionConstraint mergedConstraint = resolvedVersionConstraint.withRejectSelector(allRejects);
         resolved = resolveVersion(mergedConstraint);
         return resolved;
     }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -29,6 +29,7 @@ class VersionRangeResolveTestScenarios {
     public static final FAILED = "FAILED"
     public static final IGNORE = "IGNORE"
 
+    public static final EMPTY = empty()
     public static final FIXED_7 = fixed(7)
     public static final FIXED_9 = fixed(9)
     public static final FIXED_10 = fixed(10)
@@ -59,6 +60,23 @@ class VersionRangeResolveTestScenarios {
     public static final REJECT_11 = reject(11)
     public static final REJECT_12 = reject(12)
     public static final REJECT_13 = reject(13)
+
+    public static final StrictPermutationsProvider SCENARIOS_EMPTY = StrictPermutationsProvider.check(
+        versions: [EMPTY, FIXED_12],
+        expected: "12"
+    ).and(
+        versions: [EMPTY, PREFER_12],
+        expected: "12"
+    ).and(
+        versions: [EMPTY, RANGE_10_12],
+        expected: "12"
+    ).and(
+        versions: [EMPTY, EMPTY],
+        expected: ""
+    ).and(
+        versions: [EMPTY, EMPTY, FIXED_12],
+        expected: "12"
+    )
 
     public static final StrictPermutationsProvider SCENARIOS_PREFER = StrictPermutationsProvider.check(
         versions: [PREFER_11, PREFER_12],
@@ -317,6 +335,11 @@ class VersionRangeResolveTestScenarios {
         expected: "11",
         expectedStrict: [REJECTED, "11", "11", "11"]
     )
+    private static RenderableVersion empty() {
+        def vs = new SimpleVersion()
+        vs.version = ""
+        return vs
+    }
     private static RenderableVersion fixed(int version) {
         def vs = new SimpleVersion()
         vs.version = "${version}"
@@ -382,7 +405,7 @@ class VersionRangeResolveTestScenarios {
 
         @Override
         String toString() {
-            return version
+            return version ?: "''"
         }
     }
 
@@ -456,8 +479,8 @@ class VersionRangeResolveTestScenarios {
         }
 
         StrictPermutationsProvider and(Map config) {
-            assert config.versions
-            assert config.expected
+            assert config.versions != null
+            assert config.expected != null
 
             ++batchCount
             if (!config.ignore) {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -37,6 +37,12 @@ class VersionRangeResolveTestScenarios {
     public static final FIXED_13 = fixed(13)
     public static final PREFER_11 = prefer(11)
     public static final PREFER_12 = prefer(12)
+    public static final PREFER_13 = prefer(13)
+    public static final PREFER_7_8 = prefer(7, 8)
+    public static final PREFER_10_11 = prefer(10, 11)
+    public static final PREFER_10_12 = prefer(10, 12)
+    public static final PREFER_10_14 = prefer(10, 14)
+    public static final PREFER_14_16 = prefer(14, 16)
     public static final RANGE_7_8 = range(7, 8)
     public static final RANGE_10_11 = range(10, 11)
     public static final RANGE_10_12 = range(10, 12)
@@ -55,25 +61,65 @@ class VersionRangeResolveTestScenarios {
     public static final REJECT_13 = reject(13)
 
     public static final StrictPermutationsProvider SCENARIOS_PREFER = StrictPermutationsProvider.check(
-        versions: [FIXED_11, PREFER_12],
-        expectedNoStrict: "12",
-        expectedStrict: ["11", IGNORE]
+        versions: [PREFER_11, PREFER_12],
+        expectedNoStrict: "12"
     ).and(
-        versions: [FIXED_12, PREFER_11],
-        expectedNoStrict: "12",
-        expectedStrict: ["12", IGNORE]
+        versions: [PREFER_11, PREFER_10_12],
+        expectedNoStrict: "11"
     ).and(
-        versions: [RANGE_10_12, PREFER_11],
+        versions: [PREFER_12, PREFER_10_11],
+        expectedNoStrict: "12"
+    ).and(
+        versions: [PREFER_11, PREFER_12, PREFER_10_14],
+        expectedNoStrict: "12"
+    ).and(
+        versions: [PREFER_10_11, PREFER_10_12, PREFER_10_14],
+        expectedNoStrict: "11"
+    ).and(
+        versions: [PREFER_10_11, PREFER_12, PREFER_10_14],
+        expectedNoStrict: "12"
+    ).and(
+        versions: [PREFER_12, FIXED_11],
         expectedNoStrict: "11",
-        expectedStrict: ["11", IGNORE]
+        expectedStrict: [IGNORE, "11"],
+        ignore: true
     ).and(
-        versions: [RANGE_10_11, PREFER_12],
+        versions: [PREFER_11, FIXED_12],
+        expectedNoStrict: "12",
+        expectedStrict: [IGNORE, "12"]
+    ).and(
+        versions: [PREFER_12, RANGE_10_11],
         expectedNoStrict: "11",
-        expectedStrict: ["11", IGNORE]
+        expectedStrict: [IGNORE, "11"],
+        ignore: true
     ).and(
-        versions: [RANGE_12_14, PREFER_11],
+        versions: [PREFER_12, RANGE_10_12],
+        expectedNoStrict: "12",
+        expectedStrict: [IGNORE, "12"],
+        ignore: true
+    ).and(
+        versions: [PREFER_12, RANGE_10_14],
+        expectedNoStrict: "12",
+        expectedStrict: [IGNORE, "12"]
+    ).and(
+        versions: [PREFER_11, RANGE_12_14],
         expectedNoStrict: "13",
-        expectedStrict: ["13", IGNORE]
+        expectedStrict: [IGNORE, "13"]
+    ).and(
+        versions: [PREFER_11, PREFER_12, RANGE_10_14],
+        expectedNoStrict: "12",
+        expectedStrict: [IGNORE, IGNORE, "12"]
+    ).and(
+        versions: [PREFER_11, PREFER_13, RANGE_10_12],
+        expectedNoStrict: "11",
+        expectedStrict: [IGNORE, IGNORE, "11"],
+        ignore: true
+    ).and(
+        versions: [PREFER_7_8, FIXED_12],  // No version satisfies the range [7,8]
+        expectedNoStrict: FAILED
+    ).and(
+        versions: [PREFER_14_16, FIXED_12], // No version satisfies the range [14,16]
+        expectedNoStrict: FAILED
     )
 
     public static final StrictPermutationsProvider SCENARIOS_TWO_DEPENDENCIES = StrictPermutationsProvider.check(
@@ -280,6 +326,12 @@ class VersionRangeResolveTestScenarios {
     private static RenderableVersion prefer(int version) {
         def vs = new PreferVersion()
         vs.version = "${version}"
+        return vs
+    }
+
+    private static RenderableVersion prefer(int low, int high) {
+        def vs = new PreferVersion()
+        vs.version = "[${low},${high}]"
         return vs
     }
 

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -99,8 +99,7 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [PREFER_12, FIXED_11],
         expected: "11",
-        expectedStrict: [IGNORE, "11"],
-        ignore: true
+        expectedStrict: [IGNORE, "11"]
     ).and(
         versions: [PREFER_11, FIXED_12],
         expected: "12",
@@ -108,13 +107,11 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [PREFER_12, RANGE_10_11],
         expected: "11",
-        expectedStrict: [IGNORE, "11"],
-        ignore: true
+        expectedStrict: [IGNORE, "11"]
     ).and(
         versions: [PREFER_12, RANGE_10_12],
         expected: "12",
-        expectedStrict: [IGNORE, "12"],
-        ignore: true
+        expectedStrict: [IGNORE, "12"]
     ).and(
         versions: [PREFER_12, RANGE_10_14],
         expected: "12",
@@ -130,8 +127,7 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [PREFER_11, PREFER_13, RANGE_10_12],
         expected: "11",
-        expectedStrict: [IGNORE, IGNORE, "11"],
-        ignore: true
+        expectedStrict: [IGNORE, IGNORE, "11"]
     ).and(
         versions: [PREFER_7_8, FIXED_12],  // No version satisfies the range [7,8]
         expected: FAILED
@@ -300,7 +296,7 @@ class VersionRangeResolveTestScenarios {
         expected: "12",
         expectedStrict: ["12", "12", "12", IGNORE]
     ).and(
-        ignore: true, // This will require resolving RANGE_10_14 with the knowledge that FIXED_12 rejects < "12".
+        ignore: "Will require resolving RANGE_10_14 with the knowledge that FIXED_12 rejects < '12'",
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_12],
         expected: "13",
     ).and(

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -143,15 +143,18 @@ class VersionRangeResolveTestScenarios {
     public static final StrictPermutationsProvider SCENARIOS_TWO_DEPENDENCIES = StrictPermutationsProvider.check(
         versions: [FIXED_7, FIXED_13],
         expected: "13",
-        expectedStrict: [REJECTED, "13"]
+        expectedStrict: [REJECTED, "13"],
+        conflicts: true
     ).and(
         versions: [FIXED_12, FIXED_13],
         expected: "13",
-        expectedStrict: [REJECTED, "13"]
+        expectedStrict: [REJECTED, "13"],
+        conflicts: true
     ).and(
         versions: [FIXED_12, RANGE_10_11],
         expected: "12",
-        expectedStrict: ["12", REJECTED]
+        expectedStrict: ["12", REJECTED],
+        conflicts: true
     ).and(
         versions: [FIXED_12, RANGE_10_14],
         expected: "12",
@@ -159,7 +162,8 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [FIXED_12, RANGE_13_14],
         expected: "13",
-        expectedStrict: [REJECTED, "13"]
+        expectedStrict: [REJECTED, "13"],
+        conflicts: true
     ).and(
         versions: [FIXED_12, RANGE_7_8],  // No version satisfies the range [7,8]
         expected: FAILED,
@@ -187,11 +191,13 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [DYNAMIC_PLUS, FIXED_11],
         expected: "13",
-        expectedStrict: [IGNORE, "11"]
+        expectedStrict: [IGNORE, "11"],
+        conflicts: true
     ).and(
         versions: [DYNAMIC_PLUS, RANGE_10_12],
         expected: "13",
-        expectedStrict: [IGNORE, "12"]
+        expectedStrict: [IGNORE, "12"],
+        conflicts: true
     ).and(
         versions: [DYNAMIC_PLUS, RANGE_10_16],
         expected: "13",
@@ -199,11 +205,13 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [DYNAMIC_LATEST, FIXED_11],
         expected: "13",
-        expectedStrict: [IGNORE, "11"]
+        expectedStrict: [IGNORE, "11"],
+        conflicts: true
     ).and(
         versions: [DYNAMIC_LATEST, RANGE_10_12],
         expected: "13",
-        expectedStrict: [IGNORE, "12"]
+        expectedStrict: [IGNORE, "12"],
+        conflicts: true
     ).and(
         versions: [DYNAMIC_LATEST, RANGE_10_16],
         expected: "13",
@@ -233,11 +241,13 @@ class VersionRangeResolveTestScenarios {
     public static final StrictPermutationsProvider SCENARIOS_THREE_DEPENDENCIES = StrictPermutationsProvider.check(
         versions: [FIXED_10, FIXED_12, FIXED_13],
         expected: "13",
-        expectedStrict: [REJECTED, REJECTED, "13"]
+        expectedStrict: [REJECTED, REJECTED, "13"],
+        conflicts: true
     ).and(
         versions: [FIXED_10, FIXED_12, RANGE_10_14],
         expected: "12",
-        expectedStrict: [REJECTED, "12", "12"]
+        expectedStrict: [REJECTED, "12", "12"],
+        conflicts: true
     ).and(
         versions: [FIXED_10, RANGE_10_11, RANGE_10_14],
         expected: "10",
@@ -245,11 +255,13 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [FIXED_10, RANGE_10_11, RANGE_13_14],
         expected: "13",
-        expectedStrict: [REJECTED, REJECTED, "13"]
+        expectedStrict: [REJECTED, REJECTED, "13"],
+        conflicts: true
     ).and(
         versions: [FIXED_10, RANGE_11_12, RANGE_10_14],
         expected: "12",
-        expectedStrict: [REJECTED, "12", "12"]
+        expectedStrict: [REJECTED, "12", "12"],
+        conflicts: true
     ).and(
         versions: [RANGE_10_11, RANGE_10_12, RANGE_10_14],
         expected: "11",
@@ -257,15 +269,18 @@ class VersionRangeResolveTestScenarios {
     ).and(
         versions: [RANGE_10_11, RANGE_10_12, RANGE_13_14],
         expected: "13",
-        expectedStrict: [REJECTED, REJECTED, "13"]
+        expectedStrict: [REJECTED, REJECTED, "13"],
+        conflicts: true
     ).and(
         versions: [FIXED_10, FIXED_10, FIXED_12],
         expected: "12",
-        expectedStrict: [REJECTED, REJECTED, "12"]
+        expectedStrict: [REJECTED, REJECTED, "12"],
+        conflicts: true
     ).and(
         versions: [FIXED_10, FIXED_12, RANGE_12_14],
         expected: "12",
-        expectedStrict: [REJECTED, "12", "12"]
+        expectedStrict: [REJECTED, "12", "12"],
+        conflicts: true
     )
 
     public static final StrictPermutationsProvider SCENARIOS_WITH_REJECT = StrictPermutationsProvider.check(
@@ -330,6 +345,10 @@ class VersionRangeResolveTestScenarios {
         versions: [FIXED_10, RANGE_10_11, RANGE_10_12, RANGE_13_14],
         expected: "13",
         expectedStrict: [REJECTED, REJECTED, REJECTED, "13"]
+    ).and(
+        versions: [FIXED_10, RANGE_10_11, RANGE_10_12, RANGE_10_14],
+        expected: "10",
+        expectedStrict: ["10", "10", "10", "10"]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, RANGE_10_14],
         expected: "11",
@@ -487,9 +506,10 @@ class VersionRangeResolveTestScenarios {
                 List<RenderableVersion> versions = config.versions
                 String expected = config.expected
                 List<String> expectedStrict = config.expectedStrict
+                boolean expectConflict = config.conflicts as boolean
                 List<Batch> iterations = []
                 String batchName = config.description ?: "#${batchCount} (${versions})"
-                iterations.add(new Batch(batchName, versions, expected))
+                iterations.add(new Batch(batchName, versions, expected, expectConflict))
                 if (expectedStrict) {
                     versions.size().times { idx ->
                         def expectedStrictResolution = expectedStrict[idx]
@@ -500,7 +520,7 @@ class VersionRangeResolveTestScenarios {
                                 } else {
                                     version
                                 }
-                            }, expectedStrictResolution))
+                            }, expectedStrictResolution, expectConflict))
                         }
                     }
                 }
@@ -520,6 +540,7 @@ class VersionRangeResolveTestScenarios {
             String batchName
             List<RenderableVersion> versions
             String expected
+            boolean expectConflict
         }
 
         class PermutationIterator implements Iterator<Candidate> {
@@ -527,6 +548,7 @@ class VersionRangeResolveTestScenarios {
             String currentBatch
             Iterator<List<RenderableVersion>> current
             String expected
+            boolean expectConflictResolution
 
             @Override
             boolean hasNext() {
@@ -536,10 +558,11 @@ class VersionRangeResolveTestScenarios {
             @Override
             Candidate next() {
                 if (current?.hasNext()) {
-                    return new Candidate(batch: currentBatch, candidates: current.next() as RenderableVersion[], expected: expected)
+                    return new Candidate(batch: currentBatch, candidates: current.next() as RenderableVersion[], expected: expected, conflicts: expectConflictResolution)
                 }
                 Batch nextBatch = batchesIterator.next()
                 expected = nextBatch.expected
+                expectConflictResolution = nextBatch.expectConflict
                 current = nextBatch.versions.permutations().iterator()
                 currentBatch = nextBatch.batchName
                 return next()
@@ -550,6 +573,7 @@ class VersionRangeResolveTestScenarios {
             String batch
             RenderableVersion[] candidates
             String expected
+            boolean conflicts
 
             @Override
             String toString() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/resolve/scenarios/VersionRangeResolveTestScenarios.groovy
@@ -62,259 +62,259 @@ class VersionRangeResolveTestScenarios {
 
     public static final StrictPermutationsProvider SCENARIOS_PREFER = StrictPermutationsProvider.check(
         versions: [PREFER_11, PREFER_12],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [PREFER_11, PREFER_10_12],
-        expectedNoStrict: "11"
+        expected: "11"
     ).and(
         versions: [PREFER_12, PREFER_10_11],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [PREFER_11, PREFER_12, PREFER_10_14],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [PREFER_10_11, PREFER_10_12, PREFER_10_14],
-        expectedNoStrict: "11"
+        expected: "11"
     ).and(
         versions: [PREFER_10_11, PREFER_12, PREFER_10_14],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [PREFER_12, FIXED_11],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: [IGNORE, "11"],
         ignore: true
     ).and(
         versions: [PREFER_11, FIXED_12],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [IGNORE, "12"]
     ).and(
         versions: [PREFER_12, RANGE_10_11],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: [IGNORE, "11"],
         ignore: true
     ).and(
         versions: [PREFER_12, RANGE_10_12],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [IGNORE, "12"],
         ignore: true
     ).and(
         versions: [PREFER_12, RANGE_10_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [IGNORE, "12"]
     ).and(
         versions: [PREFER_11, RANGE_12_14],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "13"]
     ).and(
         versions: [PREFER_11, PREFER_12, RANGE_10_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [IGNORE, IGNORE, "12"]
     ).and(
         versions: [PREFER_11, PREFER_13, RANGE_10_12],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: [IGNORE, IGNORE, "11"],
         ignore: true
     ).and(
         versions: [PREFER_7_8, FIXED_12],  // No version satisfies the range [7,8]
-        expectedNoStrict: FAILED
+        expected: FAILED
     ).and(
         versions: [PREFER_14_16, FIXED_12], // No version satisfies the range [14,16]
-        expectedNoStrict: FAILED
+        expected: FAILED
     )
 
     public static final StrictPermutationsProvider SCENARIOS_TWO_DEPENDENCIES = StrictPermutationsProvider.check(
         versions: [FIXED_7, FIXED_13],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, "13"]
     ).and(
         versions: [FIXED_12, FIXED_13],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, "13"]
     ).and(
         versions: [FIXED_12, RANGE_10_11],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: ["12", REJECTED]
     ).and(
         versions: [FIXED_12, RANGE_10_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: ["12", "12"]
     ).and(
         versions: [FIXED_12, RANGE_13_14],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, "13"]
     ).and(
         versions: [FIXED_12, RANGE_7_8],  // No version satisfies the range [7,8]
-        expectedNoStrict: FAILED,
+        expected: FAILED,
         expectedStrict: [FAILED, FAILED]
     ).and(
         versions: [FIXED_12, RANGE_14_16], // No version satisfies the range [14,16]
-        expectedNoStrict: FAILED,
+        expected: FAILED,
         expectedStrict: [FAILED, FAILED]
     ).and(
         versions: [RANGE_10_11, FIXED_10],
-        expectedNoStrict: "10",
+        expected: "10",
         expectedStrict: ["10", "10"]
     ).and(
         versions: [RANGE_10_14, FIXED_13],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: ["13", "13"]
     ).and(
         versions: [RANGE_10_14, RANGE_10_11],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: ["11", "11"]
     ).and(
         versions: [RANGE_10_14, RANGE_10_16],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: ["13", "13"]
     ).and(
         versions: [DYNAMIC_PLUS, FIXED_11],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "11"]
     ).and(
         versions: [DYNAMIC_PLUS, RANGE_10_12],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "12"]
     ).and(
         versions: [DYNAMIC_PLUS, RANGE_10_16],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "13"]
     ).and(
         versions: [DYNAMIC_LATEST, FIXED_11],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "11"]
     ).and(
         versions: [DYNAMIC_LATEST, RANGE_10_12],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "12"]
     ).and(
         versions: [DYNAMIC_LATEST, RANGE_10_16],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [IGNORE, "13"]
     )
 
     public static final StrictPermutationsProvider SCENARIOS_DEPENDENCY_WITH_REJECT = StrictPermutationsProvider.check(
         versions: [FIXED_12, REJECT_11],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [FIXED_12, REJECT_12],
-        expectedNoStrict: REJECTED
+        expected: REJECTED
     ).and(
         versions: [FIXED_12, REJECT_13],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [RANGE_10_12, REJECT_11],
-        expectedNoStrict: "12"
+        expected: "12"
     ).and(
         versions: [RANGE_10_12, REJECT_12],
-        expectedNoStrict: "11"
+        expected: "11"
     ).and(
         versions: [RANGE_10_12, REJECT_13],
-        expectedNoStrict: "12"
+        expected: "12"
     )
 
     public static final StrictPermutationsProvider SCENARIOS_THREE_DEPENDENCIES = StrictPermutationsProvider.check(
         versions: [FIXED_10, FIXED_12, FIXED_13],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, REJECTED, "13"]
     ).and(
         versions: [FIXED_10, FIXED_12, RANGE_10_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, "12", "12"]
     ).and(
         versions: [FIXED_10, RANGE_10_11, RANGE_10_14],
-        expectedNoStrict: "10",
+        expected: "10",
         expectedStrict: ["10", "10", "10"]
     ).and(
         versions: [FIXED_10, RANGE_10_11, RANGE_13_14],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, REJECTED, "13"]
     ).and(
         versions: [FIXED_10, RANGE_11_12, RANGE_10_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, "12", "12"]
     ).and(
         versions: [RANGE_10_11, RANGE_10_12, RANGE_10_14],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: ["11", "11", "11"]
     ).and(
         versions: [RANGE_10_11, RANGE_10_12, RANGE_13_14],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, REJECTED, "13"]
     ).and(
         versions: [FIXED_10, FIXED_10, FIXED_12],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, REJECTED, "12"]
     ).and(
         versions: [FIXED_10, FIXED_12, RANGE_12_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, "12", "12"]
     )
 
     public static final StrictPermutationsProvider SCENARIOS_WITH_REJECT = StrictPermutationsProvider.check(
         versions: [FIXED_11, FIXED_12, REJECT_11],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, "12", IGNORE]
     ).and(
         versions: [FIXED_11, FIXED_12, REJECT_12],
-        expectedNoStrict: REJECTED,
+        expected: REJECTED,
         expectedStrict: [REJECTED, REJECTED, IGNORE]
     ).and(
         versions: [FIXED_11, FIXED_12, REJECT_13],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, "12", IGNORE]
     ).and(
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_11],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: ["12", "12", "12", IGNORE]
     ).and(
         ignore: true, // This will require resolving RANGE_10_14 with the knowledge that FIXED_12 rejects < "12".
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_12],
-        expectedNoStrict: "13",
+        expected: "13",
     ).and(
         versions: [RANGE_10_14, RANGE_10_12, FIXED_12, REJECT_13],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: ["12", "12", "12", IGNORE]
     ).and(
         versions: [RANGE_10_12, RANGE_13_14, REJECT_11],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, "13", IGNORE]
     ).and(
         versions: [RANGE_10_12, RANGE_13_14, REJECT_12],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, "13", IGNORE]
     ).and(
         versions: [RANGE_10_12, RANGE_13_14, REJECT_13],
-        expectedNoStrict: REJECTED,
+        expected: REJECTED,
         expectedStrict: [REJECTED, REJECTED, IGNORE]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_11],
-        expectedNoStrict: "10",
+        expected: "10",
         expectedStrict: [REJECTED, "10", "10", IGNORE]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_12],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: [REJECTED, "11", "11", IGNORE]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, REJECT_13],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: [REJECTED, "11", "11", IGNORE]
     )
 
     public static final StrictPermutationsProvider SCENARIOS_FOUR_DEPENDENCIES = StrictPermutationsProvider.check(
         versions: [FIXED_9, FIXED_10, FIXED_11, FIXED_12],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, REJECTED, REJECTED, "12"]
     ).and(
         versions: [FIXED_10, RANGE_10_11, FIXED_12, RANGE_12_14],
-        expectedNoStrict: "12",
+        expected: "12",
         expectedStrict: [REJECTED, REJECTED, "12", "12"]
     ).and(
         versions: [FIXED_10, RANGE_10_11, RANGE_10_12, RANGE_13_14],
-        expectedNoStrict: "13",
+        expected: "13",
         expectedStrict: [REJECTED, REJECTED, REJECTED, "13"]
     ).and(
         versions: [FIXED_9, RANGE_10_11, RANGE_10_12, RANGE_10_14],
-        expectedNoStrict: "11",
+        expected: "11",
         expectedStrict: [REJECTED, "11", "11", "11"]
     )
     private static RenderableVersion fixed(int version) {
@@ -457,12 +457,12 @@ class VersionRangeResolveTestScenarios {
 
         StrictPermutationsProvider and(Map config) {
             assert config.versions
-            assert config.expectedNoStrict
+            assert config.expected
 
             ++batchCount
             if (!config.ignore) {
                 List<RenderableVersion> versions = config.versions
-                String expected = config.expectedNoStrict
+                String expected = config.expected
                 List<String> expectedStrict = config.expectedStrict
                 List<Batch> iterations = []
                 String batchName = config.description ?: "#${batchCount} (${versions})"

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -560,9 +560,8 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 implementation "org.apache.commons:commons-compress:1.5"
                 constraints {
                     api "commons-logging:commons-logging:1.1"
-                    implementation("commons-logging:commons-logging") {
-                        version { prefer "1.2" }
-                    }
+                    implementation "commons-logging:commons-logging:1.2"
+                    
                     implementation("org.tukaani:xz") {
                         version { strictly "1.6" }
                     }
@@ -605,11 +604,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 noMoreExcludes()
             }
             constraint('commons-logging:commons-logging:1.1') { rejects() }
-            constraint('commons-logging:commons-logging:') {
-                prefers('1.2')
-                strictly(null)
-                rejects()
-            }
+            constraint('commons-logging:commons-logging:1.2') { rejects() }
 
             dependency('org.apache.commons:commons-compress:1.5') {
                 rejects()


### PR DESCRIPTION
This PR introduces a difference in the way that 'prefer' constraints are resolved in the presence of other "strong" constraints. Now, a 'prefer' constraint is only weakly honoured, and will not cause the resolution of a version that conflicts with a 'strictly' or 'require' constraint. (Note that 'org:foo:1.0' defines a 'require' version constraint).