### PR TITLE
Clarify the Javadoc for InputFile and InputDirectory annotations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputDirectory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputDirectory.java
@@ -15,7 +15,11 @@
  */
 package org.gradle.api.tasks;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Marks a property as specifying an input directory for a task.</p>
@@ -24,8 +28,10 @@ import java.lang.annotation.*;
  * Annotations on setters or just the field in Java are ignored.</p>
  *
  * <p>This will cause the task to be considered out-of-date when the directory location or contents
- * have changed. To make the task dependent on the directory location but not the
- * contents, use an {@link org.gradle.api.tasks.Input} annotation instead.</p>
+ * have changed.</p>
+ *
+ * <p><strong>Note:</strong> To make the task dependent on the directory's location but not its
+ * contents, expose the path of the directory as an {@link org.gradle.api.tasks.Input} property instead.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputFile.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/InputFile.java
@@ -15,7 +15,11 @@
  */
 package org.gradle.api.tasks;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * <p>Marks a property as specifying an input file for a task.</p>
@@ -24,8 +28,10 @@ import java.lang.annotation.*;
  * Annotations on setters or just the field in Java are ignored.</p>
  *
  * <p>This will cause the task to be considered out-of-date when the file path or contents
- * have changed. To make the up-to-date check only dependent on the path and not the contents
- * of the file or directory, annotate it instead with {@link org.gradle.api.tasks.Input}.
+ * have changed.</p>
+ *
+ * <p><strong>Note:</strong> To make the task dependent on the file's location but not its
+ * contents, expose the path of the file as an {@link org.gradle.api.tasks.Input} property instead.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
When using `@Input` to expose the path of a file or directory, it should not be of type `File`.
