### PR TITLE
Make scope mappings of POM live

### DIFF
--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/pom/DefaultMavenPomFactory.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/pom/DefaultMavenPomFactory.java
@@ -37,7 +37,6 @@ public class DefaultMavenPomFactory implements Factory<MavenPom> {
     }
 
     public MavenPom create() {
-        return new DefaultMavenPom(configurationContainer,
-                new DefaultConf2ScopeMappingContainer(conf2ScopeMappingContainer.getMappings()), pomDependenciesConverter, fileResolver);
+        return new DefaultMavenPom(configurationContainer, conf2ScopeMappingContainer, pomDependenciesConverter, fileResolver);
     }
 }


### PR DESCRIPTION
The scope mappings of the POM file of the Upload task
were a copy of the mappings defined in the project.

This meant that depending on buildscript ordering mappings
might be lost if the POM was configured before all mappings
had been added. This is now fixed by making the mappings live.

Fixes https://github.com/gradle/gradle/issues/6438