### PR TITLE
Re-introduce CompatibilityAdapterForTaskInputs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/CompatibilityAdapterForTaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/CompatibilityAdapterForTaskInputs.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import javax.annotation.Nullable;
+
+/**
+ * Helper interface for binary compatibility with Gradle &lt;4.3 version of the {@link TaskInputs} interface.
+ *
+ * @deprecated The interface is only here to allow plugins built against Gradle &lt;4.3 to run and it will be removed in Gradle 6.0.
+ */
+@Deprecated
+public interface CompatibilityAdapterForTaskInputs {
+    /**
+     * <p>Registers an input property for this task. This value is persisted when the task executes, and is compared
+     * against the property value for later invocations of the task, to determine if the task is up-to-date.</p>
+     *
+     * <p>The given value for the property must be Serializable, so that it can be persisted. It should also provide a
+     * useful {@code equals()} method.</p>
+     *
+     * <p>You can specify a closure or {@code Callable} as the value of the property. In which case, the closure or
+     * {@code Callable} is executed to determine the actual property value.</p>
+     *
+     * @param name The name of the property. Must not be null.
+     * @param value The value for the property. Can be null.
+     */
+    TaskInputs property(String name, @Nullable Object value);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputPropertyBuilder.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputPropertyBuilder.java
@@ -21,7 +21,7 @@ package org.gradle.api.tasks;
  *
  * @since 4.3
  */
-public interface TaskInputPropertyBuilder extends TaskPropertyBuilder {
+public interface TaskInputPropertyBuilder extends TaskPropertyBuilder, TaskInputs {
     /**
      * Sets whether the task property is optional. If the task property is optional, it means that a value does not have to be
      * specified for the property, but any value specified must meet the validation constraints for the property.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskInputs.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * <p>You can obtain a {@code TaskInputs} instance using {@link org.gradle.api.Task#getInputs()}.</p>
  */
 @HasInternalProtocol
-public interface TaskInputs {
+public interface TaskInputs extends CompatibilityAdapterForTaskInputs{
     /**
      * Returns true if this task has declared the inputs that it consumes.
      *
@@ -88,6 +88,7 @@ public interface TaskInputs {
      * @param name The name of the property. Must not be null.
      * @param value The value for the property. Can be null.
      */
+    @Override
     TaskInputPropertyBuilder property(String name, @Nullable Object value);
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputPropertySpec.java
@@ -22,7 +22,7 @@ import org.gradle.api.tasks.TaskInputPropertyBuilder;
 import javax.annotation.Nullable;
 
 @NonNullApi
-public class DefaultTaskInputPropertySpec implements DeclaredTaskInputProperty {
+public class DefaultTaskInputPropertySpec extends TaskInputsDeprecationSupport implements DeclaredTaskInputProperty {
 
     private final String propertyName;
     private final ValidatingValue value;

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -112,6 +112,9 @@ The previously deprecated support for Play Framework 2.2 has been removed.
 - Forbid passing `null` as configuration action to the methods `from` and `to` on `CopySpec`.
 - Removed the property `bootClasspath` from `CompileOptions`.
 - Registering invalid inputs or outputs via the runtime API is now an error.
+- Chaining calls to the methods `file`, `files`, and `dir` on `TaskInputs` is now impossible.
+- Chaining calls to the methods `file`, `files`, and `dir` on `TaskOutputs` is now impossible.
+- Chaining calls to the method `property` and `properties` on `TaskInputs` is now an error.
 
 ## External contributions
 

--- a/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
+++ b/subprojects/integ-test/src/crossVersionTest/groovy/org/gradle/integtests/TaskSubclassingBinaryCompatibilityCrossVersionSpec.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.scala.ScalaCompile
 import org.gradle.api.tasks.testing.Test
 import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.plugins.ear.Ear
 import org.gradle.plugins.ide.eclipse.GenerateEclipseClasspath
 import org.gradle.plugins.ide.eclipse.GenerateEclipseJdt
@@ -47,6 +48,7 @@ import org.gradle.util.GradleVersion
 /**
  * Tests that task classes compiled against earlier versions of Gradle are still compatible.
  */
+@TargetVersions("3.0+")
 class TaskSubclassingBinaryCompatibilityCrossVersionSpec extends CrossVersionIntegrationSpec {
     @SuppressWarnings("UnnecessaryQualifiedReference")
     def "can use task subclass compiled using previous Gradle version"() {


### PR DESCRIPTION
The adapter is still needed for `TaskInputs.property` which return type
changed in 4.3.

Follow up for #6281.