### PR TITLE
Emit build operation around rootProject notifications

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -43,6 +43,7 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
     def scriptFile = file('script.gradle')
 
     Long initScriptAppId
+    Long initOtherScriptAppId
     Long settingsScriptAppId
     Long rootProjectScriptAppId
     Long rootOtherScriptAppId
@@ -63,7 +64,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         sanityCheckApplicationIds()
 
         if (notEmpty(initFile)) {
-            initScriptAppId = findScriptApplicationId(targetsGradle())
+            initScriptAppId = findScriptApplicationId(targetsGradle(), scriptFile(initFile))
+        }
+        if (hasScript(initFile, scriptFile.name)) {
+            initOtherScriptAppId = findScriptApplicationId(targetsGradle(), scriptFile(scriptFile))
         }
         if (notEmpty(settingsFile)) {
             settingsScriptAppId = findScriptApplicationId(targetsSettings())
@@ -621,12 +625,19 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         }
 
         and:
+        // put these in different scripts so that we can track that they report the correct registrant,
+        // since allprojects callbacks are executed inside an internal rootProject listener
         initFile << """
             rootProject { project ->
                 ${addBeforeProjectListeners('init file rootProject')}
             }
+            apply from: file('$scriptFile.name')
+        """
+        scriptFile << """
+            println "applying script file"
             allprojects { project ->
-                ${addAfterProjectListeners('init file allprojects')}
+                println "script allprojects"
+                ${addAfterProjectListeners('script file allprojects')}
             }
         """
 
@@ -643,12 +654,12 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         and:
         def rootAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':' })
         verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, 1)
-        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init file allprojects', ['project.afterEvaluate(Closure)'])
+        verifyHasChildren(rootAfterEvaluated, initOtherScriptAppId, 'script file allprojects', ['project.afterEvaluate(Closure)'])
 
         and:
         def subAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':sub' })
         verifyExpectedNumberOfExecuteListenerChildren(subAfterEvaluated, 1)
-        verifyHasChildren(subAfterEvaluated, initScriptAppId, 'init file allprojects', ['project.afterEvaluate(Closure)'])
+        verifyHasChildren(subAfterEvaluated, initOtherScriptAppId, 'script file allprojects', ['project.afterEvaluate(Closure)'])
     }
 
     def 'decorated listener can be removed'() {
@@ -724,7 +735,7 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
     }
 
     private static boolean hasScript(TestFile file, String scriptName) {
-        file.exists() && file.text.indexOf("apply from: rootProject.file('$scriptName')") != -1
+        file.exists() && (file.text.indexOf("apply from: rootProject.file('$scriptName')") != -1 || file.text.indexOf("apply from: file('$scriptName')") != -1)
     }
 
     private Long findOpApplicationId(Class<? extends BuildOperationType<?, ?>> opType, Spec<? super BuildOperationRecord> predicate) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/NotifyRootProjectBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/NotifyRootProjectBuildOperationIntegrationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration
