### PR TITLE
Make "belongsTo" create virtual components by default

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ComponentMetadataDetails.java
@@ -75,7 +75,7 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
     void allVariants(Action<? super VariantMetadata> action);
 
     /**
-     * Declares that this component belongs to a platform, which should be
+     * Declares that this component belongs to a virtual platform, which should be
      * considered during dependency resolution.
      * @param notation the coordinates of the owner
      *
@@ -83,4 +83,13 @@ public interface ComponentMetadataDetails extends ComponentMetadata, HasConfigur
      */
     void belongsTo(Object notation);
 
+    /**
+     * Declares that this component belongs to a platform, which should be
+     * considered during dependency resolution.
+     * @param notation the coordinates of the owner
+     * @param virtual must be set to true if the platform is a virtual platform, or false if it's a published platform
+     *
+     * @since 4.11
+     */
+    void belongsTo(Object notation, boolean virtual);
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AbstractAlignmentSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AbstractAlignmentSpec.groovy
@@ -102,10 +102,7 @@ abstract class AbstractAlignmentSpec extends AbstractModuleDependencyResolveTest
     }
 
     public final static Closure<Void> VIRTUAL_PLATFORM = {
-        expectGetMetadataMissing()
-        if (!GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-            expectHeadArtifactMissing()
-        }
+        // If the platform is declared as virtual, we won't fetch metadata
     }
 
     void expectAlignment(@DelegatesTo(value = AlignmentSpec, strategy = Closure.DELEGATE_FIRST) Closure<?> spec) {
@@ -243,7 +240,7 @@ abstract class AbstractAlignmentSpec extends AbstractModuleDependencyResolveTest
         """
     }
 
-    protected void 'a rule which declares that Groovy belongs to the Groovy and the Spring platforms'() {
+    protected void 'a rule which declares that Groovy belongs to the Groovy and the Spring platforms'(boolean groovyVirtual=false, boolean springVirtual = false) {
         buildFile << """
             dependencies {
                 components.all(GroovyRule)
@@ -253,8 +250,8 @@ abstract class AbstractAlignmentSpec extends AbstractModuleDependencyResolveTest
                 void execute(ComponentMetadataContext ctx) {
                     ctx.details.with {
                         if ('org.apache.groovy' == id.group) {
-                           belongsTo("org.apache.groovy:platform:\${id.version}")
-                           belongsTo("org.springframework:spring-platform:1.0")
+                           belongsTo("org.apache.groovy:platform:\${id.version}", $groovyVirtual)
+                           belongsTo("org.springframework:spring-platform:1.0", $springVirtual)
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -392,7 +392,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             class DeclarePlatform implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext ctx) {
                     ctx.details.with {
-                        belongsTo("org:platform:\${id.version}")
+                        belongsTo("org:platform:\${id.version}", false)
                     }
                 }
             }
@@ -584,8 +584,6 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             'org:json:1.1' {
                 expectResolve()
             }
-            'org:platform:1.0'(VIRTUAL_PLATFORM)
-            'org:platform:1.1'(VIRTUAL_PLATFORM)
         }
         run ':checkDeps'
 
@@ -775,7 +773,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         """
 
         and:
-        'a rule which declares that Groovy belongs to the Groovy and the Spring platforms'()
+        'a rule which declares that Groovy belongs to the Groovy and the Spring platforms'(true)
 
         when:
         expectAlignment {
@@ -954,7 +952,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             class DeclarePlatform implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext ctx) {
                     ctx.details.with {
-                        belongsTo("org:platform:\${id.version}")
+                        belongsTo("org:platform:\${id.version}", false)
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -65,6 +65,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.gradle.api.internal.artifacts.repositories.resolver.VirtualComponentHelper.makeVirtual;
+
 public class DefaultComponentMetadataProcessor implements ComponentMetadataProcessor {
 
     private static final Transformer<ModuleComponentResolveMetadata, WrappingComponentMetadataContext> DETAILS_TO_RESULT = new Transformer<ModuleComponentResolveMetadata, WrappingComponentMetadataContext>() {
@@ -312,7 +314,16 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
 
         @Override
         public void belongsTo(Object notation) {
-            owners.add(componentIdentifierNotationParser.parseNotation(notation));
+            belongsTo(notation, true);
+        }
+
+        @Override
+        public void belongsTo(Object notation, boolean virtual) {
+            ComponentIdentifier id = componentIdentifierNotationParser.parseNotation(notation);
+            if (virtual) {
+                id = makeVirtual(id);
+            }
+            owners.add(id);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentMetaDataResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ComponentMetaDataResolveState.java
@@ -28,20 +28,18 @@ class ComponentMetaDataResolveState {
     private final VersionedComponentChooser versionedComponentChooser;
     private final ComponentOverrideMetadata componentOverrideMetadata;
     private final ModuleComponentIdentifier componentIdentifier;
-    private final boolean retryMissing;
 
     final ModuleComponentRepository repository;
 
     private boolean searchedLocally;
     private boolean searchedRemotely;
 
-    public ComponentMetaDataResolveState(ModuleComponentIdentifier componentIdentifier, ComponentOverrideMetadata componentOverrideMetadata, ModuleComponentRepository repository, VersionedComponentChooser versionedComponentChooser, boolean retryMissing) {
+    public ComponentMetaDataResolveState(ModuleComponentIdentifier componentIdentifier, ComponentOverrideMetadata componentOverrideMetadata, ModuleComponentRepository repository, VersionedComponentChooser versionedComponentChooser) {
         this.componentOverrideMetadata = componentOverrideMetadata;
         this.componentIdentifier = componentIdentifier;
         this.repository = repository;
         this.versionedComponentChooser = versionedComponentChooser;
         this.resolveResult = new DefaultBuildableModuleComponentMetaDataResolveResult();
-        this.retryMissing = retryMissing;
     }
 
     BuildableModuleComponentMetaDataResolveResult resolve() {
@@ -49,7 +47,7 @@ class ComponentMetaDataResolveState {
             searchedLocally = true;
             process(repository.getLocalAccess());
             if (resolveResult.hasResult()) {
-                if (resolveResult.isAuthoritative() || missingButShouldNotRetry()) {
+                if (resolveResult.isAuthoritative()) {
                     // Don't bother searching remotely
                     searchedRemotely = true;
                 }
@@ -65,10 +63,6 @@ class ComponentMetaDataResolveState {
         }
 
         throw new IllegalStateException();
-    }
-
-    private boolean missingButShouldNotRetry() {
-        return resolveResult.getState() == BuildableModuleComponentMetaDataResolveResult.State.Missing && !retryMissing;
     }
 
     protected void process(ModuleComponentRepositoryAccess moduleAccess) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainComponentMetaDataResolver.java
@@ -86,7 +86,7 @@ public class RepositoryChainComponentMetaDataResolver implements ComponentMetaDa
 
         List<ComponentMetaDataResolveState> resolveStates = new ArrayList<ComponentMetaDataResolveState>();
         for (ModuleComponentRepository repository : repositories) {
-            resolveStates.add(new ComponentMetaDataResolveState(identifier, componentOverrideMetadata, repository, versionedComponentChooser, result.isRetryMissing()));
+            resolveStates.add(new ComponentMetaDataResolveState(identifier, componentOverrideMetadata, repository, versionedComponentChooser));
         }
 
         final RepositoryChainModuleResolution latestResolved = findBestMatch(resolveStates, errors);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolversChain.java
@@ -47,7 +47,8 @@ public class ComponentResolversChain {
 
     public ComponentResolversChain(List<ComponentResolvers> providers, ArtifactTypeRegistry artifactTypeRegistry) {
         List<DependencyToComponentIdResolver> depToComponentIdResolvers = new ArrayList<DependencyToComponentIdResolver>(providers.size());
-        List<ComponentMetaDataResolver> componentMetaDataResolvers = new ArrayList<ComponentMetaDataResolver>(providers.size());
+        List<ComponentMetaDataResolver> componentMetaDataResolvers = new ArrayList<ComponentMetaDataResolver>(1 + providers.size());
+        componentMetaDataResolvers.add(VirtualComponentMetadataResolver.INSTANCE);
         List<ArtifactResolver> artifactResolvers = new ArrayList<ArtifactResolver>(providers.size());
         List<OriginArtifactSelector> artifactSelectors = new ArrayList<OriginArtifactSelector>(providers.size());
         for (ComponentResolvers provider : providers) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/VirtualComponentMetadataResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/VirtualComponentMetadataResolver.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
+import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
+import org.gradle.internal.resolve.result.BuildableComponentResolveResult;
+
+/**
+ * A component metadata resolver which should be used first in chain of resolvers as it will make sure
+ * that we never "find" a virtual component, by shortcutting resolution if we find the marker interface
+ * for virtual components.
+ */
+class VirtualComponentMetadataResolver implements ComponentMetaDataResolver {
+
+    public static final ComponentMetaDataResolver INSTANCE = new VirtualComponentMetadataResolver();
+
+    private VirtualComponentMetadataResolver() {
+
+    }
+
+    @Override
+    public void resolve(ComponentIdentifier identifier, ComponentOverrideMetadata componentOverrideMetadata, BuildableComponentResolveResult result) {
+        if (identifier instanceof VirtualComponentIdentifier && identifier instanceof ModuleComponentIdentifier) {
+            result.notFound((ModuleComponentIdentifier) identifier);
+        }
+    }
+
+    @Override
+    public boolean isFetchingMetadataCheap(ComponentIdentifier identifier) {
+        return true;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -153,11 +153,6 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         return metadata;
     }
 
-    ComponentResolveMetadata getMetadataWithoutRetryMissing() {
-        resolve(false);
-        return metadata;
-    }
-
     @Override
     public ComponentIdentifier getComponentId() {
         // Use the resolved component id if available: this ensures that Maven Snapshot ids are correctly reported
@@ -193,10 +188,6 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     public void resolve() {
-        resolve(true);
-    }
-
-    public void resolve(boolean retryMissing) {
         if (alreadyResolved()) {
             return;
         }
@@ -204,7 +195,7 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         // Any metadata overrides (e.g classifier/artifacts/client-module) will be taken from the first dependency that referenced this component
         ComponentOverrideMetadata componentOverrideMetadata = DefaultComponentOverrideMetadata.forDependency(firstSelectedBy.getDependencyMetadata());
 
-        DefaultBuildableComponentResolveResult result = new DefaultBuildableComponentResolveResult(retryMissing);
+        DefaultBuildableComponentResolveResult result = new DefaultBuildableComponentResolveResult();
         resolver.resolve(componentIdentifier, componentOverrideMetadata, result);
         if (result.getFailure() != null) {
             metadataResolveFailure = result.getFailure();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
@@ -57,7 +57,7 @@ class PotentialEdge {
         version.selectedBy(selector);
         // We need to check if the target version exists. For this, we have to try to get metadata for the aligned version.
         // If it's there, it means we can align, otherwise, we must NOT add the edge, or resolution would fail
-        ComponentResolveMetadata metadata = version.getMetadataWithoutRetryMissing();
+        ComponentResolveMetadata metadata = version.getMetadata();
         return new PotentialEdge(edge, toModuleVersionId, metadata, version);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapter.java
@@ -97,7 +97,16 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
 
     @Override
     public void belongsTo(Object notation) {
-        metadata.belongsTo(componentIdentifierParser.parseNotation(notation));
+        belongsTo(notation, true);
+    }
+
+    @Override
+    public void belongsTo(Object notation, boolean virtual) {
+        ComponentIdentifier id = componentIdentifierParser.parseNotation(notation);
+        if (virtual) {
+            id = VirtualComponentHelper.makeVirtual(id);
+        }
+        metadata.belongsTo(id);
     }
 
     @Override
@@ -117,7 +126,6 @@ public class ComponentMetadataDetailsAdapter implements ComponentMetadataDetails
     public String toString() {
         return metadata.getModuleVersionId().toString();
     }
-
 
     private static class VariantNameSpec implements Spec<VariantResolveMetadata> {
         private final String name;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VirtualComponentHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VirtualComponentHelper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.resolver;
+
+import org.apache.commons.lang.ClassUtils;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.internal.Cast;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+
+public class VirtualComponentHelper {
+    /**
+     * Decorates a component identifier, marking it as virtual.
+     * @param id the original component identifier
+     * @return a virtual component identifier
+     */
+    public static VirtualComponentIdentifier makeVirtual(final ComponentIdentifier id) {
+        Class<? extends ComponentIdentifier> cidClazz = id.getClass();
+        List<Class<?>> allInterfaces = Cast.uncheckedCast(ClassUtils.getAllInterfaces(cidClazz));
+        allInterfaces.add(VirtualComponentIdentifier.class);
+        return Cast.uncheckedCast(Proxy.newProxyInstance(cidClazz.getClassLoader(), allInterfaces.toArray(new Class<?>[0]), new InvocationHandler() {
+            @Override
+            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+                return method.invoke(id, args);
+            }
+        }));
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VirtualComponentHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/VirtualComponentHelper.java
@@ -15,15 +15,10 @@
  */
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
-import org.apache.commons.lang.ClassUtils;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.internal.Cast;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.DefaultVirtualModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
-
-import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.Method;
-import java.lang.reflect.Proxy;
-import java.util.List;
 
 public class VirtualComponentHelper {
     /**
@@ -32,14 +27,14 @@ public class VirtualComponentHelper {
      * @return a virtual component identifier
      */
     public static VirtualComponentIdentifier makeVirtual(final ComponentIdentifier id) {
-        Class<? extends ComponentIdentifier> cidClazz = id.getClass();
-        List<Class<?>> allInterfaces = Cast.uncheckedCast(ClassUtils.getAllInterfaces(cidClazz));
-        allInterfaces.add(VirtualComponentIdentifier.class);
-        return Cast.uncheckedCast(Proxy.newProxyInstance(cidClazz.getClassLoader(), allInterfaces.toArray(new Class<?>[0]), new InvocationHandler() {
-            @Override
-            public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-                return method.invoke(id, args);
-            }
-        }));
+        ModuleComponentIdentifier mid = assertModuleComponentIdentifier(id);
+        return new DefaultVirtualModuleComponentIdentifier(mid.getModuleIdentifier(), mid.getVersion());
+    }
+
+    private static ModuleComponentIdentifier assertModuleComponentIdentifier(ComponentIdentifier id) {
+        if (id instanceof ModuleComponentIdentifier) {
+            return (ModuleComponentIdentifier) id;
+        }
+        throw new UnsupportedOperationException("Cannot create a virtual component from a " + id.getClass());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultVirtualModuleComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultVirtualModuleComponentIdentifier.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import com.google.common.base.Objects;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.internal.DisplayName;
+
+public class DefaultVirtualModuleComponentIdentifier implements VirtualComponentIdentifier, ModuleComponentIdentifier, DisplayName {
+    private final ModuleIdentifier moduleIdentifier;
+    private final String version;
+    private final int hashCode;
+
+    public DefaultVirtualModuleComponentIdentifier(ModuleIdentifier module, String version) {
+        assert module != null : "module cannot be null";
+        assert module.getGroup() != null : "group cannot be null";
+        assert module.getName() != null : "name cannot be null";
+        assert version != null : "version cannot be null";
+        this.moduleIdentifier = module;
+        this.version = version;
+        // Do NOT change the order of members used in hash code here, it's been empirically
+        // tested to reduce the number of collisions on a large dependency graph (performance test)
+        this.hashCode = Objects.hashCode(version, module);
+    }
+
+    public String getDisplayName() {
+        String group = moduleIdentifier.getGroup();
+        String module = moduleIdentifier.getName();
+        StringBuilder builder = new StringBuilder(group.length() + module.length() + version.length() + 2);
+        builder.append(group);
+        builder.append(":");
+        builder.append(module);
+        builder.append(":");
+        builder.append(version);
+        return builder.toString();
+    }
+
+    @Override
+    public String getCapitalizedDisplayName() {
+        return getDisplayName();
+    }
+
+    public String getGroup() {
+        return moduleIdentifier.getGroup();
+    }
+
+    public String getModule() {
+        return moduleIdentifier.getName();
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    public ModuleIdentifier getModuleIdentifier() {
+        return moduleIdentifier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultVirtualModuleComponentIdentifier that = (DefaultVirtualModuleComponentIdentifier) o;
+
+        if (!moduleIdentifier.equals(that.moduleIdentifier)) {
+            return false;
+        }
+        if (!version.equals(that.version)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    @Override
+    public String toString() {
+        return getDisplayName();
+    }
+
+}
+

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VirtualComponentIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VirtualComponentIdentifier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+
+/**
+ * This interface is used to make the difference between a "real" component
+ * and something that was either created in a component metadata rule or
+ * internally by the engine. Typically, virtual platforms.
+ */
+public interface VirtualComponentIdentifier extends ComponentIdentifier {
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableComponentResolveResult.java
@@ -41,10 +41,4 @@ public interface BuildableComponentResolveResult extends ComponentResolveResult,
      */
     void setMetadata(ComponentResolveMetadata metadata);
 
-    /**
-     * Returns true if we should retry to get the resource when it was missing. This should only
-     * be used if the result of resolution shouldn't be impacted by a missing module (that is to say,
-     * it doesn't fail if a module is missing).
-     */
-    boolean isRetryMissing();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResult.java
@@ -25,17 +25,10 @@ import org.gradle.internal.resolve.ModuleVersionNotFoundException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 public class DefaultBuildableComponentResolveResult extends DefaultResourceAwareResolveResult implements BuildableComponentResolveResult {
-    private final boolean retryMissing;
-
     private ComponentResolveMetadata metadata;
     private ModuleVersionResolveException failure;
 
     public DefaultBuildableComponentResolveResult() {
-        this(true);
-    }
-
-    public DefaultBuildableComponentResolveResult(boolean retryMissing) {
-        this.retryMissing = retryMissing;
     }
 
     public DefaultBuildableComponentResolveResult failed(ModuleVersionResolveException failure) {
@@ -106,7 +99,4 @@ public class DefaultBuildableComponentResolveResult extends DefaultResourceAware
         }
     }
 
-    public boolean isRetryMissing() {
-        return retryMissing;
-    }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
@@ -84,7 +84,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo
             metaData
         }
-        1 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -112,7 +111,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo
             metaData
         }
-        1 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -142,7 +140,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo
             metaData
         }
-        1 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -165,7 +162,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             result.attempted("scheme:thing")
             result.missing()
         }
-        1 * result.isRetryMissing() >> true
         1 * result.attempted("scheme:thing")
         1 * result.notFound(moduleComponentId)
 
@@ -190,7 +186,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.missing()
         }
-        1 * result.isRetryMissing() >> true
         1 * result.notFound(moduleComponentId)
 
         and:
@@ -219,7 +214,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo1
             metaData
         }
-        3 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -252,7 +246,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -286,7 +279,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -320,7 +312,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -361,7 +352,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -397,7 +387,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -435,7 +424,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo1
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -467,7 +455,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -502,7 +489,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
             assert it.repository == repo2
             metaData
         }
-        2 * result.isRetryMissing() >> true
         1 * result.resolved(_) >> { ModuleComponentResolveMetadata metaData ->
             assert metaData == this.metaData
         }
@@ -532,7 +518,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.missing()
         }
-        2 * result.isRetryMissing() >> true
         1 * result.failed({ it.cause == failure })
 
         and:
@@ -561,7 +546,6 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.missing()
         }
-        2 * result.isRetryMissing() >> true
         1 * result.failed({ it.cause == failure })
 
         and:


### PR DESCRIPTION
### Context

This PR is a performance optimization: it makes sure that platforms declared via `belongsTo` in a rule are _assumed virtual_. By doing so, we avoid polling external repositories to check if a module exists or not.

The `belongsTo(Object, boolean)` method can be used to "restore" the previous behavior. By using `false` as a parameter, we declare that the target platform is either published, or we don't know. The consequence is that the engine would ping the external repository to check, and therefore initiate network requests like it did before this PR.

Implementation-wise, this PR wraps a `ComponentIdentifier` by marking it with a special interface.