### PR TITLE
Support for gradle wrapper distribution mirror

### DIFF
--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/WrapperExecutor.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 public class WrapperExecutor {
     public static final String DISTRIBUTION_URL_PROPERTY = "distributionUrl";
@@ -77,7 +78,12 @@ public class WrapperExecutor {
         if (properties.getProperty(DISTRIBUTION_URL_PROPERTY) == null) {
             reportMissingProperty(DISTRIBUTION_URL_PROPERTY);
         }
-        return new URI(getProperty(DISTRIBUTION_URL_PROPERTY));
+        String distributionUrl = getProperty(DISTRIBUTION_URL_PROPERTY);
+        if (System.getenv("GRADLE_DISTRIBUTION_MIRROR")) {
+            Pattern regex = Pattern.compile("^https?://[^/]+");
+            distributionUrl = regex.matcher(distributionUrl).replaceFirst(System.getenv("GRADLE_DISTRIBUTION_MIRROR"));
+        }
+        return new URI(distributionUrl);
     }
 
     private static void loadProperties(File propertiesFile, Properties properties) throws IOException {


### PR DESCRIPTION
I don't plan to develop this further until someone from the gradle team provides feedback.

### Context

I first [opened a discussion on the Gradle forums][discuss] back in May 6th, 2018.  I hadn't seen any activity one way or another.  The full context can be read there.

I feel this is a very relevant feature for any company who desires to use gradle in significant capacity.  It makes sense for a company to mirror sources of download for all of their project dependencies.  Gradle through Gradle wrapper is no different from that desirable perspective.

Hopefully, this is up to snuff for the Gradle devs.  Nobody from the development team responded to my original forum post before I did this work.

[discuss]: https://discuss.gradle.org/t/support-for-gradle-wrapper-distribution-mirror/26838

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
