### PR TITLE
Validate Jdks at execution time

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -301,9 +301,10 @@ fun distributionImage(named: String) =
     project(":distributions").property(named) as CopySpec
 
 val validateBuildCacheConfiguration = tasks.register("validateBuildCacheConfiguration") {
+    enabled = gradle.startParameter.isBuildCacheEnabled
     doLast {
-        if (gradle.startParameter.isBuildCacheEnabled) {
-            rootProject.availableJavaInstallations.validateBuildCacheConfiguration(rootProject.buildCacheConfiguration())
+        if (rootProject.buildCacheConfiguration().remote?.isEnabled == true) {
+            rootProject.availableJavaInstallations.validateForRemoteBuildCacheUsage()
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -300,11 +300,17 @@ tasks.register<Install>("installAll") {
 fun distributionImage(named: String) =
     project(":distributions").property(named) as CopySpec
 
-afterEvaluate {
-    if (gradle.startParameter.isBuildCacheEnabled) {
-        rootProject
-            .availableJavaInstallations
-            .validateBuildCacheConfiguration(buildCacheConfiguration())
+val validateBuildCacheConfiguration = tasks.register("validateBuildCacheConfiguration") {
+    doLast {
+        if (gradle.startParameter.isBuildCacheEnabled) {
+            rootProject.availableJavaInstallations.validateBuildCacheConfiguration(rootProject.buildCacheConfiguration())
+        }
+    }
+}
+
+subprojects {
+    tasks.withType<AbstractCompile>().configureEach {
+        dependsOn(validateBuildCacheConfiguration)
     }
 }
 

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/AddVerifyProductionEnvironmentTaskPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/AddVerifyProductionEnvironmentTaskPlugin.kt
@@ -11,7 +11,7 @@ open class AddVerifyProductionEnvironmentTaskPlugin : Plugin<Project> {
         tasks.register("verifyIsProductionBuildEnvironment") {
             doLast {
                 rootProject.availableJavaInstallations {
-                    validateProductionEnvironment()
+                    validateForProductionEnvironment()
                 }
                 val systemCharset = Charset.defaultCharset().name()
                 assert(systemCharset == "UTF-8") {

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -110,8 +110,6 @@ open class AvailableJavaInstallations(project: Project, private val javaInstalla
             )
             if (buildCacheConfiguration.remote?.isEnabled == true) {
                 throw GradleException(message)
-            } else {
-                logger.warn(message)
             }
         }
     }

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -3,7 +3,6 @@ package org.gradle.gradlebuild.java
 import org.gradle.api.GradleException
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
-import org.gradle.caching.configuration.BuildCacheConfiguration
 import org.gradle.internal.jvm.JavaInfo
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.jvm.inspection.JvmVersionDetector
@@ -101,20 +100,18 @@ open class AvailableJavaInstallations(project: Project, private val javaInstalla
         else -> throw IllegalArgumentException("No Java installation found which supports Java version $javaVersion")
     }
 
-    fun validateBuildCacheConfiguration(buildCacheConfiguration: BuildCacheConfiguration) {
+    fun validateForRemoteBuildCacheUsage() {
         val validationErrors = validateCompilationJdks()
         if (validationErrors.isNotEmpty()) {
             val message = formatValidationError(
                 "In order to have cache hits from the remote build cache, your environment needs to be configured accordingly!",
                 validationErrors
             )
-            if (buildCacheConfiguration.remote?.isEnabled == true) {
-                throw GradleException(message)
-            }
+            throw GradleException(message)
         }
     }
 
-    fun validateProductionEnvironment() {
+    fun validateForProductionEnvironment() {
         val validationErrors = validateCompilationJdks() +
             mapOf(
                 validationMessage(testJavaHomePropertyName, javaInstallationForTest, oracleJdk8) to (javaInstallationForTest.vendorAndMajorVersion != oracleJdk8)

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -16,10 +16,10 @@ import java.io.File
 class JavaInstallation(val current: Boolean, val jvm: JavaInfo, val javaVersion: JavaVersion, private val javaInstallationProbe: JavaInstallationProbe) {
     val javaHome = jvm.javaHome
 
-    override fun toString(): String = "$vendor (${javaHome.absolutePath})"
+    override fun toString(): String = "$vendorAndMajorVersion (${javaHome.absolutePath})"
 
     val toolsJar: File? by lazy { jvm.toolsJar }
-    val vendor: String by lazy {
+    val vendorAndMajorVersion: String by lazy {
         ProbedLocalJavaInstallation(jvm.javaHome).apply {
             javaInstallationProbe.checkJdk(jvm.javaHome).configure(this)
         }.displayName
@@ -119,7 +119,7 @@ open class AvailableJavaInstallations(project: Project, private val javaInstalla
     fun validateProductionEnvironment() {
         val validationErrors = validateCompilationJdks() +
             mapOf(
-                validationMessage(testJavaHomePropertyName, javaInstallationForTest, oracleJdk8) to (javaInstallationForTest.vendor != oracleJdk8)
+                validationMessage(testJavaHomePropertyName, javaInstallationForTest, oracleJdk8) to (javaInstallationForTest.vendorAndMajorVersion != oracleJdk8)
             ).filterValues { it }.keys
         if (validationErrors.isNotEmpty()) {
             throw GradleException(formatValidationError("JDKs not configured correctly for production build.", validationErrors))
@@ -131,9 +131,9 @@ open class AvailableJavaInstallations(project: Project, private val javaInstalla
         val jdkForCompilation = javaInstallations.values.firstOrNull()
         return mapOf(
             "Must set project or system property '$java7HomePropertyName' to the path of an $oracleJdk7, is currently unset." to (jdkForCompilation == null),
-            validationMessage(java7HomePropertyName, jdkForCompilation, oracleJdk7) to (jdkForCompilation != null && jdkForCompilation.vendor != oracleJdk7),
-            "Must use Oracle JDK 8/9 to perform this build. Is currently ${currentJavaInstallation.vendor} at ${currentJavaInstallation.javaHome}." to
-                (currentJavaInstallation.vendor != oracleJdk8 && currentJavaInstallation.vendor != oracleJdk9)
+            validationMessage(java7HomePropertyName, jdkForCompilation, oracleJdk7) to (jdkForCompilation != null && jdkForCompilation.vendorAndMajorVersion != oracleJdk7),
+            "Must use Oracle JDK 8/9 to perform this build. Is currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
+                (currentJavaInstallation.vendorAndMajorVersion != oracleJdk8 && currentJavaInstallation.vendorAndMajorVersion != oracleJdk9)
         ).filterValues { it }.keys
     }
 
@@ -146,7 +146,7 @@ open class AvailableJavaInstallations(project: Project, private val javaInstalla
 
     private
     fun validationMessage(propertyName: String, javaInstallation: JavaInstallation?, requiredVersion: String) =
-        "Must set project or system property '$propertyName' to the path of an $requiredVersion, is currently ${javaInstallation?.vendor} at ${javaInstallation?.javaHome}."
+        "Must set project or system property '$propertyName' to the path of an $requiredVersion, is currently ${javaInstallation?.vendorAndMajorVersion} at ${javaInstallation?.javaHome}."
 
     private
     fun findJavaInstallations(javaHomes: List<String>) =

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallationsPlugin.kt
@@ -2,6 +2,7 @@ package org.gradle.gradlebuild.java
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.internal.jvm.inspection.JvmVersionDetector
 import org.gradle.jvm.toolchain.internal.JavaInstallationProbe
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.support.serviceOf
@@ -11,10 +12,12 @@ import org.gradle.kotlin.dsl.support.serviceOf
 open class AvailableJavaInstallationsPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
         val javaInstallationProbe = project.serviceOf<JavaInstallationProbe>()
+        val jvmVersionDetector = project.serviceOf<JvmVersionDetector>()
         extensions.create<AvailableJavaInstallations>(
             "availableJavaInstallations",
             project,
-            javaInstallationProbe
+            javaInstallationProbe,
+            jvmVersionDetector
         )
     }
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -102,7 +102,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
             when (compileTask) {
                 is JavaCompile -> jdkForCompilation
                 else -> availableJavaInstallations.currentJavaInstallation
-            }.vendor
+            }.vendorAndMajorVersion
         })
     }
 
@@ -165,7 +165,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
                 jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
             }
             // Includes JVM vendor and major version
-            inputs.property("javaInstallation", Callable { javaInstallationForTest.vendor })
+            inputs.property("javaInstallation", Callable { javaInstallationForTest.vendorAndMajorVersion })
             doFirst {
                 if (BuildEnvironment.isCiServer) {
                     logger.lifecycle("maxParallelForks for '$path' is $maxParallelForks")


### PR DESCRIPTION
So that configuration time can be faster by avoiding to call
JavaInstallationProbe.
