### PR TITLE
Emit registration point in listener execution build operations

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/configuration/ExecuteUserLifecycleListenerBuildOperationIntegrationTest.groovy
@@ -117,11 +117,11 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
                 })
             """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.projectsLoaded(Action)',
-            'gradle.projectsLoaded(Closure)',
-            'gradle.addListener(BuildListener)',
-            'gradle.addBuildListener(BuildListener)'
+        def expectedGradleOps = [
+            expectedOp('Gradle.projectsLoaded', 'gradle.projectsLoaded(Action)'),
+            expectedOp('Gradle.projectsLoaded', 'gradle.projectsLoaded(Closure)'),
+            expectedOp('Gradle.addListener', 'gradle.addListener(BuildListener)'),
+            expectedOp('Gradle.addBuildListener', 'gradle.addBuildListener(BuildListener)')
         ]
 
         initFile << addGradleListeners('init')
@@ -134,10 +134,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         then:
         def projectsLoaded = operations.only(NotifyProjectsLoadedBuildOperationType, { it.details.buildPath == ':' })
-        verifyExpectedNumberOfExecuteListenerChildren(projectsLoaded, expectedGradleOpProgressMessages.size() * 3)
-        verifyHasChildren(projectsLoaded, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsLoaded, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsLoaded, settingsPluginAppId, 'settings plugin', expectedGradleOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(projectsLoaded, expectedGradleOps.size() * 3)
+        verifyHasChildren(projectsLoaded, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(projectsLoaded, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(projectsLoaded, settingsPluginAppId, 'settings plugin', expectedGradleOps)
     }
 
     def 'projectsEvaluated listeners are attributed to the correct registrant'() {
@@ -162,11 +162,11 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             })
         """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.projectsEvaluated(Action)',
-            'gradle.projectsEvaluated(Closure)',
-            'gradle.addListener(BuildListener)',
-            'gradle.addBuildListener(BuildListener)'
+        def expectedGradleOps = [
+            expectedOp('Gradle.projectsEvaluated', 'gradle.projectsEvaluated(Action)'),
+            expectedOp('Gradle.projectsEvaluated', 'gradle.projectsEvaluated(Closure)'),
+            expectedOp('Gradle.addListener', 'gradle.addListener(BuildListener)'),
+            expectedOp('Gradle.addBuildListener', 'gradle.addBuildListener(BuildListener)')
         ]
 
         and:
@@ -186,13 +186,13 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         then:
         def projectsEvaluated = operations.only(NotifyProjectsEvaluatedBuildOperationType)
