### PR TITLE
Use compileAll to warm up the build cache

### DIFF
--- a/.teamcity/Gradle_AgentTest/settings.kts
+++ b/.teamcity/Gradle_AgentTest/settings.kts
@@ -1,7 +1,15 @@
 package Gradle_AgentTest
 
-import jetbrains.buildServer.configs.kotlin.v2018_1.*
-import model.*
+import jetbrains.buildServer.configs.kotlin.v2018_1.project
+import jetbrains.buildServer.configs.kotlin.v2018_1.version
+import model.CIBuildModel
+import model.JvmVersion
+import model.NoBuildCache
+import model.OS
+import model.SpecificBuild
+import model.Stage
+import model.TestCoverage
+import model.TestType
 import projects.RootProject
 
 /*
@@ -46,7 +54,7 @@ val buildModel = CIBuildModel(
         stages = listOf(
                 Stage("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer)",
                         runsIndependent = true,
-                        specificBuilds = listOf(SpecificBuild.SanityCheck),
+                        specificBuilds = listOf(SpecificBuild.CompileAll, SpecificBuild.SanityCheck),
                         functionalTests = listOf(TestCoverage(TestType.quick, OS.linux, JvmVersion.java8)))
         )
 )

--- a/.teamcity/Gradle_Check/configurations/CompileAll.kt
+++ b/.teamcity/Gradle_Check/configurations/CompileAll.kt
@@ -1,0 +1,38 @@
+package configurations
+
+import jetbrains.buildServer.configs.kotlin.v2018_1.AbsoluteId
+import model.CIBuildModel
+import model.Stage
+
+class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model, stage = stage, usesParentBuildCache = true, init = {
+    uuid = buildTypeId(model)
+    id = AbsoluteId(uuid)
+    name = "Compile All"
+    description = "Compiles all the source code and warms up the build cache"
+
+    params {
+        param("system.java9Home", "%linux.java9.oracle.64bit%")
+        param("env.JAVA_HOME", "%linux.java8.oracle.64bit%")
+    }
+
+    if (model.publishStatusToGitHub) {
+        features {
+            publishBuildStatusToGithub()
+        }
+    }
+
+    applyDefaults(
+        model,
+        this,
+        "compileAll",
+        extraParameters = buildScanTag("CompileAll")
+    )
+
+    artifactRules = """$artifactRules
+        build/build-receipt.properties
+    """.trimIndent()
+}) {
+    companion object {
+        fun buildTypeId(model: CIBuildModel) = "${model.projectPrefix}CompileAll"
+    }
+}

--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -122,7 +122,7 @@ fun ProjectFeatures.buildReportTab(title: String, startPage: String) {
 fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTasks: String, notQuick: Boolean = false, os: OS = OS.linux, extraParameters: String = "", timeout: Int = 90, extraSteps: BuildSteps.() -> Unit = {}, daemon: Boolean = true) {
     applyDefaultSettings(buildType, os, timeout)
 
-    var gradleParameterString = gradleParameters(os, daemon).joinToString(separator = " ")
+    val gradleParameterString = gradleParameters(os, daemon).joinToString(separator = " ")
 
     val buildScanTags = model.buildScanTags + listOfNotNull(buildType.stage?.id)
 
@@ -202,19 +202,19 @@ fun applyDefaultDependencies(model: CIBuildModel, buildType: BuildType, notQuick
         }
     }
 
-    if (buildType !is SanityCheck) {
+    if (buildType !is CompileAll) {
         buildType.dependencies {
-            val sanityCheckId = SanityCheck.buildTypeId(model)
-            // Sanity Check has to succeed before anything else is started
-            dependency(AbsoluteId(sanityCheckId)) {
+            val compileAllId = CompileAll.buildTypeId(model)
+            // Compile All has to succeed before anything else is started
+            dependency(AbsoluteId(compileAllId)) {
                 snapshot {
                     onDependencyFailure = FailureAction.CANCEL
                     onDependencyCancel = FailureAction.CANCEL
                 }
             }
             // Get the build receipt from sanity check to reuse the timestamp
-            artifacts(AbsoluteId(sanityCheckId)) {
-                id = "ARTIFACT_DEPENDENCY_$sanityCheckId"
+            artifacts(AbsoluteId(compileAllId)) {
+                id = "ARTIFACT_DEPENDENCY_$compileAllId"
                 cleanDestination = true
                 artifactRules = "build-receipt.properties => incoming-distributions"
             }

--- a/.teamcity/Gradle_Check/configurations/SanityCheck.kt
+++ b/.teamcity/Gradle_Check/configurations/SanityCheck.kt
@@ -24,13 +24,9 @@ class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model
     applyDefaults(
             model,
             this,
-            "compileAll sanityCheck",
+            "sanityCheck",
             extraParameters = "-DenableCodeQuality=true ${buildScanTag("SanityCheck")}"
     )
-
-    artifactRules = """$artifactRules
-        build/build-receipt.properties
-    """.trimIndent()
 }) {
     companion object {
         fun buildTypeId(model: CIBuildModel) = "${model.projectPrefix}SanityCheck"

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -1,6 +1,7 @@
 package model
 
 import configurations.BuildDistributions
+import configurations.CompileAll
 import configurations.DependenciesCheck
 import configurations.Gradleception
 import configurations.SanityCheck
@@ -19,7 +20,7 @@ data class CIBuildModel (
         val stages: List<Stage> = listOf(
             Stage("Quick Feedback - Linux Only", "Run checks and functional tests (embedded executer)",
                     specificBuilds = listOf(
-                            SpecificBuild.SanityCheck),
+                            SpecificBuild.CompileAll, SpecificBuild.SanityCheck),
                     functionalTests = listOf(
                             TestCoverage(TestType.quick, OS.linux, JvmVersion.java8)), omitsSlowProjects = true),
             Stage("Quick Feedback", "Run checks and functional tests (embedded executer)",
@@ -261,6 +262,11 @@ enum class Trigger {
 }
 
 enum class SpecificBuild {
+    CompileAll {
+        override fun create(model: CIBuildModel, stage: Stage): BuildType {
+            return CompileAll(model, stage)
+        }
+    },
     SanityCheck {
         override fun create(model: CIBuildModel, stage: Stage): BuildType {
             return SanityCheck(model, stage)

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -1,11 +1,18 @@
 
 import configurations.shouldBeSkipped
 import jetbrains.buildServer.configs.kotlin.v2018_1.Project
-import model.*
+import model.CIBuildModel
+import model.GradleSubproject
+import model.JvmVersion
+import model.NoBuildCache
+import model.OS
+import model.SpecificBuild
+import model.Stage
+import model.TestCoverage
+import model.TestType
 import org.junit.Test
 import projects.RootProject
 import java.io.File
-import java.util.regex.Pattern
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -75,10 +82,10 @@ class CIConfigIntegrationTests {
                 }
 
                 // hacky way to consider deferred tests
-                var deferredTestCount = if (stage.name.contains("Master Accept")) 10 else 0
+                val deferredTestCount = if (stage.name.contains("Master Accept")) 10 else 0
                 assertEquals(
                stage.specificBuilds.size + functionalTestCount + stage.performanceTests.size + (if (prevStage != null) 1 else 0) + deferredTestCount,
-                       it.dependencies.items.size, "${stage.name}")
+                       it.dependencies.items.size, stage.name)
             } else {
                 assertEquals(2, it.dependencies.items.size) //Individual Performance Worker
             }
@@ -94,6 +101,7 @@ class CIConfigIntegrationTests {
                 stages = listOf(
                         Stage("Quick Feedback", "Runs all checks and functional tests with an embedded test executer",
                             specificBuilds = listOf(
+                                    SpecificBuild.CompileAll,
                                     SpecificBuild.SanityCheck,
                                     SpecificBuild.BuildDistributions),
                             functionalTests = listOf(
@@ -109,7 +117,6 @@ class CIConfigIntegrationTests {
 
     @Test
     fun canDeferSlowTestsToLaterStage() {
-        val ft = listOf(TestCoverage(TestType.quick, OS.linux, JvmVersion.java8), TestCoverage(TestType.quick, OS.windows, JvmVersion.java7))
         val m = CIBuildModel(
             projectPrefix = "",
             parentBuildCache = NoBuildCache,


### PR DESCRIPTION
Sanity Check can run as a job in parallel to the functional tests.
This allows getting faster feedback for integration tests and
makes the common initial job faster.

The build cache should be populated with the whole compilation result
by this initial job, so the follow up jobs should continue using the
result of compilation via the build cache.