### PR TITLE
Make Lombok work in forked compilers

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
@@ -293,5 +293,4 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
         then:
         succeeds "compileJava"
     }
-
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AnnotationProcessingSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AnnotationProcessingSmokeTest.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.smoketests
+
+import spock.lang.Unroll
+
+class AnnotationProcessingSmokeTest extends AbstractSmokeTest {
+
+    @Unroll
+    def 'project lombok works when options.fork=#fork'() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+            ${jcenterRepository()}
+            dependencies {
+                compileOnly 'org.projectlombok:lombok:1.18.2'
+                annotationProcessor 'org.projectlombok:lombok:1.18.2'
+            }
+            compileJava.options.fork = $fork
+        """
+        file("src/main/java/ValExample.java") << """
+            import java.util.ArrayList;
+            import java.util.HashMap;
+            import lombok.val;
+            
+            public class ValExample {
+              public String example() {
+                val example = new ArrayList<String>();
+                example.add("Hello, World!");
+                val foo = example.get(0);
+                return foo.toLowerCase();
+              }
+              
+              public void example2() {
+                val map = new HashMap<Integer, String>();
+                map.put(0, "zero");
+                map.put(5, "five");
+                for (val entry : map.entrySet()) {
+                  System.out.printf("%d: %s\\n", entry.getKey(), entry.getValue());
+                }
+              }
+            }
+        """
+
+        expect:
+        runner("compileJava").build()
+
+        where:
+        fork << [true, false]
+    }
+}


### PR DESCRIPTION
Lombok (and potentially other processors) access certain compiler
internals to do their magic. While this is not valid according to
the processing spec, we still need to support it unless we want to
annoy a big part of our user base.