### PR TITLE
Use lazy API in distribution plugin

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -91,7 +91,6 @@ abstract class WellBehavedPluginTest extends AbstractPluginIntegrationTest {
             'maven-publish',
             'ivy-publish',
             'java-library-distribution',
-            'distribution',
             'play-application',
         ])
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -142,7 +142,7 @@ public class DistributionPlugin implements Plugin<ProjectInternal> {
     private void addInstallTask(final Project project, final Distribution distribution) {
         String taskName = TASK_INSTALL_NAME;
         if (!MAIN_DISTRIBUTION_NAME.equals(distribution.getName())) {
-            taskName = "install" + StringGroovyMethods.capitalize(distribution.getName()) + "Dist";
+            taskName = "install" + StringGroovyMethods.capitalize((CharSequence) distribution.getName()) + "Dist";
         }
 
         project.getTasks().register(taskName, Sync.class, new Action<Sync>() {
@@ -164,7 +164,7 @@ public class DistributionPlugin implements Plugin<ProjectInternal> {
     private void addAssembleTask(Project project, final Distribution distribution, final TaskProvider<?>... tasks) {
         String taskName = TASK_ASSEMBLE_NAME;
         if (!MAIN_DISTRIBUTION_NAME.equals(distribution.getName())) {
-            taskName = "assemble" + StringGroovyMethods.capitalize(distribution.getName()) + "Dist";
+            taskName = "assemble" + StringGroovyMethods.capitalize((CharSequence) distribution.getName()) + "Dist";
         }
 
         project.getTasks().register(taskName, DefaultTask.class, new Action<DefaultTask>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -77,7 +77,7 @@ public class DistributionPlugin implements Plugin<ProjectInternal> {
         DistributionContainer distributions = project.getExtensions().create(DistributionContainer.class, "distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations);
 
         // TODO - refactor this action out so it can be unit tested
-        distributions.all(new Action<Distribution>() {
+        distributions.configureEach(new Action<Distribution>() {
             @Override
             public void execute(final Distribution dist) {
                 ((IConventionAware) dist).getConventionMapping().map("baseName", new Callable<Object>() {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Makes a distribution's `assemble` and `install` tasks lazy. @ghale's recent changes with making `DefaultArtifactPublicationSet` register a lazy artifact makes the distribution's `Zip` and `Tar` tasks lazy, so applying the distribution plugin no longer realizes all possible tasks (as defined by `WellBehavedPluginTest`).

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
