### PR TITLE
Fix system header discovery for cygwin toolchains

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSystemHeaderDiscoveryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSystemHeaderDiscoveryIntegrationTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+
+
+class CppSystemHeaderDiscoveryIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
+    def "discovers C and C++ standard library headers"() {
+        def outputFile = file("dirs.txt")
+        buildFile << """
+            plugins { id 'cpp-application' }
+            task sysHeaders {
+                doLast {
+                    def out = file("${outputFile.toURI()}")
+                    out.text = tasks.compileDebugCpp.systemIncludes.join('\\n')
+                }
+            }
+        """
+
+        when:
+        succeeds("sysHeaders")
+
+        then:
+        def dirs = outputFile.readLines()
+        !dirs.empty
+        dirs.find { dir -> new File(dir, "stdio.h").file }
+        dirs.find { dir -> new File(dir, "iostream").file }
+    }
+}

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChain.java
@@ -221,7 +221,7 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
         for (GccCommandLineToolConfigurationInternal tool : platformToolChain.getCompilers()) {
             CommandLineToolSearchResult compiler = locate(tool);
             if (compiler.isAvailable()) {
-                SearchResult<GccMetadata> gccMetadata = getMetaDataProvider().getCompilerMetaData(compiler.getTool(), platformToolChain.getCompilerProbeArgs());
+                SearchResult<GccMetadata> gccMetadata = getMetaDataProvider().getCompilerMetaData(compiler.getTool(), platformToolChain.getCompilerProbeArgs(), toolSearchPath.getPath());
                 availability.mustBeAvailable(gccMetadata);
                 if (!gccMetadata.isAvailable()) {
                     return;
@@ -343,8 +343,8 @@ public abstract class AbstractGccCompatibleToolChain extends ExtendableToolChain
         }
 
         @Override
-        public SearchResult<GccMetadata> getCompilerMetaData(File binary, List<String> additionalArgs) {
-            return delegate.getCompilerMetaData(binary, ImmutableList.<String>builder().addAll(compilerProbeArgs).addAll(additionalArgs).build());
+        public SearchResult<GccMetadata> getCompilerMetaData(File binary, List<String> additionalArgs, List<File> searchPath) {
+            return delegate.getCompilerMetaData(binary, ImmutableList.<String>builder().addAll(compilerProbeArgs).addAll(additionalArgs).build(), searchPath);
         }
 
         @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
@@ -56,6 +56,8 @@ abstract class GccCompilerArgsTransformer<T extends NativeCompileSpec> implement
     }
 
     protected void addIncludeArgs(T spec, List<String> args) {
+        args.add("-nostdinc");
+
         for (File file : spec.getIncludeRoots()) {
             args.add("-I");
             args.add(file.getAbsolutePath());

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
@@ -56,7 +56,9 @@ abstract class GccCompilerArgsTransformer<T extends NativeCompileSpec> implement
     }
 
     protected void addIncludeArgs(T spec, List<String> args) {
-        args.add("-nostdinc");
+        if (isNoStandardIncludes()) {
+            args.add("-nostdinc");
+        }
 
         for (File file : spec.getIncludeRoots()) {
             args.add("-I");
@@ -77,6 +79,10 @@ abstract class GccCompilerArgsTransformer<T extends NativeCompileSpec> implement
 
     protected void addUserArgs(T spec, List<String> args) {
         args.addAll(spec.getAllArgs());
+    }
+
+    protected boolean isNoStandardIncludes() {
+        return true;
     }
 
     protected abstract String getLanguage();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProvider.java
@@ -228,7 +228,7 @@ class GccPlatformToolProvider extends AbstractPlatformToolProvider {
         CommandLineToolSearchResult searchResult = toolSearchPath.locate(compiler.getToolType(), compiler.getExecutable());
         String language = LANGUAGE_FOR_COMPILER.get(compilerType);
         List<String> languageArgs = language == null ? Collections.<String>emptyList() : ImmutableList.of("-x", language);
-        return metadataProvider.getCompilerMetaData(searchResult.getTool(), languageArgs);
+        return metadataProvider.getCompilerMetaData(searchResult.getTool(), languageArgs, toolSearchPath.getPath());
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCCompiler.java
@@ -35,5 +35,10 @@ class ObjectiveCCompiler extends GccCompatibleNativeCompiler<ObjectiveCCompileSp
         protected String getLanguage() {
             return "objective-c";
         }
+
+        @Override
+        protected boolean isNoStandardIncludes() {
+            return false;
+        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCPCHCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCPCHCompiler.java
@@ -34,5 +34,10 @@ public class ObjectiveCPCHCompiler extends GccCompatibleNativeCompiler<Objective
         protected String getLanguage() {
             return "objective-c-header";
         }
+
+        @Override
+        protected boolean isNoStandardIncludes() {
+            return false;
+        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppCompiler.java
@@ -35,5 +35,10 @@ class ObjectiveCppCompiler extends GccCompatibleNativeCompiler<ObjectiveCppCompi
         protected String getLanguage() {
             return "objective-c++";
         }
+
+        @Override
+        protected boolean isNoStandardIncludes() {
+            return false;
+        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppPCHCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppPCHCompiler.java
@@ -34,5 +34,10 @@ public class ObjectiveCppPCHCompiler extends GccCompatibleNativeCompiler<Objecti
         protected String getLanguage() {
             return "objective-c++-header";
         }
+
+        @Override
+        protected boolean isNoStandardIncludes() {
+            return false;
+        }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/AbstractMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/AbstractMetadataProvider.java
@@ -53,6 +53,10 @@ public abstract class AbstractMetadataProvider<T extends CompilerMetadata> imple
         }
     }
 
+    protected ExecActionFactory getExecActionFactory() {
+        return execActionFactory;
+    }
+
     protected abstract T parseCompilerOutput(String output, String error, File binary) throws BrokenResultException;
 
     private Pair<String, String> runCompiler(File gccBinary, List<String> args) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/AbstractMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/AbstractMetadataProvider.java
@@ -38,7 +38,7 @@ public abstract class AbstractMetadataProvider<T extends CompilerMetadata> imple
     }
 
     @Override
-    public SearchResult<T> getCompilerMetaData(File binary, List<String> additionalArgs) {
+    public SearchResult<T> getCompilerMetaData(File binary, List<String> additionalArgs, List<File> path) {
         List<String> allArgs = ImmutableList.<String>builder().addAll(additionalArgs).addAll(compilerArgs()).build();
         Pair<String, String> transform = runCompiler(binary, allArgs);
         if (transform == null) {
@@ -47,7 +47,7 @@ public abstract class AbstractMetadataProvider<T extends CompilerMetadata> imple
         String output = transform.getLeft();
         String error = transform.getRight();
         try {
-            return new ComponentFound<T>(parseCompilerOutput(output, error, binary));
+            return new ComponentFound<T>(parseCompilerOutput(output, error, binary, path));
         } catch (BrokenResultException e) {
             return new ComponentNotFound<T>(e.getMessage());
         }
@@ -57,7 +57,7 @@ public abstract class AbstractMetadataProvider<T extends CompilerMetadata> imple
         return execActionFactory;
     }
 
-    protected abstract T parseCompilerOutput(String output, String error, File binary) throws BrokenResultException;
+    protected abstract T parseCompilerOutput(String output, String error, File binary, List<File> path) throws BrokenResultException;
 
     private Pair<String, String> runCompiler(File gccBinary, List<String> args) {
         ExecAction exec = execActionFactory.newExecAction();

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/CompilerMetaDataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/CompilerMetaDataProvider.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public interface CompilerMetaDataProvider<T extends CompilerMetadata> {
 
-    SearchResult<T> getCompilerMetaData(File binary, List<String> additionalArgs);
+    SearchResult<T> getCompilerMetaData(File binary, List<String> additionalArgs, List<File> searchPath);
 
     CompilerType getCompilerType();
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/CompilerMetaDataProviderFactory.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/metadata/CompilerMetaDataProviderFactory.java
@@ -60,11 +60,11 @@ public class CompilerMetaDataProviderFactory {
         }
 
         @Override
-        public SearchResult<T> getCompilerMetaData(File binary, List<String> additionalArgs) {
-            Key key = new Key(binary, additionalArgs);
+        public SearchResult<T> getCompilerMetaData(File binary, List<String> additionalArgs, List<File> path) {
+            Key key = new Key(binary, additionalArgs, path);
             SearchResult<T> result = resultMap.get(key);
             if (result == null) {
-                result = delegate.getCompilerMetaData(binary, additionalArgs);
+                result = delegate.getCompilerMetaData(binary, additionalArgs, path);
                 resultMap.put(key, result);
             }
             return result;
@@ -79,21 +79,23 @@ public class CompilerMetaDataProviderFactory {
     private static class Key {
         final File gccBinary;
         final List<String> args;
+        final List<File> path;
 
-        private Key(File gccBinary, List<String> args) {
+        private Key(File gccBinary, List<String> args, List<File> path) {
             this.gccBinary = gccBinary;
             this.args = args;
+            this.path = path;
         }
 
         @Override
         public boolean equals(Object obj) {
             Key other = (Key) obj;
-            return other.gccBinary.equals(gccBinary) && other.args.equals(args);
+            return other.gccBinary.equals(gccBinary) && other.args.equals(args) && other.path.equals(path);
         }
 
         @Override
         public int hashCode() {
-            return gccBinary.hashCode() ^ args.hashCode();
+            return gccBinary.hashCode() ^ args.hashCode() ^ path.hashCode();
         }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftcToolChain.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftcToolChain.java
@@ -16,7 +16,6 @@
 
 package org.gradle.nativeplatform.toolchain.internal.swift;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -43,6 +42,7 @@ import org.gradle.platform.base.internal.toolchain.ToolChainAvailability;
 import org.gradle.process.internal.ExecActionFactory;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -94,7 +94,7 @@ public class SwiftcToolChain extends ExtendableToolChain<SwiftcPlatformToolChain
         if (!result.isAvailable()) {
             return new UnavailablePlatformToolProvider(targetPlatform.getOperatingSystem(), result);
         }
-        SearchResult<SwiftcMetadata> swiftcMetaData = compilerMetaDataProvider.getCompilerMetaData(compiler.getTool(), ImmutableList.<String>of());
+        SearchResult<SwiftcMetadata> swiftcMetaData = compilerMetaDataProvider.getCompilerMetaData(compiler.getTool(), Collections.<String>emptyList(), toolSearchPath.getPath());
         result.mustBeAvailable(swiftcMetaData);
         if (!result.isAvailable()) {
             return new UnavailablePlatformToolProvider(targetPlatform.getOperatingSystem(), result);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/metadata/SwiftcMetadataProvider.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/metadata/SwiftcMetadataProvider.java
@@ -58,7 +58,7 @@ public class SwiftcMetadataProvider extends AbstractMetadataProvider<SwiftcMetad
     }
 
     @Override
-    protected SwiftcMetadata parseCompilerOutput(String stdout, String stderr, File swiftc) {
+    protected SwiftcMetadata parseCompilerOutput(String stdout, String stderr, File swiftc, List<File> path) {
         BufferedReader reader = new BufferedReader(new StringReader(stdout));
         try {
             String line;

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/AbstractGccCompatibleToolChainTest.groovy
@@ -134,7 +134,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         and:
         toolSearchPath.locate(ToolType.CPP_COMPILER, "g++") >> compilerMissing
         toolSearchPath.locate(_, _) >> tool
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         expect:
         def platformToolChain = toolChain.select(NativeLanguage.CPP, platform)
@@ -154,7 +154,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
 
         and:
         toolSearchPath.locate(_, _) >> tool
-        metaDataProvider.getCompilerMetaData(_, _) >> wrongCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> wrongCompiler
 
         expect:
         def platformToolChain = toolChain.select(language, platform)
@@ -173,7 +173,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         and:
         toolSearchPath.locate(toolType, _) >> tool
         toolSearchPath.locate(_, _) >> missing
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         expect:
         toolChain.select(platform).available
@@ -190,7 +190,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         and:
         toolSearchPath.locate(ToolType.CPP_COMPILER, _) >> tool
         toolSearchPath.locate(_, _) >> missing
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         expect:
         toolChain.select(platform).available
@@ -203,7 +203,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
 
         and:
         toolSearchPath.locate(_, _) >> tool
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         expect:
         toolChain.select(platform).available
@@ -229,7 +229,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         platform2.operatingSystem >> dummyOs
 
         toolSearchPath.locate(_, _) >> tool
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         given:
         int platformActionApplied = 0
@@ -262,7 +262,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         platform.getOperatingSystem() >> dummyOs
         platform.getArchitecture() >> dummyArch
         toolChain.eachPlatform(action)
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         when:
         toolChain.select(platform)
@@ -287,7 +287,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         platform.operatingSystem >> dummyOs
         platform.architecture >> Architectures.forInput(arch)
         toolChain.eachPlatform(action)
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         when:
         toolChain.select(platform)
@@ -316,7 +316,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         toolSearchPath.locate(_, _) >> tool
         platform.operatingSystem >> new DefaultOperatingSystem("osx", OperatingSystem.MAC_OS)
         platform.architecture >> new DefaultArchitecture(arch)
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         toolChain.target(platform.name)
         toolChain.eachPlatform(action)
@@ -348,7 +348,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
         def platformConfig2 = Mock(Action)
 
         toolSearchPath.locate(_, _) >> tool
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         toolChain.target("platform1", platformConfig1)
         toolChain.target("platform2", platformConfig2)
@@ -370,7 +370,7 @@ class AbstractGccCompatibleToolChainTest extends Specification {
 
         when:
         toolSearchPath.locate(_, _) >> tool
-        metaDataProvider.getCompilerMetaData(_, _) >> correctCompiler
+        metaDataProvider.getCompilerMetaData(_, _, _) >> correctCompiler
 
         and:
         toolChain.target(platform.getName(), new Action<NativePlatformToolChain>() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompatibleNativeCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompatibleNativeCompilerTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.nativeplatform.toolchain.internal.NativeCompilerTest
 abstract class GccCompatibleNativeCompilerTest extends NativeCompilerTest {
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
-        [ '-c', '-Dfoo=bar', '-Dempty', '-firstArg', '-secondArg', '-I', includeDir.absoluteFile.toString(), '-isystem', systemIncludeDir.absoluteFile.toString() ]
+        [ '-c', '-Dfoo=bar', '-Dempty', '-firstArg', '-secondArg', '-nostdinc', '-I', includeDir.absoluteFile.toString(), '-isystem', systemIncludeDir.absoluteFile.toString() ]
     }
 
     def "arguments include GCC output flag and output file name"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccPlatformToolProviderTest.groovy
@@ -58,7 +58,7 @@ class GccPlatformToolProviderTest extends Specification {
 
         then:
         result == libs
-        1 * metaDataProvider.getCompilerMetaData(_, _) >> {
+        1 * metaDataProvider.getCompilerMetaData(_, _, _) >> {
             assert arguments[1] == args
             new ComponentFound(metaData)
         }
@@ -81,7 +81,7 @@ class GccPlatformToolProviderTest extends Specification {
         platformToolProvider.getCompilerMetadata(toolType)
 
         then:
-        1 * metaDataProvider.getCompilerMetaData(_, _) >> {
+        1 * metaDataProvider.getCompilerMetaData(_, _, _) >> {
             assert arguments[1] == args
             Mock(SearchResult)
         }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCCompilerTest.groovy
@@ -34,6 +34,8 @@ class ObjectiveCCompilerTest extends GccCompatibleNativeCompilerTest {
 
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
-        return [ '-x', 'objective-c' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        arguments.remove('-nostdinc')
+        return ['-x', 'objective-c'] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCPCHCompilerTest.groovy
@@ -34,6 +34,8 @@ class ObjectiveCPCHCompilerTest extends GccCompatibleNativeCompilerTest {
 
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
-        return [ '-x', 'objective-c-header' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        arguments.remove('-nostdinc')
+        return ['-x', 'objective-c-header' ] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppCompilerTest.groovy
@@ -34,6 +34,8 @@ class ObjectiveCppCompilerTest extends GccCompatibleNativeCompilerTest {
 
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
-        return [ '-x', 'objective-c++' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        arguments.remove('-nostdinc')
+        return ['-x', 'objective-c++' ] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/ObjectiveCppPCHCompilerTest.groovy
@@ -34,6 +34,8 @@ class ObjectiveCppPCHCompilerTest extends GccCompatibleNativeCompilerTest {
 
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
-        return [ '-x', 'objective-c++-header' ] + super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
+        arguments.remove('-nostdinc')
+        return ['-x', 'objective-c++-header' ] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/metadata/GccMetadataProviderTest.groovy
@@ -17,15 +17,19 @@
 package org.gradle.nativeplatform.toolchain.internal.gcc.metadata
 
 import org.gradle.api.Transformer
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.platform.base.internal.toolchain.SearchResult
 import org.gradle.process.ExecResult
 import org.gradle.process.internal.ExecAction
 import org.gradle.process.internal.ExecActionFactory
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.TreeVisitor
 import org.gradle.util.UsesNativeServices
 import org.gradle.util.VersionNumber
+import org.junit.Rule
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -36,7 +40,6 @@ import static org.gradle.nativeplatform.toolchain.internal.gcc.metadata.GccCompi
 
 @UsesNativeServices
 class GccMetadataProviderTest extends Specification {
-    def execActionFactory = Mock(ExecActionFactory)
     static def gcc4 = """#define __GNUC_MINOR__ 2
 #define __GNUC_PATCHLEVEL__ 1
 #define __GNUC__ 4
@@ -63,6 +66,11 @@ class GccMetadataProviderTest extends Specification {
 #define __GNUC_PATCHLEVEL__ 1
 #define __GNUC__ 4
 #define __amd64__ 1
+"""
+    static def gccCygwin64 = """#define __CYGWIN__ 1
+#define __GNUC__ 7
+#define __GNUC_MINOR__ 3
+#define __x86_64__ 1
 """
     static def clang = """#define __GNUC_MINOR__ 2
 #define __GNUC_PATCHLEVEL__ 1
@@ -100,7 +108,7 @@ ignoring nonexistent directory "/usr/local/include/x86_64-linux-gnu"
 ignoring nonexistent directory "/usr/lib/gcc/x86_64-linux-gnu/4.8/../../../../x86_64-linux-gnu/include"
 #include "..." search starts here:
 #include <...> search starts here:
-${includes.collect { " ${it}" }.join('\n') }
+${includes.collect { " ${it}" }.join('\n')}
 End of search list.
 """
     }
@@ -115,8 +123,8 @@ InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault
 clang -cc1 version ${version}.0 (clang-${versionWithoutDots}0.0.38) default target x86_64-apple-darwin16.7.0
 #include "..." search starts here:
 #include <...> search starts here:
-${includes.collect { " ${it}" }.join('\n') }
-${frameworks.collect { " ${it} (framework directory)" }.join('\n') }
+${includes.collect { " ${it}" }.join('\n')}
+${frameworks.collect { " ${it} (framework directory)" }.join('\n')}
  /System/Library/Frameworks (framework directory)
  /Library/Frameworks (framework directory)
 End of search list.
@@ -159,6 +167,10 @@ ignoring nonexistent directory "/include"
  /usr/include
 End of search list.
 """
+
+    @Rule
+    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    def execActionFactory = Mock(ExecActionFactory)
 
     @Unroll
     "can scrape version number from output of GCC #versionNumber"() {
@@ -235,7 +247,7 @@ End of search list.
         def binary = new File("g++")
 
         when:
-        def result = metadataProvider.getCompilerMetaData(binary, [])
+        def result = metadataProvider.getCompilerMetaData(binary, [], [])
 
         then:
         1 * execActionFactory.newExecAction() >> action
@@ -325,6 +337,27 @@ End of search list.
         result.component.systemIncludes*.path == includes
     }
 
+    def "parses gcc cygwin system includes and maps to windows paths"() {
+        def includes = [
+            '/usr/include',
+            '/usr/local/include'
+        ]
+        def mapped = [
+            'C:\\cygwin\\usr\\include',
+            'C:\\cygwin\\usr\\local\\include'
+        ]
+        def binDir = tmpDir.createDir('bin')
+        def cygpath = binDir.createFile(OperatingSystem.current().getExecutableName('cygpath'))
+
+        expect:
+        runsCompiler(gccCygwin64, gccVerboseOutput('7.3', includes))
+        mapsPath(cygpath, '/usr/include', 'C:\\cygwin\\usr\\include')
+        mapsPath(cygpath, '/usr/local/include', 'C:\\cygwin\\usr\\local\\include')
+        def provider = new GccMetadataProvider(execActionFactory, GCC)
+        def result = provider.getCompilerMetaData(new File("gcc"), [], [binDir])
+        result.component.systemIncludes*.path == mapped
+    }
+
     def correctPathSeparators(Collection<String> paths) {
         paths.collect { it.replaceAll('/', Matcher.quoteReplacement(File.separator)) }
     }
@@ -333,15 +366,29 @@ End of search list.
         output(outputStr, "", compilerType)
     }
 
-    SearchResult<GccMetadata> output(String output, String error, GccCompilerType compilerType = GCC) {
+    SearchResult<GccMetadata> output(String output, String error, GccCompilerType compilerType = GCC, List<File> path = []) {
+        runsCompiler(output, error)
+        def provider = new GccMetadataProvider(execActionFactory, compilerType)
+        provider.getCompilerMetaData(new File("g++"), [], path)
+    }
+
+    void runsCompiler(String output, String error) {
         def action = Mock(ExecAction)
         def result = Mock(ExecResult)
         1 * execActionFactory.newExecAction() >> action
         1 * action.setStandardOutput(_) >> { OutputStream outstr -> outstr << output; action }
         1 * action.setErrorOutput(_) >> { OutputStream errorstr -> errorstr << error; action }
         1 * action.execute() >> result
-        def provider = new GccMetadataProvider(execActionFactory, compilerType)
-        provider.getCompilerMetaData(new File("g++"), [])
+    }
+
+    void mapsPath(TestFile cygpath, String from, String to) {
+        def action = Mock(ExecAction)
+        def execResult = Mock(ExecResult)
+        1 * execActionFactory.newExecAction() >> action
+        1 * action.commandLine(cygpath.absolutePath, '-w', from)
+        1 * action.setStandardOutput(_) >> { OutputStream outputStream -> outputStream.write(to.bytes) }
+        1 * action.execute() >> execResult
+        _ * execResult.assertNormalExitValue()
     }
 
     Transformer transformer(constant) {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/metadata/CompilerMetaDataProviderFactoryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/metadata/CompilerMetaDataProviderFactoryTest.groovy
@@ -33,13 +33,13 @@ class CompilerMetaDataProviderFactoryTest extends Specification {
     def "caches result of actual #compiler metadata provider"() {
         def binary = new File("any")
         when:
-        def metadata = metadataProvider(compiler).getCompilerMetaData(binary, [])
+        def metadata = metadataProvider(compiler).getCompilerMetaData(binary, [], [])
 
         then:
         interaction compilerShouldBeExecuted
 
         when:
-        def newMetadata = metadataProvider(compiler).getCompilerMetaData(binary, [])
+        def newMetadata = metadataProvider(compiler).getCompilerMetaData(binary, [], [])
 
         then:
         0 * _
@@ -54,20 +54,20 @@ class CompilerMetaDataProviderFactoryTest extends Specification {
         def firstBinary = new File("first")
         def secondBinary = new File("second")
         when:
-        def firstMetadata = metadataProvider(compiler).getCompilerMetaData(firstBinary, [])
+        def firstMetadata = metadataProvider(compiler).getCompilerMetaData(firstBinary, [], [])
 
         then:
         interaction compilerShouldBeExecuted
 
         when:
-        def secondMetadata = metadataProvider(compiler).getCompilerMetaData(secondBinary, [])
+        def secondMetadata = metadataProvider(compiler).getCompilerMetaData(secondBinary, [], [])
 
         then:
         interaction compilerShouldBeExecuted
         firstMetadata != secondMetadata
 
         when:
-        def firstMetadataAgain = metadataProvider(compiler).getCompilerMetaData(firstBinary, [])
+        def firstMetadataAgain = metadataProvider(compiler).getCompilerMetaData(firstBinary, [], [])
 
         then:
         0 * _
@@ -83,20 +83,49 @@ class CompilerMetaDataProviderFactoryTest extends Specification {
         def firstArgs = ["-m32"]
         def secondArgs = ["-m64"]
         when:
-        def firstMetadata = metadataProvider(compiler).getCompilerMetaData(binary, firstArgs)
+        def firstMetadata = metadataProvider(compiler).getCompilerMetaData(binary, firstArgs, [])
 
         then:
         interaction compilerShouldBeExecuted
 
         when:
-        def secondMetadata = metadataProvider(compiler).getCompilerMetaData(binary, secondArgs)
+        def secondMetadata = metadataProvider(compiler).getCompilerMetaData(binary, secondArgs, [])
 
         then:
         interaction compilerShouldBeExecuted
         firstMetadata != secondMetadata
 
         when:
-        def firstMetadataAgain = metadataProvider(compiler).getCompilerMetaData(binary, firstArgs)
+        def firstMetadataAgain = metadataProvider(compiler).getCompilerMetaData(binary, firstArgs, [])
+
+        then:
+        0 * _
+        firstMetadataAgain.is firstMetadata
+
+        where:
+        compiler << ['gcc', 'clang', 'swiftc']
+    }
+
+    @Unroll
+    def "different #compiler paths are probed and cached"() {
+        def binary = new File("any")
+        def firstPath = []
+        def secondPath = [new File("/usr/local/bin")]
+        when:
+        def firstMetadata = metadataProvider(compiler).getCompilerMetaData(binary, [], firstPath)
+
+        then:
+        interaction compilerShouldBeExecuted
+
+        when:
+        def secondMetadata = metadataProvider(compiler).getCompilerMetaData(binary, [], secondPath)
+
+        then:
+        interaction compilerShouldBeExecuted
+        firstMetadata != secondMetadata
+
+        when:
+        def firstMetadataAgain = metadataProvider(compiler).getCompilerMetaData(binary, [], firstPath)
 
         then:
         0 * _

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/metadata/SwiftcMetadataProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/swift/metadata/SwiftcMetadataProviderTest.groovy
@@ -75,7 +75,7 @@ Target: x86_64-unknown-linux-gnu
         def binary = new File("swiftc")
 
         when:
-        def result = metadataProvider.getCompilerMetaData(binary, [])
+        def result = metadataProvider.getCompilerMetaData(binary, [], [])
 
         then:
         1 * execActionFactory.newExecAction() >> action
@@ -99,7 +99,7 @@ Target: x86_64-unknown-linux-gnu
         1 * action.setStandardOutput(_) >> { OutputStream outstr -> outstr << output; action }
         1 * action.execute() >> result
         def provider = new SwiftcMetadataProvider(execActionFactory)
-        provider.getCompilerMetaData(new File("swiftc"), [])
+        provider.getCompilerMetaData(new File("swiftc"), [], [])
     }
 
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -185,7 +185,7 @@ public class AvailableToolChains {
         if (!gppCandidates.isEmpty()) {
             File firstInPath = gppCandidates.iterator().next();
             for (File candidate : gppCandidates) {
-                SearchResult<GccMetadata> version = versionDeterminer.getCompilerMetaData(candidate, Collections.<String>emptyList());
+                SearchResult<GccMetadata> version = versionDeterminer.getCompilerMetaData(candidate, Collections.<String>emptyList(), Collections.<File>emptyList());
                 if (version.isAvailable()) {
                     InstalledGcc gcc = new InstalledGcc("gcc" + " " + version.getComponent().getVersion());
                     if (!candidate.equals(firstInPath)) {
@@ -219,7 +219,7 @@ public class AvailableToolChains {
 
         for (File swiftInstall : candidates) {
             File swiftc = new File(swiftInstall, "/usr/bin/swiftc");
-            SearchResult<SwiftcMetadata> version = versionDeterminer.getCompilerMetaData(swiftc, Collections.<String>emptyList());
+            SearchResult<SwiftcMetadata> version = versionDeterminer.getCompilerMetaData(swiftc, Collections.<String>emptyList(), Collections.<File>emptyList());
             if (version.isAvailable()) {
                 File binDir = swiftc.getParentFile();
                 toolChains.add(new InstalledSwiftc(binDir, version.getComponent().getVersion()).inPath(binDir, new File("/usr/bin")));
@@ -228,7 +228,7 @@ public class AvailableToolChains {
 
         List<File> swiftcCandidates = OperatingSystem.current().findAllInPath("swiftc");
         for (File candidate : swiftcCandidates) {
-            SearchResult<SwiftcMetadata> version = versionDeterminer.getCompilerMetaData(candidate, Collections.<String>emptyList());
+            SearchResult<SwiftcMetadata> version = versionDeterminer.getCompilerMetaData(candidate, Collections.<String>emptyList(), Collections.<File>emptyList());
             if (version.isAvailable()) {
                 File binDir = candidate.getParentFile();
                 InstalledSwiftc swiftc = new InstalledSwiftc(binDir, version.getComponent().getVersion());


### PR DESCRIPTION
### Context

This PR fixes system header discovery when building C/C++ using cygwin.

Also, this PR adds the `-nostdin` option to GCC and Clang invocations so that only the discovered or explicitly declared system header files are used when compiling. It is not applied for objective-c or objective-c++ compilation as the framework directories also need to be handled and are not yet.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
