### PR TITLE
Set mirror for all repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,10 +24,6 @@ import org.gradle.gradlebuild.ProjectGroups.javaProjects
 import org.gradle.gradlebuild.ProjectGroups.pluginProjects
 import org.gradle.gradlebuild.ProjectGroups.publishedProjects
 
-buildscript {
-    project.apply(from = "$rootDir/gradle/shared-with-buildSrc/mirrors.gradle.kts")
-}
-
 plugins {
     `java-base`
     id("gradlebuild.build-types")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,17 +138,18 @@ buildTypes {
     }
 }
 
-var kotlinDevMirrorUrl = (project.rootProject.extensions.extraProperties.get("repositoryMirrors") as Map<String, String>).get("kotlindev")
-
 allprojects {
     group = "org.gradle"
 
     repositories {
-        maven(url = "https://repo.gradle.org/gradle/libs-releases")
-        maven(url = "https://repo.gradle.org/gradle/libs")
-        maven(url = "https://repo.gradle.org/gradle/libs-milestones")
-        maven(url = "https://repo.gradle.org/gradle/libs-snapshots")
-        maven(url = kotlinDevMirrorUrl ?: "https://dl.bintray.com/kotlin/kotlin-dev")
+        maven {
+            name = "Gradle libs"
+            url = uri("https://repo.gradle.org/gradle/libs")
+        }
+        maven {
+            name = "kotlin-dev"
+            url = uri("https://dl.bintray.com/kotlin/kotlin-dev")
+        }
     }
 
     // patchExternalModules lives in the root project - we need to activate normalization there, too.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_DEFAULT_URL
 import org.gradle.plugins.ide.idea.model.IdeaModel
 
 import org.gradle.kotlin.dsl.plugins.dsl.KotlinDslPlugin
@@ -73,13 +72,18 @@ subprojects {
         }
     }
 }
