### PR TITLE
Enforcing platforms - explicit platform dependencies

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
@@ -15,8 +15,11 @@
  */
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ComponentMetadataRule
-
-import org.gradle.kotlin.dsl.*
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import org.gradle.api.attributes.Attribute
+import org.gradle.api.attributes.HasConfigurableAttributes
+import org.gradle.kotlin.dsl.extra
+import org.gradle.util.GradleVersion
 
 
 // This file contains Kotlin extensions for the gradle/gradle build
@@ -46,6 +49,23 @@ fun Project.libraryReason(name: String): String? =
 
 fun Project.testLibrary(name: String): String =
     testLibraries[name]!! as String
+
+
+// TODO: Remove this with Gradle 5 native "platform" support once we build using a compatible nightly
+val gradle5CategoryAttribute = Attribute.of("org.gradle.component.category", String::class.java)
+
+
+fun DependencyHandler.gradle5Platform(name: Any) = if (GradleVersion.current().baseVersion >= GradleVersion.version("5.0")) {
+    val dep = create(name)
+    if (dep is HasConfigurableAttributes<*>) {
+        dep.attributes {
+            attribute(gradle5CategoryAttribute, "platform")
+        }
+    }
+    dep
+} else {
+    create(name)
+}
 
 
 // TODO:kotlin-dsl Remove work around for https://github.com/gradle/kotlin-dsl/issues/639 once fixed

