### PR TITLE
Add support for excluding tests with TestFilter

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -609,6 +609,7 @@ We would like to thank the following community members for making contributions 
 - [Alex Saveau](https://github.com/SUPERCILEX) - Report all files in directory as changed for incremental task for non-incremental change (gradle/gradle#6019)
 - [Thad House](https://github.com/ThadHouse) - Allow disabling of cache cleanup by the end user (gradle/gradle#6928)
 - [Dan Sanduleac](https://github.com/dansanduleac) - Conflict resolution can be bypassed, resulting in arbitrary version chosen (gradle/gradle#7049)
+- [Felipe Lima](https://github.com/felipecsl) - Add support for excluding tests with TestFilter (gradle/gradle#6439)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/PatternMatchTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/processors/PatternMatchTestClassProcessor.java
@@ -27,7 +27,9 @@ public class PatternMatchTestClassProcessor implements TestClassProcessor {
     private final TestClassProcessor delegate;
 
     public PatternMatchTestClassProcessor(DefaultTestFilter testFilter, TestClassProcessor delegate) {
-        this.testClassSelectionMatcher = new TestSelectionMatcher(testFilter.getIncludePatterns(), testFilter.getCommandLineIncludePatterns());
+        this.testClassSelectionMatcher = new TestSelectionMatcher(
+            testFilter.getIncludePatterns(), testFilter.getExcludePatterns(),
+            testFilter.getCommandLineIncludePatterns());
         this.delegate = delegate;
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -16,6 +16,13 @@
 
 package org.gradle.api.tasks.testing;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.inject.Inject;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -76,12 +83,6 @@ import org.gradle.internal.remote.internal.inet.InetAddressFactory;
 import org.gradle.listener.ClosureBackedMethodInvocationDispatch;
 import org.gradle.util.ClosureBackedAction;
 import org.gradle.util.ConfigureUtil;
-
-import javax.inject.Inject;
-import java.io.File;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * Abstract class for all test task.
@@ -420,7 +421,9 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
 
     @TaskAction
     public void executeTests() {
-        if (getFilter().isFailOnNoMatchingTests() && (!getFilter().getIncludePatterns().isEmpty() || !filter.getCommandLineIncludePatterns().isEmpty())) {
+        if (getFilter().isFailOnNoMatchingTests() && (!getFilter().getIncludePatterns().isEmpty()
+            || !filter.getCommandLineIncludePatterns().isEmpty()
+            || !filter.getExcludePatterns().isEmpty())) {
             addTestListener(new NoMatchingTestsReporter(createNoMatchingTestErrorMessage()));
         }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.api.tasks.testing;
 
-import org.gradle.api.tasks.Input;
-
 import java.util.Set;
+
+import org.gradle.api.tasks.Input;
 
 /**
  * Allows filtering tests for execution. Some examples:
@@ -62,13 +62,23 @@ import java.util.Set;
 public interface TestFilter {
 
     /**
-     * Appends a test name pattern to the filter. Wildcard '*' is supported, either test method name or class name is supported. Examples of test names: "com.foo.FooTest.someMethod",
+     * Appends a test name pattern to the inclusion filter. Wildcard '*' is supported, either test method name or class name is supported. Examples of test names: "com.foo.FooTest.someMethod",
      * "com.foo.FooTest", "*FooTest*", "com.foo*". See examples in the docs for {@link TestFilter}.
      *
      * @param testNamePattern test name pattern to include, can be class or method name, can contain wildcard '*'
      * @return this filter object
      */
     TestFilter includeTestsMatching(String testNamePattern);
+
+    /**
+     * Appends a test name pattern to the exclusion filter. Wildcard '*' is supported, either test
+     * method name or class name is supported. Examples of test names: "com.foo.FooTest.someMethod",
+     * "com.foo.FooTest", "*FooTest*", "com.foo*". See examples in the docs for {@link TestFilter}.
+     *
+     * @param testNamePattern test name pattern to exclude, can be class or method name, can contain wildcard '*'
+     * @return this filter object
+     */
+    TestFilter excludeTestsMatching(String testNamePattern);
 
     /**
      * Returns the included test name patterns. They can be class or method names and may contain wildcard '*'. Test name patterns can be appended via {@link #includeTestsMatching(String)} or set via
@@ -80,12 +90,30 @@ public interface TestFilter {
     Set<String> getIncludePatterns();
 
     /**
+     * Returns the excluded test name patterns. They can be class or method names and may contain wildcard '*'.
+     * Test name patterns can be appended via {@link #excludeTestsMatching(String)} or set via
+     * {@link #setExcludePatterns(String...)}.
+     *
+     * @return included test name patterns
+     */
+    @Input
+    Set<String> getExcludePatterns();
+
+    /**
      * Sets the test name patterns to be included in the filter. Wildcard '*' is supported. Replaces any existing test name patterns.
      *
      * @param testNamePatterns class or method name patterns to set, may contain wildcard '*'
      * @return this filter object
      */
     TestFilter setIncludePatterns(String... testNamePatterns);
+
+    /**
+     * Sets the test name patterns to be excluded in the filter. Wildcard '*' is supported. Replaces any existing test name patterns.
+     *
+     * @param testNamePatterns class or method name patterns to set, may contain wildcard '*'
+     * @return this filter object
+     */
+    TestFilter setExcludePatterns(String... testNamePatterns);
 
     /**
      * Add a test method specified by test class name and method name.
@@ -95,6 +123,15 @@ public interface TestFilter {
      * @return this filter object
      */
     TestFilter includeTest(String className, String methodName);
+
+    /**
+     * Excludes a test method specified by test class name and method name.
+     *
+     * @param className the class name of the test to exclude
+     * @param methodName the method name of the test to exclude. Can be null.
+     * @return this filter object
+     */
+    TestFilter excludeTest(String className, String methodName);
 
     /**
      * Let the test task fail if a filter configuration was provided but no test matched the given configuration.

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestFilter.java
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.testing;
 
 import java.util.Set;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Input;
 
 /**
@@ -77,7 +78,9 @@ public interface TestFilter {
      *
      * @param testNamePattern test name pattern to exclude, can be class or method name, can contain wildcard '*'
      * @return this filter object
+     * @since 5.0
      */
+    @Incubating
     TestFilter excludeTestsMatching(String testNamePattern);
 
     /**
@@ -95,8 +98,10 @@ public interface TestFilter {
      * {@link #setExcludePatterns(String...)}.
      *
      * @return included test name patterns
+     * @since 5.0
      */
     @Input
+    @Incubating
     Set<String> getExcludePatterns();
 
     /**
@@ -112,7 +117,9 @@ public interface TestFilter {
      *
      * @param testNamePatterns class or method name patterns to set, may contain wildcard '*'
      * @return this filter object
+     * @since 5.0
      */
+    @Incubating
     TestFilter setExcludePatterns(String... testNamePatterns);
 
     /**
@@ -130,7 +137,9 @@ public interface TestFilter {
      * @param className the class name of the test to exclude
      * @param methodName the method name of the test to exclude. Can be null.
      * @return this filter object
+     * @since 5.0
      */
+    @Incubating
     TestFilter excludeTest(String className, String methodName);
 
     /**

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -22,8 +22,8 @@ import spock.lang.Unroll
 class TestSelectionMatcherTest extends Specification {
 
     def "knows if test matches class"() {
-        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
-                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, [], []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], [], input).matchesTest(className, methodName) == match
 
         where:
         input                    | className                 | methodName            | match
@@ -53,9 +53,40 @@ class TestSelectionMatcherTest extends Specification {
         ["*.foo.*"]              | "foo"                     | "aaaa"                | false
     }
 
+    def "knows if excluded test matches class"() {
+        expect: new TestSelectionMatcher([], input, []).matchesTest(className, methodName) == match
+
+        where:
+        input                    | className                 | methodName            | match
+        ["FooTest"]              | "FooTest"                 | "whatever"            | false
+        ["FooTest"]              | "fooTest"                 | "whatever"            | true
+
+        ["com.foo.FooTest"]      | "com.foo.FooTest"         | "x"                   | false
+        ["com.foo.FooTest"]      | "FooTest"                 | "x"                   | true
+        ["com.foo.FooTest"]      | "com_foo_FooTest"         | "x"                   | true
+
+        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "aaa"                 | false
+        ["com.foo.FooTest.*"]    | "com.foo.FooTest"         | "bbb"                 | false
+        ["com.foo.FooTest.*"]    | "com.foo.FooTestx"        | "bbb"                 | true
+
+        ["*.FooTest.*"]          | "com.foo.FooTest"         | "aaa"                 | false
+        ["*.FooTest.*"]          | "com.bar.FooTest"         | "aaa"                 | false
+        ["*.FooTest.*"]          | "FooTest"                 | "aaa"                 | true
+
+        ["com*FooTest"]          | "com.foo.FooTest"         | "aaa"                 | false
+        ["com*FooTest"]          | "com.FooTest"             | "bbb"                 | false
+        ["com*FooTest"]          | "FooTest"                 | "bbb"                 | true
+
+        ["*.foo.*"]              | "com.foo.FooTest"         | "aaaa"                | false
+        ["*.foo.*"]              | "com.foo.bar.BarTest"     | "aaaa"                | false
+        ["*.foo.*"]              | "foo.Test"                | "aaaa"                | true
+        ["*.foo.*"]              | "fooTest"                 | "aaaa"                | true
+        ["*.foo.*"]              | "foo"                     | "aaaa"                | true
+    }
+
     def "knows if test matches"() {
-        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
-                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, [], []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], [], input).matchesTest(className, methodName) == match
 
         where:
         input                    | className                 | methodName            | match
@@ -80,8 +111,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "matches any of input"() {
-        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
-                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, [], []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], [], input).matchesTest(className, methodName) == match
 
         where:
         input                               | className                 | methodName            | match
@@ -107,8 +138,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "regexp chars are handled"() {
-        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
-                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, [], []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], [], input).matchesTest(className, methodName) == match
 
         where:
         input                               | className                 | methodName            | match
@@ -119,8 +150,8 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "handles null test method"() {
-        expect: new TestSelectionMatcher(input, []).matchesTest(className, methodName) == match
-                new TestSelectionMatcher([], input).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, [], []).matchesTest(className, methodName) == match
+                new TestSelectionMatcher([], [], input).matchesTest(className, methodName) == match
 
         where:
         input                               | className                 | methodName            | match
@@ -134,7 +165,7 @@ class TestSelectionMatcherTest extends Specification {
     }
 
     def "script includes and command line includes both have to match"() {
-        expect: new TestSelectionMatcher(input, inputCommandLine).matchesTest(className, methodName) == match
+        expect: new TestSelectionMatcher(input, [], inputCommandLine).matchesTest(className, methodName) == match
 
         where:
         input               | inputCommandLine | className  | methodName | match
@@ -145,8 +176,8 @@ class TestSelectionMatcherTest extends Specification {
     @Unroll
     def 'can exclude as many classes as possible'() {
         expect:
-        new TestSelectionMatcher(input, []).mayIncludeClass(fullQualifiedName) == maybeMatch
-        new TestSelectionMatcher([], input).mayIncludeClass(fullQualifiedName) == maybeMatch
+        new TestSelectionMatcher(input, [], []).mayIncludeClass(fullQualifiedName) == maybeMatch
+        new TestSelectionMatcher([], [], input).mayIncludeClass(fullQualifiedName) == maybeMatch
 
         where:
         input                             | fullQualifiedName    | maybeMatch
@@ -208,7 +239,7 @@ class TestSelectionMatcherTest extends Specification {
     @Unroll
     def 'can use multiple patterns'() {
         expect:
-        new TestSelectionMatcher(pattern1, pattern2).mayIncludeClass(fullQualifiedName) == maybeMatch
+        new TestSelectionMatcher(pattern1, [], pattern2).mayIncludeClass(fullQualifiedName) == maybeMatch
 
         where:
         pattern1                | pattern2                 | fullQualifiedName    | maybeMatch

--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestClassProcessor.java
@@ -16,6 +16,12 @@
 
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
@@ -38,14 +44,10 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
 import static org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecutor.isNestedClassInsideEnclosedRunner;
-import static org.gradle.api.internal.tasks.testing.junitplatform.VintageTestNameAdapter.*;
+import static org.gradle.api.internal.tasks.testing.junitplatform.VintageTestNameAdapter.isVintageDynamicLeafTest;
+import static org.gradle.api.internal.tasks.testing.junitplatform.VintageTestNameAdapter.vintageDynamicClassName;
+import static org.gradle.api.internal.tasks.testing.junitplatform.VintageTestNameAdapter.vintageDynamicMethodName;
 import static org.junit.platform.launcher.EngineFilter.excludeEngines;
 import static org.junit.platform.launcher.EngineFilter.includeEngines;
 import static org.junit.platform.launcher.TagFilter.excludeTags;
@@ -140,7 +142,8 @@ public class JUnitPlatformTestClassProcessor extends AbstractJUnitTestClassProce
 
     private void addTestNameFilters(LauncherDiscoveryRequestBuilder requestBuilder) {
         if (!spec.getIncludedTests().isEmpty() || !spec.getIncludedTestsCommandLine().isEmpty()) {
-            TestSelectionMatcher matcher = new TestSelectionMatcher(spec.getIncludedTests(), spec.getIncludedTestsCommandLine());
+            TestSelectionMatcher matcher = new TestSelectionMatcher(spec.getIncludedTests(),
+                spec.getExcludedTests(), spec.getIncludedTestsCommandLine());
             requestBuilder.filters(new ClassMethodNameFilter(matcher));
         }
     }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitSpec.java
@@ -22,12 +22,20 @@ public class JUnitSpec implements Serializable {
     private final Set<String> includeCategories;
     private final Set<String> excludeCategories;
     private final Set<String> includedTests;
+    private final Set<String> excludedTests;
     private final Set<String> includedTestsCommandLine;
 
-    public JUnitSpec(Set<String> includeCategories, Set<String> excludeCategories, Set<String> includedTests, Set<String> includedTestsCommandLine) {
+    public JUnitSpec(
+        Set<String> includeCategories,
+        Set<String> excludeCategories,
+        Set<String> includedTests,
+        Set<String> excludedTests,
+        Set<String> includedTestsCommandLine
+    ) {
         this.includeCategories = includeCategories;
         this.excludeCategories = excludeCategories;
         this.includedTests = includedTests;
+        this.excludedTests = excludedTests;
         this.includedTestsCommandLine = includedTestsCommandLine;
     }
 
@@ -45,6 +53,10 @@ public class JUnitSpec implements Serializable {
 
     public Set<String> getIncludedTests() {
         return includedTests;
+    }
+
+    public Set<String> getExcludedTests() {
+        return excludedTests;
     }
 
     public Set<String> getIncludedTestsCommandLine() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecutor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassExecutor.java
@@ -16,6 +16,10 @@
 
 package org.gradle.api.internal.tasks.testing.junit;
 
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.tasks.testing.filter.TestSelectionMatcher;
@@ -30,10 +34,6 @@ import org.junit.runner.manipulation.Filterable;
 import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
-
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
 
 public class JUnitTestClassExecutor implements Action<String> {
     private final ClassLoader applicationClassLoader;
@@ -77,8 +77,12 @@ public class JUnitTestClassExecutor implements Action<String> {
         Request request = Request.aClass(testClass);
         Runner runner = request.getRunner();
 
-        if (!options.getIncludedTests().isEmpty() || !options.getIncludedTestsCommandLine().isEmpty()) {
-            TestSelectionMatcher matcher = new TestSelectionMatcher(options.getIncludedTests(), options.getIncludedTestsCommandLine());
+        if (!options.getIncludedTests().isEmpty()
+            || !options.getIncludedTestsCommandLine().isEmpty()
+            || !options.getExcludedTests().isEmpty()) {
+            TestSelectionMatcher matcher = new TestSelectionMatcher(
+                options.getIncludedTests(), options.getExcludedTests(),
+                options.getIncludedTestsCommandLine());
 
             // For test suites (including suite-like custom Runners), if the test suite class
             // matches the filter, run the entire suite instead of filtering away its contents.

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/JUnitTestFramework.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.testing.junit;
 
+import java.io.Serializable;
+
 import org.gradle.api.Action;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestFramework;
@@ -30,8 +32,6 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
-import java.io.Serializable;
-
 public class JUnitTestFramework implements TestFramework {
     private JUnitOptions options;
     private final JUnitDetector detector;
@@ -45,7 +45,10 @@ public class JUnitTestFramework implements TestFramework {
 
     @Override
     public WorkerTestClassProcessorFactory getProcessorFactory() {
-        return new TestClassProcessorFactoryImpl(new JUnitSpec(options.getIncludeCategories(), options.getExcludeCategories(), filter.getIncludePatterns(), filter.getCommandLineIncludePatterns()));
+        return new TestClassProcessorFactoryImpl(new JUnitSpec(
+            options.getIncludeCategories(), options.getExcludeCategories(),
+            filter.getIncludePatterns(), filter.getExcludePatterns(),
+            filter.getCommandLineIncludePatterns()));
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformSpec.java
@@ -15,13 +15,13 @@
  */
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
-import org.gradle.api.internal.tasks.testing.junit.JUnitSpec;
-import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+
+import org.gradle.api.internal.tasks.testing.junit.JUnitSpec;
+import org.gradle.api.tasks.testing.junitplatform.JUnitPlatformOptions;
 
 public class JUnitPlatformSpec extends JUnitSpec {
     private final Set<String> includeEngines;
@@ -29,8 +29,10 @@ public class JUnitPlatformSpec extends JUnitSpec {
     private final Set<String> includeTags;
     private final Set<String> excludeTags;
 
-    public JUnitPlatformSpec(JUnitPlatformOptions options, Set<String> includedTests, Set<String> includedTestsCommandLine) {
-        super(Collections.<String>emptySet(), Collections.<String>emptySet(), includedTests, includedTestsCommandLine);
+    public JUnitPlatformSpec(JUnitPlatformOptions options, Set<String> includedTests,
+        Set<String> excludedTests, Set<String> includedTestsCommandLine) {
+        super(Collections.<String>emptySet(), Collections.<String>emptySet(), includedTests,
+            excludedTests, includedTestsCommandLine);
         this.includeEngines = options.getIncludeEngines();
         this.excludeEngines = options.getExcludeEngines();
         this.includeTags = options.getIncludeTags();

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestFramework.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks.testing.junitplatform;
 
+import java.io.Serializable;
+import java.lang.reflect.Constructor;
+
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
@@ -32,9 +35,6 @@ import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
 import org.gradle.process.internal.worker.WorkerProcessBuilder;
 
-import java.io.Serializable;
-import java.lang.reflect.Constructor;
-
 public class JUnitPlatformTestFramework implements TestFramework {
     private final JUnitPlatformOptions options;
     private final DefaultTestFilter filter;
@@ -49,7 +49,9 @@ public class JUnitPlatformTestFramework implements TestFramework {
         if (!JavaVersion.current().isJava8Compatible()) {
             throw new UnsupportedJavaRuntimeException("Running JUnit platform requires Java 8+, please configure your test java executable with Java 8 or higher.");
         }
-        return new JUnitPlatformTestClassProcessorFactory(new JUnitPlatformSpec(options, filter.getIncludePatterns(), filter.getCommandLineIncludePatterns()));
+        return new JUnitPlatformTestClassProcessorFactory(new JUnitPlatformSpec(options,
+            filter.getIncludePatterns(), filter.getExcludePatterns(),
+            filter.getCommandLineIncludePatterns()));
     }
 
     @Override

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGSpec.java
@@ -16,11 +16,11 @@
 
 package org.gradle.api.internal.tasks.testing.testng;
 
-import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
-import org.gradle.api.tasks.testing.testng.TestNGOptions;
-
 import java.io.Serializable;
 import java.util.Set;
+
+import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
+import org.gradle.api.tasks.testing.testng.TestNGOptions;
 
 public class TestNGSpec implements Serializable {
     private static final long serialVersionUID = 1;
@@ -34,6 +34,7 @@ public class TestNGSpec implements Serializable {
     private final Set<String> excludeGroups;
     private final Set<String> listeners;
     private final Set<String> includedTests;
+    private final Set<String> excludedTests;
     private final Set<String> includedTestsCommandLine;
     private final String configFailurePolicy;
     private final boolean preserveOrder;
@@ -49,6 +50,7 @@ public class TestNGSpec implements Serializable {
         this.excludeGroups = options.getExcludeGroups();
         this.listeners = options.getListeners();
         this.includedTests = filter.getIncludePatterns();
+        this.excludedTests = filter.getExcludePatterns();
         this.includedTestsCommandLine = filter.getCommandLineIncludePatterns();
         this.configFailurePolicy = options.getConfigFailurePolicy();
         this.preserveOrder = options.getPreserveOrder();
@@ -89,6 +91,10 @@ public class TestNGSpec implements Serializable {
 
     public Set<String> getIncludedTests() {
         return includedTests;
+    }
+
+    public Set<String> getExcludedTests() {
+        return excludedTests;
     }
 
     public Set<String> getIncludedTestsCommandLine() {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -16,6 +16,12 @@
 
 package org.gradle.api.internal.tasks.testing.testng;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
@@ -36,13 +42,7 @@ import org.testng.ITestContext;
 import org.testng.ITestListener;
 import org.testng.TestNG;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-
-import static org.gradle.api.tasks.testing.testng.TestNGOptions.*;
+import static org.gradle.api.tasks.testing.testng.TestNGOptions.DEFAULT_CONFIG_FAILURE_POLICY;
 
 public class TestNGTestClassProcessor implements TestClassProcessor {
     private final List<Class<?>> testClasses = new ArrayList<Class<?>>();
@@ -127,7 +127,8 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         }
 
         if (!options.getIncludedTests().isEmpty() || !options.getIncludedTestsCommandLine().isEmpty()) {
-            testNg.addListener(new SelectedTestsFilter(options.getIncludedTests(), options.getIncludedTestsCommandLine()));
+            testNg.addListener(new SelectedTestsFilter(options.getIncludedTests(),
+                options.getExcludedTests(), options.getIncludedTestsCommandLine()));
         }
 
         if (!suiteFiles.isEmpty()) {
@@ -159,8 +160,9 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
 
         private final TestSelectionMatcher matcher;
 
-        public SelectedTestsFilter(Set<String> includedTests, Set<String> includedTestsCommandLine) {
-            matcher = new TestSelectionMatcher(includedTests, includedTestsCommandLine);
+        public SelectedTestsFilter(Set<String> includedTests, Set<String> excludedTests,
+            Set<String> includedTestsCommandLine) {
+            matcher = new TestSelectionMatcher(includedTests, excludedTests, includedTestsCommandLine);
         }
 
         @Override

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -35,7 +35,7 @@ class JUnitTestClassProcessorTest extends Specification {
     @Rule TestNameTestDirectoryProvider tmp = new TestNameTestDirectoryProvider()
 
     def processor = Mock(TestResultProcessor)
-    def spec = new JUnitSpec([] as Set, [] as Set, [] as Set, [] as Set)
+    def spec = new JUnitSpec([] as Set, [] as Set, [] as Set, [] as Set, [] as Set)
 
     @Subject classProcessor = withSpec(spec)
 
@@ -222,7 +222,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes specific method"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithSeveralMethods.name + ".pass"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithSeveralMethods.name + ".pass"] as Set, [] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods)
 
@@ -235,7 +235,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     def "executes multiple specific methods"() {
         classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithSeveralMethods.name + ".pass",
-                ATestClassWithSeveralMethods.name + ".pass2"] as Set, [] as Set))
+                ATestClassWithSeveralMethods.name + ".pass2"] as Set, [] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods)
 
@@ -247,7 +247,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes methods from multiple classes by pattern"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*Methods.*Slowly*"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*Methods.*Slowly*"] as Set, [] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods, ATestClassWithSlowMethods, ATestClass)
 
@@ -262,7 +262,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests for class with test runner that is not filterable when any test description matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ok"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ok"] as Set, [] as Set, [] as Set))
 
         when: process(ATestClassWithRunner)
 
@@ -277,7 +277,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "does not execute class with test runner that is not filterable when no test description matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ignoreme"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, [ATestClassWithRunner.name + ".ignoreme"] as Set, [] as Set, [] as Set))
 
         when: process(ATestClassWithRunner)
 
@@ -287,7 +287,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes no methods when method name does not match"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["does not exist"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["does not exist"] as Set, [] as Set, [] as Set))
 
         when: process(ATestClassWithSeveralMethods)
 
@@ -297,7 +297,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests within a JUnit 3 suite when the suite class name matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestClassWithSuiteMethod"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestClassWithSuiteMethod"] as Set,[] as Set,  [] as Set))
 
         //Run tests in ATestClassWithSuiteMethod only
         when: process(ATestClassWithSuiteMethod, ATestSuite)
@@ -314,7 +314,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests within a suite when the suite class name matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite"] as Set, [] as Set, [] as Set))
 
         //Run tests in ATestSuite only
         when: process(ATestClassWithSuiteMethod, ATestSuite)
@@ -333,7 +333,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "executes all tests within a custom runner suite class name matches"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ACustomSuite"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ACustomSuite"] as Set, [] as Set, [] as Set))
 
         //Run tests in ATestSuite only
         when: process(ATestClassWithSuiteMethod, ACustomSuite)
@@ -352,7 +352,7 @@ class JUnitTestClassProcessorTest extends Specification {
     }
 
     def "attempting to filter methods on a suite does NOT work"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite.ok*"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*ATestSuite.ok*"] as Set, [] as Set, [] as Set))
 
         //Doesn't run any tests
         when: process(ATestClassWithSuiteMethod, ATestSuite)
@@ -366,7 +366,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "has no errors when dealing with an empty suite"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyTestSuite"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyTestSuite"] as Set, [] as Set, [] as Set))
 
         //Run tests in AnEmptyTestSuite (e.g. no tests)
         when: process(AnEmptyTestSuite)
