### PR TITLE
Fix BuildDashboardPlugin forcing configuration of all tasks

### DIFF
--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/plugins/BuildDashboardPlugin.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/plugins/BuildDashboardPlugin.java
@@ -67,7 +67,7 @@ public class BuildDashboardPlugin implements Plugin<Project> {
         };
 
         for (Project aProject : project.getAllprojects()) {
-            aProject.getTasks().all(captureReportingTasks);
+            aProject.getTasks().configureEach(captureReportingTasks);
         }
     }
 


### PR DESCRIPTION
### Context
According to my understanding of the new [Task Configuration Avoidance](https://docs.gradle.org/4.9/userguide/task_configuration_avoidance.html), calling `all` will force configuration of the task.

This means that in it's current form the `BuildDashboardPlugin` will cause all tasks to be configured.
This fixes that issue.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