--- a/subprojects/base-services/src/main/java/org/gradle/api/internal/ReusableAction.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/internal/ReusableAction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal;
+
+/**
+ * A marker interface for rules which can be safely reused because they are either
+ * stateless, or effectively immutable. Ideally this should be inferred, which is
+ * why the interface is internal.
+ */
+public interface ReusableAction {
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
@@ -58,4 +58,17 @@ public interface DependencyConstraintHandler {
      * @param configureAction The closure to use to configure the dependency.
      */
     DependencyConstraint create(Object dependencyConstraintNotation, Action<? super DependencyConstraint> configureAction);
+
+
+    @Incubating
+    DependencyConstraint platform(Object notation);
+
+    @Incubating
+    DependencyConstraint platform(Object notation, Action<? super DependencyConstraint> configureAction);
+
+    @Incubating
+    DependencyConstraint enforcedPlatform(Object notation);
+
+    @Incubating
+    DependencyConstraint enforcedPlatform(Object notation, Action<? super DependencyConstraint> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyConstraintHandler.java
@@ -59,16 +59,53 @@ public interface DependencyConstraintHandler {
      */
     DependencyConstraint create(Object dependencyConstraintNotation, Action<? super DependencyConstraint> configureAction);
 
-
+    /**
+     * Declares a constraint on a platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     *
+     * @param notation the coordinates of the platform
+     *
+     * @since 5.0
+     */
     @Incubating
     DependencyConstraint platform(Object notation);
 
+    /**
+     * Declares a constraint on a platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     *
+     * @param notation the coordinates of the platform
+     * @param configureAction the dependency configuration block
+     *
+     * @since 5.0
+     */
     @Incubating
     DependencyConstraint platform(Object notation, Action<? super DependencyConstraint> configureAction);
 
+    /**
+     * Declares a constraint on an enforced platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     * An enforced platform is a platform for which the direct dependencies are forced, meaning
+     * that they would override any other version found in the graph.
+     *
+     * @param notation the coordinates of the platform
+     *
+     * @since 5.0
+     */
     @Incubating
     DependencyConstraint enforcedPlatform(Object notation);
 
+    /**
+     * Declares a constraint on an enforced platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     * An enforced platform is a platform for which the direct dependencies are forced, meaning
+     * that they would override any other version found in the graph.
+     *
+     * @param notation the coordinates of the platform
+     * @param configureAction the dependency configuration block
+     *
+     * @since 5.0
+     */
     @Incubating
     DependencyConstraint enforcedPlatform(Object notation, Action<? super DependencyConstraint> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -450,4 +450,16 @@ public interface DependencyHandler {
      */
     @Incubating
     void registerTransform(Action<? super VariantTransform> registrationAction);
+
+    @Incubating
+    Dependency platform(Object notation);
+
+    @Incubating
+    Dependency platform(Object notation, Action<? super Dependency> configureAction);
+
+    @Incubating
+    Dependency enforcedPlatform(Object notation);
+
+    @Incubating
+    Dependency enforcedPlatform(Object notation, Action<? super Dependency> configureAction);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -451,15 +451,53 @@ public interface DependencyHandler {
     @Incubating
     void registerTransform(Action<? super VariantTransform> registrationAction);
 
+    /**
+     * Declares a dependency on a platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     *
+     * @param notation the coordinates of the platform
+     *
+     * @since 5.0
+     */
     @Incubating
     Dependency platform(Object notation);
 
+    /**
+     * Declares a dependency on a platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     *
+     * @param notation the coordinates of the platform
+     * @param configureAction the dependency configuration block
+     *
+     * @since 5.0
+     */
     @Incubating
     Dependency platform(Object notation, Action<? super Dependency> configureAction);
 
+    /**
+     * Declares a dependency on an enforced platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     * An enforced platform is a platform for which the direct dependencies are forced, meaning
+     * that they would override any other version found in the graph.
+     *
+     * @param notation the coordinates of the platform
+     *
+     * @since 5.0
+     */
     @Incubating
     Dependency enforcedPlatform(Object notation);
 
+    /**
+     * Declares a dependency on an enforced platform. If the target coordinates represent multiple
+     * potential components, the platform component will be selected, instead of the library.
+     * An enforced platform is a platform for which the direct dependencies are forced, meaning
+     * that they would override any other version found in the graph.
+     *
+     * @param notation the coordinates of the platform
+     * @param configureAction the dependency configuration block
+     *
+     * @since 5.0
+     */
     @Incubating
     Dependency enforcedPlatform(Object notation, Action<? super Dependency> configureAction);
 }

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -66,6 +66,7 @@ dependencies {
 
     testImplementation testLibraries.jsoup
     testImplementation libraries.log4j_to_slf4j.coordinates
+    testImplementation libraries.jcl_to_slf4j.coordinates
 
     testRuntimeOnly libraries.xerces.coordinates
     testRuntimeOnly project(":diagnostics")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributes.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/attributes/DefaultImmutableAttributes.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.changedetection.state.isolation.Isolatable;
+import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
 import java.util.Comparator;
@@ -35,6 +36,10 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
             return o1.getName().compareTo(o2.getName());
         }
     };
+    // Coercion is an expensive process, so we cache the result of coercing to other attribute types.
+    // We can afford using a hashmap here because attributes are interned, and their lifetime doesn't
+    // exceed a build
+    private final Map<Attribute<?>, Object> coercionCache = Maps.newConcurrentMap();
 
     final Attribute<?> attribute;
     final Isolatable<?> value;
@@ -42,6 +47,9 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
     private final ImmutableMap<String, DefaultImmutableAttributes> hierarchyByName;
     private final int hashCode;
 
+    // Optimize for the single entry case, makes findEntry faster
+    private final String singleEntryName;
+    private final DefaultImmutableAttributes singleEntryValue;
 
     DefaultImmutableAttributes() {
         this.attribute = null;
@@ -49,6 +57,8 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
         this.hashCode = 0;
         this.hierarchy = ImmutableMap.of();
         this.hierarchyByName = ImmutableMap.of();
+        this.singleEntryName = null;
+        this.singleEntryValue = null;
     }
 
     DefaultImmutableAttributes(DefaultImmutableAttributes parent, Attribute<?> key, Isolatable<?> value) {
@@ -66,6 +76,14 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
         hashCode = 31 * hashCode + attribute.hashCode();
         hashCode = 31 * hashCode + value.hashCode();
         this.hashCode = hashCode;
+        if (hierarchyByName.size() == 1) {
+            Map.Entry<String, DefaultImmutableAttributes> entry = hierarchyByName.entrySet().iterator().next();
+            singleEntryName = entry.getKey();
+            singleEntryValue = entry.getValue();
+        } else {
+            singleEntryName = null;
+            singleEntryValue = null;
+        }
     }
 
     @Override
@@ -129,6 +147,10 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
      * Locates the entry for the attribute with the given name. Returns a 'missing' value when not present.
      */
     public AttributeValue<?> findEntry(String key) {
+        if (singleEntryName == key) {
+            // The identity check is intentional here, do not replace with .equals()
+            return singleEntryValue;
+        }
         DefaultImmutableAttributes attributes = hierarchyByName.get(key);
         return attributes == null ? MISSING : attributes;
     }
@@ -151,6 +173,15 @@ final class DefaultImmutableAttributes implements ImmutableAttributes, Attribute
 
     @Override
     public <S> S coerce(Attribute<S> otherAttribute) {
+        S s = Cast.uncheckedCast(coercionCache.get(otherAttribute));
+        if (s == null) {
+            s = uncachedCoerce(otherAttribute);
+            coercionCache.put(otherAttribute, s);
+        }
+        return s;
+    }
+
+    private <S> S uncachedCoerce(Attribute<S> otherAttribute) {
         Class<S> attributeType = otherAttribute.getType();
         if (attributeType.isAssignableFrom(attribute.getType())) {
             return (S) get();

--- a/subprojects/core/src/main/java/org/gradle/internal/action/InstantiatingAction.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/action/InstantiatingAction.java
@@ -17,17 +17,24 @@
 package org.gradle.internal.action;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.ReusableAction;
+import org.gradle.internal.Actions;
 import org.gradle.internal.reflect.Instantiator;
+
+import java.util.List;
 
 public class InstantiatingAction<DETAILS> implements Action<DETAILS> {
     private final ConfigurableRules<DETAILS> rules;
     private final Instantiator instantiator;
     private final ExceptionHandler<DETAILS> exceptionHandler;
+    private final Action<DETAILS>[] reusableRules;
 
+    @SuppressWarnings("unchecked")
     public InstantiatingAction(ConfigurableRules<DETAILS> rules, Instantiator instantiator, ExceptionHandler<DETAILS> exceptionHandler) {
         this.rules = rules;
         this.instantiator = instantiator;
         this.exceptionHandler = exceptionHandler;
+        this.reusableRules = new Action[rules.getConfigurableRules().size()];
     }
 
     public InstantiatingAction<DETAILS> withInstantiator(Instantiator instantiator) {
@@ -36,13 +43,26 @@ public class InstantiatingAction<DETAILS> implements Action<DETAILS> {
 
     @Override
     public void execute(DETAILS target) {
-        for (ConfigurableRule<DETAILS> rule : rules.getConfigurableRules()) {
+        List<ConfigurableRule<DETAILS>> configurableRules = rules.getConfigurableRules();
+        int i = 0;
+        for (ConfigurableRule<DETAILS> rule : configurableRules) {
             try {
-                Action<DETAILS> instance = instantiator.newInstance(rule.getRuleClass(), rule.getRuleParams().isolate());
+                Action<DETAILS> instance = reusableRules[i];
+                if (!(instance instanceof ReusableAction)) {
+                    instance = instantiator.newInstance(rule.getRuleClass(), rule.getRuleParams().isolate());
+                    // This second check is only done so that we can make the difference between an uninitialized rule (never seen before) and
+                    // a rule which is not reusable
+                    if (instance instanceof ReusableAction) {
+                        reusableRules[i] = instance;
+                    } else {
+                        reusableRules[i] = Actions.doNothing();
+                    }
+                }
                 instance.execute(target);
             } catch (Throwable t) {
                 exceptionHandler.handleException(target, t);
             }
+            i++;
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -17,13 +17,10 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 
-/**
- * This also tests maven's optional dependencies for the cases where we only have pom metadata available.
- */
 class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     boolean featureAvailable() {
-        gradleMetadataEnabled || (/*maven optional:*/ useMaven() && experimentalEnabled)
+        gradleMetadataEnabled
     }
 
     void "dependency constraint is ignored when feature is not enabled"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
@@ -304,6 +304,12 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
     def "rule is applied only once"() {
         given:
         withDefaultVariantToTest()
+        int invalidCount = 2
+        if (GradleMetadataResolveRunner.useMaven() && !GradleMetadataResolveRunner.gradleMetadataEnabled) {
+            // for Maven with experimental, we use variant aware matching which will (today) involve another round
+            // of execution of the rule
+            invalidCount++
+        }
         buildFile << """
             int cpt
             dependencies {
@@ -311,8 +317,8 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                     withModule('org.test:moduleB') {
                         withVariant("$variantToTest") { 
                             attributes {
-                                if (++cpt == 2) {
-                                    throw new IllegalStateException("rule should only be applied once")
+                                if (++cpt == $invalidCount) {
+                                    throw new IllegalStateException("rule should only be applied once on variant $variantToTest")
                                 }
                             }
                         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
@@ -206,6 +206,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                                 if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
                                     // when experimental resolve is on, the "compile" configuration is mapped to the "java-api" usage
                                     expectedAttributes['org.gradle.usage'] = 'java-api'
+                                    expectedAttributes['org.gradle.component.category'] = 'library'
                                 }
                             }
                         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -1705,7 +1705,7 @@ repositories {
 
 dependencies {
     implementation 'org.a:root'
-    implementation 'org:bom:1.0'
+    implementation platform('org:bom:1.0')
     constraints {
         implementation 'org.a:root:1.0'
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -496,7 +496,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             path 'org3:bar:1.0 -> org4:b:1.1 -> org4:a:1.1'
         }
 
-        buildFile << """
+        buildFile << """          
             dependencies {
                 conf 'org:xml:1.0'
                 conf 'org2:foo:1.0'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -44,7 +44,7 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         when:
         expectAlignment {
             module('core') tries('2.9.4', '2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
-            module('databind') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('databind') alignsTo('2.7.9') byVirtualPlatform()
             module('kotlin') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
             module('annotations') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
         }
@@ -57,7 +57,6 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                     forced()
                 }
                 module("org:databind:2.7.9") {
-                    forced()
                     module('org:annotations:2.7.9')
                     module('org:core:2.7.9')
                 }
@@ -69,4 +68,64 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
             }
         }
     }
+
+    def "can force a virtual platform version by forcing the platform itself via a dependency"() {
+        repository {
+            ['2.7.9', '2.9.4', '2.9.4.1'].each {
+                path "databind:$it -> core:$it"
+                path "databind:$it -> annotations:$it"
+                path "kotlin:$it -> core:$it"
+                path "kotlin:$it -> annotations:$it"
+            }
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf("org:core:2.9.4")
+                conf("org:databind:2.7.9")
+                conf("org:kotlin:2.9.4.1")                
+
+                conf enforcedPlatform("org:platform:2.7.9")
+            }
+        """
+
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        expectAlignment {
+            module('core') tries('2.9.4', '2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('databind') alignsTo('2.7.9') byVirtualPlatform()
+            module('kotlin') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('annotations') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:core:2.9.4", "org:core:2.7.9") {
+                    forced()
+                }
+                module("org:databind:2.7.9") {
+                    module('org:annotations:2.7.9')
+                    module('org:core:2.7.9')
+                }
+                edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
+                    forced()
+                    module('org:core:2.7.9')
+                    module('org:annotations:2.7.9')
+                }
+                module('org:platform:2.7.9:default') {
+                    noArtifacts()
+                    module('org:core:2.7.9')
+                    module('org:databind:2.7.9')
+                    module('org:annotations:2.7.9')
+                    module('org:kotlin:2.7.9')
+                }
+            }
+        }
+    }
+
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -239,10 +239,13 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                 path "kotlin:$v -> annotations:$v"
 
                 "org:platform:$v" {
-                    constraint("org:core:$v")
-                    constraint("org:databind:$v")
-                    constraint("org:kotlin:$v")
-                    constraint("org:annotations:$v")
+                    variant("enforced-platform") {
+                        attribute('org.gradle.component.category', 'enforced-platform')
+                        constraint("org:core:$v")
+                        constraint("org:databind:$v")
+                        constraint("org:kotlin:$v")
+                        constraint("org:annotations:$v")
+                    }
                 }
             }
         }
@@ -291,7 +294,7 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                module('org:platform:2.7.9:runtime') {
+                module('org:platform:2.7.9:enforced-platform') {
                     module('org:core:2.7.9')
                     module('org:databind:2.7.9')
                     module('org:annotations:2.7.9')
@@ -322,10 +325,13 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                 path "kotlin:$v -> annotations:$v"
 
                 "org:platform:$v" {
-                    constraint("org:core:$v")
-                    constraint("org:databind:$v")
-                    constraint("org:kotlin:$v")
-                    constraint("org:annotations:$v")
+                    variant("enforced-platform") {
+                        attribute('org.gradle.component.category', 'enforced-platform')
+                        constraint("org:core:$v")
+                        constraint("org:databind:$v")
+                        constraint("org:kotlin:$v")
+                        constraint("org:annotations:$v")
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
+import spock.lang.Ignore
 
 class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def resolve = new ResolveTestFixture(buildFile).expectDefaultConfiguration('runtime')
@@ -50,7 +51,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         buildFile << """
             dependencies {
                 compile "group:moduleA"
-                compile "group:bom:1.0"
+                compile platform("group:bom:1.0")
             }
         """
 
@@ -60,7 +61,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module("group:bom:1.0") {
+                module("group:bom:1.0:platform-runtime") {
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
@@ -69,6 +70,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         }
     }
 
+    @Ignore("This is no longer true, since a dependency on a BOM is by default a dependency on a library")
     def "can import a bom transitively"() {
         given:
         bomDependency('moduleA').publish()
@@ -107,7 +109,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         buildFile << """
             dependencies {
                 compile "group:moduleA"
-                compile "group:bom:1.0"
+                compile platform("group:bom:1.0")
             }
         """
 
@@ -117,7 +119,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module("group:bom:1.0") {
+                module("group:bom:1.0:platform-runtime") {
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
@@ -142,8 +144,8 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         buildFile << """
             dependencies {
                 compile "group:moduleA"
-                compile "group:bom:1.0"
-                compile "group:bom2:1.0"
+                compile platform("group:bom:1.0")
+                compile platform("group:bom2:1.0")
             }
         """
 
@@ -153,11 +155,11 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module("group:bom:1.0") {
+                module("group:bom:1.0:platform-runtime") {
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
-                module("group:bom2:1.0") {
+                module("group:bom2:1.0:platform-runtime") {
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
@@ -166,6 +168,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         }
     }
 
+    @Ignore("This isn't true anymore: a POM is either a platform (BOM) or a library")
     def "a bom can declare dependencies"() {
         given:
         mavenHttpRepo.module('group', 'moduleC', '1.0').allowAll().publish()
@@ -306,7 +309,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                 compile("group:moduleA") {
                     exclude(group: 'group')
                 }
-                compile "group:bom:1.0"
+                compile platform("group:bom:1.0")
             }
         """
 
@@ -316,7 +319,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module("group:bom:1.0") {
+                module("group:bom:1.0:platform-runtime") {
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }
@@ -335,7 +338,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
                 compile("group:moduleA") {
                     transitive = false
                 }
-                compile "group:bom:1.0"
+                compile platform("group:bom:1.0")
             }
         """
 
@@ -345,7 +348,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module("group:bom:1.0") {
+                module("group:bom:1.0:platform-runtime") {
                     module("group:moduleA:2.0")
                     noArtifacts()
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -69,37 +69,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
             }
         }
     }
-
-    @Ignore("This is no longer true, since a dependency on a BOM is by default a dependency on a library")
-    def "can import a bom transitively"() {
-        given:
-        bomDependency('moduleA').publish()
-        mavenHttpRepo.module('group', 'main', '5.0').allowAll().dependsOn(bom).publish()
-
-        buildFile << """
-            dependencies {
-                compile "group:moduleA"
-                compile "group:main:5.0"
-            }
-        """
-
-        when:
-        succeeds 'checkDep'
-
-        then:
-        resolve.expectGraph {
-            root(':', ':testproject:') {
-                module("group:main:5.0") {
-                    module("group:bom:1.0") {
-                        module("group:moduleA:2.0")
-                        noArtifacts()
-                    }
-                }
-                edge("group:moduleA", "group:moduleA:2.0")
-            }
-        }
-    }
-
+    
     def "a bom dependencyManagement entry can declare excludes which are applied unconditionally to module"() {
         given:
         moduleA.dependsOn(mavenHttpRepo.module("group", "moduleC", "1.0").allowAll().publish()).publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -69,7 +69,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
             }
         }
     }
-    
+
     def "a bom dependencyManagement entry can declare excludes which are applied unconditionally to module"() {
         given:
         moduleA.dependsOn(mavenHttpRepo.module("group", "moduleC", "1.0").allowAll().publish()).publish()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -250,8 +250,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context);
         }
 
-        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {
-            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory);
+        DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, ComponentMetadataHandler componentMetadataHandler) {
+            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, componentMetadataHandler);
         }
 
         DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -15,26 +15,25 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.Capability;
 
 import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Configurations {
-    public static Set<String> getNames(Collection<Configuration> configurations) {
+    public static ImmutableSet<String> getNames(Collection<Configuration> configurations) {
         if (configurations.isEmpty()) {
-            return Collections.emptySet();
+            return ImmutableSet.of();
         } else if (configurations.size()==1) {
-            return Collections.singleton(configurations.iterator().next().getName());
+            return ImmutableSet.of(configurations.iterator().next().getName());
         }
-        Set<String> names = new LinkedHashSet<String>(configurations.size());
+        ImmutableSet.Builder<String> names = new ImmutableSet.Builder<String>();
         for (Configuration configuration : configurations) {
             names.add(configuration.getName());
         }
-        return names;
+        return names.build();
     }
 
     public static Set<Capability> collectCapabilities(Configuration configuration, Set<Capability> out, Set<Configuration> visited) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultDependencyConstraint.java
@@ -35,7 +35,7 @@ import org.gradle.api.logging.Logging;
 
 import javax.annotation.Nullable;
 
-public class DefaultDependencyConstraint implements DependencyConstraint {
+public class DefaultDependencyConstraint implements DependencyConstraintInternal {
 
     private final static Logger LOG = Logging.getLogger(DefaultDependencyConstraint.class);
 
@@ -45,6 +45,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
     private String reason;
     private ImmutableAttributesFactory attributesFactory;
     private AttributeContainerInternal attributes;
+    private boolean force;
 
     public DefaultDependencyConstraint(String group, String name, String version) {
         this.moduleIdentifier = DefaultModuleIdentifier.newId(group, name);
@@ -109,7 +110,8 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         DefaultDependencyConstraint that = (DefaultDependencyConstraint) o;
         return Objects.equal(moduleIdentifier, that.moduleIdentifier) &&
             Objects.equal(versionConstraint, that.versionConstraint) &&
-            Objects.equal(attributes, that.attributes);
+            Objects.equal(attributes, that.attributes) &&
+            force == that.force;
     }
 
     @Override
@@ -152,6 +154,7 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         constraint.reason = reason;
         constraint.attributes = attributes;
         constraint.attributesFactory = attributesFactory;
+        constraint.force = force;
         return constraint;
     }
 
@@ -160,5 +163,15 @@ public class DefaultDependencyConstraint implements DependencyConstraint {
         return "constraint " +
             moduleIdentifier + ":" + versionConstraint +
             ", attributes=" + attributes;
+    }
+
+    @Override
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
+    @Override
+    public boolean isForce() {
+        return force;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DependencyConstraintInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DependencyConstraintInternal.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies;
+
+import org.gradle.api.artifacts.DependencyConstraint;
+
+public interface DependencyConstraintInternal extends DependencyConstraint {
+    void setForce(boolean force);
+    boolean isForce();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
+import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
 import org.gradle.util.ConfigureUtil;
@@ -58,6 +59,32 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     @Override
     public DependencyConstraint create(Object dependencyNotation, Action<? super DependencyConstraint> configureAction) {
         return doCreate(dependencyNotation, configureAction);
+    }
+
+    @Override
+    public DependencyConstraint platform(Object notation) {
+        return create(notation);
+    }
+
+    @Override
+    public DependencyConstraint platform(Object notation, Action<? super DependencyConstraint> configureAction) {
+        DependencyConstraint dep = platform(notation);
+        configureAction.execute(dep);
+        return dep;
+    }
+
+    @Override
+    public DependencyConstraint enforcedPlatform(Object notation) {
+        DependencyConstraintInternal platformDependency = (DependencyConstraintInternal) create(notation);
+        platformDependency.setForce(true);
+        return platformDependency;
+    }
+
+    @Override
+    public DependencyConstraint enforcedPlatform(Object notation, Action<? super DependencyConstraint> configureAction) {
+        DependencyConstraint dep = enforcedPlatform(notation);
+        configureAction.execute(dep);
+        return dep;
     }
 
     private DependencyConstraint doCreate(Object dependencyNotation, @Nullable Action<? super DependencyConstraint> configureAction) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
 import org.gradle.internal.metaobject.MethodAccess;
@@ -33,12 +34,15 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     private final ConfigurationContainer configurationContainer;
     private final DependencyFactory dependencyFactory;
     private final DynamicAddDependencyMethods dynamicMethods;
+    private final ComponentMetadataHandler componentMetadataHandler;
 
     public DefaultDependencyConstraintHandler(ConfigurationContainer configurationContainer,
-                                              DependencyFactory dependencyFactory) {
+                                              DependencyFactory dependencyFactory,
+                                              ComponentMetadataHandler componentMetadataHandler) {
         this.configurationContainer = configurationContainer;
         this.dependencyFactory = dependencyFactory;
         this.dynamicMethods = new DynamicAddDependencyMethods(configurationContainer, new DependencyConstraintAdder());
+        this.componentMetadataHandler = componentMetadataHandler;
     }
 
     @Override
@@ -77,6 +81,7 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     public DependencyConstraint enforcedPlatform(Object notation) {
         DependencyConstraintInternal platformDependency = (DependencyConstraintInternal) create(notation);
         platformDependency.setForce(true);
+        PlatformSupport.addEnforcedPlatformRule(componentMetadataHandler, platformDependency.getModule(), platformDependency.getVersion());
         return platformDependency;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -81,7 +81,7 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
     public DependencyConstraint enforcedPlatform(Object notation) {
         DependencyConstraintInternal platformDependency = (DependencyConstraintInternal) create(notation);
         platformDependency.setForce(true);
-        PlatformSupport.addEnforcedPlatformRule(componentMetadataHandler, platformDependency.getModule(), platformDependency.getVersion());
+        PlatformSupport.addPlatformAttribute(platformDependency, PlatformSupport.ENFORCED_PLATFORM);
         return platformDependency;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandler.java
@@ -67,7 +67,9 @@ public class DefaultDependencyConstraintHandler implements DependencyConstraintH
 
     @Override
     public DependencyConstraint platform(Object notation) {
-        return create(notation);
+        DependencyConstraint dependencyConstraint = create(notation);
+        PlatformSupport.addPlatformAttribute(dependencyConstraint, PlatformSupport.REGULAR_PLATFORM);
+        return dependencyConstraint;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -226,7 +226,9 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     public Dependency enforcedPlatform(Object notation) {
         Dependency platformDependency = create(notation);
         if (platformDependency instanceof ExternalModuleDependency) {
-            ((ExternalModuleDependency) platformDependency).setForce(true);
+            ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) platformDependency;
+            externalModuleDependency.setForce(true);
+            PlatformSupport.addEnforcedPlatformRule(getComponents(), externalModuleDependency.getModule(), externalModuleDependency.getVersion());
         }
         return platformDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
@@ -207,6 +208,34 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     @Override
     public void registerTransform(Action<? super VariantTransform> registrationAction) {
         transforms.registerTransform(registrationAction);
+    }
+
+    @Override
+    public Dependency platform(Object notation) {
+        return create(notation);
+    }
+
+    @Override
+    public Dependency platform(Object notation, Action<? super Dependency> configureAction) {
+        Dependency dep = platform(notation);
+        configureAction.execute(dep);
+        return dep;
+    }
+
+    @Override
+    public Dependency enforcedPlatform(Object notation) {
+        Dependency platformDependency = create(notation);
+        if (platformDependency instanceof ExternalModuleDependency) {
+            ((ExternalModuleDependency) platformDependency).setForce(true);
+        }
+        return platformDependency;
+    }
+
+    @Override
+    public Dependency enforcedPlatform(Object notation, Action<? super Dependency> configureAction) {
+        Dependency dep = enforcedPlatform(notation);
+        configureAction.execute(dep);
+        return dep;
     }
 
     private class DirectDependencyAdder implements DynamicAddDependencyMethods.DependencyAdder<Dependency> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
 import org.gradle.internal.Factory;
@@ -213,7 +214,11 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
 
     @Override
     public Dependency platform(Object notation) {
-        return create(notation);
+        Dependency dependency = create(notation);
+        if (dependency instanceof HasConfigurableAttributes) {
+            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<Object>) dependency, PlatformSupport.REGULAR_PLATFORM);
+        }
+        return dependency;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -193,6 +193,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
 
     private void configureSchema() {
         attributesSchema.attribute(ARTIFACT_FORMAT);
+        PlatformSupport.configureSchema(attributesSchema);
     }
 
     @Override
@@ -228,7 +229,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         if (platformDependency instanceof ExternalModuleDependency) {
             ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) platformDependency;
             externalModuleDependency.setForce(true);
-            PlatformSupport.addEnforcedPlatformRule(getComponents(), externalModuleDependency.getModule(), externalModuleDependency.getVersion());
+            PlatformSupport.addPlatformAttribute(externalModuleDependency, PlatformSupport.ENFORCED_PLATFORM);
         }
         return platformDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -194,7 +194,6 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
 
     private void configureSchema() {
         attributesSchema.attribute(ARTIFACT_FORMAT);
-        PlatformSupport.configureSchema(attributesSchema);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl.dependencies;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.api.artifacts.DependenciesMetadata;
+import org.gradle.api.artifacts.DependencyMetadata;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.VariantMetadata;
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
+import org.gradle.api.internal.artifacts.repositories.resolver.AbstractDependencyMetadataAdapter;
+
+abstract class PlatformSupport {
+    static void addEnforcedPlatformRule(ComponentMetadataHandler components, final ModuleIdentifier module, final String version) {
+        components.withModule(module, new Action<ComponentMetadataDetails>() {
+            @Override
+            public void execute(ComponentMetadataDetails componentMetadataDetails) {
+                if (componentMetadataDetails.getId().getVersion().equals(version)) {
+                    componentMetadataDetails.allVariants(new ForceDirectDependenciesAction());
+                }
+            }
+        });
+    }
+
+    private static class ForceDirectDependenciesAction implements Action<VariantMetadata> {
+
+        private  <T extends DependencyMetadata> void forceAll(DependenciesMetadata<T> dependencies) {
+            for (T dependency : dependencies) {
+                if (dependency instanceof AbstractDependencyMetadataAdapter) {
+                    ((AbstractDependencyMetadataAdapter) dependency).forced();
+                }
+            }
+        }
+
+        private final Action<DependenciesMetadata<?>> forceDependencies = new Action<DependenciesMetadata<?>>() {
+            @Override
+            public void execute(DependenciesMetadata<?> dependencies) {
+                forceAll(dependencies);
+            }
+        };
+
+        @Override
+        public void execute(VariantMetadata variantMetadata) {
+            variantMetadata.withDependencies(forceDependencies);
+            variantMetadata.withDependencyConstraints(forceDependencies);
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
+import org.gradle.api.internal.ReusableAction;
 
 import java.util.Set;
 
@@ -46,7 +47,7 @@ public abstract class PlatformSupport {
         });
     }
 
-    public static class ComponentCategoryDisambiguationRule implements AttributeDisambiguationRule<String> {
+    public static class ComponentCategoryDisambiguationRule implements AttributeDisambiguationRule<String>, ReusableAction {
         @Override
         public void execute(MultipleCandidatesDetails<String> details) {
             String consumerValue = details.getConsumerValue();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.clientmodule;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.Dependency;
@@ -186,7 +187,7 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
 
     private static class ClientModuleConfigurationMetadata extends DefaultConfigurationMetadata {
         ClientModuleConfigurationMetadata(ModuleComponentIdentifier componentId, String name, ModuleComponentArtifactMetadata artifact, List<ModuleDependencyMetadata> dependencies) {
-            super(componentId, name, true, true, ImmutableList.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
+            super(componentId, name, true, true, ImmutableSet.<String>of(), ImmutableList.of(artifact), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
             setDependencies(dependencies);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
@@ -35,6 +35,8 @@ import javax.annotation.Nullable;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet.NO_ARTIFACTS;
+
 class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifactSelector {
     private final Map<String, ModuleComponentRepository> repositories = new LinkedHashMap<String, ModuleComponentRepository>();
 
@@ -56,6 +58,10 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
     @Nullable
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactTypeRegistry artifactTypeRegistry, ModuleExclusion exclusions, ImmutableAttributes overriddenAttributes) {
+        if (component.getSource() == null) {
+            // virtual components have no source
+            return NO_ARTIFACTS;
+        }
         ModuleComponentRepository sourceRepository = findSourceRepository(component.getSource());
         ComponentResolveMetadata unpackedComponent = unpackSource(component);
         // First try to determine the artifacts locally before going remote

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -128,15 +128,15 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         if (relocation != null) {
             if (groupId != null && artifactId != null && artifactId.equals(relocation.getName()) && groupId.equals(relocation.getGroup())) {
                 LOGGER.error("POM relocation to an other version number is not fully supported in Gradle : {} relocated to {}.",
-                        mdBuilder.getComponentIdentifier(), relocation);
+                    mdBuilder.getComponentIdentifier(), relocation);
                 LOGGER.warn("Please update your dependency to directly use the correct version '{}'.", relocation);
                 LOGGER.warn("Resolution will only pick dependencies of the relocated element.  Artifacts and other metadata will be ignored.");
                 PomReader relocatedModule = parsePomForId(parserSettings, DefaultModuleComponentIdentifier.newId(relocation), Maps.<String, String>newHashMap());
                 addDependencies(mdBuilder, relocatedModule);
             } else {
                 LOGGER.info(mdBuilder.getComponentIdentifier()
-                        + " is relocated to " + relocation
-                        + ". Please update your dependencies.");
+                    + " is relocated to " + relocation
+                    + ". Please update your dependencies.");
                 LOGGER.debug("Relocated module will be considered as a dependency");
                 ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
                     DefaultModuleIdentifier.newId(relocation.getGroup(), relocation.getName()), new DefaultMutableVersionConstraint(relocation.getVersion()));
@@ -149,11 +149,8 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private void addDependencies(GradlePomModuleDescriptorBuilder mdBuilder, PomReader pomReader) {
-        // Only consider Maven <dependencyManagement> for BOM files
-        if (isBom(pomReader)) {
-            for (PomDependencyMgt dependencyMgt : pomReader.getDependencyMgt().values()) {
-                mdBuilder.addConstraint(dependencyMgt);
-            }
+        for (PomDependencyMgt dependencyMgt : pomReader.getDependencyMgt().values()) {
+            mdBuilder.addConstraint(dependencyMgt);
         }
 
         for (PomDependencyData dependency : pomReader.getDependencies().values()) {
@@ -165,9 +162,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
      * Overrides existing dependency management information with imported ones if existing.
      *
      * @param parseContext Parse context
-     * @param pomReader    POM reader
-     * @throws IOException
-     * @throws SAXException
+     * @param pomReader POM reader
      */
     private void overrideDependencyMgtsWithImported(DescriptorParseContext parseContext, PomReader pomReader) throws IOException, SAXException {
         Map<MavenDependencyKey, PomDependencyMgt> importedDependencyMgts = parseImportedDependencyMgts(parseContext, pomReader.parseDependencyMgt());
@@ -177,11 +172,9 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     /**
      * Parses imported dependency management information.
      *
-     * @param parseContext          Parse context
+     * @param parseContext Parse context
      * @param currentDependencyMgts Current dependency management information
      * @return Imported dependency management information
-     * @throws IOException
-     * @throws SAXException
      */
     private Map<MavenDependencyKey, PomDependencyMgt> parseImportedDependencyMgts(DescriptorParseContext parseContext, Collection<PomDependencyMgt> currentDependencyMgts) throws IOException, SAXException {
         Map<MavenDependencyKey, PomDependencyMgt> importedDependencyMgts = new LinkedHashMap<MavenDependencyKey, PomDependencyMgt>();
@@ -222,7 +215,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
     }
 
     private ModuleDependencyMetadata toDependencyMetadata(ModuleComponentSelector selector) {
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, null);
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), false, null, false);
     }
 
     private PomReader parsePomResource(DescriptorParseContext parseContext, LocallyAvailableExternalResource localResource, Map<String, String> childProperties) throws SAXException, IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/DefaultLocalComponentMetadataBuilder.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.Capability;
@@ -29,7 +30,6 @@ import org.gradle.internal.component.local.model.BuildableLocalComponentMetadata
 import org.gradle.internal.component.local.model.BuildableLocalConfigurationMetadata;
 
 import java.util.Collection;
-import java.util.Set;
 
 public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetadataBuilder {
     private final LocalConfigurationMetadataBuilder configurationMetadataBuilder;
@@ -55,8 +55,8 @@ public class DefaultLocalComponentMetadataBuilder implements LocalComponentMetad
                                                                     ConfigurationInternal configuration) {
         configuration.preventFromFurtherMutation();
 
-        Set<String> hierarchy = Configurations.getNames(configuration.getHierarchy());
-        Set<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
+        ImmutableSet<String> hierarchy = Configurations.getNames(configuration.getHierarchy());
+        ImmutableSet<String> extendsFrom = Configurations.getNames(configuration.getExtendsFrom());
         // Presence of capabilities is bound to the definition of a capabilities extension to the project
         ImmutableCapabilities capabilities =
             asImmutable(Configurations.collectCapabilities(configuration, Sets.<Capability>newHashSet(), Sets.<Configuration>newHashSet()));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -49,7 +50,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
         return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
-            Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, false, true, dependencyConstraint.getReason());
+            Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, dependencyConstraint.getReason());
     }
 
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -136,10 +136,12 @@ public class ComponentResolversChain {
     }
 
     private static class DependencyToComponentIdResolverChain implements DependencyToComponentIdResolver {
-        private final List<DependencyToComponentIdResolver> resolvers;
+        // Using an array here because we're going to iterate pretty often and it avoids the creation of an iterator
+        // that checks for concurrent modification
+        private final DependencyToComponentIdResolver[] resolvers;
 
         public DependencyToComponentIdResolverChain(List<DependencyToComponentIdResolver> resolvers) {
-            this.resolvers = resolvers;
+            this.resolvers = resolvers.toArray(new DependencyToComponentIdResolver[0]);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactSet.java
@@ -19,6 +19,8 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.transform.VariantSelector;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.operations.BuildOperationQueue;
+import org.gradle.internal.operations.RunnableBuildOperation;
 
 /**
  * Represents a container of artifacts, possibly made up of several different variants.
@@ -26,6 +28,22 @@ import org.gradle.api.specs.Spec;
  * Instances are retained during the lifetime of a build, so should avoid retaining unnecessary state.
  */
 public interface ArtifactSet {
+    ArtifactSet NO_ARTIFACTS = new ArtifactSet() {
+        @Override
+        public ResolvedArtifactSet select(Spec<? super ComponentIdentifier> componentFilter, VariantSelector selector) {
+            return new ResolvedArtifactSet() {
+                @Override
+                public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
+                    return EMPTY_RESULT;
+                }
+
+                @Override
+                public void collectBuildDependencies(BuildDependenciesVisitor visitor) {
+                }
+            };
+        }
+    };
+
     /**
      * Selects the artifacts of this set that meet the given criteria. Implementation should be eager where possible, so that selection happens immediately, but may be lazy.
      */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
@@ -41,14 +41,12 @@ class DefaultPendingDependenciesHandler implements PendingDependenciesHandler {
 
     public class DefaultVisitor implements Visitor {
         private List<PendingDependencies> noLongerPending;
-        private PendingDependencies currentPending;
 
         public boolean maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState) {
-            currentPending = null;
             ModuleIdentifier key = dependencyState.getModuleIdentifier();
             boolean isOptionalDependency = dependencyState.getDependency().isConstraint();
             if (!isOptionalDependency) {
-                currentPending = pendingDependencies.getPendingDependencies(key);
+                PendingDependencies currentPending = pendingDependencies.getPendingDependencies(key);
                 markNoLongerPending(currentPending);
                 currentPending.addHardEdge();
                 return false;
@@ -66,6 +64,11 @@ class DefaultPendingDependenciesHandler implements PendingDependenciesHandler {
             // No hard dependency, queue up pending dependency in case we see a hard dependency later.
             pendingDependencies.addNode(node);
             return true;
+        }
+
+        @Override
+        public void markNotPending(ModuleIdentifier id) {
+            markNoLongerPending(pendingDependencies.getPendingDependencies(id));
         }
 
         private void markNoLongerPending(PendingDependencies pendingDependencies) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
@@ -44,11 +44,9 @@ class DefaultPendingDependenciesHandler implements PendingDependenciesHandler {
 
         public boolean maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState) {
             ModuleIdentifier key = dependencyState.getModuleIdentifier();
-            boolean isOptionalDependency = dependencyState.getDependency().isConstraint();
-            if (!isOptionalDependency) {
-                PendingDependencies currentPending = pendingDependencies.getPendingDependencies(key);
-                markNoLongerPending(currentPending);
-                currentPending.addHardEdge();
+            boolean isConstraint = dependencyState.getDependency().isConstraint();
+            if (!isConstraint) {
+                markNotPending(key);
                 return false;
             }
 
@@ -78,6 +76,7 @@ class DefaultPendingDependenciesHandler implements PendingDependenciesHandler {
                 }
                 noLongerPending.add(pendingDependencies);
             }
+            pendingDependencies.addHardEdge();
         }
 
         public void complete() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -160,6 +160,7 @@ class EdgeState implements DependencyGraphEdge {
         targetNodeSelectionFailure = null;
         ComponentResolveMetadata targetModuleVersion = targetComponent.getMetadata();
         if (targetModuleVersion == null) {
+            targetComponent.getModule().getPlatformState().addOrphanEdge(this);
             // Broken version
             return;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -131,7 +131,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
         return force;
     }
 
-    private class LenientPlatformConfigurationMetadata extends DefaultConfigurationMetadata {
+    private class LenientPlatformConfigurationMetadata extends DefaultConfigurationMetadata implements ConfigurationMetadata {
 
         private final VirtualPlatformState platformState;
         private final ComponentIdentifier platformId;
@@ -172,6 +172,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
                             break;
                         }
                     }
+                    platformState.attachOrphanEdges();
                 }
             }
             return result == null ? Collections.<DependencyMetadata>emptyList() : result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -131,6 +131,11 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
         return force;
     }
 
+    @Override
+    public ForcingDependencyMetadata forced() {
+        return new LenientPlatformDependencyMetadata(resolveState, from, cs, componentId, platformId, true, transitive);
+    }
+
     private class LenientPlatformConfigurationMetadata extends DefaultConfigurationMetadata implements ConfigurationMetadata {
 
         private final VirtualPlatformState platformState;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -142,7 +143,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
         private final ComponentIdentifier platformId;
 
         public LenientPlatformConfigurationMetadata(VirtualPlatformState platform, ComponentIdentifier platformId) {
-            super(componentId, "default", true, false, ImmutableList.of("default"), ImmutableList.<ModuleComponentArtifactMetadata>of(), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
+            super(componentId, "default", true, false, ImmutableSet.of("default"), ImmutableList.<ModuleComponentArtifactMetadata>of(), VariantMetadataRules.noOp(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY);
             this.platformState = platform;
             this.platformId = platformId;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -102,7 +102,8 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
                     DefaultModuleComponentSelector.newSelector(module.getId(), moduleVersionIdentifier.getVersion()),
                     DefaultModuleComponentIdentifier.newId(module.getId(), moduleVersionIdentifier.getVersion()),
                     platformState.getSelectedPlatformId(),
-                    platformState.isForced()
+                    platformState.isForced(),
+                    true
                 ));
             }
             return new RealisedConfigurationMetadata(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -108,7 +109,7 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
             }
             return new RealisedConfigurationMetadata(
                 moduleComponentIdentifier, name, false, false,
-                ImmutableList.of(name), ImmutableList.<ModuleComponentArtifactMetadata>of(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, dependencies.build()
+                ImmutableSet.of(name), ImmutableList.<ModuleComponentArtifactMetadata>of(), ImmutableList.<ExcludeMetadata>of(), ImmutableAttributes.EMPTY, ImmutableCapabilities.EMPTY, dependencies.build()
             );
         }
         throw new IllegalArgumentException("Undefined configuration '" + name + "'");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -255,6 +255,7 @@ class NodeState implements DependencyGraphNode {
     private void visitOwners(Collection<EdgeState> discoveredEdges) {
         ImmutableList<? extends ComponentIdentifier> owners = component.getMetadata().getPlatformOwners();
         if (!owners.isEmpty()) {
+            PendingDependenciesHandler.Visitor visitor = resolveState.getPendingDependenciesHandler().start();
             for (ComponentIdentifier owner : owners) {
                 if (owner instanceof ModuleComponentIdentifier) {
                     ModuleComponentIdentifier platformId = (ModuleComponentIdentifier) owner;
@@ -264,8 +265,10 @@ class NodeState implements DependencyGraphNode {
                     // 1. the "platform" referenced is a real module, in which case we directly add it to the graph
                     // 2. the "platform" is a virtual, constructed thing, in which case we add virtual edges to the graph
                     addPlatformEdges(discoveredEdges, platformId, cs);
+                    visitor.markNotPending(platformId.getModuleIdentifier());
                 }
             }
+            visitor.complete();
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -279,7 +279,7 @@ class NodeState implements DependencyGraphNode {
         }
         if (metadata == null) {
             // the platform doesn't exist, so we're building a lenient one
-            metadata = new LenientPlatformResolveMetadata(platformComponentIdentifier, potentialEdge.toModuleVersionId, virtualPlatformState);
+            metadata = new LenientPlatformResolveMetadata(platformComponentIdentifier, potentialEdge.toModuleVersionId, virtualPlatformState, this, resolveState);
             potentialEdge.component.setMetadata(metadata);
         }
         if (virtualEdges == null) {
@@ -455,7 +455,7 @@ class NodeState implements DependencyGraphNode {
             previousTraversalExclusions = null;
             outgoingEdges.clear();
             virtualEdges = null;
-            resolveState.onMoreSelected(this);
+            resolveState.onFewerSelected(this);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesHandler.java
@@ -15,6 +15,8 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import org.gradle.api.artifacts.ModuleIdentifier;
+
 public interface PendingDependenciesHandler {
     Visitor start();
 
@@ -22,6 +24,8 @@ public interface PendingDependenciesHandler {
 
     interface Visitor {
         boolean maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState);
+
+        void markNotPending(ModuleIdentifier id);
 
         void complete();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -52,14 +52,14 @@ import java.util.Map;
  */
 class ResolveState implements ComponentStateFactory<ComponentState> {
     private final Spec<? super DependencyMetadata> edgeFilter;
-    private final Map<ModuleIdentifier, ModuleResolveState> modules = new LinkedHashMap<ModuleIdentifier, ModuleResolveState>();
-    private final Map<ResolvedConfigurationIdentifier, NodeState> nodes = new LinkedHashMap<ResolvedConfigurationIdentifier, NodeState>();
-    private final Map<ComponentSelector, SelectorState> selectors = new LinkedHashMap<ComponentSelector, SelectorState>();
+    private final Map<ModuleIdentifier, ModuleResolveState> modules;
+    private final Map<ResolvedConfigurationIdentifier, NodeState> nodes;
+    private final Map<ComponentSelector, SelectorState> selectors;
     private final RootNode root;
     private final IdGenerator<Long> idGenerator;
     private final DependencyToComponentIdResolver idResolver;
     private final ComponentMetaDataResolver metaDataResolver;
-    private final Deque<NodeState> queue = new ArrayDeque<NodeState>();
+    private final Deque<NodeState> queue;
     private final AttributesSchemaInternal attributesSchema;
     private final ModuleExclusions moduleExclusions;
     private final DeselectVersionAction deselectVersionAction = new DeselectVersionAction(this);
@@ -79,7 +79,8 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
                         ModuleExclusions moduleExclusions, ModuleReplacementsData moduleReplacementsData,
                         ComponentSelectorConverter componentSelectorConverter, ImmutableAttributesFactory attributesFactory,
                         DependencySubstitutionApplicator dependencySubstitutionApplicator, VersionSelectorScheme versionSelectorScheme,
-                        Comparator<Version> versionComparator, VersionParser versionParser) {
+                        Comparator<Version> versionComparator, VersionParser versionParser,
+                        int graphSize) {
         this.idGenerator = idGenerator;
         this.idResolver = idResolver;
         this.metaDataResolver = metaDataResolver;
@@ -93,6 +94,10 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         this.versionSelectorScheme = versionSelectorScheme;
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
+        this.modules = new LinkedHashMap<ModuleIdentifier, ModuleResolveState>(graphSize);
+        this.nodes = new LinkedHashMap<ResolvedConfigurationIdentifier, NodeState>(3*graphSize/2);
+        this.selectors = new LinkedHashMap<ComponentSelector, SelectorState>(5*graphSize/2);
+        this.queue = new ArrayDeque<NodeState>(graphSize);
         ComponentState rootVersion = getRevision(rootResult.getId(), rootResult.getModuleVersionId(), rootResult.getMetadata());
         final ResolvedConfigurationIdentifier id = new ResolvedConfigurationIdentifier(rootVersion.getId(), rootConfigurationName);
         ConfigurationMetadata configurationMetadata = rootVersion.getMetadata().getConfiguration(id.getConfiguration());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -112,6 +112,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes());
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), details.getReason());
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), details.getReason(), false);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.model.ForcingDependencyMetadata;
 
 import java.util.List;
 
@@ -110,5 +111,12 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
         ModuleDependencyMetadata metadata = (ModuleDependencyMetadata) getOriginalMetadata().withTarget(target);
         updateMetadata(metadata);
         return Cast.uncheckedCast(this);
+    }
+
+    public void forced() {
+        ModuleDependencyMetadata originalMetadata = getOriginalMetadata();
+        if (originalMetadata instanceof ForcingDependencyMetadata) {
+            updateMetadata((ModuleDependencyMetadata) ((ForcingDependencyMetadata) originalMetadata).forced());
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.InstantiatorFactory;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.changedetection.state.isolation.IsolatableFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.model.AttributeMatcher;
@@ -55,6 +56,7 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
         this.instantiatorFactory = instantiatorFactory;
         matcher = new DefaultAttributeMatcher(componentAttributeMatcher, mergeWith(EmptySchema.INSTANCE));
         this.isolatableFactory = isolatableFactory;
+        PlatformSupport.configureSchema(this);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -29,7 +29,6 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -39,7 +38,7 @@ public abstract class AbstractConfigurationMetadata implements ConfigurationMeta
     private final ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts;
     private final boolean transitive;
     private final boolean visible;
-    private final ImmutableList<String> hierarchy;
+    private final ImmutableSet<String> hierarchy;
     private final ImmutableList<ExcludeMetadata> excludes;
     private final ImmutableAttributes attributes;
     private final ImmutableCapabilities capabilities;
@@ -47,9 +46,9 @@ public abstract class AbstractConfigurationMetadata implements ConfigurationMeta
     private ImmutableList<ModuleDependencyMetadata> configDependencies;
 
     AbstractConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
-                                         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableList<String> hierarchy,
-                                         ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes,
-                                         ImmutableList<ModuleDependencyMetadata> configDependencies, ImmutableCapabilities capabilities) {
+                                  ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableSet<String> hierarchy,
+                                  ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes,
+                                  ImmutableList<ModuleDependencyMetadata> configDependencies, ImmutableCapabilities capabilities) {
 
         this.componentId = componentId;
         this.name = name;
@@ -79,7 +78,7 @@ public abstract class AbstractConfigurationMetadata implements ConfigurationMeta
     }
 
     @Override
-    public Collection<String> getHierarchy() {
+    public ImmutableSet<String> getHierarchy() {
         return hierarchy;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -108,15 +108,16 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
 
     @Override
     public synchronized ConfigurationMetadata getConfiguration(final String name) {
-        return populateConfigurationFromDescriptor(name, configurationDefinitions, configurations);
-    }
-
-    private ConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions, Map<String, ConfigurationMetadata> configurations) {
         ConfigurationMetadata populated = configurations.get(name);
         if (populated != null) {
             return populated;
         }
+        ConfigurationMetadata md = populateConfigurationFromDescriptor(name, configurationDefinitions, configurations);
+        configurations.put(name, md);
+        return md;
+    }
 
+    protected ConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions, Map<String, ConfigurationMetadata> configurations) {
         Configuration descriptorConfiguration = configurationDefinitions.get(name);
         if (descriptorConfiguration == null) {
             return null;
@@ -125,9 +126,7 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         ImmutableList<String> hierarchy = constructHierarchy(descriptorConfiguration);
         boolean transitive = descriptorConfiguration.isTransitive();
         boolean visible = descriptorConfiguration.isVisible();
-        populated = createConfiguration(getId(), name, transitive, visible, hierarchy, variantMetadataRules);
-        configurations.put(name, populated);
-        return populated;
+        return createConfiguration(getId(), name, transitive, visible, hierarchy, variantMetadataRules);
     }
 
     private ImmutableList<String> constructHierarchy(Configuration descriptorConfiguration) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.descriptor.Configuration;
@@ -27,7 +28,6 @@ import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 
 import javax.annotation.Nullable;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -123,22 +123,22 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
             return null;
         }
 
-        ImmutableList<String> hierarchy = constructHierarchy(descriptorConfiguration);
+        ImmutableSet<String> hierarchy = constructHierarchy(descriptorConfiguration);
         boolean transitive = descriptorConfiguration.isTransitive();
         boolean visible = descriptorConfiguration.isVisible();
         return createConfiguration(getId(), name, transitive, visible, hierarchy, variantMetadataRules);
     }
 
-    private ImmutableList<String> constructHierarchy(Configuration descriptorConfiguration) {
+    private ImmutableSet<String> constructHierarchy(Configuration descriptorConfiguration) {
         if (descriptorConfiguration.getExtendsFrom().isEmpty()) {
-            return ImmutableList.of(descriptorConfiguration.getName());
+            return ImmutableSet.of(descriptorConfiguration.getName());
         }
-        Set<String> accumulator = new LinkedHashSet<String>();
+        ImmutableSet.Builder<String> accumulator = new ImmutableSet.Builder<String>();
         populateHierarchy(descriptorConfiguration, accumulator);
-        return ImmutableList.copyOf(accumulator);
+        return accumulator.build();
     }
 
-    private void populateHierarchy(Configuration metadata, Set<String> accumulator) {
+    private void populateHierarchy(Configuration metadata, ImmutableSet.Builder<String> accumulator) {
         accumulator.add(metadata.getName());
         for (String parentName : metadata.getExtendsFrom()) {
             Configuration parent = configurationDefinitions.get(parentName);
@@ -149,7 +149,7 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
     /**
      * Creates a {@link org.gradle.internal.component.model.ConfigurationMetadata} implementation for this component.
      */
-    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules);
+    protected abstract DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, VariantMetadataRules componentMetadataRules);
 
     @Override
     public boolean equals(Object o) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -113,7 +113,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         List<ExcludeMetadata> excludes = readMavenExcludes(decoder);
         boolean constraint = decoder.readBoolean();
         String reason = decoder.readNullableString();
-        return new GradleDependencyMetadata(selector, excludes, constraint, reason);
+        return new GradleDependencyMetadata(selector, excludes, constraint, reason, false);
     }
 
     protected List<ExcludeMetadata> readMavenExcludes(Decoder decoder) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -34,7 +34,6 @@ import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -84,8 +83,8 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
     }
 
     @Override
-    public Collection<String> getHierarchy() {
-        return ImmutableList.of(variant.getName());
+    public ImmutableSet<String> getHierarchy() {
+        return ImmutableSet.of(variant.getName());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -45,6 +45,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     private final ExternalDependencyDescriptor dependencyDescriptor;
     private final String reason;
     private final boolean isTransitive;
+    private final boolean isConstraint;
 
     private boolean alwaysUseAttributeMatching;
 
@@ -54,6 +55,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         this.dependencyDescriptor = dependencyDescriptor;
         this.reason = reason;
         this.isTransitive = dependencyDescriptor.isTransitive();
+        this.isConstraint = dependencyDescriptor.isConstraint() || dependencyDescriptor.isOptional();
     }
 
     public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {
@@ -155,7 +157,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
 
     @Override
     public boolean isConstraint() {
-        return dependencyDescriptor.isConstraint() || dependencyDescriptor.isOptional();
+        return isConstraint;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -155,7 +155,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
 
     @Override
     public boolean isConstraint() {
-        return dependencyDescriptor.isOptional();
+        return dependencyDescriptor.isConstraint() || dependencyDescriptor.isOptional();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -17,11 +17,19 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.ForcingDependencyMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.List;
 
@@ -34,6 +42,8 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
     private final VariantMetadataRules componentMetadataRules;
 
     private List<ModuleDependencyMetadata> calculatedDependencies;
+
+    private final ImmutableAttributes componentLevelAttributes;
 
     // Could be precomputed, but we avoid doing so if attributes are never requested
     private ImmutableAttributes computedAttributes;
@@ -55,6 +65,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
                                          ImmutableList<ModuleDependencyMetadata> configDependencies) {
         super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependencies, ImmutableCapabilities.EMPTY);
         this.componentMetadataRules = componentMetadataRules;
+        this.componentLevelAttributes = attributes;
     }
 
     @Override
@@ -89,4 +100,120 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
         return new DefaultConfigurationMetadata(getComponentId(), newName, isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
     }
 
+    public DefaultConfigurationMetadata withForcedDependencies() {
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), componentLevelAttributes, force(getConfigDependencies()));
+    }
+
+    private ImmutableList<ModuleDependencyMetadata> force(ImmutableList<ModuleDependencyMetadata> configDependencies) {
+        ImmutableList.Builder<ModuleDependencyMetadata> dependencies = new ImmutableList.Builder<ModuleDependencyMetadata>();
+        for (ModuleDependencyMetadata configDependency : configDependencies) {
+            if (configDependency instanceof ForcingDependencyMetadata) {
+                dependencies.add((ModuleDependencyMetadata) ((ForcingDependencyMetadata) configDependency).forced());
+            } else {
+                dependencies.add(new ForcedDependencyMetadataWrapper(configDependency));
+            }
+        }
+        return dependencies.build();
+    }
+
+    public DefaultConfigurationMetadata withoutConstraints() {
+        return withConstraints(false);
+    }
+
+    public DefaultConfigurationMetadata withConstraintsOnly() {
+        return withConstraints(true);
+    }
+
+    private DefaultConfigurationMetadata withConstraints(boolean constraint) {
+        ImmutableList<ModuleDependencyMetadata> configDependencies = getConfigDependencies();
+        if (configDependencies.isEmpty()) {
+            return this;
+        }
+        int count = 0;
+        ImmutableList.Builder<ModuleDependencyMetadata> filtered = new ImmutableList.Builder<ModuleDependencyMetadata>();
+        for (ModuleDependencyMetadata configDependency : configDependencies) {
+            if (configDependency.isConstraint() == constraint) {
+                filtered.add(configDependency);
+                count++;
+            }
+        }
+        if (count == configDependencies.size()) {
+            // Avoid creating a copy if the resulting configuration is identical
+            return this;
+        }
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), componentLevelAttributes, filtered.build());
+    }
+
+    private static class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {
+        private final ModuleDependencyMetadata delegate;
+
+        private ForcedDependencyMetadataWrapper(ModuleDependencyMetadata delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public ModuleComponentSelector getSelector() {
+            return delegate.getSelector();
+        }
+
+        @Override
+        public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
+            return new ForcedDependencyMetadataWrapper(delegate.withRequestedVersion(requestedVersion));
+        }
+
+        @Override
+        public ModuleDependencyMetadata withReason(String reason) {
+            return new ForcedDependencyMetadataWrapper(delegate.withReason(reason));
+        }
+
+        @Override
+        public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+            return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+        }
+
+        @Override
+        public List<ExcludeMetadata> getExcludes() {
+            return delegate.getExcludes();
+        }
+
+        @Override
+        public List<IvyArtifactName> getArtifacts() {
+            return delegate.getArtifacts();
+        }
+
+        @Override
+        public DependencyMetadata withTarget(ComponentSelector target) {
+            return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) delegate.withTarget(target));
+        }
+
+        @Override
+        public boolean isChanging() {
+            return delegate.isChanging();
+        }
+
+        @Override
+        public boolean isTransitive() {
+            return delegate.isTransitive();
+        }
+
+        @Override
+        public boolean isConstraint() {
+            return delegate.isConstraint();
+        }
+
+        @Override
+        public String getReason() {
+            return delegate.getReason();
+        }
+
+        @Override
+        public boolean isForce() {
+            return true;
+        }
+
+        @Override
+        public ForcingDependencyMetadata forced() {
+            return this;
+        }
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -50,15 +51,15 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
     private CapabilitiesMetadata computedCapabilities;
 
     public DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
-                                           ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
-                                           VariantMetadataRules componentMetadataRules,
-                                           ImmutableList<ExcludeMetadata> excludes,
-                                           ImmutableAttributes componentLevelAttributes) {
+                                        ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                        VariantMetadataRules componentMetadataRules,
+                                        ImmutableList<ExcludeMetadata> excludes,
+                                        ImmutableAttributes componentLevelAttributes) {
         this(componentId, name, transitive, visible, hierarchy, artifacts, componentMetadataRules, excludes, componentLevelAttributes, null);
     }
 
     private DefaultConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
-                                         ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                          VariantMetadataRules componentMetadataRules,
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes attributes,
@@ -93,15 +94,15 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
     }
 
     public DefaultConfigurationMetadata withAttributes(ImmutableAttributes attributes) {
-        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), getHierarchy(), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
     }
 
     public DefaultConfigurationMetadata withAttributes(String newName, ImmutableAttributes attributes) {
-        return new DefaultConfigurationMetadata(getComponentId(), newName, isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
+        return new DefaultConfigurationMetadata(getComponentId(), newName, isTransitive(), isVisible(), getHierarchy(), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
     }
 
     public DefaultConfigurationMetadata withForcedDependencies() {
-        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), componentLevelAttributes, force(getConfigDependencies()));
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), getHierarchy(), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), componentLevelAttributes, force(getConfigDependencies()));
     }
 
     private ImmutableList<ModuleDependencyMetadata> force(ImmutableList<ModuleDependencyMetadata> configDependencies) {
@@ -141,7 +142,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
             // Avoid creating a copy if the resulting configuration is identical
             return this;
         }
-        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), componentLevelAttributes, filtered.build());
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), getHierarchy(), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), componentLevelAttributes, filtered.build());
     }
 
     private static class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -85,4 +85,8 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
         return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
     }
 
+    public DefaultConfigurationMetadata withAttributes(String newName, ImmutableAttributes attributes) {
+        return new DefaultConfigurationMetadata(getComponentId(), newName, isTransitive(), isVisible(), ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), componentMetadataRules, getExcludes(), attributes, getConfigDependencies());
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ExternalDependencyDescriptor.java
@@ -36,6 +36,8 @@ public abstract class ExternalDependencyDescriptor {
 
     public abstract boolean isOptional();
 
+    public abstract boolean isConstraint();
+
     public abstract boolean isChanging();
 
     public abstract boolean isTransitive();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -42,7 +42,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     private final String reason;
     private final boolean force;
 
-    private GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, String reason, boolean force) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, String reason, boolean force) {
         this.selector = selector;
         this.excludes = excludes;
         this.reason = reason;
@@ -129,6 +129,6 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
 
     @Override
     public ForcingDependencyMetadata forced() {
-        return new GradleDependencyMetadata(selector, excludes, pending, reason, true);
+        return new GradleDependencyMetadata(selector, excludes, constraint, reason, true);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -42,7 +42,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     private final String reason;
     private final boolean force;
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, String reason, boolean force) {
+    private GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, String reason, boolean force) {
         this.selector = selector;
         this.excludes = excludes;
         this.reason = reason;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
@@ -28,9 +29,7 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Utility class to help transform a lazy {@link ModuleComponentResolveMetadata} into a realised one.
@@ -76,16 +75,16 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         return result;
     }
 
-    public static ImmutableList<String> constructHierarchy(Configuration descriptorConfiguration, ImmutableMap<String, Configuration> configurationDefinitions) {
+    public static ImmutableSet<String> constructHierarchy(Configuration descriptorConfiguration, ImmutableMap<String, Configuration> configurationDefinitions) {
         if (descriptorConfiguration.getExtendsFrom().isEmpty()) {
-            return ImmutableList.of(descriptorConfiguration.getName());
+            return ImmutableSet.of(descriptorConfiguration.getName());
         }
-        Set<String> accumulator = new LinkedHashSet<String>();
+        ImmutableSet.Builder<String> accumulator = new ImmutableSet.Builder<String>();
         populateHierarchy(descriptorConfiguration, configurationDefinitions, accumulator);
-        return ImmutableList.copyOf(accumulator);
+        return accumulator.build();
     }
 
-    private static void populateHierarchy(Configuration metadata, ImmutableMap<String, Configuration> configurationDefinitions, Set<String> accumulator) {
+    private static void populateHierarchy(Configuration metadata, ImmutableMap<String, Configuration> configurationDefinitions, ImmutableSet.Builder<String> accumulator) {
         accumulator.add(metadata.getName());
         for (String parentName : metadata.getExtendsFrom()) {
             Configuration parent = configurationDefinitions.get(parentName);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -62,14 +62,15 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         for (ComponentVariant.Dependency dependency : dependencies) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason()));
+            result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), false));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : dependencyConstraints) {
             result.add(new GradleDependencyMetadata(
                 DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
-                dependencyConstraint.getReason()
+                dependencyConstraint.getReason(),
+                false
             ));
         }
         return result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ConfigurationMetadata;
@@ -28,13 +29,13 @@ import java.util.List;
 public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata {
 
     public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
-                                         ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                          ImmutableList<ExcludeMetadata> excludes,
                                          ImmutableAttributes componentLevelAttributes, ImmutableCapabilities capabilities) {
         this(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities, null);
     }
 
-    public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes, ImmutableCapabilities capabilities, ImmutableList<ModuleDependencyMetadata> configDependencies) {
+    public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes, ImmutableCapabilities capabilities, ImmutableList<ModuleDependencyMetadata> configDependencies) {
         super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependencies, capabilities);
     }
 
@@ -46,7 +47,7 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
     @Override
     public ConfigurationMetadata withAttributes(ImmutableAttributes attributes) {
         return new RealisedConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(),
-            ImmutableList.copyOf(getHierarchy()), ImmutableList.copyOf(getArtifacts()), getExcludes(), attributes,
+            getHierarchy(), ImmutableList.copyOf(getArtifacts()), getExcludes(), attributes,
             ImmutableCapabilities.of(getCapabilities().getCapabilities()), getConfigDependencies());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model.ivy;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -88,7 +89,7 @@ public class DefaultIvyModuleResolveMetadata extends AbstractLazyModuleComponent
     }
 
     @Override
-    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, VariantMetadataRules componentMetadataRules) {
+    protected DefaultConfigurationMetadata createConfiguration(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, VariantMetadataRules componentMetadataRules) {
         if (artifacts == null) {
             artifacts = new IdentityHashMap<Artifact, ModuleComponentArtifactMetadata>();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyConfigurationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyConfigurationHelper.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model.ivy;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
@@ -49,7 +50,7 @@ class IvyConfigurationHelper {
         this.componentId = componentId;
     }
 
-    ImmutableList<ModuleComponentArtifactMetadata> filterArtifacts(String name, ImmutableList<String> hierarchy) {
+    ImmutableList<ModuleComponentArtifactMetadata> filterArtifacts(String name, Collection<String> hierarchy) {
         Set<ModuleComponentArtifactMetadata> artifacts = new LinkedHashSet<ModuleComponentArtifactMetadata>();
         collectArtifactsFor(name, artifacts);
         for (String parent : hierarchy) {
@@ -71,7 +72,7 @@ class IvyConfigurationHelper {
         }
     }
 
-    ImmutableList<ExcludeMetadata> filterExcludes(ImmutableList<String> hierarchy) {
+    ImmutableList<ExcludeMetadata> filterExcludes(ImmutableSet<String> hierarchy) {
         ImmutableList.Builder<ExcludeMetadata> filtered = ImmutableList.builder();
         for (Exclude exclude : excludes) {
             for (String config : exclude.getConfigurations()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/IvyDependencyDescriptor.java
@@ -84,6 +84,11 @@ public class IvyDependencyDescriptor extends ExternalDependencyDescriptor {
     }
 
     @Override
+    public boolean isConstraint() {
+        return false;
+    }
+
+    @Override
     public boolean isChanging() {
         return changing;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model.ivy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -72,7 +73,7 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
         ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
         for (String configurationName: metadata.getConfigurationNames()) {
             Configuration configuration = configurationDefinitions.get(configurationName);
-            ImmutableList<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
+            ImmutableSet<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
 
             NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
             ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
@@ -128,7 +129,7 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
         this.metadata = metadata;
     }
 
-    private static RealisedConfigurationMetadata createConfiguration(IvyConfigurationHelper configurationHelper, VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, ImmutableList<ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes componentLevelAttributes, ImmutableCapabilities capabilities) {
+    private static RealisedConfigurationMetadata createConfiguration(IvyConfigurationHelper configurationHelper, VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, ImmutableList<ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes componentLevelAttributes, ImmutableCapabilities capabilities) {
         RealisedConfigurationMetadata configuration = new RealisedConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities);
         ImmutableList<ModuleDependencyMetadata> dependencyMetadata = configurationHelper.filterDependencies(configuration);
         dependencyMetadata = ImmutableList.copyOf(variantMetadataRules.applyDependencyMetadataRules(new NameOnlyVariantResolveMetadata(name), dependencyMetadata));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadataSerializationHelper.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model.ivy;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -105,7 +106,7 @@ public class RealisedIvyModuleResolveMetadataSerializationHelper extends Abstrac
             String configurationName = decoder.readString();
             Configuration configuration = configurationDefinitions.get(configurationName);
             assert configuration != null;
-            ImmutableList<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
+            ImmutableSet<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
             ImmutableAttributes attributes = getAttributeContainerSerializer().read(decoder);
             ImmutableCapabilities capabilities = readCapabilities(decoder);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
@@ -71,7 +71,7 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
 
     @Override
     public boolean isTransitive() {
-        return !isOptional();
+        return !(isConstraint() || isOptional());
     }
 
     /**
@@ -181,7 +181,12 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
 
     @Override
     public boolean isOptional() {
-        return type.optional;
+        return type == MavenDependencyType.OPTIONAL_DEPENDENCY;
+    }
+
+    @Override
+    public boolean isConstraint() {
+        return type == MavenDependencyType.DEPENDENCY_MANAGEMENT;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -101,7 +102,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         return new RealisedMavenModuleResolveMetadata(metadata, variants, derivedVariants, configurations);
     }
 
-    private static RealisedConfigurationMetadata createConfiguration(VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableList<String> hierarchy, ImmutableList<MavenDependencyDescriptor> dependencies, boolean improvedPomSupport, ImmutableAttributes attributes, ImmutableCapabilities capabilities) {
+    private static RealisedConfigurationMetadata createConfiguration(VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, ImmutableList<MavenDependencyDescriptor> dependencies, boolean improvedPomSupport, ImmutableAttributes attributes, ImmutableCapabilities capabilities) {
         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts = getArtifactsForConfiguration(componentId, name);
         RealisedConfigurationMetadata configuration = new RealisedConfigurationMetadata(componentId, name, transitive, visible, hierarchy, artifacts, ImmutableList.<ExcludeMetadata>of(), attributes, capabilities);
         ImmutableList<ModuleDependencyMetadata> dependencyMetadata = filterDependencies(componentId, configuration, dependencies, improvedPomSupport);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model.maven;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
@@ -117,7 +118,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         for (int i = 0; i < configurationsCount; i++) {
             String configurationName = decoder.readString();
             Configuration configuration = configurationDefinitions.get(configurationName);
-            ImmutableList<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
+            ImmutableSet<String> hierarchy = LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions);
             ImmutableAttributes attributes = getAttributeContainerSerializer().read(decoder);
             ImmutableCapabilities capabilities = readCapabilities(decoder);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/BuildableLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/BuildableLocalComponentMetadata.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.local.model;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
@@ -47,7 +48,7 @@ public interface BuildableLocalComponentMetadata {
      * @param hierarchy Must include name
      * @param attributes the attributes of the configuration.
      */
-    BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, Set<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities);
+    BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, ImmutableSet<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities);
 
     /**
      * Provides a backing configuration instance from which dependencies and excludes will be sourced.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -50,7 +50,6 @@ import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.component.model.VariantResolveMetadata;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -158,7 +157,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     }
 
     @Override
-    public BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, Set<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities) {
+    public BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, ImmutableSet<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities) {
         assert hierarchy.contains(name);
         DefaultLocalConfigurationMetadata conf = new DefaultLocalConfigurationMetadata(name, description, visible, transitive, extendsFrom, hierarchy, attributes, canBeConsumed, canBeResolved, capabilities);
         addToConfigurations(name, conf);
@@ -266,7 +265,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         private final String description;
         private final boolean transitive;
         private final boolean visible;
-        private final Set<String> hierarchy;
+        private final ImmutableSet<String> hierarchy;
         private final Set<String> extendsFrom;
         private final ImmutableAttributes attributes;
         private final boolean canBeConsumed;
@@ -291,7 +290,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                                                     boolean visible,
                                                     boolean transitive,
                                                     Set<String> extendsFrom,
-                                                    Set<String> hierarchy,
+                                                    ImmutableSet<String> hierarchy,
                                                     ImmutableAttributes attributes,
                                                     boolean canBeConsumed,
                                                     boolean canBeResolved,
@@ -362,7 +361,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
         }
 
         @Override
-        public Collection<String> getHierarchy() {
+        public ImmutableSet<String> getHierarchy() {
             return hierarchy;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -115,4 +115,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
         return delegate.getSelector();
     }
 
+    @Override
+    public LocalOriginDependencyMetadata forced() {
+        return new DslOriginDependencyMetadataWrapper(delegate.forced(), source);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.local.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -47,7 +48,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
     }
 
     @Override
-    public BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, Set<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities) {
+    public BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, ImmutableSet<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities) {
         assert hierarchy.contains(name);
         DefaultLocalConfigurationMetadata conf = new RootLocalConfigurationMetadata(name, description, visible, transitive, extendsFrom, hierarchy, attributes, canBeConsumed, canBeResolved, capabilities);
         addToConfigurations(name, conf);
@@ -63,7 +64,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                                        boolean visible,
                                        boolean transitive,
                                        Set<String> extendsFrom,
-                                       Set<String> hierarchy,
+                                       ImmutableSet<String> hierarchy,
                                        ImmutableAttributes attributes,
                                        boolean canBeConsumed,
                                        boolean canBeResolved,

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ConfigurationMetadata.java
@@ -17,13 +17,13 @@
 package org.gradle.internal.component.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -35,7 +35,7 @@ public interface ConfigurationMetadata extends HasAttributes {
      * for this information. However it _is_ currently used by {@link MavenDependencyDescriptor#selectLegacyConfigurations}
      * to determine if the target 'runtime' configuration includes the target 'compile' configuration.
      */
-    Collection<String> getHierarchy();
+    ImmutableSet<String> getHierarchy();
 
     String getName();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ForcingDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ForcingDependencyMetadata.java
@@ -20,4 +20,10 @@ public interface ForcingDependencyMetadata extends DependencyMetadata {
      * Was the dependency created with the 'force' attribute.
      */
     boolean isForce();
+
+    /**
+     * Returns a copy of this dependency metadata, using force.
+     * @return forced dependency metadata
+     */
+    ForcingDependencyMetadata forced();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -180,6 +180,14 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     @Override
+    public LocalOriginDependencyMetadata forced() {
+        if (force) {
+            return this;
+        }
+        return copyWithForce(true);
+    }
+
+    @Override
     public DependencyMetadata withReason(String reason) {
         if (Objects.equal(reason, this.reason)) {
             return this;
@@ -193,6 +201,10 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
 
     private LocalOriginDependencyMetadata copyWithReason(String reason) {
         return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, reason);
+    }
+
+    private LocalOriginDependencyMetadata copyWithForce(boolean force) {
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -204,7 +204,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private LocalOriginDependencyMetadata copyWithForce(boolean force) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, reason);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalOriginDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalOriginDependencyMetadata.java
@@ -29,4 +29,7 @@ public interface LocalOriginDependencyMetadata extends ForcingDependencyMetadata
 
     @Override
     LocalOriginDependencyMetadata withTarget(ComponentSelector target);
+
+    @Override
+    LocalOriginDependencyMetadata forced();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.DependencyConstraintSet
 import org.gradle.api.artifacts.VersionConstraint
+import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.api.internal.AsmBackedClassGenerator
 import spock.lang.Specification
 
@@ -34,8 +35,9 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
     private def dependencyFactory = Mock(DependencyFactory)
     private def configuration = Mock(Configuration)
     private def dependencyConstraintSet = Mock(DependencyConstraintSet)
+    private def componentMetadataHandler = Mock(ComponentMetadataHandler)
 
-    private DefaultDependencyConstraintHandler dependencyConstraintHandler = new AsmBackedClassGenerator().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory)
+    private DefaultDependencyConstraintHandler dependencyConstraintHandler = new AsmBackedClassGenerator().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory, componentMetadataHandler)
 
     void setup() {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -96,4 +96,16 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
         assert elements.size() == 1
         return elements.first()
     }
+
+    static <T extends MavenDependencyDescriptor> T firstDependency(Iterable<T> elements) {
+        elements.find { !it.constraint }
+    }
+
+    static <T extends MavenDependencyDescriptor> List<T> dependenciesOnly(Iterable<T> unfiltered) {
+        unfiltered.findAll { !it.constraint }
+    }
+
+    static <T extends MavenDependencyDescriptor> List<T> constraintsOnly(Iterable<T> unfiltered) {
+        unfiltered.findAll { it.constraint }
+    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
@@ -51,7 +51,7 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         dep.selector == moduleId('group-b', 'module-b', '1.0')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
-        dep.optional
+        dep.constraint
         !dep.transitive
     }
 
@@ -95,11 +95,11 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         depA.transitive
         def depB = metadata.dependencies.find { it.selector.group == 'group-b'}
         depB.selector == moduleId('group-b', 'module-b', '2.0')
-        depB.optional
+        depB.constraint
         !depB.transitive
     }
 
-    def "a parent pom is not a bom - dependencies declared in dependencyManagement block are ignored"() {
+    def "dependency management block from parent pom is inherited"() {
         given:
         pomFile << """
 <project>
@@ -140,7 +140,10 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         parsePom()
 
         then:
-        metadata.dependencies.empty
+        metadata.dependencies.size() == 1
+        metadata.dependencies[0].constraint
+        metadata.dependencies[0].selector.module == 'module-b'
+        metadata.dependencies[0].selector.version == '1.0'
     }
 
     def "a bom can have a parent pom - dependencyManagement entries are combined"() {
@@ -197,11 +200,11 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         then:
         def depC = metadata.dependencies.find { it.selector.group == 'group-c'}
         depC.selector == moduleId('group-c', 'module-c', '2.0')
-        depC.optional
+        depC.constraint
         !depC.transitive
         def depB = metadata.dependencies.find { it.selector.group == 'group-b'}
         depB.selector == moduleId('group-b', 'module-b', '1.0')
-        depB.optional
+        depB.constraint
         !depB.transitive
     }
 
@@ -234,7 +237,7 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         dep.selector == moduleId('group-b', 'module-b', '')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
-        dep.optional
+        dep.constraint
         !dep.transitive
     }
 
@@ -323,7 +326,7 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         dep.selector == moduleId('group-b', 'module-b', '1.0')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
-        dep.optional
+        dep.constraint
     }
 
     def "a bom can be composed of children and parents"() {
@@ -383,7 +386,7 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
 
         then:
         metadata.dependencies.size() == 3
-        metadata.dependencies.each { assert it.optional }
+        metadata.dependencies.each { assert it.constraint }
     }
 
     def "scopes defined in a bom are ignored"() {
@@ -417,7 +420,7 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         dep.selector == moduleId('group-b', 'module-b', '1.0')
         dep.scope == MavenScope.Compile //compile is the 'default' scope
         hasDefaultDependencyArtifact(dep)
-        dep.optional
+        dep.constraint
         !dep.transitive
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserProfileTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserProfileTest.groovy
@@ -282,7 +282,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Test
         def exclude = single(dep.allExcludes)
@@ -347,7 +347,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -425,7 +425,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -494,7 +494,9 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def deps = metadata.dependencies
+        deps.size() == 3
+        def dep = metadata.dependencies[0]
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -807,7 +809,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1082,7 +1084,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Test
         hasDefaultDependencyArtifact(dep)
@@ -1149,7 +1151,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1229,7 +1231,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1300,7 +1302,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1624,7 +1626,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
@@ -194,7 +194,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Test
         def excludeRule = single(dep.allExcludes)
@@ -241,8 +241,9 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 1
-        def depCompile = metadata.dependencies[0]
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 1
+        def depCompile = dependencies[0]
         depCompile.selector == moduleId('group-two', 'artifact-two', '1.1')
         depCompile.scope == MavenScope.Runtime //scope is defined in the dependency declaration and is not replaced
     }
@@ -307,8 +308,9 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 1
-        def depCompile = metadata.dependencies[0]
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 1
+        def depCompile = dependencies[0]
         depCompile.selector == moduleId('group-two', 'artifact-two', selectedVersion)
         depCompile.scope == selectedScope
 
@@ -371,7 +373,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '')
     }
 
@@ -425,7 +427,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Test
         hasDefaultDependencyArtifact(dep)
@@ -490,7 +492,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.1')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -577,7 +579,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.5')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -644,7 +646,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -834,7 +836,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -909,7 +911,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -973,7 +975,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-one', 'artifacttwo', '3')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1051,7 +1053,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-one', 'artifacttwo', '3')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1130,7 +1132,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1272,11 +1274,12 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 2
-        def artifactTwo = metadata.dependencies[0]
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 2
+        def artifactTwo = dependencies[0]
         artifactTwo.selector == moduleId('group-one', 'artifact-two', 'version-one')
         hasDefaultDependencyArtifact(artifactTwo)
-        def artifactThree = metadata.dependencies[1]
+        def artifactThree = dependencies[1]
         artifactThree.selector == moduleId('group-one', 'artifact-three', 'version-one')
         hasDefaultDependencyArtifact(artifactThree)
     }
@@ -1373,7 +1376,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-one', 'artifact-two', 'some-version')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -1992,12 +1995,13 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 2
-        def depCompile = metadata.dependencies[0]
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 2
+        def depCompile = dependencies[0]
         depCompile.selector == moduleId('group-two', 'artifact-two', '1.1')
         depCompile.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(depCompile)
-        def depTest = metadata.dependencies[1]
+        def depTest = dependencies[1]
         depTest.selector == moduleId('group-two', 'artifact-two', '1.2')
         depTest.scope == MavenScope.Test
         hasDependencyArtifact(depTest, 'artifact-two', 'test-jar', 'jar', 'tests')
@@ -2058,10 +2062,11 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 2
-        def dep1 = metadata.dependencies.find { it.dependencyArtifact == null }
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 2
+        def dep1 = dependencies.find { it.dependencyArtifact == null }
         dep1.selector == moduleId('group-two', 'artifact-two', '1.1')
-        def dep2 = metadata.dependencies.find { it.dependencyArtifact != null }
+        def dep2 = dependencies.find { it.dependencyArtifact != null }
         dep2.selector == moduleId('group-two', 'artifact-two', '')
         dep2.dependencyArtifact == new DefaultIvyArtifactName('artifact-two', 'test-jar', 'jar', 'tests')
     }
@@ -2234,12 +2239,13 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
 
         then:
         metadata.id == componentId('group-one', 'artifact-one', 'version-one')
-        metadata.dependencies.size() == 2
-        def defDep = metadata.dependencies[0]
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 2
+        def defDep = dependencies[0]
         defDep.selector == moduleId('group-one', 'artifact-two', 'version-one')
         defDep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(defDep)
-        def depJar = metadata.dependencies[1]
+        def depJar = dependencies[1]
         depJar.selector == moduleId('group-one', 'artifact-two', 'version-one')
         depJar.scope == MavenScope.Test
         hasDependencyArtifact(depJar, 'artifact-two', 'test-jar', 'jar', 'tests')
@@ -2306,12 +2312,13 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 2
-        def depGroupTwo = metadata.dependencies[0]
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 2
+        def depGroupTwo = dependencies[0]
         depGroupTwo.selector == moduleId('group-two', 'artifact-two', 'version-two')
         depGroupTwo.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(depGroupTwo)
-        def depGroupThree = metadata.dependencies[1]
+        def depGroupThree = dependencies[1]
         depGroupThree.selector == moduleId('group-three', 'artifact-three', 'version-three')
         depGroupThree.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(depGroupThree)
@@ -2380,7 +2387,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        def dep = single(metadata.dependencies)
+        def dep = firstDependency(metadata.dependencies)
         dep.selector == moduleId('group-two', 'artifact-two', '1.5')
         dep.scope == MavenScope.Compile
         hasDefaultDependencyArtifact(dep)
@@ -2424,8 +2431,9 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         parsePom()
 
         then:
-        metadata.dependencies.size() == 2
-        metadata.dependencies.every {it.selector.version == outputVersion}
+        def dependencies = dependenciesOnly(metadata.dependencies)
+        dependencies.size() == 2
+        dependencies.every {it.selector.version == outputVersion}
 
         where:
         inputVersion | outputVersion

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.gradle.api.Action
+import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolveException
@@ -117,6 +118,7 @@ class DependencyGraphBuilderTest extends Specification {
     def setup() {
         _ * configuration.name >> 'root'
         _ * configuration.path >> 'root'
+        _ * configuration.allDependencies >> Stub(DependencySet)
         _ * moduleResolver.resolve(_, _) >> { it[1].resolved(root) }
 
         builder = new DependencyGraphBuilder(idResolver, metaDataResolver, moduleResolver, moduleConflictHandler, capabilitiesConflictHandler, Specs.satisfyAll(), attributesSchema, moduleExclusions, buildOperationProcessor, moduleReplacements, dependencySubstitutionApplicator, componentSelectorConverter, TestUtil.attributesFactory(), versionSelectorScheme, Stub(Comparator), new VersionParser())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine
 
+import com.google.common.collect.ImmutableSet
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import org.gradle.api.Action
 import org.gradle.api.artifacts.DependencySet
@@ -1019,16 +1020,16 @@ class DependencyGraphBuilderTest extends Specification {
         // TODO Shouldn't really be using the local component implementation here
         def id = newId("group", name, revision)
         def metaData = new DefaultLocalComponentMetadata(id, DefaultModuleComponentIdentifier.newId(id), "release", attributesSchema)
-        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
+        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ImmutableSet.of("default"), true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
         metaData.addArtifacts("default", [new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip"))])
         return metaData
     }
 
     def rootProject(String name, String revision = '1.0', List<String> extraConfigs = []) {
         def metaData = new RootLocalComponentMetadata(newId("group", name, revision), newProjectId(":${name}"), "release", attributesSchema, NoOpDependencyLockingProvider.getInstance())
-        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ["default"] as Set<String>, true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
+        metaData.addConfiguration("default", "defaultConfig", [] as Set<String>, ImmutableSet.of("default"), true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
         extraConfigs.each { String config ->
-            metaData.addConfiguration(config, "${config}Config", ["default"] as Set<String>, ["default", config] as Set<String>, true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
+            metaData.addConfiguration(config, "${config}Config", ["default"] as Set<String>, ImmutableSet.of("default", config), true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
         }
         metaData.addArtifacts("default", [new DefaultPublishArtifact("art1", "zip", "art", null, new Date(), new File("art1.zip"))])
         return metaData

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -194,7 +194,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         dependenciesMetadata = []
         for (int i = 0; i < size; i++) {
             ModuleComponentSelector requested = newSelector(DefaultModuleIdentifier.newId("org.gradle.test", "module$size"), "1.0")
-            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null) ]
+            dependenciesMetadata += [ new GradleDependencyMetadata(requested, [], false, null, false) ]
         }
         adapter = new TestDependenciesMetadataAdapter(dependenciesMetadata)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.DependencyConstraintMetadataImpl
@@ -57,7 +58,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared versionIdentifier = new DefaultModuleVersionIdentifier("org.test", "producer", "1.0")
     @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     @Shared attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
-    @Shared schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), TestUtil.valueSnapshotter())
+    @Shared schema = createSchema()
     @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews(true))
     @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     @Shared defaultVariant
@@ -66,6 +67,13 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         Spec<VariantResolveMetadata> spec = variantName ? { it.name == variantName } as Spec<VariantResolveMetadata> : Specs.satisfyAll()
         new VariantMetadataRules.VariantAction<T>(spec, action)
     }
+
+    private DefaultAttributesSchema createSchema() {
+        def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), TestUtil.valueSnapshotter())
+        PlatformSupport.configureSchema(schema)
+        schema
+    }
+
 
     abstract boolean addAllDependenciesAsConstraints()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -80,7 +80,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     abstract void doAddDependencyMetadataRule(MutableModuleComponentResolveMetadata metadataImplementation, String variantName = null, Action<? super DependenciesMetadata> action)
 
     boolean supportedInMetadata(String metadata) {
-        !addAllDependenciesAsConstraints() || metadata != "ivy" //ivy does not support dependency constraints or optional dependencies
+        !addAllDependenciesAsConstraints() || metadata == "gradle"
     }
 
     private ivyComponentMetadata(String[] deps) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultIvyModuleResolveMetadataTest.groovy
@@ -87,10 +87,10 @@ class DefaultIvyModuleResolveMetadataTest extends AbstractLazyModuleComponentRes
         def md = metadata
 
         then:
-        md.getConfiguration("a").hierarchy == ["a"]
-        md.getConfiguration("b").hierarchy == ["b", "a"]
-        md.getConfiguration("c").hierarchy == ["c", "a"]
-        md.getConfiguration("d").hierarchy == ["d", "b", "a", "c"]
+        md.getConfiguration("a").hierarchy as List == ["a"]
+        md.getConfiguration("b").hierarchy as List  == ["b", "a"]
+        md.getConfiguration("c").hierarchy as List  == ["c", "a"]
+        md.getConfiguration("d").hierarchy as List == ["d", "b", "a", "c"]
     }
 
     def "builds and caches artifacts for a configuration"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.component.external.descriptor.Configuration
@@ -142,6 +143,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
     def "recognises java library for packaging=#packaging and improvedPomSupport=#improvedPomSupport"() {
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
+        def componentTypeAttribute = PlatformSupport.COMPONENT_CATEGORY
         def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], TestUtil.attributesFactory(), TestUtil.objectInstantiator(), improvedPomSupport)
         metadata.packaging = packaging
 
@@ -156,11 +158,23 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         assertHasOnlyStatusAttribute(runtimeConf.attributes)
 
         if (isJavaLibrary) {
-            assert variantsForGraphTraversal.size() == 2
+            assert variantsForGraphTraversal.size() == 6
             assert variantsForGraphTraversal[0].name == "compile"
             assert variantsForGraphTraversal[0].attributes.getAttribute(stringUsageAttribute) == "java-api"
             assert variantsForGraphTraversal[1].name == "runtime"
             assert variantsForGraphTraversal[1].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+            assert variantsForGraphTraversal[2].name == "platform-compile"
+            assert variantsForGraphTraversal[2].attributes.getAttribute(stringUsageAttribute) == "java-api"
+            assert variantsForGraphTraversal[2].attributes.getAttribute(componentTypeAttribute) == "platform"
+            assert variantsForGraphTraversal[3].name == "platform-runtime"
+            assert variantsForGraphTraversal[3].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+            assert variantsForGraphTraversal[3].attributes.getAttribute(componentTypeAttribute) == "platform"
+            assert variantsForGraphTraversal[4].name == "enforced-platform-compile"
+            assert variantsForGraphTraversal[4].attributes.getAttribute(stringUsageAttribute) == "java-api"
+            assert variantsForGraphTraversal[4].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
+            assert variantsForGraphTraversal[5].name == "enforced-platform-runtime"
+            assert variantsForGraphTraversal[5].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+            assert variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
         } else {
             assert !variantsForGraphTraversal
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableIvyModuleResolveMetadataTest.groovy
@@ -75,7 +75,7 @@ class DefaultMutableIvyModuleResolveMetadataTest extends AbstractMutableModuleCo
         runtime.artifacts.name.name == ["runtime.jar"]
         runtime.excludes.empty
         def defaultConfig = immutable.getConfiguration("default")
-        defaultConfig.hierarchy == ["default", "runtime"]
+        defaultConfig.hierarchy as List == ["default", "runtime"]
         defaultConfig.transitive
         defaultConfig.visible
         defaultConfig.artifacts.name.name == ["api.jar", "runtime.jar"]

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMutableMavenModuleResolveMetadataTest.groovy
@@ -49,13 +49,13 @@ class DefaultMutableMavenModuleResolveMetadataTest extends AbstractMutableModule
         expect:
         def immutable = metadata.asImmutable()
         immutable.configurationNames == ["compile", "runtime", "test", "provided", "system", "optional", "master", "default", "javadoc", "sources"] as Set
-        immutable.getConfiguration("compile").hierarchy == ["compile"]
-        immutable.getConfiguration("runtime").hierarchy == ["runtime", "compile"]
-        immutable.getConfiguration("master").hierarchy == ["master"]
-        immutable.getConfiguration("test").hierarchy == ["test", "runtime", "compile"]
-        immutable.getConfiguration("default").hierarchy == ["default", "runtime", "compile", "master"]
-        immutable.getConfiguration("provided").hierarchy == ["provided"]
-        immutable.getConfiguration("optional").hierarchy == ["optional"]
+        immutable.getConfiguration("compile").hierarchy as List == ["compile"]
+        immutable.getConfiguration("runtime").hierarchy as List == ["runtime", "compile"]
+        immutable.getConfiguration("master").hierarchy as List == ["master"]
+        immutable.getConfiguration("test").hierarchy as List == ["test", "runtime", "compile"]
+        immutable.getConfiguration("default").hierarchy as List == ["default", "runtime", "compile", "master"]
+        immutable.getConfiguration("provided").hierarchy as List == ["provided"]
+        immutable.getConfiguration("optional").hierarchy as List == ["optional"]
     }
 
     def "default metadata"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -43,7 +43,7 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
             variantAction(variantName, action))
     }
 
-    def "maven optional dependencies are accessible as dependency constraints"() {
+    def "maven optional dependencies are not accessible as dependency constraints"() {
         given:
         def mavenMetadata = mavenMetadataFactory.create(componentIdentifier, [
             new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, newSelector(DefaultModuleIdentifier.newId("org", "notOptional"), "1.0"), null, []),
@@ -62,8 +62,7 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
 
         then:
         def dependencies = selectTargetConfigurationMetadata(mavenMetadata).dependencies
-        dependencies.size() == 2
+        dependencies.size() == 1
         !dependencies[0].constraint
-        dependencies[1].constraint
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ExternalDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/ExternalDependencyDescriptorTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.external.model
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.VersionConstraint
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -70,7 +71,7 @@ abstract class ExternalDependencyDescriptorTest extends Specification {
 
     def configuration(String name, String... parents) {
         def config = Stub(ConfigurationMetadata)
-        config.hierarchy >> ([name] as Set) + (parents as Set)
+        config.hierarchy >> ImmutableSet.copyOf(([name] as Set) + (parents as Set))
         return config
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model
 
 import com.google.common.collect.ImmutableListMultimap
+import com.google.common.collect.ImmutableSet
 import com.google.common.collect.LinkedHashMultimap
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
@@ -91,7 +92,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfiguration = Stub(ConfigurationMetadata)
 
         given:
-        fromConfiguration.hierarchy >> (['config', 'super'] as LinkedHashSet)
+        fromConfiguration.hierarchy >> ImmutableSet.of('config', 'super')
         def metadata = createWithArtifacts(requested, [artifact1, artifact2, artifact3])
 
         expect:
@@ -165,7 +166,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfig = Stub(ConfigurationMetadata)
         def toConfig1 = Stub(ConfigurationMetadata)
         def toConfig2 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
         toComponent.getConfiguration("to-1") >> toConfig1
         toComponent.getConfiguration("to-2") >> toConfig2
 
@@ -185,7 +186,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfig = Stub(ConfigurationMetadata)
         def toConfig1 = Stub(ConfigurationMetadata)
         def toConfig2 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from", "super"]
+        fromConfig.hierarchy >> ImmutableSet.of("from", "super")
         toComponent.getConfiguration("to-1") >> toConfig1
         toComponent.getConfiguration("to-2") >> toConfig2
 
@@ -206,8 +207,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfig2 = Stub(ConfigurationMetadata)
         def toConfig1 = Stub(ConfigurationMetadata)
         def toConfig2 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
-        fromConfig2.hierarchy >> ["other"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
+        fromConfig2.hierarchy >> ImmutableSet.of("other")
         toComponent.getConfiguration("to-1") >> toConfig1
         toComponent.getConfiguration("to-2") >> toConfig2
 
@@ -225,7 +226,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromComponent = Stub(ComponentIdentifier)
         def toComponent = Stub(ComponentResolveMetadata)
         def fromConfig = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
         def toConfig1 = config('to-1', true)
         def toConfig2 = config('to-2', true)
         def toConfig3 = config('to-3', false)
@@ -248,7 +249,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def toConfig1 = Stub(ConfigurationMetadata)
         toConfig1.visible >> visible
         toConfig1.name >> name
-        toConfig1.getHierarchy() >> [name]
+        toConfig1.getHierarchy() >> ImmutableSet.of(name)
         toConfig1
     }
 
@@ -260,9 +261,9 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfig3 = Stub(ConfigurationMetadata)
         def toConfig1 = Stub(ConfigurationMetadata)
         def toConfig2 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
-        fromConfig2.hierarchy >> ["child", "from"]
-        fromConfig3.hierarchy >> ["other"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
+        fromConfig2.hierarchy >> ImmutableSet.of("child", "from")
+        fromConfig3.hierarchy >> ImmutableSet.of("other")
         toComponent.getConfiguration("to-1") >> toConfig1
         toComponent.getConfiguration("to-2") >> toConfig2
 
@@ -287,9 +288,9 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def toConfig1 = Stub(ConfigurationMetadata)
         def toConfig2 = Stub(ConfigurationMetadata)
         def toConfig3 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
-        fromConfig2.hierarchy >> ["child", "from"]
-        fromConfig3.hierarchy >> ["other"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
+        fromConfig2.hierarchy >> ImmutableSet.of("child", "from")
+        fromConfig3.hierarchy >> ImmutableSet.of("other")
         toComponent.getConfiguration("to-1") >> toConfig1
         toComponent.getConfiguration("to-2") >> toConfig2
         toComponent.getConfiguration("to-3") >> toConfig3
@@ -314,9 +315,9 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfig3 = Stub(ConfigurationMetadata)
         def toConfig1 = Stub(ConfigurationMetadata)
         def toConfig2 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
-        fromConfig2.hierarchy >> ["other"]
-        fromConfig3.hierarchy >> ["other2"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
+        fromConfig2.hierarchy >> ImmutableSet.of("other")
+        fromConfig3.hierarchy >> ImmutableSet.of("other2")
         toConfig1.visible >> true
         toConfig2.visible >> true
         toComponent.getConfigurationNames() >> ["to-1", "to-2"]
@@ -342,8 +343,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def fromConfig = Stub(ConfigurationMetadata)
         def fromConfig2 = Stub(ConfigurationMetadata)
         def toConfig1 = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["a"]
-        fromConfig2.hierarchy >> ["other", "a"]
+        fromConfig.hierarchy >> ImmutableSet.of("a")
+        fromConfig2.hierarchy >> ImmutableSet.of("other", "a")
         toComponent.getConfiguration("a") >> toConfig1
 
         def configMapping = LinkedHashMultimap.create()
@@ -364,8 +365,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def toConfig2 = Stub(ConfigurationMetadata)
         fromConfig.name >> "a"
         fromConfig2.name >> "b"
-        fromConfig.hierarchy >> ["a"]
-        fromConfig2.hierarchy >> ["b", "a"]
+        fromConfig.hierarchy >> ImmutableSet.of("a")
+        fromConfig2.hierarchy >> ImmutableSet.of("b", "a")
         toComponent.getConfiguration("a") >> toConfig1
         toComponent.getConfiguration("b") >> toConfig2
 
@@ -387,8 +388,8 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def toConfig2 = Stub(ConfigurationMetadata)
         fromConfig.name >> "a"
         fromConfig2.name >> "b"
-        fromConfig.hierarchy >> ["a"]
-        fromConfig2.hierarchy >> ["b", "a"]
+        fromConfig.hierarchy >> ImmutableSet.of("a")
+        fromConfig2.hierarchy >> ImmutableSet.of("b", "a")
         toComponent.getConfiguration("a") >> toConfig1
         toComponent.getConfiguration("b") >> toConfig2
 
@@ -419,7 +420,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         def toComponent = Stub(ComponentResolveMetadata)
         toComponent.id >> toId
         def fromConfig = Stub(ConfigurationMetadata)
-        fromConfig.hierarchy >> ["from"]
+        fromConfig.hierarchy >> ImmutableSet.of("from")
         fromConfig.name >> "from"
         toComponent.getConfiguration(_) >> null
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
@@ -31,6 +31,7 @@
  */
 package org.gradle.internal.component.external.model
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
@@ -130,7 +131,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         fromRuntime2.name >> "provided"
         toComponent.getConfiguration("runtime") >> toRuntime
         toComponent.getConfiguration("master") >> toMaster
-        toRuntime.hierarchy >> ["runtime", "compile"]
+        toRuntime.hierarchy >> ImmutableSet.of("runtime", "compile")
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
@@ -148,7 +149,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         fromRuntime.name >> "runtime"
         toComponent.getConfiguration("runtime") >> toRuntime
         toComponent.getConfiguration("master") >> null
-        toRuntime.hierarchy >> ["compile", "runtime"]
+        toRuntime.hierarchy >> ImmutableSet.of("compile", "runtime")
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
@@ -165,7 +166,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         fromRuntime.name >> "runtime"
         toComponent.getConfiguration("runtime") >> toRuntime
         toComponent.getConfiguration("master") >> toMaster
-        toRuntime.hierarchy >> ["compile", "runtime"]
+        toRuntime.hierarchy >> ImmutableSet.of("compile", "runtime")
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
@@ -201,7 +202,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("runtime") >> null
         toComponent.getConfiguration("default") >> toDefault
         toComponent.getConfiguration("master") >> toMaster
-        toDefault.hierarchy >> ["compile", "default"]
+        toDefault.hierarchy >> ImmutableSet.of("compile", "default")
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
         def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.local.model
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
@@ -45,8 +46,8 @@ class DefaultLocalComponentMetadataTest extends Specification {
 
     def "can lookup configuration after it has been added"() {
         when:
-        metadata.addConfiguration("super", "description", [] as Set, ["super"] as Set, false, false, null, true, true, ImmutableCapabilities.EMPTY)
-        metadata.addConfiguration("conf", "description", ["super"] as Set, ["super", "conf"] as Set, true, true, null, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration("super", "description", [] as Set, ImmutableSet.of("super"), false, false, null, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration("conf", "description", ["super"] as Set, ImmutableSet.of("super", "conf"), true, true, null, true, true, ImmutableCapabilities.EMPTY)
 
         then:
         metadata.configurationNames == ['conf', 'super'] as Set
@@ -67,8 +68,8 @@ class DefaultLocalComponentMetadataTest extends Specification {
     def "configuration has no dependencies or artifacts when none have been added"() {
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
         when:
-        metadata.addConfiguration("super", "description", [] as Set, ["super"] as Set, false, false, null, true, true, ImmutableCapabilities.EMPTY)
-        metadata.addConfiguration("conf", "description", ["super"] as Set, ["super", "conf"] as Set, true, true, null, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration("super", "description", [] as Set, ImmutableSet.of("super"), false, false, null, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration("conf", "description", ["super"] as Set, ImmutableSet.of("super", "conf"), true, true, null, true, true, ImmutableCapabilities.EMPTY)
 
         then:
         def conf = metadata.getConfiguration('conf')
@@ -126,7 +127,7 @@ class DefaultLocalComponentMetadataTest extends Specification {
     }
 
     private addConfiguration(String name, Collection<String> extendsFrom = [], AttributeContainerInternal attributes = ImmutableAttributes.EMPTY) {
-        metadata.addConfiguration(name, "", extendsFrom as Set, (extendsFrom + [name]) as Set, true, true, attributes as ImmutableAttributes, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration(name, "", extendsFrom as Set, ImmutableSet.copyOf(extendsFrom + [name]), true, true, attributes as ImmutableAttributes, true, true, ImmutableCapabilities.EMPTY)
     }
 
     def addArtifact(String configuration, IvyArtifactName name, File file, TaskDependency buildDeps = null) {
@@ -302,8 +303,8 @@ class DefaultLocalComponentMetadataTest extends Specification {
 
     def "builds and caches exclude rules for a configuration"() {
         given:
-        def compile = metadata.addConfiguration("compile", null, [] as Set, ["compile"] as Set, true, true, null, true, true, ImmutableCapabilities.EMPTY)
-        def runtime = metadata.addConfiguration("runtime", null, ["compile"] as Set, ["compile", "runtime"] as Set, true, true, null, true, true, ImmutableCapabilities.EMPTY)
+        def compile = metadata.addConfiguration("compile", null, [] as Set, ImmutableSet.of("compile"), true, true, null, true, true, ImmutableCapabilities.EMPTY)
+        def runtime = metadata.addConfiguration("runtime", null, ["compile"] as Set, ImmutableSet.of("compile", "runtime"), true, true, null, true, true, ImmutableCapabilities.EMPTY)
 
         def rule1 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "module1"))
         def rule2 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "module1"))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/RootLocalComponentMetadataTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.component.local.model
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
@@ -86,7 +87,7 @@ class RootLocalComponentMetadataTest extends DefaultLocalComponentMetadataTest {
     }
 
     private addConfiguration(String name, Collection<String> extendsFrom = [], ImmutableAttributes attributes = ImmutableAttributes.EMPTY) {
-        metadata.addConfiguration(name, "", extendsFrom as Set, (extendsFrom + [name]) as Set, true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration(name, "", extendsFrom as Set, ImmutableSet.copyOf(extendsFrom + [name]), true, true, attributes, true, true, ImmutableCapabilities.EMPTY)
     }
 
 }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -112,10 +112,10 @@ class ModuleVersionSpec {
     }
 
     void variant(String variant, Map<String, String> attributes) {
-        variants << new VariantSpec(name:variant, attributes:attributes)
+        variants << new VariantSpec(name: variant, attributes: attributes)
     }
 
-    void variant(String name, @DelegatesTo(value= VariantSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
+    void variant(String name, @DelegatesTo(value = VariantSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
         def variant = new VariantSpec(name: name)
         spec.delegate = variant
         spec.resolveStrategy = Closure.DELEGATE_FIRST
@@ -275,7 +275,7 @@ class ModuleVersionSpec {
         if (variants) {
             variants.each { variant ->
                 module.withVariant(variant.name) {
-                    attributes = attributes? attributes + variant.attributes : variant.attributes
+                    attributes = attributes ? attributes + variant.attributes : variant.attributes
                     artifacts = variant.artifacts.collect {
                         // publish variant files as "classified". This can be arbitrary in practice, this
                         // just makes it easier for publishing specs
@@ -289,8 +289,13 @@ class ModuleVersionSpec {
                             dependsOn(*args)
                         }
                     }
+                    variant.constraints.each {
+                        def args = it.split(':') as List
+                        constraint(*args)
+                    }
+
                     capabilities = variant.capabilities.collect {
-                        new CapabilitySpec(group: it.group, name: it.name, version:it.version)
+                        new CapabilitySpec(group: it.group, name: it.name, version: it.version)
                     }
                 }
             }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -2237,7 +2237,7 @@ org:foo:[1.0,) -> 1.1
             }
 
             dependencies {
-                implementation 'org:bom:1.0'
+                implementation platform('org:bom:1.0')
                 implementation 'org:leaf'
             }
         """
@@ -2249,8 +2249,9 @@ org:foo:[1.0,) -> 1.1
         outputContains """
 org:leaf:1.0 (by constraint)
    variant "compile" [
-      org.gradle.status = release (not requested)
-      org.gradle.usage  = java-api
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -1,7 +1,8 @@
 org.ow2.asm:asm:6.0
    variant "compile" [
-      org.gradle.status = release (not requested)
-      org.gradle.usage  = java-api
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : we require a JDK 9 compatible bytecode generator

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/constraintsFromBOM/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/constraintsFromBOM/build.gradle
@@ -7,7 +7,7 @@ repositories {
 // tag::dependency-on-bom[]
 dependencies {
     // import a BOM
-    implementation 'org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE'
+    implementation platform('org.springframework.boot:spring-boot-dependencies:1.5.8.RELEASE')
 
     // define dependencies without versions
     implementation 'com.google.code.gson:gson'

--- a/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
+++ b/subprojects/internal-integ-testing/internal-integ-testing.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     compile(library("jackson_annotations"))
     compile(library("jackson_databind"))
     compile(library("ivy"))
-    compile(testLibrary("sshd"))
+    compile(gradle5Platform(testLibrary("sshd")))
     compile(library("gson"))
     compile(library("joda"))
     compile(library("jsch"))

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -124,7 +124,7 @@ allprojects {
         compare("lenient filtered first level dependencies", actualFirstLevel, expectedFirstLevel)
 
         def actualConfigurations = findLines(configDetails, 'configuration') as Set
-        def expectedConfigurations = graph.nodesWithoutRoot.collect { "[${it.moduleVersionId}]" }
+        def expectedConfigurations = graph.nodesWithoutRoot.collect { "[${it.moduleVersionId}]".toString() } - graph.virtualConfigurations.collect { "[${it}]".toString() }
         compare("configurations in graph", actualConfigurations, expectedConfigurations)
 
         def actualComponents = findLines(configDetails, 'component')
@@ -322,6 +322,7 @@ allprojects {
         private String defaultConfig
 
         final Set<NodeBuilder> constraints = new LinkedHashSet<>()
+        final Set<String> virtualConfigurations = []
 
         GraphBuilder(String defaultConfig) {
             this.defaultConfig = defaultConfig
@@ -335,6 +336,10 @@ allprojects {
             def nodes = new HashSet<>()
             visitDeps(root.deps, nodes, new HashSet<>())
             return nodes
+        }
+
+        void virtualConfiguration(String id) {
+            virtualConfigurations << id
         }
 
         private void visitDeps(List<EdgeBuilder> edges, Set<NodeBuilder> nodes, Set<NodeBuilder> seen) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -59,4 +59,8 @@ class VariantMetadataSpec {
         config()
         dependencies += spec
     }
+
+    void constraint(String group, String module, String version, String reason = null, Map<String, ?> attributes=[:]) {
+        dependencyConstraints << new DependencyConstraintSpec(group, module, version, null, null, null, reason, attributes)
+    }
 }

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     compile(library("commons_httpclient"))
     compile(library("jsch"))
     compile(library("commons_math"))
+    compile(library("jcl_to_slf4j"))
 
     flamegraph("com.github.oehme:jfr-flame-graph:v0.0.10:all")
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import spock.lang.Ignore
 import spock.lang.Issue
 
 class MavenPublishMultiProjectIntegTest extends AbstractMavenPublishIntegTest {
@@ -328,6 +329,7 @@ project(":project2") {
         }
     }
 
+    @Ignore("TODO: CC, there's currently no support for platform() on a local project. We must think about the concept of Gradle platform first")
     def "publish and resolve java-library with dependency on java-library-platform"() {
         given:
         javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -20,11 +20,13 @@ import org.gradle.performance.AbstractToolingApiCrossVersionPerformanceTest
 import org.gradle.tooling.model.ExternalDependency
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.idea.IdeaProject
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
+@Ignore("Temporarily ignore until we have a snapshot build to rebaseline")
 class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerformanceTest {
 
     @Unroll

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -16,6 +16,7 @@
 package org.gradle.language.base.internal.model;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -85,7 +86,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
                 usage,
                 String.format("Request metadata: %s", componentId.getDisplayName()),
                 Collections.<String>emptySet(),
-                Collections.singleton(usage),
+                ImmutableSet.of(usage),
                 true,
                 true,
                 ImmutableAttributes.EMPTY,
@@ -168,7 +169,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
     }
 
     @Override
-    public BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, Set<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities) {
+    public BuildableLocalConfigurationMetadata addConfiguration(String name, String description, Set<String> extendsFrom, ImmutableSet<String> hierarchy, boolean visible, boolean transitive, ImmutableAttributes attributes, boolean canBeConsumed, boolean canBeResolved, ImmutableCapabilities capabilities) {
         assert hierarchy.contains(name);
         DefaultLocalConfigurationMetadata conf = new LibraryLocalConfigurationMetadata(name, description, visible, transitive, extendsFrom, hierarchy, attributes, canBeConsumed, canBeResolved, capabilities);
         addToConfigurations(name, conf);
@@ -182,7 +183,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
                                           boolean visible,
                                           boolean transitive,
                                           Set<String> extendsFrom,
-                                          Set<String> hierarchy,
+                                          ImmutableSet<String> hierarchy,
                                           ImmutableAttributes attributes,
                                           boolean canBeConsumed,
                                           boolean canBeResolved,

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.AttributeCompatibilityRule;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
@@ -122,7 +123,8 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private void configureSchema(ProjectInternal project) {
-        AttributeMatchingStrategy<Usage> matchingStrategy = project.getDependencies().getAttributesSchema().attribute(Usage.USAGE_ATTRIBUTE);
+        AttributesSchema attributesSchema = project.getDependencies().getAttributesSchema();
+        AttributeMatchingStrategy<Usage> matchingStrategy = attributesSchema.attribute(Usage.USAGE_ATTRIBUTE);
         matchingStrategy.getCompatibilityRules().add(UsageCompatibilityRules.class);
         matchingStrategy.getDisambiguationRules().add(UsageDisambiguationRules.class, new Action<ActionConfiguration>() {
             @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.internal.ReusableAction;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -402,7 +403,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         test.workingDir(project.getProjectDir());
     }
 
-    static class UsageDisambiguationRules implements AttributeDisambiguationRule<Usage> {
+    static class UsageDisambiguationRules implements AttributeDisambiguationRule<Usage>, ReusableAction {
         final Usage javaApi;
         final Usage javaApiClasses;
         final Usage javaRuntimeJars;
@@ -447,7 +448,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         }
     }
 
-    static class UsageCompatibilityRules implements AttributeCompatibilityRule<Usage> {
+    static class UsageCompatibilityRules implements AttributeCompatibilityRule<Usage>, ReusableAction {
         @Override
         public void execute(CompatibilityCheckDetails<Usage> details) {
             if (details.getConsumerValue().getName().equals(Usage.JAVA_API)) {

--- a/subprojects/resources-http/resources-http.gradle
+++ b/subprojects/resources-http/resources-http.gradle
@@ -31,6 +31,7 @@ dependencies {
     api libraries.commons_httpclient.coordinates
 
     implementation libraries.slf4j_api.coordinates
+    implementation libraries.jcl_to_slf4j.coordinates
     implementation libraries.jcifs.coordinates
     implementation libraries.guava.coordinates
     implementation libraries.commons_lang.coordinates

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -37,7 +37,7 @@ abstract class AbstractSmokeTest extends Specification {
          */
 
         // https://plugins.gradle.org/plugin/nebula.dependency-recommender
-        static nebulaDependencyRecommender = "6.1.1"
+        static nebulaDependencyRecommender = "6.1.4"
 
         // https://plugins.gradle.org/plugin/nebula.plugin-plugin
         static nebulaPluginPlugin = "7.1.9"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -84,50 +84,39 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
             module("org.springframework:spring-core:${springVersion}")
         }
         def springContextDeps = {
-            module("org.springframework:spring-aop:${springVersion}", directBomDependency ? {} : springAopDeps).byReason(reason3)
-            module("org.springframework:spring-beans:${springVersion}", directBomDependency ? {} : springBeansDeps).byReason(reason3)
-            module("org.springframework:spring-core:${springVersion}",)
-            module("org.springframework:spring-expression:${springVersion}", directBomDependency ? {} : springExpressionDeps).byReason(reason3)
+            module("org.springframework:spring-aop:${springVersion}", springAopDeps).byReason(reason3)
+            module("org.springframework:spring-beans:${springVersion}", springBeansDeps).byReason(reason3)
+            module("org.springframework:spring-core:${springVersion}")
+            module("org.springframework:spring-expression:${springVersion}", springExpressionDeps).byReason(reason3)
         }
         def springTestDeps = {
-            module("org.springframework:spring-aop:${springVersion}")
-            module("org.springframework:spring-beans:${springVersion}")
-            module("org.springframework:spring-context:${springVersion}")
             module("org.springframework:spring-core:${springVersion}")
-            module("junit:junit:4.12")
-            module("org.hamcrest:hamcrest-core:1.3")
         }
         def springBootDeps = {
-            module("org.springframework:spring-core:${springVersion}", directBomDependency ? {} : springCoreDeps).byReason(reason3)
-            module("org.springframework:spring-context:${springVersion}", directBomDependency ? {} : springContextDeps).byReason(reason3)
-            module("org.springframework:spring-test:${springVersion}")
-            module("junit:junit:4.12")
+            module("org.springframework:spring-core:${springVersion}", springCoreDeps).byReason(reason3)
+            module("org.springframework:spring-context:${springVersion}", springContextDeps).byReason(reason3)
         }
         def springBootAutoconfigureDeps = {
             module("org.springframework.boot:spring-boot:$bomVersion")
         }
         def springBootTestDeps = {
             module("org.springframework.boot:spring-boot:$bomVersion")
-            module("org.springframework:spring-test:${springVersion}")
-            module("junit:junit:4.12")
-            module("org.hamcrest:hamcrest-core:1.3")
         }
         def springBootTestAutoconfigureDeps = {
             module("org.springframework.boot:spring-boot-test:$bomVersion")
             module("org.springframework.boot:spring-boot-autoconfigure:$bomVersion")
-            module("org.springframework:spring-test:${springVersion}")
         }
 
         resolve.expectDefaultConfiguration('compile')
         resolve.expectGraph {
             root(':', ':springbootproject:') {
                 if (directBomDependency) {
-                    module("org.springframework.boot:spring-boot-dependencies:$bomVersion") {
-                        module("org.springframework:spring-core:${springVersion}", springCoreDeps)
-                        module("org.springframework:spring-aop:${springVersion}", springAopDeps)
-                        module("org.springframework:spring-beans:${springVersion}", springBeansDeps)
-                        module("org.springframework:spring-context:${springVersion}", springContextDeps)
-                        module("org.springframework:spring-expression:${springVersion}", springExpressionDeps)
+                    module("org.springframework.boot:spring-boot-dependencies:$bomVersion:${bomSupportProvider == 'gradle' ? 'platform-compile' : 'compile'}") {
+                        module("org.springframework:spring-core:${springVersion}")
+                        module("org.springframework:spring-aop:${springVersion}")
+                        module("org.springframework:spring-beans:${springVersion}")
+                        module("org.springframework:spring-context:${springVersion}")
+                        module("org.springframework:spring-expression:${springVersion}")
                         module("org.springframework:spring-test:${springVersion}")
                         module("org.springframework:spring-jcl:${springVersion}")
                         module("org.springframework.boot:spring-boot:$bomVersion")
@@ -136,7 +125,8 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
                         module("org.springframework.boot:spring-boot-test-autoconfigure:$bomVersion")
                         module("junit:junit:4.12")
                         module("org.hamcrest:hamcrest-core:1.3")
-                    }.noArtifacts()
+                        noArtifacts()
+                    }
                 }
                 edge("org.springframework.boot:spring-boot-test-autoconfigure", "org.springframework.boot:spring-boot-test-autoconfigure:$bomVersion", springBootTestAutoconfigureDeps).byReason(reason1)
                 edge("org.springframework.boot:spring-boot-test", "org.springframework.boot:spring-boot-test:$bomVersion", springBootTestDeps).byReason(reason2)
@@ -149,8 +139,8 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
 
         where:
         bomSupportProvider                    | directBomDependency | reason1            | reason2            | reason3            | bomDeclaration                                        | dependencyManagementPlugin
-        "gradle"                              | true                | "requested"        | "requested"        | "requested"        | "dependencies { implementation $bom }"                | ""
-        "nebula recommender plugin"           | false               | "requested"        | "requested"        | "requested"        | "dependencyRecommendations { mavenBom module: $bom }" | "id 'nebula.dependency-recommender' version '${TestedVersions.nebulaDependencyRecommender}'"
-        "spring dependency management plugin" | false               | "selected by rule" | "selected by rule" | "selected by rule" | "dependencyManagement { imports { mavenBom $bom } }"  | "id 'io.spring.dependency-management' version '${TestedVersions.springDependencyManagement}'"
+        "gradle"                              | true                | "requested"        | "requested"        | "requested"        | "dependencies { implementation platform($bom) }"      | ""
+        "nebula recommender plugin"           | false               | "requested"        | "requested"        | "requested"        | "dependencyRecommendations { mavenBom module: $bom }" | "id 'nebula.dependency-recommender' version '${AbstractSmokeTest.TestedVersions.nebulaDependencyRecommender}'"
+        "spring dependency management plugin" | false               | "selected by rule" | "selected by rule" | "selected by rule" | "dependencyManagement { imports { mavenBom $bom } }"  | "id 'io.spring.dependency-management' version '${AbstractSmokeTest.TestedVersions.springDependencyManagement}'"
     }
 }


### PR DESCRIPTION
### Context

This PR adds support for adding explicit dependencies on platforms and _enforcing platforms_. When a platform is enforced, its version is fixed, overrides any other version of the platform in the graph, but also the versions of the components of the platform.

## Dependencies on platforms

A dependency on a platform can be declared by using the `platform` keyword in a dependencies or dependency constraints block:

```
dependencies {
    implementation platform("my:platform:1.0")
}
```

Currently, this implies that the target component is a BOM, because there's effectively no other way to publish a platform, but future work will make it possible to publish platforms directly from Gradle, including using the Gradle metadata format.

## Enforced platforms

There are 3 ways to enforce a platform:

1. by forcing a member of the platform
2. by declaring a `enforcedPlatform` dependency
3. by declaring a `enforcedPlatform` constraint

The first case is a legacy, practical way to enforce alignment. The 2d case is a better modeled version, and corresponds to the way we should actually declare usage of platforms. However, this has a drawback, as the corresponding dependency would be published in POM files, and break Maven consumers (as they would get a dependency on a non-existent, virtual, platform).

The 3rd version aligns what is possible to do with a dependency, but on a platform. This also, by accident, works around the publishing problem as it would be published as a `<dependencyManagement>` constraint for Maven consumers.

Note that it should be possible to fix the publishing problem by remembering that the resolution of the platform is virtual, but this is not implemented in this PR.

