### PR TITLE
Upgrade build-scan plugin for gradle build to 1.16-rc-1

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -10,7 +10,7 @@ apply<PrecompiledScriptPlugins>()
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.7")
     implementation("org.jsoup:jsoup:1.11.2")
-    implementation("com.gradle:build-scan-plugin:1.15.2")
+    implementation("com.gradle:build-scan-plugin:1.16-rc-1")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
 }


### PR DESCRIPTION
### Context

Update gradle build to use the latest 1.16-rc-1 scans plugin, prior to a release

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
