### PR TITLE
Use JaCoCo 0.8.2 by default

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.8.1</literal></td>
+                <td><literal>0.8.2</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -19,6 +19,10 @@ For the gradle/gradle build, heap usage dropped by 60 MB to 450 MB, that is a 12
 
 The [Build Init plugin](userguide/build_init_plugin.html) now generates build scripts that use the recommended `implementation`, `testImplementation`, and `testRuntimeOnly` configurations instead of `compile`, `testCompile`, and `testRuntime`, respectively, for all build setup types.
 
+### Default JaCoCo version upgraded to 0.8.2
+
+[The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.2](http://www.jacoco.org/jacoco/trunk/doc/changes.html) by default.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/build.gradle
@@ -23,7 +23,7 @@ apply plugin: "jacoco"
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.1"
+    toolVersion = "0.8.2"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -55,7 +55,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * The jacoco version used if none is explicitly specified.
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.8.1";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.2";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -45,6 +45,7 @@ class JacocoAgentJarTest extends Specification {
         '0.7.9'               | true
         '0.8.0'               | true
         '0.8.1'               | true
+        '0.8.2'               | true
     }
 
     @Unroll
@@ -67,5 +68,6 @@ class JacocoAgentJarTest extends Specification {
         '0.7.9'               | true
         '0.8.0'               | true
         '0.8.1'               | true
+        '0.8.2'               | true
     }
 }


### PR DESCRIPTION
This release includes

* Experimental support for **Java 11** and **Java 12** class files, including JEP 12 "preview features" - "experimental" since both are not released, but we believe that no other changes will be needed on JaCoCo side, especially for 11
* Several new bytecode filters, mainly for **Kotlin** users

Full changelog - http://www.jacoco.org/jacoco/trunk/doc/changes.html