-        verifyExpectedNumberOfExecuteListenerChildren(projectsEvaluated, expectedGradleOpProgressMessages.size() * 6)
-        verifyHasChildren(projectsEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsEvaluated, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsEvaluated, rootProjectScriptAppId, 'project script', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsEvaluated, rootProjectPluginAppId, 'project plugin', expectedGradleOpProgressMessages)
-        verifyHasChildren(projectsEvaluated, rootOtherScriptAppId, 'other script', expectedGradleOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(projectsEvaluated, expectedGradleOps.size() * 6)
+        verifyHasChildren(projectsEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(projectsEvaluated, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(projectsEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOps)
+        verifyHasChildren(projectsEvaluated, rootProjectScriptAppId, 'project script', expectedGradleOps)
+        verifyHasChildren(projectsEvaluated, rootProjectPluginAppId, 'project plugin', expectedGradleOps)
+        verifyHasChildren(projectsEvaluated, rootOtherScriptAppId, 'other script', expectedGradleOps)
     }
 
     def 'beforeEvaluate listeners are attributed to the correct registrant'() {
@@ -221,11 +221,11 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             })
         """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.beforeProject(Action)',
-            'gradle.beforeProject(Closure)',
-            'gradle.addListener(ProjectEvaluationListener)',
-            'gradle.addProjectEvaluationListener(ProjectEvaluationListener)'
+        def expectedGradleOps = [
+            expectedOp('Gradle.beforeProject', 'gradle.beforeProject(Action)'),
+            expectedOp('Gradle.beforeProject', 'gradle.beforeProject(Closure)'),
+            expectedOp('Gradle.addListener', 'gradle.addListener(ProjectEvaluationListener)'),
+            expectedOp('Gradle.addProjectEvaluationListener', 'gradle.addProjectEvaluationListener(ProjectEvaluationListener)')
         ]
         def addProjectListeners = { String source, String target = null ->
             """
@@ -239,9 +239,9 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             ${target == null ? '' : "}"}
         """
         }
-        def expectedProjectOpProgressMessages = [
-            'project.beforeEvaluate(Action)',
-            'project.beforeEvaluate(Closure)',
+        def expectedProjectOps = [
+            expectedOp('Project.beforeEvaluate', 'project.beforeEvaluate(Action)'),
+            expectedOp('Project.beforeEvaluate', 'project.beforeEvaluate(Closure)')
         ]
 
         and:
@@ -270,10 +270,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         then:
         def rootBeforeEvaluated = operations.only(NotifyProjectBeforeEvaluatedBuildOperationType, { it.details.projectPath == ':' })
-        verifyExpectedNumberOfExecuteListenerChildren(rootBeforeEvaluated, expectedGradleOpProgressMessages.size() * 3)
-        verifyHasChildren(rootBeforeEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(rootBeforeEvaluated, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(rootBeforeEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(rootBeforeEvaluated, expectedGradleOps.size() * 3)
+        verifyHasChildren(rootBeforeEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(rootBeforeEvaluated, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(rootBeforeEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOps)
         // these all execute too late to catch any beforeProject/beforeEvaluate callbacks for itself
         verifyHasNoChildren(rootBeforeEvaluated, rootProjectScriptAppId)
         verifyHasNoChildren(rootBeforeEvaluated, rootProjectPluginAppId)
@@ -284,11 +284,11 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         and:
         def subBeforeEvaluated = operations.only(NotifyProjectBeforeEvaluatedBuildOperationType, { it.details.projectPath == ':sub' })
-        verifyExpectedNumberOfExecuteListenerChildren(subBeforeEvaluated, expectedGradleOpProgressMessages.size() * 4 + expectedProjectOpProgressMessages.size())
-        verifyHasChildren(subBeforeEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(subBeforeEvaluated, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(subBeforeEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOpProgressMessages)
-        verifyHasChildren(subBeforeEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOpProgressMessages + expectedProjectOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(subBeforeEvaluated, expectedGradleOps.size() * 4 + expectedProjectOps.size())
+        verifyHasChildren(subBeforeEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(subBeforeEvaluated, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(subBeforeEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOps)
+        verifyHasChildren(subBeforeEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOps + expectedProjectOps)
         // these execute too late to catch any beforeProject/beforeEvaluate callbacks for itself
         verifyHasNoChildren(subBeforeEvaluated, rootProjectPluginAppId)
         verifyHasNoChildren(subBeforeEvaluated, rootOtherScriptAppId)
@@ -329,13 +329,13 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             })
         """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.afterProject(Action)',
-            'gradle.afterProject(Closure(0))',
-            'gradle.afterProject(Closure(1))',
-            'gradle.afterProject(Closure(2))',
-            'gradle.addListener(ProjectEvaluationListener)',
-            'gradle.addProjectEvaluationListener(ProjectEvaluationListener)'
+        def expectedGradleOps = [
+            expectedOp('Gradle.afterProject', 'gradle.afterProject(Action)'),
+            expectedOp('Gradle.afterProject', 'gradle.afterProject(Closure(0))'),
+            expectedOp('Gradle.afterProject', 'gradle.afterProject(Closure(1))'),
+            expectedOp('Gradle.afterProject', 'gradle.afterProject(Closure(2))'),
+            expectedOp('Gradle.addListener', 'gradle.addListener(ProjectEvaluationListener)'),
+            expectedOp('Gradle.addProjectEvaluationListener', 'gradle.addProjectEvaluationListener(ProjectEvaluationListener)')
         ]
         def addProjectListeners = { String source, String target = null ->
             """
@@ -349,9 +349,9 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             ${target == null ? '' : '}'}
         """
         }
-        def expectedProjectOpProgressMessages = [
-            'project.afterEvaluate(Action)',
-            'project.afterEvaluate(Closure)',
+        def expectedProjectOps = [
+            expectedOp('Project.afterEvaluate', 'project.afterEvaluate(Action)'),
+            expectedOp('Project.afterEvaluate', 'project.afterEvaluate(Closure)')
         ]
 
         and:
@@ -380,29 +380,29 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         then:
         def rootAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':' })
-        verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, expectedGradleOpProgressMessages.size() * 4 + expectedProjectOpProgressMessages.size() * 3)
-        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOpProgressMessages + expectedProjectOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, rootProjectPluginAppId, 'root project plugin', expectedProjectOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, rootOtherScriptAppId, 'other script', expectedProjectOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, expectedGradleOps.size() * 4 + expectedProjectOps.size() * 3)
+        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(rootAfterEvaluated, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(rootAfterEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOps)
+        verifyHasChildren(rootAfterEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOps + expectedProjectOps)
+        verifyHasChildren(rootAfterEvaluated, rootProjectPluginAppId, 'root project plugin', expectedProjectOps)
+        verifyHasChildren(rootAfterEvaluated, rootOtherScriptAppId, 'other script', expectedProjectOps)
         verifyHasNoChildren(rootAfterEvaluated, subProjectScriptAppId) // executed too late to catch any afterProject/afterEvaluate callbacks for earlier evaluated project
         verifyHasNoChildren(rootAfterEvaluated, subProjectPluginAppId) // we don't cross configure the plugin
         verifyHasNoChildren(rootAfterEvaluated, subOtherScriptAppId) // we don't cross configure the script
 
         and:
         def subAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':sub' })
