### PR TITLE
Make watchpoint registration faster

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/jdk7/WatchServiceFileWatcherBackingTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/filewatch/jdk7/WatchServiceFileWatcherBackingTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.internal.filewatch.AbstractFileWatcherTest
 import org.gradle.internal.filewatch.FileWatcher
 import org.gradle.internal.filewatch.FileWatcherEvent
 import org.gradle.internal.filewatch.FileWatcherListener
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.util.UsesNativeServices
 import spock.lang.AutoCleanup
 import spock.lang.Unroll
@@ -37,7 +36,9 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
-import static org.gradle.internal.filewatch.jdk7.WatchServiceFileWatcherBackingTest.DirNotExistsTestScenario.*
+import static org.gradle.internal.filewatch.jdk7.WatchServiceFileWatcherBackingTest.DirNotExistsTestScenario.SIBLINGS_PARENT_EXISTS_INITIALLY
+import static org.gradle.internal.filewatch.jdk7.WatchServiceFileWatcherBackingTest.DirNotExistsTestScenario.SIBLING_EXISTS_INITIALLY
+import static org.gradle.internal.filewatch.jdk7.WatchServiceFileWatcherBackingTest.DirNotExistsTestScenario.SIBLING_NOT_EXISTING_INITIALLY
 
 @UsesNativeServices
 class WatchServiceFileWatcherBackingTest extends AbstractFileWatcherTest {
@@ -51,8 +52,6 @@ class WatchServiceFileWatcherBackingTest extends AbstractFileWatcherTest {
         SIBLINGS_PARENT_EXISTS_INITIALLY,
         SIBLING_NOT_EXISTING_INITIALLY
     }
-
-    def fileSystem = Stub(FileSystem)
 
     @Unroll
     def "checks for scenario when the first directory to watch doesn't exist - #testScenario"() {
@@ -86,7 +85,7 @@ class WatchServiceFileWatcherBackingTest extends AbstractFileWatcherTest {
         def watchService = FileSystems.getDefault().newWatchService()
         // holds all registered watches so that we can check that sibling wasn't watched at all
         def registeredWatches = [].asSynchronized()
-        def watchServiceRegistrar = new WatchServiceRegistrar(watchService, listener, fileSystem) {
+        def watchServiceRegistrar = new WatchServiceRegistrar(watchService, listener) {
             @Override
             protected void watchDir(Path dir) throws IOException {
                 registeredWatches.add(dir.toFile().absolutePath)
@@ -157,7 +156,7 @@ class WatchServiceFileWatcherBackingTest extends AbstractFileWatcherTest {
         def onError = Mock(Action)
         def listener = Mock(FileWatcherListener)
         def watchService = Mock(WatchService)
-        def fileWatcher = new WatchServiceFileWatcherBacking(onError, listener, watchService, fileSystem)
+        def fileWatcher = new WatchServiceFileWatcherBacking(onError, listener, watchService)
         def listenerExecutorService = MoreExecutors.listeningDecorator(executorService)
         def mockExecutorService = Mock(ListeningExecutorService)
         def submitLatch = new CountDownLatch(1)

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/Jdk7FileWatcherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/Jdk7FileWatcherFactory.java
@@ -44,7 +44,7 @@ public class Jdk7FileWatcherFactory implements FileWatcherFactory {
     public FileWatcher watch(Action<? super Throwable> onError, FileWatcherListener listener) {
         try {
             WatchService watchService = FileSystems.getDefault().newWatchService();
-            WatchServiceFileWatcherBacking backing = new WatchServiceFileWatcherBacking(onError, listener, watchService, fileSystem);
+            WatchServiceFileWatcherBacking backing = new WatchServiceFileWatcherBacking(onError, listener, watchService);
             return backing.start(executor);
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceFileWatcherBacking.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceFileWatcherBacking.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.internal.filewatch.FileWatcher;
 import org.gradle.internal.filewatch.FileWatcherEvent;
 import org.gradle.internal.filewatch.FileWatcherListener;
-import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,8 +68,8 @@ public class WatchServiceFileWatcherBacking {
         }
     };
 
-    WatchServiceFileWatcherBacking(Action<? super Throwable> onError, FileWatcherListener listener, WatchService watchService, FileSystem fileSystem) throws IOException {
-        this(onError, listener, watchService, new WatchServiceRegistrar(watchService, listener, fileSystem));
+    WatchServiceFileWatcherBacking(Action<? super Throwable> onError, FileWatcherListener listener, WatchService watchService) throws IOException {
+        this(onError, listener, watchService, new WatchServiceRegistrar(watchService, listener));
     }
 
     WatchServiceFileWatcherBacking(Action<? super Throwable> onError, FileWatcherListener listener, WatchService watchService, WatchServiceRegistrar watchServiceRegistrar) throws IOException {

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceRegistrar.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceRegistrar.java
@@ -25,7 +25,6 @@ import org.gradle.internal.UncheckedException;
 import org.gradle.internal.filewatch.FileWatcher;
 import org.gradle.internal.filewatch.FileWatcherEvent;
 import org.gradle.internal.filewatch.FileWatcherListener;
-import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 import org.gradle.internal.os.OperatingSystem;
 
 import java.io.File;
@@ -60,10 +59,10 @@ class WatchServiceRegistrar implements FileWatcherListener {
     private final WatchPointsRegistry watchPointsRegistry;
     private final HashMap<Path, WatchKey> watchKeys = new HashMap<Path, WatchKey>();
 
-    WatchServiceRegistrar(WatchService watchService, FileWatcherListener delegate, FileSystem fileSystem) {
+    WatchServiceRegistrar(WatchService watchService, FileWatcherListener delegate) {
         this.watchService = watchService;
         this.delegate = delegate;
-        this.watchPointsRegistry = new WatchPointsRegistry(!FILE_TREE_WATCHING_SUPPORTED, fileSystem);
+        this.watchPointsRegistry = new WatchPointsRegistry(!FILE_TREE_WATCHING_SUPPORTED);
     }
 
     private static WatchEvent.Modifier[] instantiateWatchModifiers() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/jdk7/WatchPointsRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/jdk7/WatchPointsRegistryTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.filewatch.jdk7
 
 import org.gradle.api.internal.file.FileSystemSubset
 import org.gradle.internal.filewatch.jdk7.WatchPointsRegistry.Delta
-import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.UsesNativeServices
@@ -34,7 +33,7 @@ class WatchPointsRegistryTest extends Specification {
     TestFile rootDir
 
     def setup() {
-        registry = new WatchPointsRegistry(true, Stub(FileSystem))
+        registry = new WatchPointsRegistry(true)
         rootDir = testDir.createDir("root")
     }
 
@@ -70,7 +69,7 @@ class WatchPointsRegistryTest extends Specification {
 
     def "child doesn't get added when parent has already been added when createNewStartingPointsUnderExistingRoots==false"() {
         given:
-        registry = new WatchPointsRegistry(false, Stub(FileSystem))
+        registry = new WatchPointsRegistry(false)
         def dirs = [rootDir.createDir("a/b"), rootDir.createDir("a/b/c")]
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/jdk7/WatchServiceRegistrarTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/filewatch/jdk7/WatchServiceRegistrarTest.groovy
@@ -33,7 +33,7 @@ class WatchServiceRegistrarTest extends Specification {
     def "registering gets retried"() {
         given:
         WatchService watchService = Mock()
-        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener), fileSystem)
+        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener))
         def rootDirPath = Mock(Path)
         def watchKey = Mock(WatchKey)
 
@@ -51,7 +51,7 @@ class WatchServiceRegistrarTest extends Specification {
     def "exception gets thrown after retrying once"() {
         given:
         WatchService watchService = Mock()
-        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener), fileSystem)
+        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener))
         def rootDirPath = Mock(Path)
 
         when:
@@ -69,7 +69,7 @@ class WatchServiceRegistrarTest extends Specification {
     def "silently ignore exception for deleted files"() {
         given:
         WatchService watchService = Mock()
-        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener), fileSystem)
+        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener))
         def rootDirPath = Mock(Path)
         def fileSystem = Mock(FileSystem)
         def fileSystemProvider = Mock(FileSystemProvider)
@@ -90,7 +90,7 @@ class WatchServiceRegistrarTest extends Specification {
     def "rethrow without retrying"() {
         given:
         WatchService watchService = Mock()
-        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener), fileSystem)
+        WatchServiceRegistrar registrar = new WatchServiceRegistrar(watchService, Mock(FileWatcherListener))
         def rootDirPath = Mock(Path)
         def fileSystem = Mock(FileSystem)
         def fileSystemProvider = Mock(FileSystemProvider)


### PR DESCRIPTION
The watchpoint registration algorithm was quadratic in the
number of input files that all the tasks in a build had.

This was particularly visible in the case of the Kotlin plugin,
which had one task that used individual class files instead of a
file tree for a class directory. The overhead for that project
dropped from about 1 minute to near zero.