### PR TITLE
Add samples as an input to `integTest:integTest`

### DIFF
--- a/subprojects/integ-test/integ-test.gradle
+++ b/subprojects/integ-test/integ-test.gradle
@@ -35,6 +35,7 @@ testFixtures {
 
 integTestTasks.configureEach { task ->
     task.libsRepository.required = true
+    task.gradleInstallationForTest.samplesRequired.set(true)
 }
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty


### PR DESCRIPTION
Given that the user guide samples will be tested there.