### PR TITLE
Better support for forced versions in dependency insight

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
@@ -75,8 +75,4 @@ public enum ComponentSelectionCause {
     public String getDefaultReason() {
         return defaultReason;
     }
-
-    public boolean isExpected() {
-        return this == REQUESTED || this == ROOT;
-    }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ComponentSelectionCause.java
@@ -75,4 +75,8 @@ public enum ComponentSelectionCause {
     public String getDefaultReason() {
         return defaultReason;
     }
+
+    public boolean isExpected() {
+        return this == REQUESTED || this == ROOT;
+    }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -430,7 +430,6 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - Selected by rule : $expected
 
 org:a:1 -> org:b:1""")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -98,7 +98,7 @@ public class VersionSelectionReasons {
 
         public boolean isExpected() {
             ComponentSelectionCause cause = Iterables.getLast(descriptions).getCause();
-            return cause == ComponentSelectionCause.ROOT || cause == ComponentSelectionCause.REQUESTED;
+            return cause.isExpected();
         }
 
         public boolean isCompositeSubstitution() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/VersionSelectionReasons.java
@@ -58,6 +58,10 @@ public class VersionSelectionReasons {
         return new DefaultComponentSelectionReason(descriptions);
     }
 
+    public static boolean isCauseExpected(ComponentSelectionDescriptor descriptor) {
+        return descriptor.getCause() == ComponentSelectionCause.REQUESTED || descriptor.getCause() == ComponentSelectionCause.ROOT;
+    }
+
     private static class DefaultComponentSelectionReason implements ComponentSelectionReasonInternal {
 
         private final ArrayDeque<ComponentSelectionDescriptorInternal> descriptions;
@@ -97,8 +101,7 @@ public class VersionSelectionReasons {
         }
 
         public boolean isExpected() {
-            ComponentSelectionCause cause = Iterables.getLast(descriptions).getCause();
-            return cause.isExpected();
+            return isCauseExpected(Iterables.getLast(descriptions));
         }
 
         public boolean isCompositeSubstitution() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -445,7 +445,7 @@ org:foo:1.0 FAILED
 org:foo:1.0 FAILED
 \\--- lockedConf
 
-org:foo:1.1 (via constraint) FAILED
+org:foo:1.1 (by constraint) FAILED
    Failures:
       - Could not resolve org:foo:1.1. (already reported)
 
@@ -1796,7 +1796,7 @@ foo:foo:1.0
 
         then:
         if (!rejected) {
-            outputContains """org:foo:$selected (via constraint)
+            outputContains """org:foo:$selected (by constraint)
    variant "default" [
       org.gradle.status = release (not requested)
       Requested attributes not found in the selected variant:
@@ -2131,7 +2131,7 @@ org:foo:[1.0,) -> 1.1
 
         then:
         outputContains """
-org:leaf:1.0 (via constraint)
+org:leaf:1.0 (by constraint)
    variant "compile" [
       org.gradle.status = release (not requested)
       org.gradle.usage  = java-api
@@ -2297,7 +2297,7 @@ org:bar:[1.0,) FAILED
 org:bar:[1.0,) FAILED
 \\--- compileClasspath
 
-org:foo: (via constraint) FAILED
+org:foo: (by constraint) FAILED
    Failures:
       - Could not resolve org:foo.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -199,7 +199,6 @@ org:leaf2:2.5
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
 
 org:leaf2:2.5
@@ -330,7 +329,6 @@ org:leaf2:2.5
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
 
 org:leaf2:2.5
@@ -662,7 +660,6 @@ org.test:bar:2.0
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - Selected by rule : why not?
 
 org:bar:1.0 -> org.test:bar:2.0
@@ -681,7 +678,6 @@ org:foo:2.0
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - Selected by rule : because I am in control
 
 org:foo:1.0 -> 2.0
@@ -726,7 +722,6 @@ org:foo:1.0 -> 2.0
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - Selected by rule : foo superceded by bar
 
 org:foo:1.0 -> org:bar:1.0
@@ -819,7 +814,6 @@ org:leaf:2.0 -> org:new-leaf:77
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - Selected by rule : I am not sure I want to explain
 
 org:bar:1.0 -> 2.0
@@ -830,7 +824,6 @@ org:foo:2.0
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - Selected by rule : I want to
 
 org:foo:1.0 -> 2.0
@@ -873,7 +866,6 @@ org:leaf:1.6
       org.gradle.status = integration (not requested)
    ]
    Selection reasons:
-      - Was requested
       - By conflict resolution : between versions 1.6 and 1.6
 
 org:leaf:1.+ -> 1.6
@@ -1822,7 +1814,6 @@ org:foo -> $selected
          org.gradle.usage  = java-api
    ]
    Selection reasons:
-      - Was requested
       - By constraint : $rejected
 
 org:foo -> $selected
@@ -1876,7 +1867,6 @@ org:foo -> $selected
          org.gradle.usage  = java-api
    ]
    Selection reasons:
-      - Was requested
       - By constraint : ${rejected}${reason}
 
 org:foo -> $selected
@@ -2092,7 +2082,6 @@ org:bar:1.0
          org.gradle.usage  = java-api
    ]
    Selection reasons:
-      - Was requested
       - Rejection : 1.2 by rule because version 1.2 is bad
       - Rejection : 1.1 by rule because version 1.1 is bad
 
@@ -2432,7 +2421,6 @@ org:foo:1.0
          org.gradle.usage  = java-api
    ]
    Selection reasons:
