### PR TITLE
Use one build operation per transform step

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -205,10 +205,10 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         then:
         output.count("> Transform lib1.jar (project :lib) with MakeBlueToGreenThings") == 1
         output.count("> Transform lib2.jar (project :lib) with MakeBlueToGreenThings") == 1
-        output.count("> Transform lib1.jar.green with MakeGreenToYellowThings") == 1
-        output.count("> Transform lib2.jar.green with MakeGreenToYellowThings") == 1
-        output.count("> Transform lib1.jar.green with MakeGreenToRedThings") == 1
-        output.count("> Transform lib2.jar.green with MakeGreenToRedThings") == 1
+        output.count("> Transform lib1.jar (project :lib) with MakeGreenToYellowThings") == 1
+        output.count("> Transform lib2.jar (project :lib) with MakeGreenToYellowThings") == 1
+        output.count("> Transform lib1.jar (project :lib) with MakeGreenToRedThings") == 1
+        output.count("> Transform lib2.jar (project :lib) with MakeGreenToRedThings") == 1
     }
 
     def "each file is transformed once per set of configuration parameters"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformInfoFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformInfoFactory.java
@@ -62,7 +62,7 @@ public class DefaultTransformInfoFactory implements TransformInfoFactory {
                 transformInfo = TransformInfo.initial(transformerChain.iterator().next(), singleArtifactSet);
             } else {
                 TransformInfo previous = getOrCreate(singleArtifactSet, transformerChain.subList(0, transformerChain.size() - 1));
-                transformInfo = TransformInfo.chained(transformerChain.get(transformerChain.size() - 1), previous);
+                transformInfo = TransformInfo.chained(transformerChain.get(transformerChain.size() - 1), previous, singleArtifactSet.getArtifactId());
             }
             transformations.put(key, transformInfo);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformArtifactOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformArtifactOperation.java
