### PR TITLE
Replace logging of configuration name with identity path

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -217,7 +217,7 @@ dependencies {
 
         then:
         lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0-SNAPSHOT'])
-        outputContains('Dependency lock state for configuration \'lockedConf\' contains changing modules: [org:bar:1.0-SNAPSHOT]. This means that dependencies content may still change over time.')
+        outputContains('Dependency lock state for configuration \':lockedConf\' contains changing modules: [org:bar:1.0-SNAPSHOT]. This means that dependencies content may still change over time.')
 
         when:
         mavenRepo.module('org', 'bar', '1.0-SNAPSHOT').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MultiProjectDependencyLockingIntegrationTest.groovy
@@ -144,6 +144,7 @@ project(':second') {
         succeeds ':first:dependencies', '--configuration', 'compileClasspath', '--write-locks'
 
         then:
+        outputContains('Persisted dependency lock state for configuration \':first:compileClasspath\'')
         firstLockFileFixture.verifyLockfile('compileClasspath', ['org:foo:1.1'])
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -124,21 +124,15 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         services.add(DependencyMetaDataProvider.class, dependencyMetaDataProvider);
         services.add(ProjectFinder.class, projectFinder);
         services.add(DomainObjectContext.class, domainObjectContext);
-        services.addProvider(new DependencyResolutionScopeServices(false));
+        services.addProvider(new DependencyResolutionScopeServices());
         return services.get(DependencyResolutionServices.class);
     }
 
     public void addDslServices(ServiceRegistration registration) {
-        registration.addProvider(new DependencyResolutionScopeServices(true));
+        registration.addProvider(new DependencyResolutionScopeServices());
     }
 
     private static class DependencyResolutionScopeServices {
-
-        private boolean isProjectScope;
-
-        public DependencyResolutionScopeServices(boolean isProjectScope) {
-            this.isProjectScope = isProjectScope;
-        }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory) {
             return instantiatorFactory.decorate().newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher(), instantiatorFactory, isolatableFactory);
@@ -253,7 +247,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context) {
-            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, isProjectScope);
+            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context);
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -252,8 +252,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingHandler.class, configurationContainer);
         }
 
-        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter) {
-            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, isProjectScope);
+        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context) {
+            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, isProjectScope);
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DefaultDependencyLockingProvider.java
@@ -45,9 +45,9 @@ public class DefaultDependencyLockingProvider implements DependencyLockingProvid
     private final LockEntryFilter lockEntryFilter;
     private final DomainObjectContext context;
 
