### PR TITLE
Always use upper case for script compile build operation language

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/internal/scripts/CompileScriptBuildOperationType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/internal/scripts/CompileScriptBuildOperationType.java
@@ -31,6 +31,7 @@ public class CompileScriptBuildOperationType implements BuildOperationType<Compi
     public interface Details {
         /**
          * The build script backing language.
+         * The language should be upper case. E.g GROOVY
          * */
         String getLanguage();
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyCompileScriptBuildOperationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/groovy/scripts/GroovyCompileScriptBuildOperationIntegrationTest.groovy
@@ -59,14 +59,14 @@ class GroovyCompileScriptBuildOperationIntegrationTest extends AbstractIntegrati
         ]
 
         scriptCompiles.details*.language == [
-            'groovy',
-            'groovy',
-            'groovy',
-            'groovy',
-            'groovy',
-            'groovy',
-            'groovy',
-            'groovy'
+            'GROOVY',
+            'GROOVY',
+            'GROOVY',
+            'GROOVY',
+            'GROOVY',
+            'GROOVY',
+            'GROOVY',
+            'GROOVY'
         ]
         scriptCompiles.details*.stage == [
             CLASSPATH,

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildOperationBackedScriptCompilationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/BuildOperationBackedScriptCompilationHandler.java
@@ -33,7 +33,7 @@ import java.io.File;
 
 public class BuildOperationBackedScriptCompilationHandler implements ScriptCompilationHandler {
 
-    public static final String GROOVY_LANGUAGE = "groovy";
+    public static final String GROOVY_LANGUAGE = "GROOVY";
 
     private static final CompileScriptBuildOperationType.Result RESULT = new CompileScriptBuildOperationType.Result() {
     };


### PR DESCRIPTION
### Context

tiny tweak to script compile build operation language to always be upper case. Groovy and Kotlin should be exposed in upper case.
