### PR TITLE
Every task must run after clean in `gradle/gradle`

### DIFF
--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanupPlugin.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanupPlugin.kt
@@ -33,12 +33,17 @@ class CleanupPlugin : Plugin<Project> {
 
         if (BuildEnvironment.isCiServer) {
             tasks {
-                getByName("clean") { // TODO: See https://github.com/gradle/gradle-native/issues/718
+                val cleanTask = getByName("clean") { // TODO: See https://github.com/gradle/gradle-native/issues/718
                     dependsOn(killExistingProcessesStartedByGradle)
                 }
                 subprojects {
                     this.tasks.configureEach {
                         mustRunAfter(killExistingProcessesStartedByGradle)
+
+                        // Workaround for https://github.com/gradle/gradle/issues/2488
+                        if (this != cleanTask) {
+                            mustRunAfter(cleanTask)
+                        }
                     }
                 }
             }

--- a/subprojects/distributions/distributions.gradle
+++ b/subprojects/distributions/distributions.gradle
@@ -32,8 +32,7 @@ tasks.withType(AbstractArchiveTask).configureEach {
     destinationDir = rootProject.distsDir
 }
 
-def clean = tasks.named("clean")
-clean.configure {
+tasks.named("clean").configure {
     delete tasks.withType(AbstractArchiveTask)*.archivePath
 }
 
@@ -96,7 +95,6 @@ ext {
 }
 
 def allZip = tasks.register("allZip", Zip) {
-    mustRunAfter clean
     classifier = 'all'
     into(zipRootFolder) {
         with allDistImage
@@ -104,7 +102,6 @@ def allZip = tasks.register("allZip", Zip) {
 }
 
 def binZip = tasks.register("binZip", Zip) {
-    mustRunAfter clean
     classifier = 'bin'
     into(zipRootFolder) {
         with binWithDistDocImage
@@ -112,7 +109,6 @@ def binZip = tasks.register("binZip", Zip) {
 }
 
 def srcZip = tasks.register("srcZip", Zip) {
-    mustRunAfter clean
     classifier = 'src'
     into(zipRootFolder) {
         from(rootProject.file('gradlew')) {


### PR DESCRIPTION
Fixes problems when :distributions:clean ran after `:distributions:binZip`.

This is a workaround for https://github.com/gradle/gradle/issues/2488.