### PR TITLE
Improve performance for getRegularFileSnapshot

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -93,6 +93,16 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
     @Override
     public HashCode getRegularFileContentHash(final File file) {
         final String absolutePath = file.getAbsolutePath();
+        FileMetadataSnapshot metadata = fileSystemMirror.getMetadata(absolutePath);
+        if (metadata != null) {
+            if (metadata.getType() != FileType.RegularFile) {
+                return null;
+            }
+            PhysicalSnapshot snapshot = fileSystemMirror.getSnapshot(absolutePath);
+            if (snapshot != null) {
+                return snapshot.getHash();
+            }
+        }
         return producingSnapshots.guardByKey(absolutePath, new Factory<HashCode>() {
             @Nullable
             @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/DefaultFileSystemSnapshotter.java
@@ -92,21 +92,12 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
 
     @Override
     public HashCode getRegularFileContentHash(final File file) {
-        final String absolutePath = file.getAbsolutePath();
-        PhysicalSnapshot snapshot = fileSystemMirror.getSnapshot(absolutePath);
-        if (snapshot != null) {
-            return snapshot.getType() == FileType.RegularFile ? snapshot.getHash() : null;
-        }
-        FileMetadataSnapshot metadata = fileSystemMirror.getMetadata(absolutePath);
-        if (metadata != null && metadata.getType() != FileType.RegularFile) {
-            return null;
-        }
-
+        String absolutePath = file.getAbsolutePath();
+        final String internedAbsolutePath = internPath(file);
         return producingSnapshots.guardByKey(absolutePath, new Factory<HashCode>() {
             @Nullable
             @Override
             public HashCode create() {
-                String internedAbsolutePath = internPath(file);
                 FileMetadataSnapshot metadata = statAndCache(internedAbsolutePath, file);
                 if (metadata.getType() != FileType.RegularFile) {
                     return null;

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/nativeplatform/RealWorldNativePluginPerformanceTest.groovy
@@ -38,7 +38,6 @@ class RealWorldNativePluginPerformanceTest extends AbstractCrossVersionPerforman
         runner.tasksToRun = ['build']
         runner.gradleOpts = ["-Xms1500m", "-Xmx2500m"]
         runner.warmUpRuns = 5
-        runner.targetVersions = ["4.10-20180804183336+0000"]
         runner.runs = 10
 
         if (parallelWorkers) {


### PR DESCRIPTION
By interning the path only when necessary.

This fixes a performance regression for `build on nativeMonolithicOverlapping with 0 parallel workers`. See https://builds.gradle.org/viewLog.html?buildId=14777265&buildTypeId=Gradle_Check_PerformanceTestCoordinator&tab=report_project944_Performance.