### PR TITLE
Only run static Groovy compile subclassing tests with Gradle 2.1+

### DIFF
--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/StaticGroovyTaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/StaticGroovyTaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests
+
+
+import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetVersions
+import org.gradle.util.GradleVersion
+import spock.lang.Issue
+/**
+ * Tests that task classes compiled against earlier versions of Gradle using the static Groovy compiler are still compatible.
+ *
+ * <p>Note: Groovy introduced static compilation ({@link groovy.transform.CompileStatic}) in Groovy 2.0.0.
+ * We switched to using Groovy 2.3.3 from 1.8.6 in Gradle 2.0. However, Groovy 2.3.3 shipped with Gradle 2.0 had a bug that prevents the test to be compiled.
+ * Thus the first version we test with is Gradle 2.1 that shipped with Groovy 2.3.6 which fixed that issue.
+ */
+@TargetVersions("2.1+")
+class StaticGroovyTaskSubclassingBinaryCompatibilityCrossVersionSpec extends CrossVersionIntegrationSpec {
+
+    @Issue("https://github.com/gradle/gradle/issues/6027")
+    def "task can use project.file() from statically typed Groovy"() {
+        when:
+        file("producer/build.gradle") << """
+            apply plugin: 'groovy'
+            dependencies {
+                ${previous.version < GradleVersion.version("1.4-rc-1") ? "groovy" : "compile"} localGroovy()
+                compile gradleApi()
+            }
+        """
+
+        file("producer/src/main/groovy/SubclassTask.groovy") << """
+            import groovy.transform.CompileStatic
+            import org.gradle.api.DefaultTask
+            import org.gradle.api.tasks.TaskAction
+
+            @CompileStatic
+            class SubclassTask extends DefaultTask {
+                @TaskAction
+                void doGet() {
+                    project.file("file.txt")
+                }
+            }
+        """
+
+        buildFile << """
+            buildscript {
+                dependencies { classpath fileTree(dir: "producer/build/libs", include: '*.jar') }
+            }
+
+            task task(type: SubclassTask)
+        """
+
+        then:
+        version previous requireGradleDistribution() withTasks 'assemble' inDirectory(file("producer")) run()
+        version current requireGradleDistribution() withTasks 'task' run()
+    }
+}

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
@@ -44,8 +44,6 @@ import org.gradle.plugins.ide.idea.GenerateIdeaProject
 import org.gradle.plugins.ide.idea.GenerateIdeaWorkspace
 import org.gradle.plugins.signing.Sign
 import org.gradle.util.GradleVersion
-import spock.lang.Issue
-
 /**
  * Tests that task classes compiled against earlier versions of Gradle are still compatible.
  */
@@ -210,43 +208,5 @@ apply plugin: SomePlugin
         then:
         version previous requireGradleDistribution() withTasks 'assemble' inDirectory(file("producer")) run()
         version current requireGradleDistribution() withTasks 't' run()
-    }
-
-    @Issue("https://github.com/gradle/gradle/issues/6027")
-    def "task can use project.file() from statically typed Groovy"() {
-        when:
-        file("producer/build.gradle") << """
-            apply plugin: 'groovy'
-            dependencies {
-                ${previous.version < GradleVersion.version("1.4-rc-1") ? "groovy" : "compile"} localGroovy()
-                compile gradleApi()
-            }
-        """
-
-        file("producer/src/main/groovy/SubclassTask.groovy") << """
-            import groovy.transform.CompileStatic
-            import org.gradle.api.DefaultTask
-            import org.gradle.api.tasks.TaskAction
-
-            @CompileStatic
-            class SubclassTask extends DefaultTask {
-                @TaskAction
-                void doGet() {
-                    project.file("file.txt")
-                }
-            }
-        """
-
-        buildFile << """
-            buildscript {
-                dependencies { classpath fileTree(dir: "producer/build/libs", include: '*.jar') }
-            }
-
-            task task(type: SubclassTask)
-        """
-
-        then:
-        version previous requireGradleDistribution() withTasks 'assemble' inDirectory(file("producer")) run()
-        version current requireGradleDistribution() withTasks 'task' run()
     }
 }


### PR DESCRIPTION
Groovy introduced static compilation ({@link groovy.transform.CompileStatic}) in Groovy 2.0.0. We switched to using Groovy 2.3.3 from 1.8.6 in Gradle 2.0. However, Groovy 2.3.3 shipped with Gradle 2.0 had a bug that prevents the test to be compiled. Thus the first version we test with is Gradle 2.1 that shipped with Groovy 2.3.6 which fixed that issue.