-      - Was requested
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
@@ -2497,7 +2485,6 @@ planet:mercury:1.0.2
          org.gradle.usage  = java-api
    ]
    Selection reasons:
-      - Was requested
       - By conflict resolution : between versions 1.0.2 and 1.0.1
 
 planet:mercury:1.0.2
@@ -2525,7 +2512,6 @@ planet:venus:2.0.1
          org.gradle.usage  = java-api
    ]
    Selection reasons:
-      - Was requested
       - By conflict resolution : between versions 2.0.0, 2.0.1 and 1.0
 
 planet:venus:2.0.1

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -172,6 +172,12 @@ public class DependencyInsightReporter {
             ComponentSelectionDescriptorInternal descriptor = (ComponentSelectionDescriptorInternal) entry;
             ComponentSelectionCause cause = descriptor.getCause();
             boolean hasCustomDescription = descriptor.hasCustomDescription();
+
+            if (cause.isExpected() && !hasCustomDescription) {
+                // Don't render empty 'requested' reason
+                continue;
+            }
+
             String message = null;
             if (hasCustomDescription) {
                 selectionReasons.shouldDisplay();

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -178,16 +178,33 @@ public class DependencyInsightReporter {
                 continue;
             }
 
-            String message = null;
             if (hasCustomDescription) {
                 selectionReasons.shouldDisplay();
-                message = descriptor.getDescription();
             }
-            String prettyCause = prettyCause(cause);
-            Section item = new DefaultSection(hasCustomDescription ? prettyCause + " : " + message : prettyCause);
+            Section item = new DefaultSection(render(descriptor));
             selectionReasons.addChild(item);
         }
         return selectionReasons;
+    }
+
+    private static String getReasonDescription(ComponentSelectionReason reason) {
+        ComponentSelectionReasonInternal r = (ComponentSelectionReasonInternal) reason;
+        return getReasonDescription(r);
+    }
+
+    private static String getReasonDescription(ComponentSelectionReasonInternal reason) {
+        if (reason.isExpected()) {
+            return null;
+        }
+        ComponentSelectionDescriptor last = Iterables.getLast(reason.getDescriptions());
+        return render(last).toLowerCase();
+    }
+
+    private static String render(ComponentSelectionDescriptor descriptor) {
+        if (((ComponentSelectionDescriptorInternal) descriptor).hasCustomDescription()) {
+            return prettyCause(descriptor.getCause()) + " : " + descriptor.getDescription();
+        }
+        return prettyCause(descriptor.getCause());
     }
 
     private static String prettyCause(ComponentSelectionCause cause) {
@@ -210,36 +227,6 @@ public class DependencyInsightReporter {
                 return "By constraint";
         }
         return "Unknown";
-    }
-
-    private static String getReasonDescription(ComponentSelectionReason reason) {
-        ComponentSelectionReasonInternal r = (ComponentSelectionReasonInternal) reason;
-        String description = getReasonDescription(r);
-        if (reason.isConstrained()) {
-            if (!r.hasCustomDescriptions()) {
-                return "via constraint";
-            } else {
-                return "via constraint, " + description;
-            }
-        }
-        return description;
-    }
-
-    private static String getReasonDescription(ComponentSelectionReasonInternal reason) {
-        if (!reason.hasCustomDescriptions()) {
-            return reason.isExpected() ? null : Iterables.getLast(reason.getDescriptions()).getDescription();
-        }
-        return getLastCustomReason(reason);
-    }
-
-    private static String getLastCustomReason(ComponentSelectionReasonInternal reason) {
-        String lastCustomReason = null;
-        for (ComponentSelectionDescriptor descriptor : reason.getDescriptions()) {
-            if (((ComponentSelectionDescriptorInternal) descriptor).hasCustomDescription()) {
-                lastCustomReason = descriptor.getDescription();
-            }
-        }
-        return lastCustomReason;
     }
 
     private static class SelectionReasonsSection extends DefaultSection {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionP
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DefaultSection;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyEdge;
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.DependencyReportHeader;
@@ -167,10 +168,9 @@ public class DependencyInsightReporter {
         DefaultSection selectionReasons = new DefaultSection("Selection reasons");
         for (ComponentSelectionDescriptor entry : reason.getDescriptions()) {
             ComponentSelectionDescriptorInternal descriptor = (ComponentSelectionDescriptorInternal) entry;
-            ComponentSelectionCause cause = descriptor.getCause();
             boolean hasCustomDescription = descriptor.hasCustomDescription();
 
-            if (cause.isExpected() && !hasCustomDescription) {
+            if (VersionSelectionReasons.isCauseExpected(descriptor) && !hasCustomDescription) {
                 // Don't render empty 'requested' reason
                 continue;
             }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -116,7 +116,7 @@ class DependencyInsightReporterSpec extends Specification {
         sorted.size() == 5
 
         sorted[0].name == 'a:x:2.0'
-        sorted[0].description == 'conflict resolution'
+        sorted[0].description == 'by conflict resolution'
 
         sorted[1].name == 'a:x:2.0'
         sorted[1].description == null

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out
@@ -3,7 +3,6 @@ commons-codec:commons-codec:1.7
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Was requested
       - By conflict resolution : between versions 1.7 and 1.6
 
 commons-codec:commons-codec:1.7


### PR DESCRIPTION
This PR improved the support for `force` version in the dependency insight report:
- Refactored rendering of selection reasons to be more consistent and complete when multiple reasons are present
- Removed the pointless "Was requested" reason from the report
- Display `force` selection reasons in the presence of dependency constraints
- Provide the module details in a `force` selection reason