### PR TITLE
Create own build type for compileAll

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,11 +43,15 @@ defaultTasks("assemble")
 base.archivesBaseName = "gradle"
 
 buildTypes {
+    create("compileAllBuild") {
+        tasks(":createBuildReceipt", "compileAll")
+        projectProperties("ignoreIncomingBuildReceipt" to true)
+    }
+
     create("sanityCheck") {
         tasks(
             "classes", "doc:checkstyleApi", "codeQuality",
             "docs:check", "distribution:checkBinaryCompatibility", "javadocAll")
-        projectProperties("ignoreIncomingBuildReceipt" to true)
     }
 
     // Used by the first phase of the build pipeline, running only last version on multiversion - tests


### PR DESCRIPTION
This build type should be called from our CI scripts, so we don't need
to call the two tasks + set the project property.

The name `compileAll` clashes with the existing `compileAll` tasks, so
we cannot use that name as a build type.
