### PR TITLE
Fix BuildScanPluginCompatibility after Kotlin DSL 1.0-RC3

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
@@ -230,7 +230,7 @@ class BuildScanConfigIntegrationTest extends AbstractIntegrationSpec {
         scanPlugin.runtimeVersion = "1.15.1"
 
         when:
-        succeeds "t", "-P${BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE}=true"
+        succeeds "t", "-D${BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE}=true"
 
         then:
         scanPlugin.assertUnsupportedMessage(output, BuildScanPluginCompatibility.UNSUPPORTED_KOTLIN_SCRIPT_BUILD_CACHING_MESSAGE)
@@ -241,7 +241,7 @@ class BuildScanConfigIntegrationTest extends AbstractIntegrationSpec {
         scanPlugin.runtimeVersion = "1.15.2"
 
         when:
-        succeeds "t", "-P${BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE}=true"
+        succeeds "t", "-D${BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE}=true"
 
         then:
         scanPlugin.assertUnsupportedMessage(output, null)

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigServices.java
@@ -31,8 +31,8 @@ import org.gradle.vcs.internal.VcsResolver;
  */
 public class BuildScanConfigServices {
 
-    BuildScanPluginCompatibility createBuildScanPluginCompatibility(StartParameter startParameter) {
-        return new BuildScanPluginCompatibility(startParameter);
+    BuildScanPluginCompatibility createBuildScanPluginCompatibility() {
+        return new BuildScanPluginCompatibility();
     }
 
     BuildScanConfigManager createBuildScanConfigManager(

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.scan.config;
 
-import org.gradle.StartParameter;
 import org.gradle.util.VersionNumber;
 
 class BuildScanPluginCompatibility {
@@ -39,12 +38,6 @@ class BuildScanPluginCompatibility {
     public static final String UNSUPPORTED_TOGGLE_MESSAGE = "Build scan support disabled by secret toggle";
     public static final String KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE = "org.gradle.kotlin.dsl.caching.buildcache";
 
-    private final StartParameter startParameter;
-
-    public BuildScanPluginCompatibility(StartParameter startParameter) {
-        this.startParameter = startParameter;
-    }
-
     String unsupportedReason(VersionNumber pluginVersion, BuildScanConfig.Attributes attributes) {
         if (isEarlierThan(pluginVersion, MIN_SUPPORTED_VERSION)) {
             return UNSUPPORTED_PLUGIN_VERSION_MESSAGE;
@@ -66,7 +59,7 @@ class BuildScanPluginCompatibility {
     }
 
     private boolean isKotlinBuildCachingEnabled() {
-        return Boolean.valueOf(startParameter.getProjectProperties().get(KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE));
+        return Boolean.getBoolean(KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE);
     }
 
     private static boolean isEarlierThan(VersionNumber pluginVersion, VersionNumber minSupportedVersion) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
@@ -28,7 +28,6 @@ class BuildScanConfigManagerTest extends Specification {
     boolean scanDisabled
 
     def attributes = Mock(BuildScanConfig.Attributes)
-    def projectProperties = [:]
 
     def "conveys configuration"() {
         when:
@@ -111,9 +110,10 @@ class BuildScanConfigManagerTest extends Specification {
         version << ["1.11", "1.12"]
     }
 
+    @RestoreSystemProperties
     def "throws if kotlin script build caching used and version doesnt support"() {
         given:
-        projectProperties[BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE] = "true"
+        System.setProperty(BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE, "true")
 
         when:
         config("1.9")
@@ -123,9 +123,10 @@ class BuildScanConfigManagerTest extends Specification {
     }
 
     @Unroll
+    @RestoreSystemProperties
     def "does not throw if kotlin script build caching used and version #version"() {
         given:
-        projectProperties[BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE] = "true"
+        System.setProperty(BuildScanPluginCompatibility.KOTLIN_SCRIPT_BUILD_CACHE_TOGGLE, "true")
 
         when:
         config(version)
@@ -165,10 +166,9 @@ class BuildScanConfigManagerTest extends Specification {
             isBuildScan() >> scanEnabled
             isNoBuildScan() >> scanDisabled
             getSystemPropertiesArgs() >> { [:] }
-            getProjectProperties() >> { projectProperties }
         }
 
-        new BuildScanConfigManager(startParameter, Mock(ListenerManager), new BuildScanPluginCompatibility(startParameter), { attributes })
+        new BuildScanConfigManager(startParameter, Mock(ListenerManager), new BuildScanPluginCompatibility(), { attributes })
     }
 
     BuildScanConfig config(String versionNumber = BuildScanPluginCompatibility.MIN_SUPPORTED_VERSION) {


### PR DESCRIPTION
The toggle moved from a project property to a system property

See https://github.com/gradle/kotlin-dsl/issues/1032