-var pluginPortalUrl = (project.rootProject.extensions.extraProperties.get("repositoryMirrors") as Map<String, String>).get("gradleplugins")
 
 allprojects {
     repositories {
-        maven(url = "https://repo.gradle.org/gradle/libs-releases")
-        maven(url = "https://repo.gradle.org/gradle/libs-snapshots")
-        maven(url = pluginPortalUrl ?: PLUGIN_PORTAL_DEFAULT_URL)
+        gradlePluginPortal()
+        maven {
+            name = "Gradle libs"
+            url = uri("https://repo.gradle.org/gradle/libs")
+        }
+        maven {
+            name = "kotlin-dev"
+            url = uri("https://dl.bintray.com/kotlin/kotlin-dev")
+        }
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -23,11 +23,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import java.util.Properties
 
-
-buildscript {
-    project.apply(from = "$rootDir/../gradle/shared-with-buildSrc/mirrors.gradle.kts")
-}
-
 plugins {
     `kotlin-dsl`
     id("org.gradle.kotlin.ktlint-convention") version "0.1.14" apply false

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -14,25 +14,12 @@
  * limitations under the License.
  */
 
-fun findMirrorUrls(): Map<String, String> =
-    if ("CI" in java.lang.System.getenv()) {
-        System.getenv("REPO_MIRROR_URLS")?.split(',')?.associate { nameToUrl ->
-            val (name, url) = nameToUrl.split(':', limit = 2)
-            name to url
-        } ?: emptyMap()
-    } else {
-        emptyMap()
-    }
-
-
-fun RepositoryHandler.kotlinDev(): MavenArtifactRepository {
-    val kotlinDevMirrorUrl = findMirrorUrls()["kotlindev"]
-    return maven(url = kotlinDevMirrorUrl ?: "https://dl.bintray.com/kotlin/kotlin-dev")
-}
-
 pluginManagement {
     repositories {
-        kotlinDev()
+        maven {
+            name = "kotlin-dev"
+            url = uri("https://dl.bintray.com/kotlin/kotlin-dev")
+        }
         gradlePluginPortal()
     }
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -25,6 +25,7 @@ pluginManagement {
 }
 
 apply(from = "../gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
+apply(from = "../gradle/shared-with-buildSrc/mirrors.settings.gradle.kts")
 
 val upperCaseLetters = "\\p{Upper}".toRegex()
 

--- a/gradle/shared-with-buildSrc/mirrors.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.gradle.kts
@@ -59,9 +59,7 @@ fun withMirrors(handler: RepositoryHandler) {
         if (this is MavenArtifactRepository) {
             originalUrls.forEach { name, orignalUrl ->
                 if (normalizeUrl(orignalUrl) == normalizeUrl(this.url.toString()) && mirrorUrls.containsKey(name)) {
-                    val mirrorUrl = mirrorUrls.get(name)
-                    println("Replacing repository ${this.name}'s url ${this.url} to ${mirrorUrl}")
-                    this.setUrl(mirrorUrl)
+                    this.setUrl(mirrorUrls.get(name))
                 }
             }
         }

--- a/gradle/shared-with-buildSrc/mirrors.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.gradle.kts
@@ -14,34 +14,73 @@
  * limitations under the License.
  */
 
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-val repositoryMirrors = findMirrorUrls()
-rootProject.extensions.extraProperties.set("repositoryMirrors", repositoryMirrors)
 
-val gradleMirrorUrl = repositoryMirrors["gradle"]
-if (gradleMirrorUrl != null) {
-    project.allprojects {
-        buildscript.repositories {
-            maven {
-                name = "gradle-mirror"
-                url = uri(gradleMirrorUrl)
-            }
-        }
-        repositories {
-            maven {
-                name = "gradle-mirror"
-                url = uri(gradleMirrorUrl)
+val originalUrls: Map<String, String> = mapOf(
+    "jcenter" to "https://jcenter.bintray.com/",
+    "mavencentral" to "https://repo.maven.apache.org/maven2/",
+    "google" to "https://dl.google.com/dl/android/maven2/",
+    "gradle" to "https://repo.gradle.org/gradle/repo",
+    "gradleplugins" to "https://plugins.gradle.org/m2",
+    "gradlejavascript" to "https://repo.gradle.org/gradle/javascript-public",
+    "gradle-libs" to "https://repo.gradle.org/gradle/libs",
+    "gradle-releases" to "https://repo.gradle.org/gradle/libs-releases",
+    "gradle-snapshots" to "https://repo.gradle.org/gradle/libs-snapshots",
+    "kotlindev" to "https://dl.bintray.com/kotlin/kotlin-dev/",
+    "kotlineap" to "https://dl.bintray.com/kotlin/kotlin-eap/"
+)
+
+val mirrorUrls: Map<String, String> =
+    System.getenv("REPO_MIRROR_URLS")?.split(',')?.associate { nameToUrl ->
+        val (name, url) = nameToUrl.split(':', limit = 2)
+        name to url
+    } ?: emptyMap()
+
+fun withMirrors(handler: RepositoryHandler) {
+    if ("CI" !in System.getenv()) {
+        return
+    }
+    handler.all {
+        if (this is MavenArtifactRepository) {
+            originalUrls.forEach { name, orignalUrl ->
+                if (normalizeUrl(orignalUrl) == normalizeUrl(this.url.toString()) && mirrorUrls.containsKey(name)) {
+                    val mirrorUrl = mirrorUrls.get(name)
+                    println("Replacing repository ${this.name}'s url ${this.url} to ${mirrorUrl}")
+                    this.setUrl(mirrorUrl)
+                }
             }
         }
     }
 }
 
-fun findMirrorUrls(): Map<String, String> =
-    if ("CI" in java.lang.System.getenv()) {
-        System.getenv("REPO_MIRROR_URLS")?.split(',')?.associate { nameToUrl ->
-            val (name, url) = nameToUrl.split(':', limit = 2)
-            name to url
-        } ?: emptyMap()
-    } else {
-        emptyMap()
+fun normalizeUrl(url: String): String {
+    val result = url.replace("https://", "http://")
+    return if (result.endsWith("/")) result else result + "/"
+}
+
+project.allprojects {
+    buildscript.configurations["classpath"].incoming.beforeResolve {
+        withMirrors(buildscript.repositories)
     }
+    afterEvaluate {
+        withMirrors(repositories)
+    }
+}
+
+val settings = (gradle as org.gradle.api.internal.GradleInternal).settings
+withMirrors(settings.pluginManagement.repositories)

--- a/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/mirrors.settings.gradle.kts
@@ -57,8 +57,8 @@ fun withMirrors(handler: RepositoryHandler) {
     }
     handler.all {
         if (this is MavenArtifactRepository) {
-            originalUrls.forEach { name, orignalUrl ->
-                if (normalizeUrl(orignalUrl) == normalizeUrl(this.url.toString()) && mirrorUrls.containsKey(name)) {
+            originalUrls.forEach { name, originalUrl ->
+                if (normalizeUrl(originalUrl) == normalizeUrl(this.url.toString()) && mirrorUrls.containsKey(name)) {
                     this.setUrl(mirrorUrls.get(name))
                 }
             }
@@ -71,7 +71,7 @@ fun normalizeUrl(url: String): String {
     return if (result.endsWith("/")) result else result + "/"
 }
 
-project.allprojects {
+gradle.allprojects {
     buildscript.configurations["classpath"].incoming.beforeResolve {
         withMirrors(buildscript.repositories)
     }
@@ -80,5 +80,6 @@ project.allprojects {
     }
 }
 
-val settings = (gradle as org.gradle.api.internal.GradleInternal).settings
-withMirrors(settings.pluginManagement.repositories)
+gradle.settingsEvaluated {
+    withMirrors(settings.pluginManagement.repositories)
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,7 @@
  */
 
 apply(from = "gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts")
+apply(from = "gradle/shared-with-buildSrc/mirrors.settings.gradle.kts")
 
 enableFeaturePreview("IMPROVED_POM_SUPPORT")
 


### PR DESCRIPTION
Refine repository management and mirrors

Previously our repository/mirror management mechanism had several defects:

- Some plugins registered repository which we didn't manage (e.g. `kotlin-dsl` registered `kotlin-dev` repository).
- The duplicate code existed in both `buildSrc/settings.gradle.kts` and `mirrors.gradle.kts`.
- It's extremely confusing that which repositories we're using in the build.
- `libs-release/libs-snapshots/libs-milestones` are unnecessary when `libs` is present.
- Some repositories are not mirrored at all.

This PR refines the whole repository/mirror management by:

- Users define repositories in the common way: declare repositories in build script via repositories block.
- The mirror script replaces the repository url after everything is set.
- No duplicate code.