@@ -33,15 +33,13 @@ class TransformArtifactOperation implements RunnableBuildOperation {
     private final ComponentArtifactIdentifier artifactId;
     private final File file;
     private final ArtifactTransformer transform;
-    private final BuildOperationCategory category;
     private Throwable failure;
     private List<File> result;
 
-    TransformArtifactOperation(ComponentArtifactIdentifier artifactId,  File file, ArtifactTransformer transform, BuildOperationCategory category) {
+    TransformArtifactOperation(ComponentArtifactIdentifier artifactId, File file, ArtifactTransformer transform) {
         this.artifactId = artifactId;
         this.file = file;
         this.transform = transform;
-        this.category = category;
     }
 
     @Override
@@ -61,7 +59,7 @@ class TransformArtifactOperation implements RunnableBuildOperation {
         String displayName = "Transform " + artifactId.getDisplayName() + " with " + transform.getDisplayName();
         return BuildOperationDescriptor.displayName(displayName)
             .progressDisplayName(displayName)
-            .operationType(category);
+            .operationType(BuildOperationCategory.UNCATEGORIZED);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformFileOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformFileOperation.java
@@ -31,14 +31,12 @@ class TransformFileOperation implements RunnableBuildOperation {
     private static final Logger LOGGER = LoggerFactory.getLogger(TransformFileOperation.class);
     private final File file;
     private final ArtifactTransformer transform;
-    private final BuildOperationCategory category;
     private Throwable failure;
     private List<File> result;
 
-    TransformFileOperation(File file, ArtifactTransformer transform, BuildOperationCategory category) {
+    TransformFileOperation(File file, ArtifactTransformer transform) {
         this.file = file;
         this.transform = transform;
-        this.category = category;
     }
 
     @Override
@@ -58,7 +56,7 @@ class TransformFileOperation implements RunnableBuildOperation {
         String displayName = "Transform " + file.getName() + " with " + transform.getDisplayName();
         return BuildOperationDescriptor.displayName(displayName)
             .progressDisplayName(displayName)
-            .operationType(category);
+            .operationType(BuildOperationCategory.UNCATEGORIZED);
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInfo.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInfo.java
@@ -185,7 +185,7 @@ public abstract class TransformInfo extends WorkInfo {
                 }
                 ResolvedArtifactResult artifact = Iterables.getOnlyElement(visitor.getArtifacts());
 
-                TransformArtifactOperation operation = new TransformArtifactOperation(artifact.getId(), artifact.getFile(), artifactTransformer, BuildOperationCategory.UNCATEGORIZED);
+                TransformArtifactOperation operation = new TransformArtifactOperation(artifact.getId(), artifact.getFile(), artifactTransformer);
                 operation.run(context);
                 this.failure = operation.getFailure();
                 this.result = operation.getResult();
@@ -240,7 +240,7 @@ public abstract class TransformInfo extends WorkInfo {
                 }
                 ImmutableList.Builder<File> builder = ImmutableList.builder();
                 for (File inputFile : previousTransform.getResult()) {
-                    TransformFileOperation operation = new TransformFileOperation(inputFile, artifactTransformer, BuildOperationCategory.UNCATEGORIZED);
+                    TransformFileOperation operation = new TransformFileOperation(inputFile, artifactTransformer);
                     operation.run(context);
                     if (operation.getFailure() != null) {
                         this.failure = operation.getFailure();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInfo.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformInfo.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Iterables;
 import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.ResolveException;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
@@ -31,6 +32,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import org.gradle.execution.taskgraph.TaskDependencyResolver;
 import org.gradle.execution.taskgraph.WorkInfo;
 import org.gradle.internal.operations.BuildOperationCategory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
@@ -50,8 +53,8 @@ public abstract class TransformInfo extends WorkInfo {
     protected List<File> result;
     protected Throwable failure;
 
-    public static TransformInfo chained(UserCodeBackedTransformer current, TransformInfo previous) {
-        return new ChainedTransformInfo(current, previous);
+    public static TransformInfo chained(UserCodeBackedTransformer current, TransformInfo previous, ComponentArtifactIdentifier artifactId) {
+        return new ChainedTransformInfo(current, previous, artifactId);
     }
 
     public static TransformInfo initial(UserCodeBackedTransformer initial, BuildableSingleResolvedArtifactSet artifact) {
@@ -126,28 +129,10 @@ public abstract class TransformInfo extends WorkInfo {
 
         @Override
         public void execute(BuildOperationExecutor buildOperationExecutor) {
-            ResolveArtifacts resolveArtifacts = new ResolveArtifacts(artifactSet);
-            buildOperationExecutor.runAll(resolveArtifacts);
-            ResolvedArtifactCollectingVisitor visitor = new ResolvedArtifactCollectingVisitor();
-            resolveArtifacts.getResult().visit(visitor);
-            Set<Throwable> failures = visitor.getFailures();
-            if (!failures.isEmpty()) {
-                Throwable failure;
-                if (failures.size() == 1 && Iterables.getOnlyElement(failures) instanceof ResolveException) {
-                    failure = Iterables.getOnlyElement(failures);
-                } else {
-                    failure = new DefaultLenientConfiguration.ArtifactResolveException("artifacts", artifactTransformer.getDisplayName(), "artifact transform", failures);
-                }
-                this.failure = failure;
-                this.result = Collections.emptyList();
-                return;
-            }
-            ResolvedArtifactResult artifact = Iterables.getOnlyElement(visitor.getArtifacts());
-
-            TransformArtifactOperation operation = new TransformArtifactOperation(artifact.getId(), artifact.getFile(), artifactTransformer, BuildOperationCategory.TRANSFORM);
-            buildOperationExecutor.run(operation);
-            this.result = operation.getResult();
-            this.failure = operation.getFailure();
+            InitialArtifactTransformationStepOperation transformationStep = new InitialArtifactTransformationStepOperation(buildOperationExecutor);
+            buildOperationExecutor.run(transformationStep);
+            this.result = transformationStep.getResult();
+            this.failure = transformationStep.getFailure();
         }
 
         @Override
@@ -162,45 +147,129 @@ public abstract class TransformInfo extends WorkInfo {
         private Set<WorkInfo> getDependencies(TaskDependencyResolver dependencyResolver) {
             return dependencyResolver.resolveDependenciesFor(null, artifactSet.getBuildDependencies());
         }
+
+        private class InitialArtifactTransformationStepOperation implements RunnableBuildOperation {
+            private List<File> result;
+            private Throwable failure;
+            private final BuildOperationExecutor buildOperationExecutor;
+
+            public InitialArtifactTransformationStepOperation(BuildOperationExecutor buildOperationExecutor) {
+                this.buildOperationExecutor = buildOperationExecutor;
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                String displayName = "Transform " + artifactSet.getArtifactId().getDisplayName() + " with " + artifactTransformer.getDisplayName();
+                return BuildOperationDescriptor.displayName(displayName)
+                    .progressDisplayName(displayName)
+                    .operationType(BuildOperationCategory.TRANSFORM);
+            }
+
+            @Override
+            public void run(BuildOperationContext context) {
+                ResolveArtifacts resolveArtifacts = new ResolveArtifacts(artifactSet);
+                buildOperationExecutor.runAll(resolveArtifacts);
+                ResolvedArtifactCollectingVisitor visitor = new ResolvedArtifactCollectingVisitor();
+                resolveArtifacts.getResult().visit(visitor);
+                Set<Throwable> failures = visitor.getFailures();
+                if (!failures.isEmpty()) {
+                    Throwable failure;
+                    if (failures.size() == 1 && Iterables.getOnlyElement(failures) instanceof ResolveException) {
+                        failure = Iterables.getOnlyElement(failures);
+                    } else {
+                        failure = new DefaultLenientConfiguration.ArtifactResolveException("artifacts", artifactTransformer.getDisplayName(), "artifact transform", failures);
+                    }
+                    this.failure = failure;
+                    this.result = Collections.emptyList();
+                    return;
+                }
+                ResolvedArtifactResult artifact = Iterables.getOnlyElement(visitor.getArtifacts());
+
+                TransformArtifactOperation operation = new TransformArtifactOperation(artifact.getId(), artifact.getFile(), artifactTransformer, BuildOperationCategory.UNCATEGORIZED);
+                operation.run(context);
+                this.failure = operation.getFailure();
+                this.result = operation.getResult();
+            }
+
+            public List<File> getResult() {
+                return result;
+            }
+
+            public Throwable getFailure() {
+                return failure;
+            }
+        }
     }
 
     private static class ChainedTransformInfo extends TransformInfo {
         private final TransformInfo previousTransform;
+        private final ComponentArtifactIdentifier artifactId;
 
-        public ChainedTransformInfo(UserCodeBackedTransformer artifactTransformer, TransformInfo previousTransform) {
+        public ChainedTransformInfo(UserCodeBackedTransformer artifactTransformer, TransformInfo previousTransform, ComponentArtifactIdentifier artifactId) {
             super(artifactTransformer);
             this.previousTransform = previousTransform;
+            this.artifactId = artifactId;
         }
 
         @Override
         public void execute(BuildOperationExecutor buildOperationExecutor) {
-            Throwable previousFailure = previousTransform.getFailure();
-            if (previousFailure != null) {
-                this.failure = previousFailure;
-                this.result = Collections.emptyList();
-                return;
-            }
-            ImmutableList.Builder<File> builder = ImmutableList.builder();
-            for (File inputFile : previousTransform.getResult()) {
-                TransformFileOperation operation = new TransformFileOperation(inputFile, artifactTransformer, BuildOperationCategory.TRANSFORM);
-                buildOperationExecutor.run(operation);
-                if (operation.getFailure() != null) {
-                    this.failure = operation.getFailure();
-                    this.result = Collections.emptyList();
-                    return;
-                }
-                List<File> result = operation.getResult();
-                if (result != null) {
-                    builder.addAll(result);
-                }
-            }
-            this.result = builder.build();
+            ChainedArtifactTransformStepOperation chainedArtifactTransformStep = new ChainedArtifactTransformStepOperation();
+            buildOperationExecutor.run(chainedArtifactTransformStep);
+            this.result = chainedArtifactTransformStep.getResult();
+            this.failure = chainedArtifactTransformStep.getFailure();
         }
 
         @Override
         public void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<WorkInfo> processHardSuccessor) {
             addDependencySuccessor(previousTransform);
             processHardSuccessor.execute(previousTransform);
+        }
+
+        private class ChainedArtifactTransformStepOperation implements RunnableBuildOperation {
+
+            private List<File> result;
+            private Throwable failure;
+
+            @Override
+            public void run(BuildOperationContext context) {
+                Throwable previousFailure = previousTransform.getFailure();
+                if (previousFailure != null) {
+                    this.failure = previousFailure;
+                    this.result = Collections.emptyList();
+                    return;
+                }
+                ImmutableList.Builder<File> builder = ImmutableList.builder();
+                for (File inputFile : previousTransform.getResult()) {
+                    TransformFileOperation operation = new TransformFileOperation(inputFile, artifactTransformer, BuildOperationCategory.UNCATEGORIZED);
+                    operation.run(context);
+                    if (operation.getFailure() != null) {
+                        this.failure = operation.getFailure();
+                        this.result = Collections.emptyList();
+                        return;
+                    }
+                    List<File> result = operation.getResult();
+                    if (result != null) {
+                        builder.addAll(result);
+                    }
+                }
+                this.result = builder.build();
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                String displayName = "Transform " + artifactId.getDisplayName() + " with " + artifactTransformer.getDisplayName();
+                return BuildOperationDescriptor.displayName(displayName)
+                    .progressDisplayName(displayName)
+                    .operationType(BuildOperationCategory.TRANSFORM);
+            }
+
+            public List<File> getResult() {
+                return result;
+            }
+
+            public Throwable getFailure() {
+                return failure;
+            }
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
-import org.gradle.internal.operations.BuildOperationCategory;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
@@ -45,7 +44,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     public void artifactAvailable(ResolvableArtifact artifact) {
         ComponentArtifactIdentifier artifactId = artifact.getId();
         File file = artifact.getFile();
-        TransformArtifactOperation operation = new TransformArtifactOperation(artifactId, file, transform, BuildOperationCategory.UNCATEGORIZED);
+        TransformArtifactOperation operation = new TransformArtifactOperation(artifactId, file, transform);
         artifactResults.put(artifactId, operation);
         if (transform.hasCachedResult(file)) {
             operation.run(null);
@@ -67,7 +66,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
 
     @Override
     public void fileAvailable(File file) {
-        TransformFileOperation operation = new TransformFileOperation(file, transform, BuildOperationCategory.UNCATEGORIZED);
+        TransformFileOperation operation = new TransformFileOperation(file, transform);
         fileResults.put(file, operation);
         if (transform.hasCachedResult(file)) {
             operation.run(null);


### PR DESCRIPTION
This fixes the problem that we show more than 100% in the progress
bar when there are artifact transforms producing more than one artifact.