### PR TITLE
Trim performance test scenario names

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/TestScenarioSelector.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/TestScenarioSelector.java
@@ -43,7 +43,7 @@ public class TestScenarioSelector {
             throw new IllegalArgumentException("Test ID cannot contain ';', but was '" + testId + "'");
         }
         String scenarioProperty = System.getProperty("org.gradle.performance.scenarios", "");
-        List<String> scenarios = Splitter.on(";").omitEmptyStrings().splitToList(scenarioProperty);
+        List<String> scenarios = Splitter.on(";").omitEmptyStrings().trimResults().splitToList(scenarioProperty);
         boolean shouldRun = scenarios.isEmpty() || scenarios.contains(testId);
         String scenarioList = System.getProperty("org.gradle.performance.scenario.list");
         if (shouldRun && scenarioList != null) {


### PR DESCRIPTION
This is to avoid missing a scenario because of preceding or trailing whitespace.
