### PR TITLE
Deferred Jacoco plugin changes round 2

### DIFF
--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -171,7 +171,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
     public Object configureDefaultOutputPathForJacocoMerge() {
         DeprecationLogger
             .nagUserOfDiscontinuedMethod("JacocoPlugin.configureDefaultOutputPathForJacocoMerge()");
-        project.getTasks().withType(JacocoMerge.class, new Action<JacocoMerge>() {
+        project.getTasks().withType(JacocoMerge.class).configureEach(new Action<JacocoMerge>() {
             @Override
             public void execute(final JacocoMerge task) {
                 task.setDestinationFile(project.provider(new Callable<File>() {

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -263,6 +263,12 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
                     reportTask.getReports().all(new Action<ConfigurableReport>() {
                         @Override
                         public void execute(final ConfigurableReport report) {
+                            /*
+                             * For someone looking for the difference between this and the duplicate code above
+                             * this one uses the `testTaskProvider` and the `reportTask`. The other just
+                             * uses the `reportTask`.
+                             * https://github.com/gradle/gradle/issues/6343
+                             */
                             if (report.getOutputType().equals(Report.OutputType.DIRECTORY)) {
                                 report.setDestination(project.provider(new Callable<File>() {
                                     @Override


### PR DESCRIPTION
### Context
@big-guy This is a second round of changes that I think might be relevant.

In particular, keeping `JacocoMerge` lazy.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
