### PR TITLE
Add a test for consistent handling of root directories between `@InputFiles` and `@InputDirectory

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -321,23 +321,22 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
                 }
             }           
             
-            File inputDir = file("inputDir" + property("select"))
-            inputDir.mkdirs()
-            
             task myTask(type: MyTask) {
-                input = inputDir
+                input = file(inputDir)
                 output = project.file("build/output.txt")
-            } 
+            }          
+
+            myTask.input.mkdirs()
         """
         String myTask = ':myTask'
 
         when:
-        run myTask, '-Pselect=1'
+        run myTask, '-PinputDir=inputDir1'
         then:
         executedAndNotSkipped(myTask)
 
         when:
-        run myTask, '-Pselect=2'
+        run myTask, '-PinputDir=inputDir2'
         then:
         executedAndNotSkipped(myTask)
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskUpToDateIntegrationTest.groovy
@@ -17,6 +17,8 @@
 
 package org.gradle.integtests
 
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFiles
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -301,5 +303,45 @@ class TaskUpToDateIntegrationTest extends AbstractIntegrationSpec {
         run 'myTask', "--info"
         then:
         skipped(':myTask')
+    }
+
+    @Unroll
+    @Issue("https://github.com/gradle/gradle/issues/4204")
+    def "changing path of empty root directory makes task out of date for #inputAnnotation"() {
+        buildFile << """
+            class MyTask extends DefaultTask {
+                @${inputAnnotation}
+                File input
+                @OutputFile
+                File output
+                
+                @TaskAction
+                void doStuff() {
+                    output.text = input.list().join('\\n')
+                }
+            }           
+            
+            File inputDir = file("inputDir" + property("select"))
+            inputDir.mkdirs()
+            
+            task myTask(type: MyTask) {
+                input = inputDir
+                output = project.file("build/output.txt")
+            } 
+        """
+        String myTask = ':myTask'
+
+        when:
+        run myTask, '-Pselect=1'
+        then:
+        executedAndNotSkipped(myTask)
+
+        when:
+        run myTask, '-Pselect=2'
+        then:
+        executedAndNotSkipped(myTask)
+
+        where:
+        inputAnnotation << [InputFiles.name, InputDirectory.name]
     }
 }


### PR DESCRIPTION
This has been fixed by the file system refactorings.

Fixes #4204