### PR TITLE
Disable scan plugin <= 1.15.1 if Kotlin script build caching is used

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
@@ -39,7 +39,6 @@ class BuildScanConfigIntegrationTest extends AbstractIntegrationSpec {
         """
     }
 
-
     def "enabled and disabled are false with no flags"() {
         when:
         succeeds "t"
@@ -224,6 +223,28 @@ class BuildScanConfigIntegrationTest extends AbstractIntegrationSpec {
         then:
         scanPlugin.assertUnsupportedMessage(output, BuildScanPluginCompatibility.UNSUPPORTED_TOGGLE_MESSAGE)
         scanPlugin.attributes(output) != null
+    }
+
+    def "unsupported for pre 1.15.2 versions when kotlin script build caching used"() {
+        given:
+        scanPlugin.runtimeVersion = "1.15.1"
+
+        when:
+        succeeds "t", "-P${BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE}=true"
+
+        then:
+        scanPlugin.assertUnsupportedMessage(output, BuildScanPluginCompatibility.UNSUPPORTED_KOTLIN_SCRIPT_BUILD_CACHING_MESSAGE)
+    }
+
+    def "supported for 1.15.2 versions when kotlin script build caching used"() {
+        given:
+        scanPlugin.runtimeVersion = "1.15.2"
+
+        when:
+        succeeds "t", "-P${BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE}=true"
+
+        then:
+        scanPlugin.assertUnsupportedMessage(output, null)
     }
 
     void installVcsMappings() {

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
@@ -31,8 +31,8 @@ import org.gradle.vcs.internal.VcsResolver;
  */
 public class BuildScanConfigServices {
 
-    BuildScanPluginCompatibility createBuildScanPluginCompatibility() {
-        return new BuildScanPluginCompatibility();
+    BuildScanPluginCompatibility createBuildScanPluginCompatibility(StartParameter startParameter) {
+        return new BuildScanPluginCompatibility(startParameter);
     }
 
     BuildScanConfigManager createBuildScanConfigManager(

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.scan.config;
 
+import org.gradle.StartParameter;
 import org.gradle.util.VersionNumber;
 
 class BuildScanPluginCompatibility {
@@ -29,9 +30,20 @@ class BuildScanPluginCompatibility {
     public static final String UNSUPPORTED_VCS_MAPPINGS_MESSAGE =
         "Build scans are not supported when using VCS mappings. It may be supported when using newer versions of the build scan plugin.";
 
+    public static final VersionNumber MIN_VERSION_FOR_KOTLIN_SCRIPT_BUILD_CACHING = VersionNumber.parse("1.15.2");
+    public static final String UNSUPPORTED_KOTLIN_SCRIPT_BUILD_CACHING_MESSAGE =
+        "Build scans are not supported when using using the build cache to cache Kotlin build scripts.";
+
     // Used just to test the mechanism
     public static final String UNSUPPORTED_TOGGLE = "org.gradle.internal.unsupported-scan-plugin";
     public static final String UNSUPPORTED_TOGGLE_MESSAGE = "Build scan support disabled by secret toggle";
+    public static final String KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE = "org.gradle.kotlin.dsl.caching.buildcache";
+
+    private final StartParameter startParameter;
+
+    public BuildScanPluginCompatibility(StartParameter startParameter) {
+        this.startParameter = startParameter;
+    }
 
     String unsupportedReason(VersionNumber pluginVersion, BuildScanConfig.Attributes attributes) {
         if (isEarlierThan(pluginVersion, MIN_SUPPORTED_VERSION)) {
@@ -42,11 +54,19 @@ class BuildScanPluginCompatibility {
             return UNSUPPORTED_VCS_MAPPINGS_MESSAGE;
         }
 
+        if (isEarlierThan(pluginVersion, MIN_VERSION_FOR_KOTLIN_SCRIPT_BUILD_CACHING) && isKotlinBuildCachingEnabled()) {
+            return UNSUPPORTED_KOTLIN_SCRIPT_BUILD_CACHING_MESSAGE;
+        }
+
         if (Boolean.getBoolean(UNSUPPORTED_TOGGLE)) {
             return UNSUPPORTED_TOGGLE_MESSAGE;
         }
 
         return null;
+    }
+
+    private boolean isKotlinBuildCachingEnabled() {
+        return Boolean.valueOf(startParameter.getProjectProperties().get(KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE));
     }
 
     private static boolean isEarlierThan(VersionNumber pluginVersion, VersionNumber minSupportedVersion) {


### PR DESCRIPTION
CI: https://builds.gradle.org/project.html?projectId=Gradle&tab=projectOverview&branch_Gradle=ldaley%2Fdisable-scan-plugin-for-kotlin-script-build-caching