### PR TITLE
Remove '@' from Provider link in more_about_tasks

### DIFF
--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -723,7 +723,7 @@ This means that changes which only touch the implementation of classes do not ma
 When analyzing `@link:{javadocPath}/org/gradle/api/tasks/Nested.html[Nested]` task properties for declared input and output sub-properties Gradle uses the type of the actual value.
 Hence it can discover all sub-properties declared by a runtime sub-type.
 
-When adding `@link:{javadocPath}/org/gradle/api/tasks/Nested.html[Nested]` to a `@link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider]`, the value of the `Provider` is treated as a nested input.
+When adding `@link:{javadocPath}/org/gradle/api/tasks/Nested.html[Nested]` to a `link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider]`, the value of the `Provider` is treated as a nested input.
 
 When adding `@link:{javadocPath}/org/gradle/api/tasks/Nested.html[Nested]` to an iterable, each element is treated as a separate nested input.
 Each nested input in the iterable is assigned a name, which by default is the dollar sign followed by the index in the iterable, e.g. `$2`.


### PR DESCRIPTION
### Context
Simple documentation fix. `Provider` is an interface, not an annotation.

Making this change through the github UI. There's no good way for me to sign off through this mechanism without checking out this branch locally.

@eriwen This is probably one for you.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
