### PR TITLE
Make FileUtils#calculateRoots more efficient

### DIFF
--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/FileUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/FileUtilsTest.groovy
@@ -70,6 +70,8 @@ class FileUtilsTest extends Specification {
         toRoots(files("a/a", "a/a")) == files("a/a")
         toRoots(files("a", "b", "c")) == files("a", "b", "c")
         toRoots(files("a/a", "a/a/a", "a/b/a")) == files("a/a", "a/b/a")
+        toRoots(files("a/a/a", "a/a", "a/b/a")) == files("a/a", "a/b/a")
+        toRoots(files("a/a", "a/a-1", "a/a/a")) == files("a/a", "a/a-1")
         toRoots(files("a/a", "a/a/a", "b/a/a")) == files("a/a", "b/a/a")
         toRoots(files("a/a/a/a/a/a/a/a/a", "a/b")) == files("a/a/a/a/a/a/a/a/a", "a/b")
         toRoots(files("a/a/a/a/a/a/a/a/a", "a/b", "b/a/a/a/a/a/a/a/a/a/a/a")) == files("a/a/a/a/a/a/a/a/a", "a/b", "b/a/a/a/a/a/a/a/a/a/a/a")

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -189,6 +189,7 @@ We would like to thank the following community members for making contributions 
 - [Georg Friedrich](https://github.com/GFriedrich) - Base Java Library Distribution Plugin on Java Library Plugin (gradle/gradle#5695)
 - [Stefan M.](https://github.com/StefMa) — Include Kotlin DSL samples in Gradle wrapper and Java Gradle Plugin user manual chapters (gradle/gradle#5923 and gradle/gradle#6485)
 - [Jean-Baptiste Nizet](https://github.com/jnizet) — Include Kotlin DSL samples in Gradle Base Plugin user manual chapter (gradle/gradle#6488)
+- [Xiang Li](https://github.com/lixiangconan) and [Theodore Ni](https://github.com/tjni) - Make FileUtils#calculateRoots more efficient (gradle/gradle#6455)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 


### PR DESCRIPTION
Instead of a quadratic algorithm (comparing every
file against every other file), it now uses an
O(nlogn) algorithm, sorting the files first and
then removing all those that are covered by their
predecessors.