### PR TITLE
Fix deprecation warning

### DIFF
--- a/subprojects/platform-play/src/main/java/org/gradle/scala/internal/reflect/ScalaListBuffer.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/scala/internal/reflect/ScalaListBuffer.java
@@ -23,7 +23,7 @@ public class ScalaListBuffer {
     public static <T> Object fromList(ClassLoader cl, List<T> list) {
         try {
             Class<?> bufferClass = cl.loadClass("scala.collection.mutable.ListBuffer");
-            Object buffer = bufferClass.newInstance();
+            Object buffer = bufferClass.getConstructor().newInstance();
             Method bufferPlusEq = bufferClass.getMethod("$plus$eq", Object.class);
 
             for (T elem : list) {


### PR DESCRIPTION
Calling Class.newInstance() is deprecated on Java 9/10 and caused
compilation to fail for `platformPlay` when Java 9 or 10 is used.