### PR TITLE
Fix Play2.6-https-hang issue

### DIFF
--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/basic/Play26HttpsIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/basic/Play26HttpsIntegrationTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.play.integtest.basic
+
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
+import org.gradle.play.integtest.fixtures.AbstractMultiVersionPlayContinuousBuildIntegrationTest
+import org.gradle.play.integtest.fixtures.PlayApp
+import org.gradle.play.integtest.fixtures.RunningPlayApp
+import org.gradle.play.integtest.fixtures.app.BasicPlayApp
+import org.gradle.play.internal.DefaultPlayPlatform
+import spock.lang.Issue
+
+@Issue('https://github.com/gradle/gradle/issues/4622')
+@TargetCoverage({ [DefaultPlayPlatform.DEFAULT_PLAY_VERSION] })
+@IntegrationTestTimeout(600)
+class Play26HttpsIntegrationTest extends AbstractMultiVersionPlayContinuousBuildIntegrationTest {
+    RunningPlayApp runningApp = new RunningPlayApp(testDirectory)
+    PlayApp playApp = new BasicPlayApp(versionNumber)
+
+    def setup() {
+        useRepositoryMirrors()
+    }
+
+    def 'can enable https.port'() {
+        when:
+        buildFile << '''
+            tasks.withType(PlayRun) {
+                forkOptions.jvmArgs = ["-Dhttps.port=0"]
+            }
+        '''
+
+        then:
+        succeeds "runPlayBinary"
+
+        and:
+        appIsRunningAndDeployed()
+
+        and:
+        runningApp.output().contains('Listening for HTTPS on')
+    }
+}

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayWorkerServer.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayWorkerServer.java
@@ -45,6 +45,7 @@ public class PlayWorkerServer implements Action<WorkerProcessContext>, PlayRunWo
     private final BlockingQueue<PlayAppLifecycleUpdate> events = new SynchronousQueue<PlayAppLifecycleUpdate>();
 
     private boolean stopRequested;
+    private boolean serverStarted;
     private Reloader.Result latestStatus;
 
     public PlayWorkerServer(PlayRunSpec runSpec, VersionedPlayRunAdapter runAdapter) {
@@ -58,6 +59,7 @@ public class PlayWorkerServer implements Action<WorkerProcessContext>, PlayRunWo
         context.getServerConnection().addIncoming(PlayRunWorkerServerProtocol.class, this);
         context.getServerConnection().connect();
         final PlayAppLifecycleUpdate result = start();
+        serverStarted = true;
         try {
             clientProtocol.update(result);
             while (!stopRequested) {
@@ -127,6 +129,9 @@ public class PlayWorkerServer implements Action<WorkerProcessContext>, PlayRunWo
     public Result requireUpToDate() throws InterruptedException {
         lock.lock();
         try {
+            if (!serverStarted) {
+                return new Result(true, null);
+            }
             if (!stopRequested) {
                 LOGGER.debug("requireUpToDate");
                 events.put(PlayAppLifecycleUpdate.reloadRequested());


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/4622

If https enabled, Play 2.6 will call `BuildLink.reload()` method during initialization phase:

```
        at java.util.concurrent.SynchronousQueue.put(SynchronousQueue.java:877)
	at org.gradle.play.internal.run.PlayWorkerServer.requireUpToDate(PlayWorkerServer.java:132)
	at org.gradle.play.internal.run.DefaultVersionedPlayRunAdapter$1.invoke(DefaultVersionedPlayRunAdapter.java:73)
	at com.sun.proxy.$Proxy2.reload(Unknown Source)
	at play.core.server.DevServerStart$$anon$1.get(DevServerStart.scala:123)
	- locked <0x00000006c003df38> (a play.core.server.DevServerStart$$anon$1)
	at play.core.server.ssl.ServerSSLEngine$.createSSLEngineProvider(ServerSSLEngine.scala:29)
```

This will make the whole application stuck. This PR fixes this issue by adding a boolean flag in
`PlayWorkerServer`.