### PR TITLE
Forbid registering invalid file inputs via the runtime API

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildSymlinkHandlingIntegrationTest.groovy
@@ -122,17 +122,16 @@ task work {
         result.assertTasksSkipped(":work")
     }
 
-    def "symlink may reference missing input file"() {
+    def "symlink may not reference missing input file"() {
         file("in-dir").createDir()
         def link = file("in.txt")
         link.createLink("other")
         assert !link.exists()
 
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        succeeds("work")
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':work'.
- - File '$link' specified for property '\$1' does not exist."""
+        fails("work")
+        failure.assertHasDescription("A problem was found with the configuration of task ':work'.")
+        failure.assertHasCause("File '$link' specified for property '\$1' does not exist.")
     }
 
     def "can replace input file with symlink to file with same content"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputFilePropertiesIntegrationTest.groovy
@@ -54,13 +54,13 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
 
     @Unroll
     @Issue("https://github.com/gradle/gradle/issues/3193")
-    def "TaskInputs.#method shows deprecation warning when used with complex input"() {
+    def "TaskInputs.#method shows error message when used with complex input"() {
         buildFile << """
             task dependencyTask {
             }
 
             task test {
-                inputs.$method(dependencyTask)
+                inputs.$method(dependencyTask).withPropertyName('input')
                 doFirst {
                     // Need a task action to not skip this task
                 }
@@ -68,13 +68,47 @@ class TaskInputFilePropertiesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
-        executer.expectDeprecationWarning()
-        succeeds "test"
-
-        output.contains "Using TaskInputs.$method() with something that doesn't resolve to a File object has been deprecated. This is scheduled to be removed in Gradle 5.0. Use TaskInputs.files() instead."
+        fails "test"
+        failure.assertHasDescription("A problem was found with the configuration of task ':test'.")
+        failure.assertHasCause("Value 'task ':dependencyTask'' specified for property 'input' cannot be converted to a ${targetType}.")
 
         where:
-        method << ["file", "dir"]
+        method | targetType
+        "dir"  | "directory"
+        "file" | "file"
+    }
+
+    @Unroll
+    def "#annotation.simpleName shows error message when used with complex input"() {
+        buildFile << """
+            import org.gradle.api.internal.tasks.properties.GetInputFilesVisitor
+            import org.gradle.api.internal.tasks.TaskPropertyUtils
+            import org.gradle.api.internal.tasks.properties.PropertyWalker
+
+            class CustomTask extends DefaultTask {
+                @Optional @${annotation.name} input
+                @TaskAction void doSomething() {
+                    println("Yay!")
+                }
+            }
+
+            task dependencyTask {
+            }
+
+            task customTask(type: CustomTask) {
+                input = dependencyTask
+            }
+        """
+
+        expect:
+        fails "customTask"
+        failure.assertHasDescription("A problem was found with the configuration of task ':customTask'.")
+        failure.assertHasCause("Value 'task ':dependencyTask'' specified for property 'input' cannot be converted to a ${targetType}.")
+
+        where:
+        annotation     | targetType
+        InputDirectory | "directory"
+        InputFile      | "file"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/3792")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -492,7 +492,7 @@ task someTask(type: SomeTask) {
         "${Provider.name}<String>"       | "providers.provider { 'a' }"    | "providers.provider { 'b' }"
     }
 
-    def "null input properties registered via TaskInputs.property are reported"() {
+    def "null input properties registered via TaskInputs.property are not allowed"() {
         buildFile << """
             task test {
                 inputs.property("input", { null })
@@ -500,10 +500,9 @@ task someTask(type: SomeTask) {
             }
         """
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
- - No value has been specified for property 'input'."""
+        fails "test"
+        failure.assertHasDescription("A problem was found with the configuration of task ':test'.")
+        failure.assertHasCause("No value has been specified for property 'input'.")
     }
 
     def "optional null input properties registered via TaskInputs.property are allowed"() {
@@ -518,7 +517,7 @@ task someTask(type: SomeTask) {
     }
 
     @Unroll
-    def "null input files registered via TaskInputs.#method are reported"() {
+    def "null input files registered via TaskInputs.#method are not allowed"() {
         buildFile << """
             task test {
                 inputs.${method}({ null }) withPropertyName "input"
@@ -526,10 +525,9 @@ task someTask(type: SomeTask) {
             }
         """
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
- - No value has been specified for property 'input'."""
+        fails "test"
+        failure.assertHasDescription("A problem was found with the configuration of task ':test'.")
+        failure.assertHasCause("No value has been specified for property 'input'.")
 
         where:
         method << ["file", "files", "dir"]
@@ -551,7 +549,7 @@ task someTask(type: SomeTask) {
     }
 
     @Unroll
-    def "null output files registered via TaskOutputs.#method are reported"() {
+    def "null output files registered via TaskOutputs.#method are not allowed"() {
         buildFile << """
             task test {
                 outputs.${method}({ null }) withPropertyName "output"
@@ -559,10 +557,9 @@ task someTask(type: SomeTask) {
             }
         """
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
- - No value has been specified for property 'output'."""
+        fails "test"
+        failure.assertHasDescription("A problem was found with the configuration of task ':test'.")
+        failure.assertHasCause("No value has been specified for property 'output'.")
 
         where:
         method << ["file", "files", "dir", "dirs"]
@@ -584,7 +581,7 @@ task someTask(type: SomeTask) {
     }
 
     @Unroll
-    def "missing input files registered via TaskInputs.#method are reported"() {
+    def "missing input files registered via TaskInputs.#method are not allowed"() {
         buildFile << """
             task test {
                 inputs.${method}({ "missing" }) withPropertyName "input"
@@ -593,11 +590,9 @@ task someTask(type: SomeTask) {
         """
 
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        succeeds "test"
-        def expectedString = """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
- - $type '${file("missing")}' specified for property 'input' does not exist."""
-        output.contains expectedString
+        fails "test"
+        failure.assertHasDescription("A problem was found with the configuration of task ':test'.")
+        failure.assertHasCause("$type '${file("missing")}' specified for property 'input' does not exist.")
 
         where:
         method | type
@@ -606,7 +601,7 @@ task someTask(type: SomeTask) {
     }
 
     @Unroll
-    def "wrong input file type registered via TaskInputs.#method is reported"() {
+    def "wrong input file type registered via TaskInputs.#method is not allowed"() {
         file("input-file.txt").touch()
         file("input-dir").createDir()
         buildFile << """
@@ -617,10 +612,9 @@ task someTask(type: SomeTask) {
         """
 
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        succeeds "test"
-        output.contains """Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods has been deprecated. This is scheduled to be removed in Gradle 5.0. A problem was found with the configuration of task ':test'.
- - ${type.capitalize()} '${file(path)}' specified for property 'input' is not a $type."""
+        fails "test"
+        failure.assertHasDescription("A problem was found with the configuration of task ':test'.")
+        failure.assertHasCause("${type.capitalize()} '${file(path)}' specified for property 'input' is not a $type.")
 
         where:
         method | path             | type
@@ -629,7 +623,7 @@ task someTask(type: SomeTask) {
     }
 
     @Unroll
-    def "wrong output file type registered via TaskOutputs.#method is reported"() {
+    def "wrong output file type registered via TaskOutputs.#method is not allowed"() {
         file("input-file.txt").touch()
         file("input-dir").createDir()
         buildFile << """
@@ -640,20 +634,15 @@ task someTask(type: SomeTask) {
         """
 
         expect:
-        executer.expectDeprecationWarning().withFullDeprecationStackTraceDisabled()
-        if (expectToFail) {
-            fails "test"
-        } else {
-            succeeds "test"
-        }
-        output.contains message.replace("<PATH>", file(path).absolutePath)
+        fails "test"
+        failure.assertHasCause(message.replace("<PATH>", file(path).absolutePath))
 
         where:
-        method  | path             | expectToFail | message
-        "file"  | "input-dir"      | false        | "Cannot write to file '<PATH>' specified for property 'output' as it is a directory."
-        "files" | "input-dir"      | false        | "Cannot write to file '<PATH>' specified for property 'output' as it is a directory."
-        "dir"   | "input-file.txt" | true         | "Directory '<PATH>' specified for property 'output' is not a directory."
-        "dirs"  | "input-file.txt" | true         | "Directory '<PATH>' specified for property 'output' is not a directory."
+        method  | path             | message
+        "file"  | "input-dir"      | "Cannot write to file '<PATH>' specified for property 'output' as it is a directory."
+        "files" | "input-dir"      | "Cannot write to file '<PATH>' specified for property 'output' as it is a directory."
+        "dir"   | "input-file.txt" | "Directory '<PATH>' specified for property 'output' is not a directory."
+        "dirs"  | "input-file.txt" | "Directory '<PATH>' specified for property 'output' is not a directory."
     }
 
     def "can specify null as an input property in ad-hoc task"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultPropertySpecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultPropertySpecFactory.java
@@ -33,14 +33,23 @@ public class DefaultPropertySpecFactory implements PropertySpecFactory {
     }
 
     @Override
-    public DeclaredTaskInputFileProperty createInputFileSpec(ValidatingValue paths, ValidationAction validationAction) {
-        return new DefaultTaskInputFilePropertySpec(task.getName(), resolver, paths, validationAction);
+    public DeclaredTaskInputFileProperty createInputFileSpec(ValidatingValue paths) {
+        return createInputFilesSpec(paths, ValidationActions.INPUT_FILE_VALIDATOR);
     }
 
     @Override
-    public DeclaredTaskInputFileProperty createInputDirSpec(ValidatingValue dirPath, ValidationAction validator) {
+    public DeclaredTaskInputFileProperty createInputFilesSpec(ValidatingValue paths) {
+        return createInputFilesSpec(paths, ValidationActions.NO_OP);
+    }
+
+    @Override
+    public DeclaredTaskInputFileProperty createInputDirSpec(ValidatingValue dirPath) {
         FileTreeInternal fileTree = resolver.resolveFilesAsTree(dirPath);
-        return createInputFileSpec(new FileTreeValue(dirPath, fileTree), validator);
+        return createInputFilesSpec(new FileTreeValue(dirPath, fileTree), ValidationActions.INPUT_DIRECTORY_VALIDATOR);
+    }
+
+    private DeclaredTaskInputFileProperty createInputFilesSpec(ValidatingValue paths, ValidationAction validationAction) {
+        return new DefaultTaskInputFilePropertySpec(task.getName(), resolver, paths, validationAction);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -30,8 +30,6 @@ import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.tasks.TaskInputPropertyBuilder;
 import org.gradle.api.tasks.TaskInputs;
-import org.gradle.internal.typeconversion.UnsupportedNotationException;
-import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -89,7 +87,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
             @Override
             public TaskInputFilePropertyBuilderInternal call() {
                 StaticValue value = new StaticValue(unpackVarargs(paths));
-                DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFileSpec(value, ValidationActions.NO_OP);
+                DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFilesSpec(value);
                 registeredFileProperties.add(fileSpec);
                 return fileSpec;
             }
@@ -109,7 +107,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
             @Override
             public TaskInputFilePropertyBuilderInternal call() {
                 StaticValue value = new StaticValue(path);
-                DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFileSpec(value, RUNTIME_INPUT_FILE_VALIDATOR);
+                DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFileSpec(value);
                 registeredFileProperties.add(fileSpec);
                 return fileSpec;
             }
@@ -122,7 +120,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
             @Override
             public TaskInputFilePropertyBuilderInternal call() {
                 StaticValue value = new StaticValue(dirPath);
-                DeclaredTaskInputFileProperty dirSpec = specFactory.createInputDirSpec(value, RUNTIME_INPUT_DIRECTORY_VALIDATOR);
+                DeclaredTaskInputFileProperty dirSpec = specFactory.createInputDirSpec(value);
                 registeredFileProperties.add(dirSpec);
                 return dirSpec;
             }
@@ -209,24 +207,6 @@ public class DefaultTaskInputs implements TaskInputsInternal {
             });
         }
     }
-
-    private static final ValidationAction RUNTIME_INPUT_FILE_VALIDATOR = wrapRuntimeApiValidator("file", ValidationActions.INPUT_FILE_VALIDATOR);
-
-    private static final ValidationAction RUNTIME_INPUT_DIRECTORY_VALIDATOR = wrapRuntimeApiValidator("dir", ValidationActions.INPUT_DIRECTORY_VALIDATOR);
-
-    private static ValidationAction wrapRuntimeApiValidator(final String method, final ValidationAction validator) {
-        return new ValidationAction() {
-            @Override
-            public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
-                try {
-                    validator.validate(propertyName, value, context, severity);
-                } catch (UnsupportedNotationException ex) {
-                    DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("Using TaskInputs." + method + "() with something that doesn't resolve to a File object", "Use TaskInputs.files() instead.");
-                }
-            }
-        };
-    }
-
 
     private static class HasInputsVisitor extends PropertyVisitor.Adapter {
         private boolean hasInputs;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskValidationContext.java
@@ -23,12 +23,10 @@ import java.util.Collection;
 public class DefaultTaskValidationContext implements TaskValidationContext {
     private final FileResolver resolver;
     private final Collection<String> messages;
-    private Severity highestSeverity;
 
     public DefaultTaskValidationContext(FileResolver resolver, Collection<String> messages) {
         this.resolver = resolver;
         this.messages = messages;
-        this.highestSeverity = Severity.WARNING;
     }
 
     @Override
@@ -37,15 +35,7 @@ public class DefaultTaskValidationContext implements TaskValidationContext {
     }
 
     @Override
-    public void recordValidationMessage(Severity severity, String message) {
-        if (severity.compareTo(highestSeverity) > 0) {
-            highestSeverity = severity;
-        }
+    public void recordValidationMessage(String message) {
         messages.add(message);
-    }
-
-    @Override
-    public Severity getHighestSeverity() {
-        return highestSeverity;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/PropertySpecFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/PropertySpecFactory.java
@@ -17,9 +17,11 @@
 package org.gradle.api.internal.tasks;
 
 public interface PropertySpecFactory {
-    DeclaredTaskInputFileProperty createInputFileSpec(ValidatingValue paths, ValidationAction validationAction);
+    DeclaredTaskInputFileProperty createInputFileSpec(ValidatingValue paths);
 
-    DeclaredTaskInputFileProperty createInputDirSpec(ValidatingValue dirPath, ValidationAction validator);
+    DeclaredTaskInputFileProperty createInputFilesSpec(ValidatingValue paths);
+
+    DeclaredTaskInputFileProperty createInputDirSpec(ValidatingValue dirPath);
 
     DefaultTaskInputPropertySpec createInputPropertySpec(String name, ValidatingValue value);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
@@ -18,8 +18,6 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.util.DeferredUtil;
 
-import static org.gradle.api.internal.tasks.TaskValidationContext.Severity.WARNING;
-
 public class StaticValue implements ValidatingValue {
     private final Object value;
 
@@ -37,10 +35,10 @@ public class StaticValue implements ValidatingValue {
         Object unpacked = DeferredUtil.unpack(value);
         if (unpacked == null) {
             if (!optional) {
-                context.recordValidationMessage(WARNING, String.format("No value has been specified for property '%s'.", propertyName));
+                context.recordValidationMessage(String.format("No value has been specified for property '%s'.", propertyName));
             }
         } else {
-            valueValidator.validate(propertyName, unpacked, context, WARNING);
+            valueValidator.validate(propertyName, unpacked, context);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
@@ -16,62 +16,11 @@
 
 package org.gradle.api.internal.tasks;
 
-import com.google.common.collect.Lists;
-import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Task;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.tasks.TaskValidationException;
-import org.gradle.util.DeprecationLogger;
-
-import java.util.List;
 
 public interface TaskValidationContext {
 
-    String DEPRECATION_SUMMARY = "Registering invalid inputs and outputs via TaskInputs and TaskOutputs methods";
-
-    enum Severity {
-        WARNING() {
-            @Override
-            public boolean report(Task task, List<String> messages, TaskStateInternal state) {
-                StringBuilder contextualAdviceBuilder = new StringBuilder(getMainMessage(task, messages));
-                for (String message : messages) {
-                    contextualAdviceBuilder.append("\n - ");
-                    contextualAdviceBuilder.append(message);
-                }
-                DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause(DEPRECATION_SUMMARY, null, contextualAdviceBuilder.toString());
-                return true;
-            }
-        },
-        ERROR() {
-            @Override
-            public boolean report(Task task, List<String> messages, TaskStateInternal state) {
-                List<InvalidUserDataException> causes = Lists.newArrayListWithCapacity(messages.size());
-                for (String message : messages) {
-                    causes.add(new InvalidUserDataException(message));
-                }
-                String errorMessage = getMainMessage(task, messages);
-                state.setOutcome(new TaskValidationException(errorMessage, causes));
-                return false;
-            }
-        };
-
-        private static String getMainMessage(Task task, List<String> messages) {
-            if (messages.size() == 1) {
-                return String.format("A problem was found with the configuration of %s.", task);
-            } else {
-                return String.format("Some problems were found with the configuration of %s.", task);
-            }
-        }
-
-        /**
-         * Reports task validation errors. Returns {@code true} if task execution should continue, {@code false} otherwise.
-         */
-        public abstract boolean report(Task task, List<String> messages, TaskStateInternal state);
-    }
-
     FileResolver getResolver();
 
-    void recordValidationMessage(Severity severity, String message);
-
-    Severity getHighestSeverity();
+    void recordValidationMessage(String message);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ValidationAction.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ValidationAction.java
@@ -16,5 +16,5 @@
 package org.gradle.api.internal.tasks;
 
 public interface ValidationAction {
-    void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity);
+    void validate(String propertyName, Object value, TaskValidationContext context);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ValidationActions.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/ValidationActions.java
@@ -25,43 +25,43 @@ import java.util.Map;
 public enum ValidationActions implements ValidationAction {
     NO_OP {
         @Override
-        public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object value, TaskValidationContext context) {
         }
     },
     INPUT_FILE_VALIDATOR {
         @Override
-        public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object value, TaskValidationContext context) {
             File file = toFile(context, value);
             if (!file.exists()) {
-                context.recordValidationMessage(severity, String.format("File '%s' specified for property '%s' does not exist.", file, propertyName));
+                context.recordValidationMessage(String.format("File '%s' specified for property '%s' does not exist.", file, propertyName));
             } else if (!file.isFile()) {
-                context.recordValidationMessage(severity, String.format("File '%s' specified for property '%s' is not a file.", file, propertyName));
+                context.recordValidationMessage(String.format("File '%s' specified for property '%s' is not a file.", file, propertyName));
             }
         }
     },
     INPUT_DIRECTORY_VALIDATOR {
         @Override
-        public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object value, TaskValidationContext context) {
             File directory = toDirectory(context, value);
             if (!directory.exists()) {
-                context.recordValidationMessage(severity, String.format("Directory '%s' specified for property '%s' does not exist.", directory, propertyName));
+                context.recordValidationMessage(String.format("Directory '%s' specified for property '%s' does not exist.", directory, propertyName));
             } else if (!directory.isDirectory()) {
-                context.recordValidationMessage(severity, String.format("Directory '%s' specified for property '%s' is not a directory.", directory, propertyName));
+                context.recordValidationMessage(String.format("Directory '%s' specified for property '%s' is not a directory.", directory, propertyName));
             }
         }
     },
     OUTPUT_DIRECTORY_VALIDATOR {
         @Override
-        public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object value, TaskValidationContext context) {
             File directory = toFile(context, value);
             if (directory.exists()) {
                 if (!directory.isDirectory()) {
-                    context.recordValidationMessage(severity, String.format("Directory '%s' specified for property '%s' is not a directory.", directory, propertyName));
+                    context.recordValidationMessage(String.format("Directory '%s' specified for property '%s' is not a directory.", directory, propertyName));
                 }
             } else {
                 for (File candidate = directory.getParentFile(); candidate != null && !candidate.isDirectory(); candidate = candidate.getParentFile()) {
                     if (candidate.exists() && !candidate.isDirectory()) {
-                        context.recordValidationMessage(severity, String.format("Cannot write to directory '%s' specified for property '%s', as ancestor '%s' is not a directory.", directory, propertyName, candidate));
+                        context.recordValidationMessage(String.format("Cannot write to directory '%s' specified for property '%s', as ancestor '%s' is not a directory.", directory, propertyName, candidate));
                         return;
                     }
                 }
@@ -70,25 +70,25 @@ public enum ValidationActions implements ValidationAction {
     },
     OUTPUT_DIRECTORIES_VALIDATOR {
         @Override
-        public void validate(String propertyName, Object values, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object values, TaskValidationContext context) {
             for (File directory : toFiles(context, values)) {
-                OUTPUT_DIRECTORY_VALIDATOR.validate(propertyName, directory, context, severity);
+                OUTPUT_DIRECTORY_VALIDATOR.validate(propertyName, directory, context);
             }
         }
     },
     OUTPUT_FILE_VALIDATOR {
         @Override
-        public void validate(String propertyName, Object value, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object value, TaskValidationContext context) {
             File file = toFile(context, value);
             if (file.exists()) {
                 if (file.isDirectory()) {
-                    context.recordValidationMessage(severity, String.format("Cannot write to file '%s' specified for property '%s' as it is a directory.", file, propertyName));
+                    context.recordValidationMessage(String.format("Cannot write to file '%s' specified for property '%s' as it is a directory.", file, propertyName));
                 }
                 // else, assume we can write to anything that exists and is not a directory
             } else {
                 for (File candidate = file.getParentFile(); candidate != null && !candidate.isDirectory(); candidate = candidate.getParentFile()) {
                     if (candidate.exists() && !candidate.isDirectory()) {
-                        context.recordValidationMessage(severity, String.format("Cannot write to file '%s' specified for property '%s', as ancestor '%s' is not a directory.", file, propertyName, candidate));
+                        context.recordValidationMessage(String.format("Cannot write to file '%s' specified for property '%s', as ancestor '%s' is not a directory.", file, propertyName, candidate));
                         break;
                     }
                 }
@@ -97,9 +97,9 @@ public enum ValidationActions implements ValidationAction {
     },
     OUTPUT_FILES_VALIDATOR {
         @Override
-        public void validate(String propertyName, Object values, TaskValidationContext context, TaskValidationContext.Severity severity) {
+        public void validate(String propertyName, Object values, TaskValidationContext context) {
             for (File file : toFiles(context, values)) {
-                OUTPUT_FILE_VALIDATOR.validate(propertyName, file, context, severity);
+                OUTPUT_FILE_VALIDATOR.validate(propertyName, file, context);
             }
         }
     };

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskProperties.java
@@ -17,10 +17,8 @@
 package org.gradle.api.internal.tasks.execution;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Multimap;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.TaskInternal;
@@ -256,7 +254,6 @@ public class DefaultTaskProperties implements TaskProperties {
 
     private static class ValidationVisitor extends PropertyVisitor.Adapter {
         private final List<ValidatingTaskPropertySpec> taskPropertySpecs = new ArrayList<ValidatingTaskPropertySpec>();
-        private final Multimap<TaskValidationContext.Severity, String> messages = ArrayListMultimap.create();
 
         @Override
         public void visitInputFileProperty(TaskInputFilePropertySpec inputFileProperty) {
@@ -271,10 +268,6 @@ public class DefaultTaskProperties implements TaskProperties {
         @Override
         public void visitOutputFileProperty(TaskOutputFilePropertySpec outputFileProperty) {
             taskPropertySpecs.add((ValidatingTaskPropertySpec) outputFileProperty);
-        }
-
-        public Multimap<TaskValidationContext.Severity, String> getMessages() {
-            return messages;
         }
 
         public List<ValidatingTaskPropertySpec> getTaskPropertySpecs() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/ClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/ClasspathPropertyAnnotationHandler.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.properties.annotations;
 
 import org.gradle.api.internal.tasks.DeclaredTaskInputFileProperty;
 import org.gradle.api.internal.tasks.PropertySpecFactory;
-import org.gradle.api.internal.tasks.ValidationActions;
 import org.gradle.api.internal.tasks.properties.BeanPropertyContext;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
@@ -48,7 +47,7 @@ public class ClasspathPropertyAnnotationHandler implements OverridingPropertyAnn
 
     @Override
     public void visitPropertyValue(PropertyValue propertyValue, PropertyVisitor visitor, PropertySpecFactory specFactory, BeanPropertyContext context) {
-        DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFileSpec(propertyValue, ValidationActions.NO_OP);
+        DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFilesSpec(propertyValue);
         fileSpec
             .withPropertyName(propertyValue.getPropertyName())
             .withNormalizer(ClasspathNormalizer.class)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/CompileClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/CompileClasspathPropertyAnnotationHandler.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.properties.annotations;
 
 import org.gradle.api.internal.tasks.DeclaredTaskInputFileProperty;
 import org.gradle.api.internal.tasks.PropertySpecFactory;
-import org.gradle.api.internal.tasks.ValidationActions;
 import org.gradle.api.internal.tasks.properties.BeanPropertyContext;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
@@ -48,7 +47,7 @@ public class CompileClasspathPropertyAnnotationHandler implements OverridingProp
 
     @Override
     public void visitPropertyValue(PropertyValue propertyValue, PropertyVisitor visitor, PropertySpecFactory specFactory, BeanPropertyContext context) {
-        DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFileSpec(propertyValue, ValidationActions.NO_OP);
+        DeclaredTaskInputFileProperty fileSpec = specFactory.createInputFilesSpec(propertyValue);
         fileSpec
             .withPropertyName(propertyValue.getPropertyName())
             .withNormalizer(CompileClasspathNormalizer.class)

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputDirectoryPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputDirectoryPropertyAnnotationHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.tasks.properties.annotations;
 
 import org.gradle.api.internal.tasks.DeclaredTaskInputFileProperty;
 import org.gradle.api.internal.tasks.PropertySpecFactory;
-import org.gradle.api.internal.tasks.ValidationActions;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.tasks.InputDirectory;
 
@@ -30,6 +29,6 @@ public class InputDirectoryPropertyAnnotationHandler extends AbstractInputProper
 
     @Override
     protected DeclaredTaskInputFileProperty createFileSpec(PropertyValue propertyValue, PropertySpecFactory specFactory) {
-        return specFactory.createInputDirSpec(propertyValue, ValidationActions.INPUT_DIRECTORY_VALIDATOR);
+        return specFactory.createInputDirSpec(propertyValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputFilePropertyAnnotationHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.tasks.properties.annotations;
 
 import org.gradle.api.internal.tasks.DeclaredTaskInputFileProperty;
 import org.gradle.api.internal.tasks.PropertySpecFactory;
-import org.gradle.api.internal.tasks.ValidationActions;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.tasks.InputFile;
 
@@ -30,6 +29,6 @@ public class InputFilePropertyAnnotationHandler extends AbstractInputPropertyAnn
 
     @Override
     protected DeclaredTaskInputFileProperty createFileSpec(PropertyValue propertyValue, PropertySpecFactory specFactory) {
-        return specFactory.createInputFileSpec(propertyValue, ValidationActions.INPUT_FILE_VALIDATOR);
+        return specFactory.createInputFileSpec(propertyValue);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputFilesPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputFilesPropertyAnnotationHandler.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.tasks.properties.annotations;
 
 import org.gradle.api.internal.tasks.DeclaredTaskInputFileProperty;
 import org.gradle.api.internal.tasks.PropertySpecFactory;
-import org.gradle.api.internal.tasks.ValidationActions;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.tasks.InputFiles;
 
@@ -30,7 +29,7 @@ public class InputFilesPropertyAnnotationHandler extends AbstractInputPropertyAn
 
     @Override
     protected DeclaredTaskInputFileProperty createFileSpec(PropertyValue propertyValue, PropertySpecFactory specFactory) {
-        return specFactory.createInputFileSpec(propertyValue, ValidationActions.NO_OP);
+        return specFactory.createInputFilesSpec(propertyValue);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
@@ -30,8 +30,6 @@ import org.gradle.internal.UncheckedException;
 import javax.annotation.Nullable;
 import java.lang.annotation.Annotation;
 
-import static org.gradle.api.internal.tasks.TaskValidationContext.Severity.ERROR;
-
 public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
 
     @Override
@@ -92,7 +90,7 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
 
         @Override
         public void validate(String propertyName, boolean optional, ValidationAction valueValidator, TaskValidationContext context) {
-            context.recordValidationMessage(ERROR, String.format("No value has been specified for property '%s'.", propertyName));
+            context.recordValidationMessage(String.format("No value has been specified for property '%s'.", propertyName));
         }
 
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -43,8 +43,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Queue;
 
-import static org.gradle.api.internal.tasks.TaskValidationContext.Severity.ERROR;
-
 public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Object> {
     protected AbstractNestedRuntimeBeanNode(@Nullable RuntimeBeanNode<?> parentNode, @Nullable String propertyName, Object bean, TypeMetadata typeMetadata) {
         super(parentNode, propertyName, bean, typeMetadata);
@@ -149,10 +147,10 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
             Object unpacked = DeferredUtil.unpack(getValue());
             if (unpacked == null) {
                 if (!optional) {
-                    context.recordValidationMessage(ERROR, String.format("No value has been specified for property '%s'.", propertyName));
+                    context.recordValidationMessage(String.format("No value has been specified for property '%s'.", propertyName));
                 }
             } else {
-                valueValidator.validate(propertyName, unpacked, context, ERROR);
+                valueValidator.validate(propertyName, unpacked, context);
             }
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/changedetection/changes/DefaultTaskArtifactStateRepositoryTest.groovy
@@ -816,7 +816,9 @@ class DefaultTaskArtifactStateRepositoryTest extends AbstractProjectBuilderSpec 
                 }
             }
             if (inputProperties != null) {
-                task.getInputs().properties(inputProperties)
+                inputProperties.each { key, value ->
+                    task.getInputs().property(key, value).optional(true)
+                }
             }
             if (outputFiles != null) {
                 outputFiles.each { String property, Collection<? extends File> files ->

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ValidatingTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ValidatingTaskExecuterTest.groovy
@@ -29,9 +29,6 @@ import org.gradle.api.internal.tasks.TaskValidationContext
 import org.gradle.api.tasks.TaskValidationException
 import spock.lang.Specification
 
-import static org.gradle.api.internal.tasks.TaskValidationContext.Severity.ERROR
-import static org.gradle.api.internal.tasks.TaskValidationContext.Severity.WARNING
-
 class ValidatingTaskExecuterTest extends Specification {
     def target = Mock(TaskExecuter)
     def task = Mock(TaskInternal)
@@ -65,7 +62,7 @@ class ValidatingTaskExecuterTest extends Specification {
         then:
         1 * task.getProject() >> project
         1 * executionContext.getTaskProperties() >> taskProperties
-        1 * taskProperties.validate(_) >> { TaskValidationContext context -> context.recordValidationMessage(ERROR,'failure') }
+        1 * taskProperties.validate(_) >> { TaskValidationContext context -> context.recordValidationMessage('failure') }
         1 * state.setOutcome(!null as Throwable) >> {
             def failure = it[0]
             assert failure instanceof TaskValidationException
@@ -84,8 +81,8 @@ class ValidatingTaskExecuterTest extends Specification {
         1 * task.getProject() >> project
         1 * executionContext.getTaskProperties() >> taskProperties
         1 * taskProperties.validate(_) >> { TaskValidationContext context ->
-            context.recordValidationMessage(ERROR, 'failure1')
-            context.recordValidationMessage(ERROR, 'failure2')
+            context.recordValidationMessage('failure1')
+            context.recordValidationMessage('failure2')
         }
         1 * state.setOutcome(!null as Throwable) >> {
             def failure = it[0]
@@ -96,21 +93,6 @@ class ValidatingTaskExecuterTest extends Specification {
             assert failure.causes[1] instanceof InvalidUserDataException
             assert failure.causes[1].message == 'failure2'
         }
-        0 * _
-    }
-
-    def "executes task when there are multiple warnings"() {
-        when:
-        executer.execute(task, state, executionContext)
-
-        then:
-        1 * task.getProject() >> project
-        1 * executionContext.getTaskProperties() >> taskProperties
-        1 * taskProperties.validate(_) >> { TaskValidationContext context ->
-            context.recordValidationMessage(WARNING, 'warning1')
-            context.recordValidationMessage(WARNING, 'warning2')
-        }
-        1 * target.execute(task, state, executionContext)
         0 * _
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandlerTest.groovy
@@ -56,7 +56,7 @@ class NestedBeanAnnotationHandlerTest extends Specification {
         taskInputPropertySpec.validate(validationContext)
 
         then:
-        1 * validationContext.recordValidationMessage(TaskValidationContext.Severity.ERROR, "No value has been specified for property 'name'.")
+        1 * validationContext.recordValidationMessage("No value has been specified for property 'name'.")
         0 * _
     }
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -94,6 +94,7 @@ The previously deprecated support for Play Framework 2.2 has been removed.
 - Removed the property `styleSheet` from `ScalaDocOptions`.
 - Forbid passing `null` as configuration action to the methods `from` and `to` on `CopySpec`.
 - Removed the property `bootClasspath` from `CompileOptions`.
+- Registering invalid inputs or outputs via the runtime API is now an error.
 
 ## External contributions
 


### PR DESCRIPTION
Fixes #6280.
Fixes #6282.
