### PR TITLE
Make DefaultArtifactPublicationSet use a lazy provider

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -263,24 +263,22 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
     public void addLater(Provider<? extends T> provider) {
         assertMutable();
         ProviderInternal<? extends T> providerInternal = Cast.uncheckedCast(provider);
+        store.addPending(providerInternal);
         if (eventRegister.isSubscribed(providerInternal.getType())) {
             doAdd(provider.get(), eventRegister.getAddActions());
-            return;
         }
-        store.addPending(providerInternal);
     }
 
     @Override
     public void addAllLater(Provider<? extends Iterable<T>> provider) {
         assertMutable();
         CollectionProviderInternal<T, ? extends Iterable<T>> providerInternal = Cast.uncheckedCast(provider);
+        store.addPendingCollection(providerInternal);
         if (eventRegister.isSubscribed(providerInternal.getElementType())) {
             for (T value : provider.get()) {
                 doAdd(value, eventRegister.getAddActions());
             }
-            return;
         }
-        store.addPendingCollection(providerInternal);
     }
 
     protected void didAdd(T toAdd) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -76,4 +76,26 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
         then:
         outputContains("Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set.")
     }
+
+    def "jar task is created lazily"() {
+        buildFile << """
+            apply plugin: 'java'
+
+            tasks.named('jar').configure {
+                println "jar task created"
+            }
+            
+            task printArtifacts {
+                doLast {
+                    configurations.runtime.artifacts.files.each { println it }
+                }
+            }
+        """
+
+        when:
+        succeeds("printArtifacts")
+
+        then:
+        result.groupedOutput.task(':printArtifacts').output.contains("jar task created")
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -15,44 +15,111 @@
  */
 package org.gradle.api.internal.plugins;
 
+import com.google.common.collect.Sets;
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
+import org.gradle.api.internal.provider.AbstractProvider;
+import org.gradle.api.internal.provider.ChangingValue;
+import org.gradle.api.internal.provider.ChangingValueHandler;
+import org.gradle.api.internal.provider.CollectionProviderInternal;
+
+import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * The policy for which artifacts should be published by default when none are explicitly declared.
  */
 public class DefaultArtifactPublicationSet {
-    private final PublishArtifactSet artifacts;
-    private PublishArtifact defaultArtifact;
+    private final PublishArtifactSet artifactContainer;
+    private DefaultArtifactProvider defaultArtifactProvider;
 
-    public DefaultArtifactPublicationSet(PublishArtifactSet artifacts) {
-        this.artifacts = artifacts;
+    public DefaultArtifactPublicationSet(PublishArtifactSet artifactContainer) {
+        this.artifactContainer = artifactContainer;
     }
 
     public void addCandidate(PublishArtifact artifact) {
-        String thisType = artifact.getType();
-
-        if (defaultArtifact == null) {
-            artifacts.add(artifact);
-            defaultArtifact = artifact;
-            return;
+        if (defaultArtifactProvider == null) {
+            defaultArtifactProvider = new DefaultArtifactProvider();
+            artifactContainer.addAllLater(defaultArtifactProvider);
         }
-
-        String currentType = defaultArtifact.getType();
-        if (thisType.equals("ear")) {
-            replaceCurrent(artifact);
-        } else if (thisType.equals("war")) {
-            if (currentType.equals("jar")) {
-                replaceCurrent(artifact);
-            }
-        } else if (!thisType.equals("jar")) {
-            artifacts.add(artifact);
-        }
+        defaultArtifactProvider.addArtifact(artifact);
     }
 
-    private void replaceCurrent(PublishArtifact artifact) {
-        artifacts.remove(defaultArtifact);
-        artifacts.add(artifact);
-        defaultArtifact = artifact;
+    private static class DefaultArtifactProvider extends AbstractProvider<Set<PublishArtifact>> implements CollectionProviderInternal<PublishArtifact, Set<PublishArtifact>>, ChangingValue<Set<PublishArtifact>> {
+        private Set<PublishArtifact> defaultArtifacts;
+        private Set<PublishArtifact> artifacts;
+        private PublishArtifact currentDefault;
+        private final ChangingValueHandler<Set<PublishArtifact>> changingValue = new ChangingValueHandler<Set<PublishArtifact>>();
+
+        void addArtifact(PublishArtifact artifact) {
+            if (artifacts == null) {
+                artifacts = Sets.newLinkedHashSet();
+            }
+
+            if (artifacts.add(artifact) && defaultArtifacts != null) {
+                Set<PublishArtifact> previousArtifacts = Sets.newLinkedHashSet(defaultArtifacts);
+                defaultArtifacts = null;
+                changingValue.handle(previousArtifacts);
+            }
+        }
+
+        @Override
+        public Class<? extends PublishArtifact> getElementType() {
+            return PublishArtifact.class;
+        }
+
+        @Override
+        public int size() {
+            return artifacts.size();
+        }
+
+        @Nullable
+        @Override
+        public Class<Set<PublishArtifact>> getType() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Set<PublishArtifact> getOrNull() {
+            if (defaultArtifacts == null) {
+                defaultArtifacts = Sets.newLinkedHashSet();
+                currentDefault = null;
+                if (artifacts != null) {
+                    for (PublishArtifact artifact : artifacts) {
+                        String thisType = artifact.getType();
+
+                        if (currentDefault == null) {
+                            defaultArtifacts.add(artifact);
+                            currentDefault = artifact;
+                        } else {
+                            String currentType = currentDefault.getType();
+                            if (thisType.equals("ear")) {
+                                replaceCurrent(artifact);
+                            } else if (thisType.equals("war")) {
+                                if (currentType.equals("jar")) {
+                                    replaceCurrent(artifact);
+                                }
+                            } else if (!thisType.equals("jar")) {
+                                defaultArtifacts.add(artifact);
+                            }
+                        }
+                    }
+                }
+            }
+            return defaultArtifacts;
+        }
+
+        void replaceCurrent(PublishArtifact artifact) {
+            defaultArtifacts.remove(currentDefault);
+            defaultArtifacts.add(artifact);
+            currentDefault = artifact;
+        }
+
+        @Override
+        public void onValueChange(Action<Set<PublishArtifact>> action) {
+            changingValue.onValueChange(action);
+        }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -306,7 +306,11 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
             public void execute(Jar jar) {
                 jar.setDescription("Assembles a jar archive containing the main classes.");
                 jar.setGroup(BasePlugin.BUILD_GROUP);
-                jar.from(pluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput());
+                // We need to handle the case where the main source set has been removed before the task is realized
+                SourceSet mainSourceSet = pluginConvention.getSourceSets().findByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                if (mainSourceSet != null) {
+                    jar.from(mainSourceSet.getOutput());
+                }
             }
         });
         // TODO: Allow this to be added lazily


### PR DESCRIPTION
This changes `DefaultArtifactPublicationSet` to register a lazy provider in the artifacts container and avoid automatically realizing the jar task immediately after its artifact is added.