### PR TITLE
Decrease first use of largeJavaMultiProjectKotlinDsl runs to 5

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -61,8 +61,8 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
 
         where:
         testProject                         | runs
-        LARGE_MONOLITHIC_JAVA_PROJECT       | null
-        LARGE_JAVA_MULTI_PROJECT            | null
+        LARGE_MONOLITHIC_JAVA_PROJECT       | 10
+        LARGE_JAVA_MULTI_PROJECT            | 10
         LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL | 5
     }
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -39,6 +39,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
+        runner.runs = runs
         runner.useDaemon = false
         runner.targetVersions = ["4.10-20180808213557+0000"]
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
@@ -59,10 +60,10 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         result.assertCurrentVersionHasNotRegressed()
 
         where:
-        testProject                              | _
-        LARGE_MONOLITHIC_JAVA_PROJECT            | _
-        LARGE_JAVA_MULTI_PROJECT                 | _
-        LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL      | _
+        testProject                         | runs
+        LARGE_MONOLITHIC_JAVA_PROJECT       | null
+        LARGE_JAVA_MULTI_PROJECT            | null
+        LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL | 5
     }
 
     @Unroll


### PR DESCRIPTION
Currently, first use of largeJavaMultiProjectKotlinDsl's run count is 40, and each running costs 1.5min,
which means each time it needs to run (40+40)*1.5=120min, that's too long. Now we're decreasing the run count to 5.
