### PR TITLE
Provide more details for a forced module or dependency

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -300,7 +300,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         resolve.expectGraph {
             root(":", ":depsub:") {
                 edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
-                    forced()
+                    forced("module org.utils:impl:1.5")
                     edge("org.utils:api:1.5", "org.utils:api:1.6").selectedByRule()
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
@@ -395,7 +395,7 @@ task checkDeps {
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:foo:1.1', 'org:foo:1.0').forced()
+                edge('org:foo:1.1', 'org:foo:1.0').forced("dependency org:foo:1.0")
                 module('org:foo:1.0')
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionResultApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolutionResultApiIntegrationTest.groovy
@@ -79,7 +79,7 @@ class ResolutionResultApiIntegrationTest extends AbstractDependencyResolutionTes
         output.contains """
 cool-project:5.0 root
 foo:1.0 between versions 0.5 and 1.0
-leaf:2.0 forced
+leaf:2.0 module org:leaf:2.0
 bar:1.0 requested
 baz:1.0 requested
 """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
@@ -252,7 +252,7 @@ configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
                 module('org.test:maven:1.0') {
                     configuration = 'compile'
                     edge('org.test:ivy:1.0', 'org.test:ivy:1.2') {
-                        forced()
+                        forced("module org.test:ivy:1.2")
                         artifact(name: 'compile')
                         artifact(name: 'master')
                         module('org.test:m1:1.0')

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
+import org.gradle.internal.Describables;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -59,8 +60,8 @@ public class ModuleForcingResolveRule implements Action<DependencySubstitutionIn
             ModuleIdentifier key = selector.getModuleIdentifier();
             if (forcedModules.containsKey(key)) {
                 DefaultImmutableVersionConstraint versionConstraint = new DefaultImmutableVersionConstraint(forcedModules.get(key));
-                details.useTarget(newSelector(key, versionConstraint, selector.getAttributes()), VersionSelectionReasons.FORCED);
-
+                ModuleComponentSelector newSelector = newSelector(key, versionConstraint, selector.getAttributes());
+                details.useTarget(newSelector, VersionSelectionReasons.FORCED.withReason(Describables.of("module", newSelector)));
             }
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons;
+import org.gradle.internal.Describables;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 
@@ -46,7 +47,7 @@ class SelectorStateResolverResults {
 
             if (selectorState.isForce()) {
                 T forcedComponent = componentForIdResolveResult(componentFactory, idResolveResult, selectorState);
-                forcedComponent.addCause(VersionSelectionReasons.FORCED);
+                forcedComponent.addCause(VersionSelectionReasons.FORCED.withReason(Describables.of("dependency", forcedComponent.getComponentId())));
                 return Collections.singletonList(forcedComponent);
             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
@@ -28,7 +29,7 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionCon
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
-public class DefaultModuleComponentSelector implements ModuleComponentSelector {
+public class DefaultModuleComponentSelector implements ModuleComponentSelector, Describable {
     private final ModuleIdentifier moduleIdentifier;
     private final ImmutableVersionConstraint versionConstraint;
     private final ImmutableAttributes attributes;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/DefaultResolutionStrategySpec.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionsInternal
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
 import org.gradle.internal.Actions
+import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.locking.NoOpDependencyLockingProvider
 import org.gradle.internal.rules.NoInputsRuleAction
@@ -100,6 +101,7 @@ class DefaultResolutionStrategySpec extends Specification {
         given:
         strategy.force 'org:bar:1.0', 'org:foo:2.0'
         def details = Mock(DependencySubstitutionInternal)
+        def target = DefaultModuleComponentSelector.newSelector(mid, "2.0")
 
         when:
         strategy.dependencySubstitutionRule.execute(details)
@@ -109,7 +111,7 @@ class DefaultResolutionStrategySpec extends Specification {
         _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
         _ * details.getRequested() >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
         _ * details.getOldRequested() >> newSelector(mid, "1.0")
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, "2.0"), VersionSelectionReasons.FORCED)
+        1 * details.useTarget(target, VersionSelectionReasons.FORCED.withReason(Describables.of("module", target)))
         0 * details._
     }
 
@@ -130,6 +132,7 @@ class DefaultResolutionStrategySpec extends Specification {
         strategy.force 'org:bar:1.0', 'org:foo:2.0'
         def details = Mock(DependencySubstitutionInternal)
         def substitutionAction = Mock(Action)
+        def target = DefaultModuleComponentSelector.newSelector(mid, "2.0")
 
         when:
         strategy.dependencySubstitutionRule.execute(details)
@@ -138,7 +141,7 @@ class DefaultResolutionStrategySpec extends Specification {
         dependencySubstitutions.ruleAction >> substitutionAction
         _ * details.requested >> DefaultModuleComponentSelector.newSelector(mid, new DefaultMutableVersionConstraint("1.0"))
         _ * details.oldRequested >> newSelector(mid, "1.0")
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid, "2.0"), VersionSelectionReasons.FORCED)
+        1 * details.useTarget(target, VersionSelectionReasons.FORCED.withReason(Describables.of("module", target)))
         _ * globalDependencySubstitutions.ruleAction >> Actions.doNothing()
 
         then: //user rules follow:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRuleSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRuleSpec.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons
+import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import spock.lang.Specification
 
@@ -41,6 +42,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
     def "forces modules"() {
         given:
         def details = Mock(DependencySubstitutionInternal)
+        def target = DefaultModuleComponentSelector.newSelector(mid(requested.group, requested.name), forcedVersion)
 
         when:
         new ModuleForcingResolveRule([
@@ -54,7 +56,7 @@ class ModuleForcingResolveRuleSpec extends Specification {
         then:
         _ * details.requested >> DefaultModuleComponentSelector.newSelector(requested)
         _ * details.getOldRequested() >> requested
-        1 * details.useTarget(DefaultModuleComponentSelector.newSelector(mid(requested.group, requested.name), forcedVersion), VersionSelectionReasons.FORCED)
+        1 * details.useTarget(target, VersionSelectionReasons.FORCED.withReason(Describables.of("module", target)))
         0 * details._
 
         where:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -491,10 +491,12 @@ org:foo:1.+ FAILED
 
         then:
         outputContains """
-org:leaf:1.0 (forced)
+org:leaf:1.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+   Selection reasons:
+      - Forced : module org:leaf:1.0
 
 org:leaf:1.0
 \\--- org:foo:1.0
@@ -912,10 +914,12 @@ org:leaf:latest.integration -> 1.6
 
         then:
         outputContains """
-org:leaf:2.0 (forced)
+org:leaf:2.0
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+   Selection reasons:
+      - Forced : module org:leaf:2.0
 
 org:leaf:2.0
 \\--- org:bar:1.0
@@ -958,10 +962,12 @@ org:leaf:1.0 -> 2.0
 
         then:
         outputContains """
-org:leaf:1.5 (forced)
+org:leaf:1.5
    variant "runtime" [
       org.gradle.status = release (not requested)
    ]
+   Selection reasons:
+      - Forced : module org:leaf:1.5
 
 org:leaf:1.0 -> 1.5
 \\--- org:foo:1.0
@@ -1005,10 +1011,12 @@ org:leaf:2.0 -> 1.5
 
         then:
         outputContains """
-org:leaf:1.0 (forced)
+org:leaf:1.0
    variant "default+runtime" [
       org.gradle.status = release (not requested)
    ]
+   Selection reasons:
+      - Forced : dependency org:leaf:1.0
 
 org:leaf:1.0
 +--- conf
@@ -1056,7 +1064,7 @@ org:leaf:2.0
       org.gradle.status = release (not requested)
    ]
    Selection reasons:
-      - Forced
+      - Forced : module org:leaf:2.0
       - By constraint
 
 org:leaf:1.0 -> 2.0
@@ -1189,7 +1197,9 @@ org:middle:1.0 FAILED
         run "insight"
 
         then:
-        outputContains """org:middle:2.0 (forced) FAILED
+        outputContains """org:middle:2.0 FAILED
+   Selection reasons:
+      - Forced : module org:middle:2.0
    Failures:
       - Could not find org:middle:2.0.
         Searched in the following locations:

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -696,8 +696,8 @@ allprojects {
         /**
          * Marks that this node has a forced vers.
          */
-        NodeBuilder forced() {
-            reasons << 'forced'
+        NodeBuilder forced(String message) {
+            reasons << "${ComponentSelectionCause.FORCED.defaultReason}: $message".toString()
             this
         }
 


### PR DESCRIPTION
Instead of showing `(forced)` or `Forced` in the dependencyInsight report, with this PR we show:
`Forced : module org:foo:1.0` or `Forced : dependency org:foo:1.0`.

It's not clear to me if this adds enough value, or if it's just noise.