### PR TITLE
Don't duplicate tests from testng xml suites when maxForks > 1

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestSuiteRunInfo.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestSuiteRunInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import java.io.File;
+
+public class DefaultTestSuiteRunInfo implements TestSuiteRunInfo{
+    private File suiteFile;
+
+    public DefaultTestSuiteRunInfo(File suiteFile) {
+        this.suiteFile = suiteFile;
+    }
+
+    public String getTestSuiteName(){
+        return suiteFile.getName();
+    }
+    public File getFile(){
+        return suiteFile;
+    }
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/SuiteTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/SuiteTestClassProcessor.java
@@ -56,6 +56,16 @@ public class SuiteTestClassProcessor implements TestClassProcessor {
     }
 
     @Override
+    public void processTestSuite(TestSuiteRunInfo testSuite) {
+        try {
+            processor.processTestSuite(testSuite);
+        } catch (Throwable t) {
+            resultProcessor.failure(suiteDescriptor.getId(), new TestSuiteExecutionException(String.format(
+                "Could not execute test suite '%s'.", testSuite.getTestSuiteName()), t));
+        }
+    }
+
+    @Override
     public void stop() {
         try {
             processor.stop();

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestClassProcessor.java
@@ -38,6 +38,14 @@ public interface TestClassProcessor extends Stoppable {
     void processTestClass(TestClassRunInfo testClass);
 
     /**
+     * Accepts the given test suite for processing. May execute synchronously, asynchronously, or defer execution for
+     * later.
+     *
+     * @param testSuite The test class.
+     */
+    void processTestSuite(TestSuiteRunInfo testSuite);
+
+    /**
      * Completes any pending or asynchronous processing. Blocks until all processing is complete. The processor should
      * not use the result processor provided to {@link #startProcessing(TestResultProcessor)} after this method has
      * returned.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestSuiteRunInfo.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/TestSuiteRunInfo.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.testing;
+
+import java.io.File;
+
+public interface TestSuiteRunInfo {
+    String getTestSuiteName();
+    File getFile();
+}

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/PatternMatchTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/PatternMatchTestClassProcessor.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.testing.processors;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
 
@@ -41,6 +42,11 @@ public class PatternMatchTestClassProcessor implements TestClassProcessor {
         if (testClassSelectionMatcher.mayIncludeClass(testClass.getTestClassName())) {
             delegate.processTestClass(testClass);
         }
+    }
+
+    @Override
+    public void processTestSuite(TestSuiteRunInfo testSuite) {
+        delegate.processTestSuite(testSuite);
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RestartEveryNTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RestartEveryNTestClassProcessor.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.testing.processors;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 import org.gradle.internal.Factory;
 
 public class RestartEveryNTestClassProcessor implements TestClassProcessor {
@@ -54,6 +55,20 @@ public class RestartEveryNTestClassProcessor implements TestClassProcessor {
         if (testCount == restartEvery) {
             endBatch();
         }
+    }
+
+    @Override
+    public void processTestSuite(TestSuiteRunInfo testSuite) {
+        if (stoppedNow) {
+            return;
+        }
+
+        if (processor == null) {
+            processor = factory.create();
+            processor.startProcessing(resultProcessor);
+        }
+        processor.processTestSuite(testSuite);
+        testCount++;
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/RunPreviousFailedFirstTestClassProcessor.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.testing.processors;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -50,6 +51,11 @@ public class RunPreviousFailedFirstTestClassProcessor implements TestClassProces
         } else {
             otherTestClasses.add(testClass);
         }
+    }
+
+    @Override
+    public void processTestSuite(TestSuiteRunInfo testSuite) {
+        delegate.processTestSuite(testSuite);
     }
 
     @Override

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/RemoteTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/RemoteTestClassProcessor.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing.worker;
 
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 
 /**
  * @see org.gradle.api.internal.tasks.testing.TestClassProcessor
@@ -31,6 +32,11 @@ public interface RemoteTestClassProcessor {
      * Does not block.
      */
     void processTestClass(TestClassRunInfo testClass);
+
+    /**
+     * Does not block.
+     */
+    void processTestSuite(TestSuiteRunInfo testSuiteRunInfo);
 
     /**
      * Does not block.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestEventSerializer.java
@@ -22,11 +22,14 @@ import org.gradle.api.tasks.testing.TestResult;
 import org.gradle.internal.id.CompositeIdGenerator;
 import org.gradle.internal.serialize.*;
 
+import java.io.File;
+
 public class TestEventSerializer {
     public static SerializerRegistry create() {
         BaseSerializerFactory factory = new BaseSerializerFactory();
         DefaultSerializerRegistry registry = new DefaultSerializerRegistry();
         registry.register(DefaultTestClassRunInfo.class, new DefaultTestClassRunInfoSerializer());
+        registry.register(DefaultTestSuiteRunInfo.class, new DefaultTestSuiteRunInfoSerializer());
         registry.register(CompositeIdGenerator.CompositeId.class, new IdSerializer());
         registry.register(DefaultTestSuiteDescriptor.class, new DefaultTestSuiteDescriptorSerializer());
         registry.register(WorkerTestClassProcessor.WorkerTestSuiteDescriptor.class, new WorkerTestSuiteDescriptorSerializer());
@@ -86,6 +89,18 @@ public class TestEventSerializer {
         @Override
         public void write(Encoder encoder, DefaultTestClassRunInfo value) throws Exception {
             encoder.writeString(value.getTestClassName());
+        }
+    }
+
+    private static class DefaultTestSuiteRunInfoSerializer implements Serializer<DefaultTestSuiteRunInfo> {
+        @Override
+        public DefaultTestSuiteRunInfo read(Decoder decoder) throws Exception {
+            return new DefaultTestSuiteRunInfo(new File(decoder.readString()));
+        }
+
+        @Override
+        public void write(Encoder encoder, DefaultTestSuiteRunInfo value) throws Exception {
+            encoder.writeString(value.getFile().getAbsolutePath());
         }
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 import org.gradle.api.internal.tasks.testing.WorkerTestClassProcessorFactory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.actor.ActorFactory;
@@ -115,6 +116,20 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
         Thread.currentThread().setName("Test worker");
         try {
             processor.processTestClass(testClass);
+        } catch (AccessControlException e) {
+            completed.countDown();
+            throw e;
+        } finally {
+            // Clean the interrupted status
+            Thread.interrupted();
+        }
+    }
+
+    @Override
+    public void processTestSuite(final TestSuiteRunInfo testSuite) {
+        Thread.currentThread().setName("Test worker");
+        try {
+            processor.processTestSuite(testSuite);
         } catch (AccessControlException e) {
             completed.countDown();
             throw e;

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AbstractJUnitTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/AbstractJUnitTestClassProcessor.java
@@ -17,9 +17,11 @@
 package org.gradle.api.internal.tasks.testing.junit;
 
 import org.gradle.api.Action;
+import org.gradle.api.GradleException;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 import org.gradle.api.internal.tasks.testing.results.AttachParentTestResultProcessor;
 import org.gradle.internal.actor.Actor;
 import org.gradle.internal.actor.ActorFactory;
@@ -64,6 +66,11 @@ public abstract class AbstractJUnitTestClassProcessor<T extends JUnitSpec> imple
     public void processTestClass(TestClassRunInfo testClass) {
         LOGGER.debug("Executing test class {}", testClass.getTestClassName());
         executor.execute(testClass.getTestClassName());
+    }
+
+    @Override
+    public void processTestSuite(TestSuiteRunInfo testSuite) {
+        throw new GradleException("This method is unimplemented - it should never be called.");
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGDetector.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGDetector.java
@@ -15,17 +15,35 @@
  */
 package org.gradle.api.internal.tasks.testing.testng;
 
+import org.gradle.api.internal.tasks.testing.DefaultTestSuiteRunInfo;
+import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.detection.AbstractTestFrameworkDetector;
 import org.gradle.api.internal.tasks.testing.detection.ClassFileExtractionManager;
+import org.gradle.api.tasks.testing.testng.TestNGOptions;
+
+import java.io.File;
 
 class TestNGDetector extends AbstractTestFrameworkDetector<TestNGTestClassDetector> {
-    TestNGDetector(ClassFileExtractionManager classFileExtractionManager) {
+    private final TestNGOptions testNGOptions;
+    private final File temporaryDirectory;
+
+    TestNGDetector(ClassFileExtractionManager classFileExtractionManager, TestNGOptions testNGOptions, File temporaryDirectory) {
         super(classFileExtractionManager);
+        this.testNGOptions = testNGOptions;
+        this.temporaryDirectory = temporaryDirectory;
     }
 
     @Override
     protected TestNGTestClassDetector createClassVisitor() {
         return new TestNGTestClassDetector(this);
+    }
+
+    @Override
+    public void startDetection(TestClassProcessor testClassProcessor) {
+        super.startDetection(testClassProcessor);
+        for (File file : testNGOptions.getSuites(temporaryDirectory)){
+            testClassProcessor.processTestSuite(new DefaultTestSuiteRunInfo(file));
+        }
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestFramework.java
@@ -54,7 +54,7 @@ public class TestNGTestFramework implements TestFramework {
         this.filter = filter;
         options = instantiator.newInstance(TestNGOptions.class, testTask.getProject().getProjectDir());
         conventionMapOutputDirectory(options, testTask.getReports().getHtml());
-        detector = new TestNGDetector(new ClassFileExtractionManager(testTask.getTemporaryDirFactory()));
+        detector = new TestNGDetector(new ClassFileExtractionManager(testTask.getTemporaryDirFactory()), options, testTask.getTemporaryDir());
         classLoaderFactory = new TestClassLoaderFactory(classLoaderCache, testTask);
     }
 
@@ -133,17 +133,17 @@ public class TestNGTestFramework implements TestFramework {
     private static class TestClassProcessorFactoryImpl implements WorkerTestClassProcessorFactory, Serializable {
         private final File testReportDir;
         private final TestNGSpec options;
-        private final List<File> suiteFiles;
+        private final boolean runSuites;
 
         public TestClassProcessorFactoryImpl(File testReportDir, TestNGSpec options, List<File> suiteFiles) {
             this.testReportDir = testReportDir;
             this.options = options;
-            this.suiteFiles = suiteFiles;
+            this.runSuites = !suiteFiles.isEmpty();
         }
 
         @Override
         public TestClassProcessor create(ServiceRegistry serviceRegistry) {
-            return new TestNGTestClassProcessor(testReportDir, options, suiteFiles, serviceRegistry.get(IdGenerator.class), serviceRegistry.get(Clock.class), serviceRegistry.get(ActorFactory.class));
+            return new TestNGTestClassProcessor(testReportDir, options, serviceRegistry.get(IdGenerator.class), serviceRegistry.get(Clock.class), serviceRegistry.get(ActorFactory.class), runSuites);
         }
     }
 }

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.testing.testng
 
 import org.gradle.api.GradleException
 import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo
+import org.gradle.api.internal.tasks.testing.DefaultTestSuiteRunInfo
 import org.gradle.api.internal.tasks.testing.TestResultProcessor
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter
 import org.gradle.api.tasks.testing.TestResult.ResultType
@@ -47,7 +48,7 @@ class TestNGTestClassProcessorTest extends Specification {
 
     def options = Spy(TestNGSpec, constructorArgs:[new TestNGOptions(dir.testDirectory), new DefaultTestFilter()])
 
-    @Subject classProcessor = new TestNGTestClassProcessor(dir.testDirectory, options, [], new LongIdGenerator(), Time.clock(), new TestActorFactory())
+    @Subject classProcessor = new TestNGTestClassProcessor(dir.testDirectory, options, new LongIdGenerator(), Time.clock(), new TestActorFactory(), false)
 
     void process(Class ... clazz) {
         classProcessor.startProcessing(processor)
@@ -260,10 +261,11 @@ class TestNGTestClassProcessorTest extends Specification {
     </classes>
   </test>
 </suite>"""
-        classProcessor = new TestNGTestClassProcessor(dir.testDirectory, options, [suite], new LongIdGenerator(), Time.clock(), new TestActorFactory())
+        classProcessor = new TestNGTestClassProcessor(dir.testDirectory, options, new LongIdGenerator(), Time.clock(), new TestActorFactory(), true)
 
         when:
         classProcessor.startProcessing(processor)
+        classProcessor.processTestSuite(new DefaultTestSuiteRunInfo(suite))
         classProcessor.stop()
 
         then: 1 * processor.started({ it.id == 1 && it.name == 'AwesomeSuite' && it.className == null }, { it.parentId == null })
@@ -304,10 +306,12 @@ class TestNGTestClassProcessorTest extends Specification {
     </classes>
   </test>
 </suite>"""
-        classProcessor = new TestNGTestClassProcessor(dir.testDirectory, options, [suite1, suite2], new LongIdGenerator(), Time.clock(), new TestActorFactory())
+        classProcessor = new TestNGTestClassProcessor(dir.testDirectory, options, new LongIdGenerator(), Time.clock(), new TestActorFactory(), true)
 
         when:
         classProcessor.startProcessing(processor)
+        classProcessor.processTestSuite(new DefaultTestSuiteRunInfo(suite1))
+        classProcessor.processTestSuite(new DefaultTestSuiteRunInfo(suite2))
         classProcessor.stop()
 
         then: 1 * processor.started({ it.id == 1 && it.name == 'suite 1' && it.className == null }, { it.parentId == null })

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/execution/XCTestExecuter.java
@@ -17,11 +17,13 @@
 package org.gradle.nativeplatform.test.xctest.internal.execution;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.GradleException;
 import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestSuiteRunInfo;
 import org.gradle.api.internal.tasks.testing.processors.TestMainAction;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.internal.id.IdGenerator;
@@ -166,6 +168,11 @@ public class XCTestExecuter implements TestExecuter<XCTestTestExecutionSpec> {
             } finally {
                 execHandle = null;
             }
+        }
+
+        @Override
+        public void processTestSuite(TestSuiteRunInfo testSuite) {
+            throw new GradleException("This exception should never be thrown / reachable");
         }
 
         private ExecHandle executeTest(String testName, OutputStream outputStream, OutputStream errorStream) {


### PR DESCRIPTION
### Context

This pull requests makes test xml suites for TestNG runnable in parallel through a single task, enabling fine-grained control of test execution in parallel, forked JVMs.

Fixes [Issue: #2783 - The use of TestNG suites in combination with maxParallelForks causes tests to be execute multiple times](https://github.com/gradle/gradle/issues/2783).

I think this pull request is a nice first stab at fixing the problem, but I'm not familiar enough with the codebase to say that it's the correct way. I'm willing to implement it differently if need be.

My personal use case is that I work on a legacy project, and certain tests are not allowed to run in parallel within the same JVM. 
These tests are in the same module however, and I'd like to speed up our tests by runnign them in parallel in separate JVMs, but cannot, since they are in the same gradle project.

#### Background

When using TestNG in with gradle, there are two configuration options: 

##### 1) Configure TestNG & class scanning through gradle. 

This is generally the preferred method as it easily grants access to things like parallelization, rerunning tasks first, and other gradle driven enhancements.

##### 2) Specify or build suite xml files for TestNG to use. 

This (in my mind) is usually for legacy projects that need finer grained control. A major draw back is that you cannot run the xml files in parallel JVMs.

The way xml files are handled currently doesn't play well with setting max parallel forks. 
The root cause is that the xml files would get passed to every test executor fork as they are created, and get executed one per test executor.

This initial fix moves test suite xml tracking from the test class processor creation to be handled more like test classes - passed around between the executors so they can be assigned one by one. 
That fixes [Issue: #2783](https://github.com/gradle/gradle/issues/2783) in the following ways

 1) When one test suite is specified but maxForks > 1, the suite gets executed a single executor only once
 2) When more than one test suite is specified and maxForks > 1, the test suites get assigned round-robin to the test executor, before they are run.
 3) When maxForks = 1, things behave as they have been behaving

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
