### PR TITLE
Avoid expensive ExceptionUtils.getRootCause

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ResolveExceptionAnalyzer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ResolveExceptionAnalyzer.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.internal.resolve;
 
-import org.apache.commons.lang.exception.ExceptionUtils;
+import com.google.common.base.Throwables;
 import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
 
 import java.io.InterruptedIOException;
@@ -33,7 +33,7 @@ public class ResolveExceptionAnalyzer {
     }
 
     public static boolean isCriticalFailure(Throwable throwable) {
-        Throwable rootCause = ExceptionUtils.getRootCause(throwable);
+        Throwable rootCause = Throwables.getRootCause(throwable);
         return isTimeoutException(rootCause) || isUnrecoverable5xxStatusCode(rootCause);
     }
 


### PR DESCRIPTION
This method uses reflection to work on very old Java versions.
This is not necessary for our purposes, we can just use getCause
instead. Using the commons-lang method caused a severe slowdown
when there were many resolution errors.