### PR TITLE
Remove temporary method from `JavaPluginExtension`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -65,7 +65,7 @@ subprojects {
             val validateTaskProperties = tasks.register("validateTaskProperties", ValidateTaskProperties::class.java) {
                 outputFile.set(project.the<ReportingExtension>().baseDirectory.file("task-properties/report.txt"))
 
-                val mainSourceSet = project.java.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME]
+                val mainSourceSet = project.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME]
                 classes = mainSourceSet.output.classesDirs
                 classpath = mainSourceSet.compileClasspath
                 dependsOn(mainSourceSet.output)

--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -57,8 +57,4 @@ val buildReceiptResource = tasks.register<Copy>("buildReceiptResource") {
     destinationDir = file("${gradlebuildJava.generatedTestResourcesDir}/$buildReceiptPackage")
 }
 
-java.sourceSets {
-    "main" {
-        output.dir(mapOf("builtBy" to buildReceiptResource), gradlebuildJava.generatedTestResourcesDir)
-    }
-}
+sourceSets["main"].output.dir(mapOf("builtBy" to buildReceiptResource), gradlebuildJava.generatedTestResourcesDir)

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -64,7 +64,7 @@ val prepareVersionsInfo = tasks.register<PrepareVersionsInfo>("prepareVersionsIn
     mostRecentSnapshot = releasedVersions.mostRecentSnapshot
 }
 
-java.sourceSets["main"].output.dir(mapOf("builtBy" to prepareVersionsInfo), generatedResourcesDir)
+sourceSets["main"].output.dir(mapOf("builtBy" to prepareVersionsInfo), generatedResourcesDir)
 
 ideConfiguration {
     makeAllSourceDirsTestSourceDirsToWorkaroundIssuesWithIDEA13()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.experimental.categories.Category
 import org.junit.rules.TestName
 import spock.lang.AutoCleanup
+import spock.lang.Ignore
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -94,6 +95,7 @@ class GradleBuildPerformanceTest extends Specification {
         runner.testGroup = 'gradle build'
     }
 
+    @Ignore
     def "help on the gradle build comparing the build"() {
 
         given:

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.tasks.SourceSetContainer;
 
 /**
  * Common configuration for Java based projects. This is added by the {@link JavaBasePlugin}.
@@ -50,7 +49,4 @@ public interface JavaPluginExtension {
      * @param value The value for the target compatibility
      */
     void setTargetCompatibility(JavaVersion value);
-
-    // TODO - this will be removed
-    SourceSetContainer getSourceSets();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -19,7 +19,6 @@ package org.gradle.api.plugins.internal;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.tasks.SourceSetContainer;
 
 public class DefaultJavaPluginExtension implements JavaPluginExtension {
     private final JavaPluginConvention convention;
@@ -46,10 +45,5 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     @Override
     public void setTargetCompatibility(JavaVersion value) {
         convention.setTargetCompatibility(value);
-    }
-
-    @Override
-    public SourceSetContainer getSourceSets() {
-        return convention.getSourceSets();
     }
 }


### PR DESCRIPTION
### Context

This PR removes the `java.sourceSets` method. The top level `sourceSets` extension should be used instead and is also still available through the `JavaPluginConvention`.

This is a breaking change for Kotlkn DSL. The breakage is already noted in the release notes.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
