### PR TITLE
Show conflict resolution reason for 2nd level dependencies

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
@@ -17,6 +17,8 @@
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.result.ComponentSelectionCause;
+import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 
@@ -45,4 +47,16 @@ public class InvertedRenderableModuleResult extends RenderableModuleResult {
         }
         return new LinkedHashSet<RenderableDependency>(children.values());
     }
+
+    @Override
+    public String getName() {
+        String base = super.getName();
+        for (ComponentSelectionDescriptor descriptor : module.getSelectionReason().getDescriptions()) {
+            if (descriptor.getCause() == ComponentSelectionCause.CONFLICT_RESOLUTION) {
+                return base + " (" + descriptor.getCause().getDefaultReason() + " " + descriptor.getDescription() + ")";
+            }
+        }
+        return base;
+    }
+
 }


### PR DESCRIPTION
The dependencyInsight report shows a full suite of selection reasons
for the dependency being analysed, but shows only the selected version
for dependencies that are transitively responsible for the target
dependency.

With this change, we report the conflict resolution reason for any higher-order
dependencies that were selected through conflict resolution.

See https://github.com/nebula-plugins/gradle-nebula-integration/issues/9