+
+
+import org.gradle.api.internal.tasks.RegisterTaskBuildOperationType
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.BuildOperationsFixture
+import org.gradle.internal.invocation.NotifyRootProjectBuildOperationType
+
+class NotifyRootProjectBuildOperationIntegrationTest extends AbstractIntegrationSpec {
+
+    def operations = new BuildOperationsFixture(executer, temporaryFolder)
+
+    def initFile = file('init.gradle')
+
+    private void run() {
+        def args = initFile.exists() ? ['-I', initFile.name, 'help'] : ['help']
+        succeeds(*args)
+
+        // useful for inspecting ops when things go wrong
+        operations.debugTree({ op -> !op.hasDetailsOfType(RegisterTaskBuildOperationType.Details) })
+    }
+
+    def 'rootProject notification emits build operation'() {
+        given:
+        initFile << "rootProject { }"
+        file('buildSrc/build.gradle') << ''
+        file('included/build.gradle') << ''
+        file('settings.gradle') << "includeBuild './included'"
+
+        when:
+        run()
+
+        then:
+        verifyExpectedNotifyRootProjectOp(':')
+        verifyExpectedNotifyRootProjectOp(':buildSrc')
+        verifyExpectedNotifyRootProjectOp(':included')
+    }
+
+    private void verifyExpectedNotifyRootProjectOp(String buildPath) {
+        def op = operations.only(NotifyRootProjectBuildOperationType, { it.details.buildPath == buildPath })
+        assert op.displayName == "Notify rootProject listeners"
+        assert op.children*.displayName == ["Execute 'rootProject {}' action"]
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/NotifyRootProjectBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/NotifyRootProjectBuildOperationType.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.invocation;
+
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.UsedByScanPlugin;
+
+/**
+ * An operation to run the rootProject lifecycle hook.
+ *
+ * @since 4.10
+ */
+public class NotifyRootProjectBuildOperationType implements BuildOperationType<NotifyRootProjectBuildOperationType.Details, NotifyRootProjectBuildOperationType.Result> {
+
+    @UsedByScanPlugin
+    public interface Details {
+        String getBuildPath();
+    }
+
+    @UsedByScanPlugin
+    public interface Result {
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -481,7 +481,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         throw new UnsupportedOperationException();
     }
 
-    static final NotifyRootProjectBuildOperationType.Result NOTIFY_ROOT_PROJECT_RESULT =  new NotifyRootProjectBuildOperationType.Result() {};
+    private static final NotifyRootProjectBuildOperationType.Result NOTIFY_ROOT_PROJECT_RESULT =  new NotifyRootProjectBuildOperationType.Result() {};
 
     private void executeRootProjectActions() {
         getBuildOperationExecutor().run(new RunnableBuildOperation() {

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -51,6 +51,11 @@ import org.gradle.internal.event.ListenerBroadcast;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.installation.CurrentGradleInstallation;
 import org.gradle.internal.installation.GradleInstallation;
+import org.gradle.internal.invocation.NotifyRootProjectBuildOperationType;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.resource.TextResourceLoader;
 import org.gradle.internal.scan.config.BuildScanConfigInit;
 import org.gradle.internal.service.ServiceRegistry;
@@ -91,7 +96,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
             @Override
             public void projectsLoaded(Gradle gradle) {
                 if (!rootProjectActions.isEmpty()) {
-                    services.get(CrossProjectConfigurator.class).rootProject(rootProject, rootProjectActions);
+                    executeRootProjectActions();
                 }
                 projectsLoaded = true;
             }
@@ -228,20 +233,24 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void rootProject(Action<? super Project> action) {
+        rootProject("rootProject", action);
+    }
+
+    private void rootProject(String listenerName, Action<? super Project> action) {
         if (projectsLoaded) {
             assert rootProject != null;
             action.execute(rootProject);
         } else {
             // only need to decorate when this callback is delayed
-            rootProjectActions.add(getListenerBuildOperationDecorator().decorate("rootProject", action));
+            rootProjectActions.add(getListenerBuildOperationDecorator().decorate(listenerName, action));
         }
     }
 
     @Override
     public void allprojects(final Action<? super Project> action) {
-        rootProject(new Action<Project>() {
+        rootProject("allprojects", new Action<Project>() {
             public void execute(Project project) {
-                project.allprojects(getListenerBuildOperationDecorator().decorate("allprojects", action));
+                project.allprojects(action);
             }
         });
     }
@@ -467,4 +476,32 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
         throw new UnsupportedOperationException();
     }
 
+    @Inject
+    protected BuildOperationExecutor getBuildOperationExecutor() {
+        throw new UnsupportedOperationException();
+    }
+
+    static final NotifyRootProjectBuildOperationType.Result NOTIFY_ROOT_PROJECT_RESULT =  new NotifyRootProjectBuildOperationType.Result() {};
+
+    private void executeRootProjectActions() {
+        getBuildOperationExecutor().run(new RunnableBuildOperation() {
+            @Override
+            public void run(BuildOperationContext context) {
+                services.get(CrossProjectConfigurator.class).rootProject(rootProject, rootProjectActions);
+                context.setResult(NOTIFY_ROOT_PROJECT_RESULT);
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor
+                    .displayName("Notify rootProject listeners")
+                    .details(new NotifyRootProjectBuildOperationType.Details() {
+                        @Override
+                        public String getBuildPath() {
+                            return getIdentityPath().getPath();
+                        }
+                    });
+            }
+        });
+    }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
@@ -314,10 +314,9 @@ class PluginApplicationBuildProgressCrossVersionSpec extends ToolingApiSpecifica
 
         java.parent == rootProjectAction.
             child("Cross-configure project :").
-            child('Execute rootProject listener').
+            child('Execute allprojects listener').
             child("Execute 'allprojects {}' action").
-            child("Cross-configure project :").
-            child('Execute allprojects listener')
+            child("Cross-configure project :")
         javaBase.parent == java
         base.parent == javaBase
     }


### PR DESCRIPTION
### Context
Required to distinguish rootProject and projectsLoaded listener executions, given that rootProject listener executions happen inside projectsLoaded as an implementation detail.

Pattern for new op follows existing `NotifyProjectBeforeEvaluatedBuildOperationType` etc etc ops

Also fixed a bug in attribution of listeners registered in `allprojects` callbacks.