### PR TITLE
Use mirrors when building from Src

### DIFF
--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -24,6 +24,7 @@ import org.gradle.util.TestPrecondition
 
 import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.repoMirrorUrlsEnvironment
 
 class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
 
@@ -50,6 +51,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')
+            withEnvironmentVars(repoMirrorUrlsEnvironment())
             withArguments("-Djava9Home=${System.getProperty('java9Home')}", "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")
             withWarningMode(null)
         }.run()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -21,11 +21,11 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.test.fixtures.dsl.GradleDsl
 
-import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
-import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 import static org.gradle.api.artifacts.ArtifactRepositoryContainer.GOOGLE_URL
 import static org.gradle.api.artifacts.ArtifactRepositoryContainer.MAVEN_CENTRAL_URL
 import static org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.BINTRAY_JCENTER_URL
+import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
+import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 
 @CompileStatic
 class RepoScriptBlockUtil {
@@ -87,6 +87,11 @@ class RepoScriptBlockUtil {
     }
 
     private RepoScriptBlockUtil() {
+    }
+
+    static Map<String, String> repoMirrorUrlsEnvironment() {
+        def mirrors = MirroredRepository.values().collect { MirroredRepository repo -> "${repo.name()}:${repo.mirrorUrl}".toString() }
+        ['REPO_MIRRORS_URL': mirrors.join(',')]
     }
 
     static String jcenterRepository(GradleDsl dsl = GROOVY) {


### PR DESCRIPTION
SrcDistributionIntegrationSpec should also use the repository mirror for building the Gradle build from source when available.