### PR TITLE
Leverage defaultDependencies for zinc configuration

### DIFF
--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -22,6 +22,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.SourceDirectorySet;
@@ -72,8 +73,14 @@ public class ScalaBasePlugin implements Plugin<Project> {
         configureScaladoc(project, scalaRuntime);
     }
 
-    private static void configureConfigurations(Project project) {
-        project.getConfigurations().create(ZINC_CONFIGURATION_NAME).setVisible(false).setDescription("The Zinc incremental compiler to be used for this Scala project.");
+    private static void configureConfigurations(final Project project) {
+        project.getConfigurations().create(ZINC_CONFIGURATION_NAME).setVisible(false).setDescription("The Zinc incremental compiler to be used for this Scala project.")
+            .defaultDependencies(new Action<DependencySet>() {
+                @Override
+                public void execute(DependencySet dependencies) {
+                    dependencies.add(project.getDependencies().create("com.typesafe.zinc:zinc:" + DefaultScalaToolProvider.DEFAULT_ZINC_VERSION));
+                }
+            });
     }
 
     private static ScalaRuntime configureScalaRuntimeExtension(Project project) {
@@ -160,11 +167,7 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 compile.getConventionMapping().map("zincClasspath", new Callable<Configuration>() {
                     @Override
                     public Configuration call() throws Exception {
-                        Configuration config = project.getConfigurations().getAt(ZINC_CONFIGURATION_NAME);
-                        if (config.getDependencies().isEmpty()) {
-                            project.getDependencies().add("zinc", "com.typesafe.zinc:zinc:" + DefaultScalaToolProvider.DEFAULT_ZINC_VERSION);
-                        }
-                        return config;
+                        return project.getConfigurations().getAt(ZINC_CONFIGURATION_NAME);
                     }
                 });
             }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/plugins/scala/ScalaBasePluginTest.groovy
@@ -65,7 +65,7 @@ class ScalaBasePluginTest {
         project.sourceSets.create('custom')
         def task = project.tasks.compileCustomScala
         assert task.zincClasspath instanceof Configuration
-        assert task.zincClasspath.dependencies.find { it.name.contains('zinc') }
+        assert task.zincClasspath.incoming.dependencies.find { it.name.contains('zinc') }
     }
 
     @Test


### PR DESCRIPTION
This replaces the previous dependency injection through convention
mapping. The main benefit is that the `zinc` configuration is populated
whether or not the `zincClasspath` property is accessed.