### PR TITLE
Ensure file lock is released before cache cleanup

### DIFF
--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheAccess.java
@@ -165,6 +165,10 @@ public class DefaultCacheAccess implements CacheCoordinator {
         try {
             // Take ownership
             takeOwnershipNow();
+            if (fileLockHeldByOwner != null) {
+                fileLockHeldByOwner.run();
+            }
+            crossProcessCacheAccess.close();
             if (cleanupAction != null) {
                 try {
                     if (cleanupAction.requiresCleanup()) {
@@ -174,10 +178,6 @@ public class DefaultCacheAccess implements CacheCoordinator {
                     LOG.debug("Cache {} could not run cleanup action {}", cacheDisplayName, cleanupAction);
                 }
             }
-            if (fileLockHeldByOwner != null) {
-                fileLockHeldByOwner.run();
-            }
-            crossProcessCacheAccess.close();
             if (cacheClosedCount != 1) {
                 LOG.debug("Cache {} was closed {} times.", cacheDisplayName, cacheClosedCount);
             }


### PR DESCRIPTION
Caches with on-demand locking keep hold of file locks unless contended
by other Gradle processes. Prior to this commit, such previously
acquired file locks were held for the complete duration of cache
cleanup only to be released immediately afterwards. While cache cleanup
was running, requests to release such file locks from other processes
(via `DefaultFileLockContentionHandler`) were not processed because the
`stateLock` of `DefaultCacheAccess` was already locked by another
thread and thus, the `ContentionAction` in
`LockOnDemandCrossProcessCacheAccess` was blocked until the `close()`
method in `DefaultCacheAccess` was finished.

Since cache cleanup only deletes files that are no longer in use, it
does not use file locking (which would not work anyway because the
current cache access infrastructure is not usable while the cache is
already being closed). Thus, this commit closes the
`CrossProcessCacheAccess` of the `DefaultCacheAccess` *before* cleaning
up caches.

Issue: gradle/gradle-private#1412