-    public DefaultDependencyLockingProvider(FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, boolean isProjectScope) {
+    public DefaultDependencyLockingProvider(FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context) {
         this.context = context;
-        this.lockFileReaderWriter = new LockFileReaderWriter(fileResolver, context, isProjectScope);
+        this.lockFileReaderWriter = new LockFileReaderWriter(fileResolver, context);
         this.writeLocks = startParameter.isWriteDependencyLocks();
         if (writeLocks) {
             LOGGER.debug("Write locks is enabled");

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -43,11 +43,9 @@ public class LockFileReaderWriter {
 
     private final Path lockFilesRoot;
     private final DomainObjectContext context;
-    private final boolean isProjectScope;
 
-    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context, boolean isProjectScope) {
+    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context) {
         this.context = context;
-        this.isProjectScope = isProjectScope;
         Path resolve = null;
         if (fileResolver.canResolveRelativePath()) {
             resolve = fileResolver.resolve(DEPENDENCY_LOCKING_FOLDER).toPath();
@@ -96,10 +94,10 @@ public class LockFileReaderWriter {
     }
 
     private String decorate(String configurationName) {
-        if (isProjectScope) {
-            return configurationName;
-        } else {
+        if (context.isScript()) {
             return "buildscript-" + configurationName;
+        } else {
+            return configurationName;
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockFileReaderWriter.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.locking;
 
 import org.gradle.api.internal.DocumentationRegistry;
+import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -41,9 +42,11 @@ public class LockFileReaderWriter {
                                                  "# This file is expected to be part of source control.\n";
 
     private final Path lockFilesRoot;
+    private final DomainObjectContext context;
     private final boolean isProjectScope;
 
-    public LockFileReaderWriter(FileResolver fileResolver, boolean isProjectScope) {
+    public LockFileReaderWriter(FileResolver fileResolver, DomainObjectContext context, boolean isProjectScope) {
+        this.context = context;
         this.isProjectScope = isProjectScope;
         Path resolve = null;
         if (fileResolver.canResolveRelativePath()) {
@@ -102,7 +105,7 @@ public class LockFileReaderWriter {
 
     private void checkValidRoot(String configurationName) {
         if (lockFilesRoot == null) {
-            throw new IllegalStateException("Dependency locking cannot be used for configuration '" + configurationName + "'." +
+            throw new IllegalStateException("Dependency locking cannot be used for configuration '" + context.identityPath(configurationName) + "'." +
                 " See limitations in the documentation (" + DOC_REG.getDocumentationFor("dependency_locking", "locking_limitations") +").");
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DefaultDependencyLockingProviderTest.groovy
@@ -50,13 +50,13 @@ class DefaultDependencyLockingProviderTest extends Specification {
         resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
         startParameter.getLockedDependenciesToUpdate() >> []
-        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, true)
+        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context)
     }
 
     def 'can persist resolved modules as lockfile'() {
         given:
         startParameter.isWriteDependencyLocks() >> true
-        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, true)
+        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context)
         def modules = [module('org', 'foo', '1.0'), module('org','bar','1.3')] as Set
 
         when:
@@ -86,7 +86,7 @@ org:foo:1.0
         startParameter = Mock()
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org:foo']
-        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, true)
+        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context)
         lockDir.file('conf.lockfile') << """org:bar:1.3
 org:foo:1.0
 """
@@ -103,7 +103,7 @@ org:foo:1.0
         startParameter = Mock()
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org:*']
-        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, true)
+        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context)
         lockDir.file('conf.lockfile') << """org:bar:1.3
 org:foo:1.0
 """
@@ -120,7 +120,7 @@ org:foo:1.0
         startParameter = Mock()
         startParameter.isWriteDependencyLocks() >> true
         startParameter.getLockedDependenciesToUpdate() >> ['org.*:foo']
-        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context, true)
+        provider = new DefaultDependencyLockingProvider(resolver, startParameter, context)
         lockDir.file('conf.lockfile') << """org.bar:foo:1.3
 com:foo:1.0
 """

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/LockFileReaderWriterTest.groovy
@@ -40,7 +40,7 @@ class LockFileReaderWriterTest extends Specification {
         context.identityPath(_) >> { String value -> Path.path(value) }
         resolver.canResolveRelativePath() >> true
         resolver.resolve(LockFileReaderWriter.DEPENDENCY_LOCKING_FOLDER) >> lockDir
-        lockFileReaderWriter = new LockFileReaderWriter(resolver, context, true)
+        lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
     }
 
     def 'writes a lock file on persist'() {
@@ -69,7 +69,8 @@ line2"""
 
     def 'writes a lock file with prefix on persist'() {
         when:
-        lockFileReaderWriter = new LockFileReaderWriter(resolver, context, false)
+        context.isScript() >> true
+        lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
         lockFileReaderWriter.writeLockFile('conf', ['line1', 'line2'])
 
         then:
@@ -80,7 +81,8 @@ line2
 
     def 'reads a lock file with prefix'() {
         given:
-        lockFileReaderWriter = new LockFileReaderWriter(resolver, context, false)
+        context.isScript() >> true
+        lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
         lockDir.file('buildscript-conf.lockfile') << """#Ignored
 line1
 
@@ -96,7 +98,7 @@ line2"""
     def 'fails to read a lockfile if root could not be determined'() {
         FileResolver resolver = Mock()
         resolver.canResolveRelativePath() >> false
-        lockFileReaderWriter = new LockFileReaderWriter(resolver, context, true)
+        lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
 
         when:
         lockFileReaderWriter.readLockFile('foo')
@@ -111,7 +113,7 @@ line2"""
     def 'fails to write a lockfile if root could not be determined'() {
         FileResolver resolver = Mock()
         resolver.canResolveRelativePath() >> false
-        lockFileReaderWriter = new LockFileReaderWriter(resolver, context, true)
+        lockFileReaderWriter = new LockFileReaderWriter(resolver, context)
 
         when:
         lockFileReaderWriter.writeLockFile('foo', [])


### PR DESCRIPTION
Previously dependency locking was only reporting the name of the
configuration. This however made it hard to pinpoint a source of problem
 in a multi project build. With this change, now the full identity path
of the configuration is reported.