### PR TITLE
Fix incorrect conflict detection

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverResults.java
@@ -102,12 +102,20 @@ class SelectorStateResolverResults {
         // Check already-resolved dependencies and use this version if it's compatible
         for (Registration registration : results) {
             ResolvableSelectorState other = registration.selector;
-            if (included(other, resolveResult)) {
+            if (included(other, resolveResult) || sameVersion(resolveResult, registration)) {
                 registration.result = resolveResult;
             }
         }
 
         results.add(new Registration(dep, resolveResult));
+    }
+
+    private boolean sameVersion(ComponentIdResolveResult resolveResult, Registration registration) {
+        ComponentIdResolveResult current = registration.result;
+        if (current.getFailure()==null && resolveResult.getFailure() == null) {
+            return current.getModuleVersionId().equals(resolveResult.getModuleVersionId());
+        }
+        return false;
     }
 
     private boolean included(ResolvableSelectorState dep, ComponentIdResolveResult candidate) {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -872,9 +872,6 @@ org:leaf:1.6
    variant "default" [
       org.gradle.status = integration (not requested)
    ]
-   Selection reasons:
-      - Was requested
-      - By conflict resolution : between versions 1.6 and 1.6
 
 org:leaf:1.+ -> 1.6
 \\--- org:top:1.0


### PR DESCRIPTION
### Context

Whenever 2 selectors agree on the version to use but one of them
is not a "shortcutting" selector, we created a conflict, instead
of checking if they agreed before.

Fixes #6403

