### PR TITLE
Improve locking and resolution of latest.* or + versions

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.resolve.locking
 
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
-import org.gradle.util.ToBeImplemented
 import spock.lang.Unroll
 
 class DependencyLockingIntegrationTest extends AbstractDependencyResolutionTest {
@@ -454,7 +453,6 @@ dependencies {
         "+"         | "2.1"
     }
 
-    @ToBeImplemented // Currently `1.+` and `+` are resolved differently when dependency locking is enabled for a configuration
     def "version selector combinations are resolved equally for locked and unlocked configurations"() {
         ['foo', 'foz', 'bar', 'baz'].each { artifact ->
             mavenRepo.module('org', artifact, '1.0').publish()
@@ -473,8 +471,7 @@ configurations {
     conf
     lockEnabledConf {
         extendsFrom conf
-        // Enable locking for this configuration to demonstrate the failure
-        // resolutionStrategy.activateDependencyLocking()
+         resolutionStrategy.activateDependencyLocking()
     }
 }
 dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -453,51 +453,6 @@ dependencies {
         "+"         | "2.1"
     }
 
-    def "version selector combinations are resolved equally for locked and unlocked configurations"() {
-        ['foo', 'foz', 'bar', 'baz'].each { artifact ->
-            mavenRepo.module('org', artifact, '1.0').publish()
-            mavenRepo.module('org', artifact, '1.1').publish()
-            mavenRepo.module('org', artifact, '1.2').publish()
-            mavenRepo.module('org', artifact, '2.0').publish()
-        }
-
-        buildFile << """
-repositories {
-    maven {
-        url '${mavenRepo.uri}'
-    }
-}
-configurations {
-    conf
-    lockEnabledConf {
-        extendsFrom conf
-         resolutionStrategy.activateDependencyLocking()
-    }
-}
-dependencies {
-    conf 'org:foo:[1.0,)'
-    conf 'org:foo:1.1'
-    
-    conf 'org:foz:latest.integration'
-    conf 'org:foz:1.1'
-    
-    conf 'org:bar:1.+'
-    conf 'org:bar:1.1' // With dependency locking enabled, '1.1' is selected. Without, we select '1.2'.
-    
-    conf 'org:baz:+'
-    conf 'org:baz:1.1' // With dependency locking enabled, '1.1' is selected. Without, we select '2.0'.
-}
-task check {
-    doLast {
-        assert configurations.conf*.name == configurations.lockEnabledConf*.name
-    }
-}
-"""
-
-        expect:
-        succeeds 'check'
-    }
-
     def 'upgrades lock file'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.1').publish()

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -78,7 +78,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
         @Override
         void maybeAddGeneratedDependencies(ImmutableList.Builder<LocalOriginDependencyMetadata> result) {
             if (configurationLocked) {
-                dependencyLockingState = dependencyLockingProvider.loadLockState(getName());
+                DependencyLockingState dependencyLockingState = getDependencyLockingState();
                 boolean strict = dependencyLockingState.mustValidateLockState();
                 for (ModuleComponentIdentifier lockedDependency : dependencyLockingState.getLockedDependencies()) {
                     String lockedVersion = lockedDependency.getVersion();
@@ -101,6 +101,9 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
 
         @Override
         public DependencyLockingState getDependencyLockingState() {
+            if (dependencyLockingState == null) {
+                dependencyLockingState = dependencyLockingProvider.loadLockState(getName());
+            }
             return dependencyLockingState;
         }
     }


### PR DESCRIPTION
This PR improves the situation described in #6340 but also shows the limitation of the current approach.
It can either serve as a way of closing the gap or as a line indicating that the solution needs to be rethought.