### PR TITLE
Fix tooling-api eclipse configuration

### DIFF
--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -22,6 +22,7 @@ import org.gradle.gradlebuild.packaging.ShadedJarExtension
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 import org.gradle.plugins.ide.eclipse.model.Classpath
+import org.gradle.plugins.ide.eclipse.model.SourceFolder
 
 plugins {
     id("gradlebuild.shaded-jar")
@@ -84,8 +85,8 @@ eclipse {
     classpath {
         file.whenMerged(Action<Classpath> {
             //**TODO
-            entries.removeAll { path.contains("src/test/groovy") }
-            entries.removeAll { path.contains("src/integTest/groovy") }
+            entries.removeAll { it is SourceFolder && it.path.contains("src/test/groovy") }
+            entries.removeAll { it is SourceFolder && it.path.contains("src/integTest/groovy") }
         })
     }
 }

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -76,8 +76,9 @@ apply(from = "buildship.gradle")
 
 tasks.named("sourceJar").configureAs<Jar> {
     configurations.compile.allDependencies.withType<ProjectDependency>().forEach {
-        from(it.dependencyProject.java.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].groovy.srcDirs)
-        from(it.dependencyProject.java.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].java.srcDirs)
+        val sourceSet = it.dependencyProject.java.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME]
+        from(sourceSet.groovy.srcDirs)
+        from(sourceSet.java.srcDirs)
     }
 }
 


### PR DESCRIPTION
There was an oversight in the conversion from Groovy. The identifier `path` inside the lambda passed to `entries.removeAll` was meant to reference the given `ClasspathEntry` `path` so it should be qualified by `it`. 