### PR TITLE
WIP: Treat POM optional dependencies as `prefer` constraints

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
@@ -279,4 +279,54 @@ dependencies {
         }
     }
 
+    @RequiredFeatures([
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
+        @RequiredFeature(feature = GradleMetadataResolveRunner.EXPERIMENTAL_RESOLVE_BEHAVIOR, value = "true")
+    ])
+    def "optional dependency version will not upgrade version from non-optional dependency"() {
+        given:
+        repository {
+            'org.gradle:test:1.45' {
+                dependsOn group:'org.gradle', artifact:'not-upgraded', version:'1.45', optional: 'true'
+                dependsOn group:'org.gradle', artifact:'recommended', version:'1.45', optional: 'true'
+            }
+            'org.gradle:not-upgraded:1.44'()
+            'org.gradle:recommended:1.45'()
+        }
+        and:
+
+        buildFile << """
+dependencies {
+    conf "org.gradle:test:1.45"
+    conf "org.gradle:not-upgraded:1.44"
+    conf "org.gradle:recommended"
+}
+"""
+
+        repositoryInteractions {
+            'org.gradle:test:1.45' {
+                expectResolve()
+            }
+            'org.gradle:not-upgraded:1.44' {
+                expectResolve()
+            }
+            'org.gradle:recommended:1.45' {
+                expectResolve()
+            }
+        }
+
+        expect:
+        succeeds "checkDep"
+        resolve.expectGraph {
+            root(':', ':testproject:') {
+                module("org.gradle:not-upgraded:1.44")
+                edge("org.gradle:recommended", "org.gradle:recommended:1.45")
+                module("org.gradle:test:1.45") {
+                    edge("org.gradle:not-upgraded:1.45", "org.gradle:not-upgraded:1.44")
+                    module("org.gradle:recommended:1.45")
+                }
+            }
+        }
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraint.java
@@ -21,6 +21,7 @@ import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 
 public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint implements ImmutableVersionConstraint {
@@ -126,6 +127,10 @@ public class DefaultImmutableVersionConstraint extends AbstractVersionConstraint
             return of();
         }
         return new DefaultImmutableVersionConstraint(version);
+    }
+
+    public static ImmutableVersionConstraint prefer(String version) {
+        return new DefaultImmutableVersionConstraint(version, "", "", Collections.<String>emptyList());
     }
 
     public static ImmutableVersionConstraint of(String preferredVersion, String requiredVersion, String strictVersion, List<String> rejects) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -50,7 +50,7 @@ public enum CacheLayout {
         .changedTo(53, "4.6-rc-1")
         .changedTo(56, "4.7-rc-1")
         .changedTo(58, "4.8-rc-1")
-        .changedTo(63, "4.10-rc-1")),
+        .changedTo(64, "4.10-rc-1")),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
@@ -128,7 +129,10 @@ public class GradlePomModuleDescriptorBuilder {
 
         String version = determineVersion(dep);
         String mappedVersion = convertVersionFromMavenSyntax(version);
-        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dep.getGroupId(), dep.getArtifactId()), new DefaultImmutableVersionConstraint(mappedVersion));
+        VersionConstraint versionConstraint = optional
+            ? DefaultImmutableVersionConstraint.prefer(mappedVersion)
+            : DefaultImmutableVersionConstraint.of(mappedVersion);
+        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dep.getGroupId(), dep.getArtifactId()), versionConstraint);
 
         // Some POMs depend on themselves, don't add this dependency: Ivy doesn't allow this!
         // Example: http://repo2.maven.org/maven2/net/jini/jsk-platform/2.1/jsk-platform-2.1.pom

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,10 +54,10 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.63'
-        cacheLayout.version == CacheVersion.parse("2.63")
-        cacheLayout.version.toString() == '2.63'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.63')
+        cacheLayout.key == 'metadata-2.64'
+        cacheLayout.version == CacheVersion.parse("2.64")
+        cacheLayout.version.toString() == '2.64'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.64')
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }


### PR DESCRIPTION
Demonstrates a fix for #5434 by treating any version from a POM optional dependency as a `prefer` version constraint. Note that several tests that validate the old behaviour now fail.