-        verifyExpectedNumberOfExecuteListenerChildren(subAfterEvaluated, expectedGradleOpProgressMessages.size() * 5 + expectedProjectOpProgressMessages.size() * 4)
-        verifyHasChildren(subAfterEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(subAfterEvaluated, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(subAfterEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOpProgressMessages)
-        verifyHasChildren(subAfterEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOpProgressMessages + expectedProjectOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(subAfterEvaluated, expectedGradleOps.size() * 5 + expectedProjectOps.size() * 4)
+        verifyHasChildren(subAfterEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(subAfterEvaluated, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(subAfterEvaluated, settingsPluginAppId, 'settings plugin', expectedGradleOps)
+        verifyHasChildren(subAfterEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOps + expectedProjectOps)
         verifyHasNoChildren(subAfterEvaluated, rootProjectPluginAppId) // we don't cross configure the plugin
         verifyHasNoChildren(subAfterEvaluated, rootOtherScriptAppId) // we don't cross configure the plugin
-        verifyHasChildren(subAfterEvaluated, subProjectScriptAppId, 'sub project script', expectedGradleOpProgressMessages + expectedProjectOpProgressMessages)
-        verifyHasChildren(subAfterEvaluated, subProjectPluginAppId, 'sub project plugin', expectedProjectOpProgressMessages)
-        verifyHasChildren(subAfterEvaluated, subOtherScriptAppId, 'other script', expectedProjectOpProgressMessages)
+        verifyHasChildren(subAfterEvaluated, subProjectScriptAppId, 'sub project script', expectedGradleOps + expectedProjectOps)
+        verifyHasChildren(subAfterEvaluated, subProjectPluginAppId, 'sub project plugin', expectedProjectOps)
+        verifyHasChildren(subAfterEvaluated, subOtherScriptAppId, 'other script', expectedProjectOps)
     }
 
     def 'nested afterEvaluate listeners are attributed to the correct registrant'() {
@@ -420,10 +420,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             }
         """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.afterProject(Closure)',
-            'nested gradle.afterProject(Closure)',
-            'nested nested gradle.afterProject(Closure)',
+        def expectedGradleOps = [
+            expectedOp('Gradle.afterProject', 'gradle.afterProject(Closure)'),
+            expectedOp('Project.afterEvaluate', 'nested gradle.afterProject(Closure)'),
+            expectedOp('Project.afterEvaluate', 'nested nested gradle.afterProject(Closure)')
         ]
         def addProjectListeners = { String source ->
             """
@@ -438,10 +438,10 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             }
         """
         }
-        def expectedProjectOpProgressMessages = [
-            'project.afterEvaluate(Closure)',
-            'nested project.afterEvaluate(Closure)',
-            'nested nested project.afterEvaluate(Closure)',
+        def expectedProjectOps = [
+            expectedOp('Project.afterEvaluate', 'project.afterEvaluate(Closure)'),
+            expectedOp('Project.afterEvaluate', 'nested project.afterEvaluate(Closure)'),
+            expectedOp('Project.afterEvaluate', 'nested nested project.afterEvaluate(Closure)')
         ]
 
         scriptFile << addProjectListeners('other script')
@@ -458,11 +458,11 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         then:
         def rootAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':' })
-        verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, expectedGradleOpProgressMessages.size() * 2 + expectedProjectOpProgressMessages.size() * 3)
-        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOpProgressMessages + expectedProjectOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, rootProjectPluginAppId, 'root project plugin', expectedProjectOpProgressMessages)
-        verifyHasChildren(rootAfterEvaluated, rootOtherScriptAppId, 'other script', expectedProjectOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, expectedGradleOps.size() * 2 + expectedProjectOps.size() * 3)
+        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(rootAfterEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOps + expectedProjectOps)
+        verifyHasChildren(rootAfterEvaluated, rootProjectPluginAppId, 'root project plugin', expectedProjectOps)
+        verifyHasChildren(rootAfterEvaluated, rootOtherScriptAppId, 'other script', expectedProjectOps)
     }
 
     def 'taskGraph whenReady action listeners are attributed to the correct registrant'() {
@@ -487,11 +487,11 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             }            
         """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.addListener(TaskExecutionGraphListener)',
-            'gradle.taskGraph.addTaskExecutionGraphListener(TaskExecutionGraphListener)',
-            'gradle.taskGraph.whenReady(Action)',
-            'gradle.taskGraph.whenReady(Closure)',
+        def expectedGradleOps = [
+            expectedOp('Gradle.addListener', 'gradle.addListener(TaskExecutionGraphListener)'),
+            expectedOp('TaskExecutionGraph.addTaskExecutionGraphListener', 'gradle.taskGraph.addTaskExecutionGraphListener(TaskExecutionGraphListener)'),
+            expectedOp('TaskExecutionGraph.whenReady', 'gradle.taskGraph.whenReady(Action)'),
+            expectedOp('TaskExecutionGraph.whenReady', 'gradle.taskGraph.whenReady(Closure)')
         ]
 
         scriptFile << addGradleListeners('other script')
@@ -509,12 +509,12 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
 
         then:
         def whenReadyEvaluated = operations.only(NotifyTaskGraphWhenReadyBuildOperationType)
-        verifyExpectedNumberOfExecuteListenerChildren(whenReadyEvaluated, expectedGradleOpProgressMessages.size() * 5)
-        verifyHasChildren(whenReadyEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
-        verifyHasChildren(whenReadyEvaluated, settingsScriptAppId, 'settings', expectedGradleOpProgressMessages)
-        verifyHasChildren(whenReadyEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOpProgressMessages)
-        verifyHasChildren(whenReadyEvaluated, rootProjectPluginAppId, 'root project plugin', expectedGradleOpProgressMessages)
-        verifyHasChildren(whenReadyEvaluated, rootOtherScriptAppId, 'other script', expectedGradleOpProgressMessages)
+        verifyExpectedNumberOfExecuteListenerChildren(whenReadyEvaluated, expectedGradleOps.size() * 5)
+        verifyHasChildren(whenReadyEvaluated, initScriptAppId, 'init', expectedGradleOps)
+        verifyHasChildren(whenReadyEvaluated, settingsScriptAppId, 'settings', expectedGradleOps)
+        verifyHasChildren(whenReadyEvaluated, rootProjectScriptAppId, 'root project script', expectedGradleOps)
+        verifyHasChildren(whenReadyEvaluated, rootProjectPluginAppId, 'root project plugin', expectedGradleOps)
+        verifyHasChildren(whenReadyEvaluated, rootOtherScriptAppId, 'other script', expectedGradleOps)
     }
 
     def 'listeners that implement multiple interfaces are decorated correctly'() {
@@ -550,8 +550,8 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
             gradle.addListener(new ComboListener())
         """
         }
-        def expectedGradleOpProgressMessages = [
-            'gradle.addListener(ComboListener)'
+        def expectedGradleOps = [
+            expectedOp('Gradle.addListener', 'gradle.addListener(ComboListener)')
         ]
 
         initFile << addGradleListeners('init')
@@ -562,27 +562,27 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         then:
         def projectsEvaluated = operations.only(NotifyProjectsEvaluatedBuildOperationType)
         verifyExpectedNumberOfExecuteListenerChildren(projectsEvaluated, 1)
-        verifyHasChildren(projectsEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
+        verifyHasChildren(projectsEvaluated, initScriptAppId, 'init', expectedGradleOps)
 
         and:
         def projectsLoaded = operations.only(NotifyProjectsLoadedBuildOperationType)
         verifyExpectedNumberOfExecuteListenerChildren(projectsLoaded, 1)
-        verifyHasChildren(projectsLoaded, initScriptAppId, 'init', expectedGradleOpProgressMessages)
+        verifyHasChildren(projectsLoaded, initScriptAppId, 'init', expectedGradleOps)
 
         and:
         def rootBeforeEvaluated = operations.only(NotifyProjectBeforeEvaluatedBuildOperationType)
         verifyExpectedNumberOfExecuteListenerChildren(rootBeforeEvaluated, 1)
-        verifyHasChildren(rootBeforeEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
+        verifyHasChildren(rootBeforeEvaluated, initScriptAppId, 'init', expectedGradleOps)
 
         and:
         def rootAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':' })
         verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, 1)
-        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
+        verifyHasChildren(rootAfterEvaluated, initScriptAppId, 'init', expectedGradleOps)
 
         and:
         def whenReadyEvaluated = operations.only(NotifyTaskGraphWhenReadyBuildOperationType)
         verifyExpectedNumberOfExecuteListenerChildren(whenReadyEvaluated, 1)
-        verifyHasChildren(whenReadyEvaluated, initScriptAppId, 'init', expectedGradleOpProgressMessages)
+        verifyHasChildren(whenReadyEvaluated, initScriptAppId, 'init', expectedGradleOps)
     }
 
     def 'no extra executions for composite builds'() {
@@ -647,17 +647,17 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         then:
         def rootBeforeEvaluated = operations.only(NotifyProjectBeforeEvaluatedBuildOperationType, { it.details.projectPath == ':' })
         verifyExpectedNumberOfExecuteListenerChildren(rootBeforeEvaluated, 1)
-        verifyHasChildren(rootBeforeEvaluated, initScriptAppId, 'init file rootProject', ['project.beforeEvaluate(Closure)'])
+        verifyHasChildren(rootBeforeEvaluated, initScriptAppId, 'init file rootProject', [expectedOp('Project.beforeEvaluate', 'project.beforeEvaluate(Closure)')])
 
         and:
         def rootAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':' })
         verifyExpectedNumberOfExecuteListenerChildren(rootAfterEvaluated, 1)
-        verifyHasChildren(rootAfterEvaluated, initOtherScriptAppId, 'script file allprojects', ['project.afterEvaluate(Closure)'])
+        verifyHasChildren(rootAfterEvaluated, initOtherScriptAppId, 'script file allprojects', [expectedOp('Project.afterEvaluate', 'project.afterEvaluate(Closure)')])
 
         and:
         def subAfterEvaluated = operations.only(NotifyProjectAfterEvaluatedBuildOperationType, { it.details.projectPath == ':sub' })
         verifyExpectedNumberOfExecuteListenerChildren(subAfterEvaluated, 1)
-        verifyHasChildren(subAfterEvaluated, initOtherScriptAppId, 'script file allprojects', ['project.afterEvaluate(Closure)'])
+        verifyHasChildren(subAfterEvaluated, initOtherScriptAppId, 'script file allprojects', [expectedOp('Project.afterEvaluate', 'project.afterEvaluate(Closure)')])
     }
 
     def 'decorated listener can be removed'() {
@@ -700,9 +700,9 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         assert op.children.findAll { it.hasDetailsOfType(ExecuteListenerBuildOperationType.Details) }.size() == expectedChildren
     }
 
-    private static List<BuildOperationRecord> verifyHasChildren(BuildOperationRecord op, long expectedApplicationId, String sourceName, List<String> expectedProgressMessages) {
+    private static List<BuildOperationRecord> verifyHasChildren(BuildOperationRecord op, long expectedApplicationId, String sourceName, List<ExpectedOperation> expectedOps) {
         def matchingChildren = op.children.findAll { it.hasDetailsOfType(ExecuteListenerBuildOperationType.Details) && it.details.applicationId == expectedApplicationId }
-        verifyExpectedOps(matchingChildren, expectedProgressMessages.collect { "$it from $sourceName" })
+        verifyExpectedOps(matchingChildren, addSource(expectedOps, sourceName))
         matchingChildren
     }
 
@@ -710,10 +710,12 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         assert op.children.findAll { it.hasDetailsOfType(ExecuteListenerBuildOperationType.Details) && it.details.applicationId == expectedApplicationId }.empty
     }
 
-    private static void verifyExpectedOps(List<BuildOperationRecord> ops, List<String> expectedProgressMessages) {
-        assert ops.size() == expectedProgressMessages.size()
+    private static void verifyExpectedOps(List<BuildOperationRecord> ops, List<ExpectedOperation> expectedOps) {
+        assert ops.size() == expectedOps.size()
         // no guarantees about listener execution order
-        assert ops.collect { progress(it) } as Set == expectedProgressMessages as Set
+        assert ops.find { op ->
+            expectedOps.find { expectedOperation -> op.details.registrationPoint == expectedOperation.registrationPoint && progress(op) == expectedOperation.progressMessage } != null
+        }
     }
 
     private static String progress(BuildOperationRecord op) {
@@ -804,5 +806,18 @@ class ExecuteUserLifecycleListenerBuildOperationIntegrationTest extends Abstract
         def pluginAppliedOps = operations.all(ApplyPluginBuildOperationType)
         def scriptAppliedOps = operations.all(ApplyScriptPluginBuildOperationType)
         assert ((pluginAppliedOps + scriptAppliedOps)*.details*.applicationId as Set).size() == pluginAppliedOps.size() + scriptAppliedOps.size()
+    }
+
+    private static expectedOp(String registrationPoint, String progressMessage) {
+        return new ExpectedOperation(registrationPoint: registrationPoint, progressMessage: progressMessage)
+    }
+
+    private static List<ExpectedOperation> addSource(List<ExpectedOperation> tuples, String sourceName) {
+        tuples.collect { expectedOp(it.registrationPoint, "$it.progressMessage from $sourceName") }
+    }
+
+    private static class ExpectedOperation {
+        String registrationPoint
+        String progressMessage
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -978,25 +978,25 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public void beforeEvaluate(Action<? super Project> action) {
         assertMutatingMethodAllowed("Project#beforeEvaluate(Action)");
-        evaluationListener.add("beforeEvaluate", getListenerBuildOperationDecorator().decorate("beforeEvaluate", action));
+        evaluationListener.add("beforeEvaluate", getListenerBuildOperationDecorator().decorate("Project.beforeEvaluate", action));
     }
 
     @Override
     public void afterEvaluate(Action<? super Project> action) {
         assertMutatingMethodAllowed("Project#afterEvaluate(Action)");
-        evaluationListener.add("afterEvaluate", getListenerBuildOperationDecorator().decorate("afterEvaluate", action));
+        evaluationListener.add("afterEvaluate", getListenerBuildOperationDecorator().decorate("Project.afterEvaluate", action));
     }
 
     @Override
     public void beforeEvaluate(Closure closure) {
         assertMutatingMethodAllowed("Project#beforeEvaluate(Closure)");
-        evaluationListener.add(new ClosureBackedMethodInvocationDispatch("beforeEvaluate", getListenerBuildOperationDecorator().decorate("beforeEvaluate", closure)));
+        evaluationListener.add(new ClosureBackedMethodInvocationDispatch("beforeEvaluate", getListenerBuildOperationDecorator().decorate("Project.beforeEvaluate", closure)));
     }
 
     @Override
     public void afterEvaluate(Closure closure) {
         assertMutatingMethodAllowed("Project#afterEvaluate(Closure)");
-        evaluationListener.add(new ClosureBackedMethodInvocationDispatch("afterEvaluate", getListenerBuildOperationDecorator().decorate("afterEvaluate", closure)));
+        evaluationListener.add(new ClosureBackedMethodInvocationDispatch("afterEvaluate", getListenerBuildOperationDecorator().decorate("Project.afterEvaluate", closure)));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/configuration/internal/ExecuteListenerBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/internal/ExecuteListenerBuildOperationType.java
@@ -39,6 +39,14 @@ public final class ExecuteListenerBuildOperationType implements BuildOperationTy
          * @see org.gradle.configuration.ApplyScriptPluginBuildOperationType.Details#getApplicationId()
          */
         Long getApplicationId();
+
+        /**
+         * The registration point of the listener. E.g. Project.beforeEvaluate etc.
+         *
+         * <p>General contract is interface-simplename.method-name</p>
+         */
+
+        String getRegistrationPoint();
     }
 
     public interface Result {
@@ -46,9 +54,11 @@ public final class ExecuteListenerBuildOperationType implements BuildOperationTy
 
     static class DetailsImpl implements Details {
         final UserCodeApplicationId applicationId;
+        final String registrationPoint;
 
-        DetailsImpl(UserCodeApplicationId applicationId) {
+        DetailsImpl(UserCodeApplicationId applicationId, String registrationPoint) {
             this.applicationId = applicationId;
+            this.registrationPoint = registrationPoint;
         }
 
         @Override
@@ -56,6 +66,10 @@ public final class ExecuteListenerBuildOperationType implements BuildOperationTy
             return applicationId.longValue();
         }
 
+        @Override
+        public String getRegistrationPoint() {
+            return registrationPoint;
+        }
     }
 
     static final Result RESULT = new Result() {

--- a/subprojects/core/src/main/java/org/gradle/configuration/internal/ListenerBuildOperationDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/internal/ListenerBuildOperationDecorator.java
@@ -38,10 +38,10 @@ public interface ListenerBuildOperationDecorator {
      * Does not decorate any action that implements {@link InternalListener}.
      * Does not decorate if there is not currently a script or plugin being applied on the thread.
      *
-     * @param name the name of the listener (e.g. projectsLoaded) - used in the operation description
+     * @param registrationPoint the place that the listener was registered - used in the operation description / details
      * @param action the action to decorate
      */
-    <T> Action<T> decorate(String name, Action<T> action);
+    <T> Action<T> decorate(String registrationPoint, Action<T> action);
 
     /**
      * Decorates a closure listener.
@@ -49,10 +49,10 @@ public interface ListenerBuildOperationDecorator {
      * Does not decorate any action that implements {@link InternalListener}.
      * Does not decorate if there is not currently a script or plugin being applied on the thread.
      *
-     * @param name the name of the listener (e.g. projectsLoaded) - used in the operation description
+     * @param registrationPoint the place that the listener was registered - used in the operation description / details
      * @param closure the closure to decorate
      */
-    <T> Closure<T> decorate(String name, Closure<T> closure);
+    <T> Closure<T> decorate(String registrationPoint, Closure<T> closure);
 
     /**
      * Decorates a listener type object.
@@ -63,16 +63,19 @@ public interface ListenerBuildOperationDecorator {
      * Does not decorate if there is not currently a script or plugin being applied on the thread.
      *
      * @param cls the type of the listener
+     * @param registrationPoint the place that the listener was registered - used in the operation description / details
      * @param listener the listener
      */
-    <T> T decorate(Class<T> cls, T listener);
+    <T> T decorate(String registrationPoint, Class<T> cls, T listener);
 
     /**
      * Decorates a listener of unknown type.
      * <p>
-     * @see #decorate(Class, Object)
+     * @param registrationPoint the place that the listener was registered - used in the operation description / details
+     * @param listener the listener object to decorate
+     * @see #decorate(String, Class, Object)
      */
-    Object decorateUnknownListener(Object listener);
+    Object decorateUnknownListener(String registrationPoint, Object listener);
 
 
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -154,7 +154,7 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     public void addTaskExecutionGraphListener(TaskExecutionGraphListener listener) {
-        graphListeners.add(listenerBuildOperationDecorator.decorate(TaskExecutionGraphListener.class, listener));
+        graphListeners.add(listenerBuildOperationDecorator.decorate("TaskExecutionGraph.addTaskExecutionGraphListener", TaskExecutionGraphListener.class, listener));
     }
 
     public void removeTaskExecutionGraphListener(TaskExecutionGraphListener listener) {
@@ -162,11 +162,11 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     }
 
     public void whenReady(final Closure closure) {
-        graphListeners.add(new ClosureBackedMethodInvocationDispatch("graphPopulated", listenerBuildOperationDecorator.decorate("graphPopulated", closure)));
+        graphListeners.add(new ClosureBackedMethodInvocationDispatch("graphPopulated", listenerBuildOperationDecorator.decorate("TaskExecutionGraph.whenReady", closure)));
     }
 
     public void whenReady(final Action<TaskExecutionGraph> action) {
-        graphListeners.add(listenerBuildOperationDecorator.decorate(TaskExecutionGraphListener.class, new TaskExecutionGraphListener() {
+        graphListeners.add(listenerBuildOperationDecorator.decorate("TaskExecutionGraph.whenReady", TaskExecutionGraphListener.class, new TaskExecutionGraphListener() {
             @Override
             public void graphPopulated(TaskExecutionGraph graph) {
                 action.execute(graph);

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -268,7 +268,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public ProjectEvaluationListener addProjectEvaluationListener(ProjectEvaluationListener listener) {
-        addListener(listener);
+        addListener("Gradle.addProjectEvaluationListener", listener);
         return listener;
     }
 
@@ -279,22 +279,22 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void beforeProject(Closure closure) {
-        projectEvaluationListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("beforeEvaluate", getListenerBuildOperationDecorator().decorate("beforeEvaluate", closure)));
+        projectEvaluationListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("beforeEvaluate", getListenerBuildOperationDecorator().decorate("Gradle.beforeProject", closure)));
     }
 
     @Override
     public void beforeProject(Action<? super Project> action) {
-        projectEvaluationListenerBroadcast.add("beforeEvaluate", getListenerBuildOperationDecorator().decorate("beforeEvaluate", action));
+        projectEvaluationListenerBroadcast.add("beforeEvaluate", getListenerBuildOperationDecorator().decorate("Gradle.beforeProject", action));
     }
 
     @Override
     public void afterProject(Closure closure) {
-        projectEvaluationListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("afterEvaluate", getListenerBuildOperationDecorator().decorate("afterEvaluate", closure)));
+        projectEvaluationListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("afterEvaluate", getListenerBuildOperationDecorator().decorate("Gradle.afterProject", closure)));
     }
 
     @Override
     public void afterProject(Action<? super Project> action) {
-        projectEvaluationListenerBroadcast.add("afterEvaluate", getListenerBuildOperationDecorator().decorate("afterEvaluate", action));
+        projectEvaluationListenerBroadcast.add("afterEvaluate", getListenerBuildOperationDecorator().decorate("Gradle.afterProject", action));
     }
 
     @Override
@@ -319,22 +319,22 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void projectsLoaded(Closure closure) {
-        buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("projectsLoaded", getListenerBuildOperationDecorator().decorate("projectsLoaded", closure)));
+        buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("projectsLoaded", getListenerBuildOperationDecorator().decorate("Gradle.projectsLoaded", closure)));
     }
 
     @Override
     public void projectsLoaded(Action<? super Gradle> action) {
-        buildListenerBroadcast.add("projectsLoaded", getListenerBuildOperationDecorator().decorate("projectsLoaded", action));
+        buildListenerBroadcast.add("projectsLoaded", getListenerBuildOperationDecorator().decorate("Gradle.projectsLoaded", action));
     }
 
     @Override
     public void projectsEvaluated(Closure closure) {
-        buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("projectsEvaluated", getListenerBuildOperationDecorator().decorate("projectsEvaluated", closure)));
+        buildListenerBroadcast.add(new ClosureBackedMethodInvocationDispatch("projectsEvaluated", getListenerBuildOperationDecorator().decorate("Gradle.projectsEvaluated", closure)));
     }
 
     @Override
     public void projectsEvaluated(Action<? super Gradle> action) {
-        buildListenerBroadcast.add("projectsEvaluated", getListenerBuildOperationDecorator().decorate("projectsEvaluated", action));
+        buildListenerBroadcast.add("projectsEvaluated", getListenerBuildOperationDecorator().decorate("Gradle.projectsEvaluated", action));
     }
 
     @Override
@@ -349,13 +349,17 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void addListener(Object listener) {
-        getListenerManager().addListener(getListenerBuildOperationDecorator().decorateUnknownListener(listener));
+        addListener("Gradle.addListener", listener);
+    }
+
+    private void addListener(String registrationPoint, Object listener) {
+        getListenerManager().addListener(getListenerBuildOperationDecorator().decorateUnknownListener(registrationPoint, listener));
     }
 
     @Override
     public void removeListener(Object listener) {
         // do same decoration as in addListener to remove correctly
-        getListenerManager().removeListener(getListenerBuildOperationDecorator().decorateUnknownListener(listener));
+        getListenerManager().removeListener(getListenerBuildOperationDecorator().decorateUnknownListener(null, listener));
     }
 
     @Override
@@ -370,7 +374,7 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void addBuildListener(BuildListener buildListener) {
-        addListener(buildListener);
+        addListener("Gradle.addBuildListener", buildListener);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
+++ b/subprojects/core/src/main/java/org/gradle/invocation/DefaultGradle.java
@@ -228,20 +228,24 @@ public class DefaultGradle extends AbstractPluginAware implements GradleInternal
 
     @Override
     public void rootProject(Action<? super Project> action) {
+        rootProject("rootProject", action);
+    }
+
+    private void rootProject(String registrationSite, Action<? super Project> action) {
         if (projectsLoaded) {
             assert rootProject != null;
             action.execute(rootProject);
         } else {
             // only need to decorate when this callback is delayed
-            rootProjectActions.add(getListenerBuildOperationDecorator().decorate("rootProject", action));
+            rootProjectActions.add(getListenerBuildOperationDecorator().decorate(registrationSite, action));
         }
     }
 
     @Override
     public void allprojects(final Action<? super Project> action) {
-        rootProject(new Action<Project>() {
+        rootProject("allprojects", new Action<Project>() {
             public void execute(Project project) {
-                project.allprojects(getListenerBuildOperationDecorator().decorate("allprojects", action));
+                project.allprojects(action);
             }
         });
     }

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
@@ -61,16 +61,16 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         decorator.decorate('foo', action) is action
 
         and:
-        decorator.decorate(BuildListener, buildListener) is buildListener
-        decorator.decorateUnknownListener(buildListener) is buildListener
+        decorator.decorate('foo', BuildListener, buildListener) is buildListener
+        decorator.decorateUnknownListener('foo', buildListener) is buildListener
 
         and:
-        decorator.decorate(ProjectEvaluationListener, projectEvaluationListener) is projectEvaluationListener
-        decorator.decorateUnknownListener(projectEvaluationListener) is projectEvaluationListener
+        decorator.decorate('foo', ProjectEvaluationListener, projectEvaluationListener) is projectEvaluationListener
+        decorator.decorateUnknownListener('foo', projectEvaluationListener) is projectEvaluationListener
 
         and:
-        decorator.decorate(TaskExecutionGraphListener, graphListener) is graphListener
-        decorator.decorateUnknownListener(graphListener) is graphListener
+        decorator.decorate('foo', TaskExecutionGraphListener, graphListener) is graphListener
+        decorator.decorateUnknownListener('foo', graphListener) is graphListener
     }
 
     def 'ignores classes which do not implement any of the supported interfaces'() {
@@ -78,8 +78,8 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         def testListener = Mock(TestListener)
 
         expect:
-        decorator.decorate(TestListener, testListener) is testListener
-        decorator.decorateUnknownListener(testListener) is testListener
+        decorator.decorate('foo', TestListener, testListener) is testListener
+        decorator.decorateUnknownListener('foo', testListener) is testListener
     }
 
     def 'decorates actions'() {
@@ -222,7 +222,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         def id = context.push()
 
         when:
-        def decoratedListener = decorateAsObject ? decorator.decorateUnknownListener(listener) as BuildListener : decorator.decorate(BuildListener, listener)
+        def decoratedListener = decorateAsObject ? decorator.decorateUnknownListener('foo', listener) as BuildListener : decorator.decorate('foo', BuildListener, listener)
 
         then:
         !decoratedListener.is(listener)
@@ -252,7 +252,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.projectsLoaded(projectsLoadedArg)
 
         and:
-        verifyExpectedOp('projectsLoaded', id)
+        verifyExpectedOp('foo', id)
 
         when:
         resetOps()
@@ -262,7 +262,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.projectsEvaluated(projectsEvaluatedArg)
 
         and:
-        verifyExpectedOp('projectsEvaluated', id)
+        verifyExpectedOp('foo', id)
 
         when:
         resetOps()
@@ -288,7 +288,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         def id = context.push()
 
         when:
-        def decoratedListener = decorateAsObject ? decorator.decorateUnknownListener(listener) as ProjectEvaluationListener : decorator.decorate(ProjectEvaluationListener, listener)
+        def decoratedListener = decorateAsObject ? decorator.decorateUnknownListener('foo', listener) as ProjectEvaluationListener : decorator.decorate('foo', ProjectEvaluationListener, listener)
 
         then:
         !decoratedListener.is(listener)
@@ -300,7 +300,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.beforeEvaluate(beforeEvaluateArg)
 
         and:
-        verifyExpectedOp('beforeEvaluate', id)
+        verifyExpectedOp('foo', id)
 
         when:
         resetOps()
@@ -310,7 +310,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.afterEvaluate(afterEvaluateArg1, afterEvaluateArg2)
 
         and:
-        verifyExpectedOp('afterEvaluate', id)
+        verifyExpectedOp('foo', id)
 
         where:
         decorateAsObject << [true, false]
@@ -324,7 +324,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         def id = context.push()
 
         when:
-        def decoratedListener = decorateAsObject ? decorator.decorateUnknownListener(listener) as TaskExecutionGraphListener : decorator.decorate(TaskExecutionGraphListener, listener)
+        def decoratedListener = decorateAsObject ? decorator.decorateUnknownListener('foo', listener) as TaskExecutionGraphListener : decorator.decorate('foo', TaskExecutionGraphListener, listener)
 
         then:
         !decoratedListener.is(listener)
@@ -336,7 +336,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.graphPopulated(arg)
 
         and:
-        verifyExpectedOp('graphPopulated', id)
+        verifyExpectedOp('foo', id)
 
         where:
         decorateAsObject << [true, false]
@@ -352,7 +352,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         def id = context.push()
 
         when:
-        def decoratedListener = decorator.decorateUnknownListener(listener) as ComboListener
+        def decoratedListener = decorator.decorateUnknownListener('foo', listener) as ComboListener
 
         then:
         !decoratedListener.is(listener)
@@ -373,7 +373,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.projectsLoaded(projectsLoadedArg)
 
         and:
-        verifyExpectedOp('projectsLoaded', id)
+        verifyExpectedOp('foo', id)
 
         when:
         resetOps()
@@ -383,7 +383,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.beforeEvaluate(beforeEvaluateArg)
 
         and:
-        verifyExpectedOp('beforeEvaluate', id)
+        verifyExpectedOp('foo', id)
 
         when:
         resetOps()
@@ -393,7 +393,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         1 * listener.graphPopulated(graphPopulatedArg)
 
         and:
-        verifyExpectedOp('graphPopulated', id)
+        verifyExpectedOp('foo', id)
 
         when:
         resetOps()
@@ -421,7 +421,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
 
         when:
         context.push()
-        def decorated = decorator.decorate(BuildListener, undecorated)
+        def decorated = decorator.decorate('foo', BuildListener, undecorated)
         context.pop()
         listenerManager.addListener(decorated)
         broadcast.projectsLoaded(gradle)
@@ -446,10 +446,10 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         assert buildOperationExecutor.operations.empty
     }
 
-    private void verifyExpectedOp(String expectedName, UserCodeApplicationId id) {
+    private void verifyExpectedOp(String expectedRegistrationPoint, UserCodeApplicationId id) {
         assert buildOperationExecutor.operations.size() == 1
         def op = buildOperationExecutor.operations.first()
-        assert op.displayName == "Execute $expectedName listener"
+        assert op.displayName == "Execute $expectedRegistrationPoint listener"
         assert (op.details as ExecuteListenerBuildOperationType.Details).applicationId == id.longValue()
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/configuration/internal/TestListenerBuildOperationDecorator.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/configuration/internal/TestListenerBuildOperationDecorator.groovy
@@ -21,22 +21,22 @@ import org.gradle.api.Action
 class TestListenerBuildOperationDecorator implements ListenerBuildOperationDecorator {
 
     @Override
-    <T> Action<T> decorate(String name, Action<T> action) {
+    <T> Action<T> decorate(String registrationPoint, Action<T> action) {
         action
     }
 
     @Override
-    <T> Closure<T> decorate(String name, Closure<T> closure) {
+    <T> Closure<T> decorate(String registrationPoint, Closure<T> closure) {
         return closure
     }
 
     @Override
-    <T> T decorate(Class<T> cls, T listener) {
+    <T> T decorate(String registrationPoint, Class<T> cls, T listener) {
         listener
     }
 
     @Override
-    Object decorateUnknownListener(Object listener) {
+    Object decorateUnknownListener(String registrationPoint, Object listener) {
         listener
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r40/PluginApplicationBuildProgressCrossVersionSpec.groovy
@@ -314,10 +314,9 @@ class PluginApplicationBuildProgressCrossVersionSpec extends ToolingApiSpecifica
 
         java.parent == rootProjectAction.
             child("Cross-configure project :").
-            child('Execute rootProject listener').
+            child('Execute allprojects listener').
             child("Execute 'allprojects {}' action").
-            child("Cross-configure project :").
-            child('Execute allprojects listener')
+            child("Cross-configure project :")
         javaBase.parent == java
         base.parent == javaBase
     }


### PR DESCRIPTION
### Context
Required to distinguish rootProject and projectsLoaded listener executions, given that rootProject listener executions happen inside projectsLoaded as an implementation detail.

Will also assist users to find callsite of slow or otherwise problematic listeners.

Also fixed a bug in attribution of listeners registered in allprojects callbacks.