@@ -378,7 +378,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be run with a class-level filter"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest"] as Set, [] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -398,7 +398,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be filtered by method name"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest*"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest*"] as Set, [] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -414,7 +414,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be filtered by iteration only."() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.*[1]"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.*[1]"] as Set, [] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -430,7 +430,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be filtered by full method name"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest[1]"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AParameterizedTest.helpfulTest[1]"] as Set, [] as Set, [] as Set))
 
         when: process(AParameterizedTest)
 
@@ -444,7 +444,7 @@ class JUnitTestClassProcessorTest extends Specification {
 
     @Issue("GRADLE-3112")
     def "parameterized tests can be empty"() {
-        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyParameterizedTest"] as Set, [] as Set))
+        classProcessor = withSpec(new JUnitSpec([] as Set, [] as Set, ["*AnEmptyParameterizedTest"] as Set, [] as Set, [] as Set))
 
         when: process(AnEmptyParameterizedTest)
 


### PR DESCRIPTION
### Context
This change adds the ability to exclude the execution of individual test methods with the `--excludeTests` command line option for the `Test` task.

This has been previously discussed/requested [here](https://discuss.gradle.org/t/how-to-exclude-a-single-test-method/20860) and aims to solve a real use case we currently have.

This can be used in conjunction with `--tests` but using both options together may lead to confusing/unexpected results and should be discouraged IMHO.

Still TODO adding unit tests for this functionality, but wanted to open the PR to check if this is something that you folks would be open to merge.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
