### PR TITLE
Rename a new tooling API method for clarity

### DIFF
--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/GradleBuildBuilderTest.groovy
@@ -56,7 +56,7 @@ class GradleBuildBuilderTest extends Specification {
         model.projects*.name == ["root", "child1", "child2"]
         model.projects*.path == [":", ":child1", ":child2"]
         model.includedBuilds.empty
-        model.allBuilds.empty
+        model.editableBuilds.empty
 
         where:
         startProject | _
@@ -120,12 +120,12 @@ class GradleBuildBuilderTest extends Specification {
         model2.rootDir == dir2
         model2.includedBuilds.empty
 
-        model.allBuilds.size() == 2
-        model.allBuilds[0] == model1
-        model.allBuilds[1] == model2
+        model.editableBuilds.size() == 2
+        model.editableBuilds[0] == model1
+        model.editableBuilds[1] == model2
 
-        model1.allBuilds.empty
-        model2.allBuilds.empty
+        model1.editableBuilds.empty
+        model2.editableBuilds.empty
     }
 
     interface TestIncludedBuild extends IncludedBuild, IncludedBuildState {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r410/GradleBuildModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r410/GradleBuildModelCrossVersionSpec.groovy
@@ -82,17 +82,17 @@ class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
         GradleBuild rootBuild = loadToolingModel(GradleBuild)
 
         then:
-        rootBuild.allBuilds.size() == 2
+        rootBuild.editableBuilds.size() == 2
 
-        def buildB = rootBuild.allBuilds[0]
+        def buildB = rootBuild.editableBuilds[0]
         buildB.buildIdentifier.rootDir == buildBDir
         buildB.rootProject.name == "buildB"
-        buildB.allBuilds.empty
+        buildB.editableBuilds.empty
 
-        def buildC = rootBuild.allBuilds[1]
+        def buildC = rootBuild.editableBuilds[1]
         buildC.buildIdentifier.rootDir == buildCDir
         buildC.rootProject.name == "buildC"
-        buildC.allBuilds.empty
+        buildC.editableBuilds.empty
     }
 
     @ToolingApiVersion(">=4.10")
@@ -116,16 +116,16 @@ class GradleBuildModelCrossVersionSpec extends ToolingApiSpecification {
         GradleBuild rootBuild = loadToolingModel(GradleBuild)
 
         then:
-        rootBuild.allBuilds.size() == 2
+        rootBuild.editableBuilds.size() == 2
 
-        def buildB = rootBuild.allBuilds[0]
+        def buildB = rootBuild.editableBuilds[0]
         buildB.buildIdentifier.rootDir == buildBDir
         buildB.rootProject.name == "buildB"
-        buildB.allBuilds.empty
+        buildB.editableBuilds.empty
 
-        def buildC = rootBuild.allBuilds[1]
+        def buildC = rootBuild.editableBuilds[1]
         buildC.buildIdentifier.rootDir == buildCDir
         buildC.rootProject.name == "buildC"
-        buildC.allBuilds.empty
+        buildC.editableBuilds.empty
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/IncludedBuildsMixin.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/IncludedBuildsMixin.java
@@ -34,7 +34,7 @@ public class IncludedBuildsMixin implements Serializable {
         return ImmutableDomainObjectSet.of(Collections.<GradleBuild>emptyList());
     }
 
-    public DomainObjectSet<? extends GradleBuild> getAllBuilds() {
+    public DomainObjectSet<? extends GradleBuild> getEditableBuilds() {
         return gradleBuild.getIncludedBuilds();
     }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/gradle/DefaultGradleBuild.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/gradle/DefaultGradleBuild.java
@@ -47,7 +47,7 @@ public class DefaultGradleBuild implements Serializable, GradleBuildIdentity {
         projects.add(project);
     }
 
-    public Set<DefaultGradleBuild> getAllBuilds() {
+    public Set<DefaultGradleBuild> getEditableBuilds() {
         return allBuilds;
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/gradle/GradleBuild.java
@@ -50,19 +50,19 @@ public interface GradleBuild extends Model, BuildModel {
     DomainObjectSet<? extends BasicGradleProject> getProjects();
 
     /**
-     * Returns the included builds that were referenced by this build.
+     * Returns the included builds that were referenced by this build. This is the set of builds that were directly included by this build via its {@link org.gradle.api.initialization.Settings} instance.
      *
      * @since 3.3
      */
     DomainObjectSet<? extends GradleBuild> getIncludedBuilds();
 
     /**
-     * Returns all builds contained in this build, and for which tooling models should be built when importing into an IDE. This is not necessarily the same as {@link #getIncludedBuilds()}, as an included build is not necessarily 'owned' by a build that includes it.
+     * Returns all builds contained in this build for which tooling models should be built when importing into an IDE.
      *
-     * <p>For the root build, this set contains all builds that participate in the composite build, including those from all nested included builds. For other builds, this set is empty.</p>
+     * <p>This is not always the same the builds returned by {@link #getIncludedBuilds()}. For the root build, the 'editable' builds set contains all builds that participate in the composite build, including those directly included by the root build plus all builds included by any nested included builds transitively. For all other builds, this set is empty.</p>
      *
      * @since 4.10
      */
     @Incubating
-    DomainObjectSet<? extends GradleBuild> getAllBuilds();
+    DomainObjectSet<? extends GradleBuild> getEditableBuilds();
 }

--- a/subprojects/tooling-builders-native/src/crossVersionTest/groovy/org/gradle/language/cpp/tooling/r410/FetchAllCppProjects.java
+++ b/subprojects/tooling-builders-native/src/crossVersionTest/groovy/org/gradle/language/cpp/tooling/r410/FetchAllCppProjects.java
@@ -31,7 +31,7 @@ public class FetchAllCppProjects implements BuildAction<List<CppProject>>, Seria
     public List<CppProject> execute(BuildController controller) {
         List<CppProject> projects = new ArrayList<CppProject>();
         collectModelsForBuild(controller, controller.getBuildModel(), projects);
-        for (GradleBuild build : controller.getBuildModel().getAllBuilds()) {
+        for (GradleBuild build : controller.getBuildModel().getEditableBuilds()) {
             collectModelsForBuild(controller, build, projects);
         }
         return projects;


### PR DESCRIPTION
### Context

Rename a tooling API method and update Javadocs to hopefully make the purpose of the method clearer.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
