### PR TITLE
Replace `tasks.named(n).configureAs<T> {}` by `tasks.named<T>(n) {}`

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/kotlin-dsl-upstream.kt
@@ -6,7 +6,6 @@ import org.gradle.api.UnknownDomainObjectException
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskContainer
-import org.gradle.api.tasks.TaskProvider
 
 
 // This file contains members intended to be pulled upstream into the next Gradle Kotlin DSL release
@@ -76,12 +75,3 @@ fun <reified T : Task> TaskContainer.register(name: String, noinline configurati
 
 inline fun <reified T : Task> TaskContainer.withType(): TaskCollection<T> =
     withType(T::class.java)
-
-
-inline fun <reified T : Any> TaskProvider<out Task>.configureAs(noinline configurationAction: T.() -> Unit) =
-    configure {
-        configurationAction(
-            this as? T
-                ?: throw IllegalArgumentException(
-                    "Task of type '${javaClass.name}' cannot be cast to '${T::class.qualifiedName}'."))
-    }

--- a/subprojects/build-comparison/build-comparison.gradle.kts
+++ b/subprojects/build-comparison/build-comparison.gradle.kts
@@ -53,7 +53,7 @@ testFixtures {
     from(":core")
 }
 
-tasks.named("processResources").configureAs<Copy> {
+tasks.named<Copy>("processResources") {
     from(css) {
         into("org/gradle/api/plugins/buildcomparison/render/internal/html")
         include("base.css")

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -72,6 +72,6 @@ testFilesCleanup {
     policy.set(WhenNotEmpty.REPORT)
 }
 
-tasks.named("classpathManifest").configureAs<ClasspathManifest> {
+tasks.named<ClasspathManifest>("classpathManifest") {
     additionalProjects = listOf(project(":runtimeApiInfo"))
 }

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -64,7 +64,7 @@ val reportResources = tasks.register<Copy>("reportResources") {
 
 java.sourceSets["main"].output.dir(mapOf("builtBy" to reportResources), generatedResourcesDir)
 
-tasks.named("jar").configureAs<Jar> {
+tasks.named<Jar>("jar") {
     inputs.files(flamegraph)
     from(files(deferred{ flamegraph.map { zipTree(it) } }))
 }

--- a/subprojects/runtime-api-info/runtime-api-info.gradle.kts
+++ b/subprojects/runtime-api-info/runtime-api-info.gradle.kts
@@ -41,7 +41,7 @@ val generateTestKitPackageList = tasks.register<PackageListGenerator>("generateT
     outputFile = file("$runtimeShadedPath/test-kit-relocated.txt")
 }
 
-tasks.named("jar").configureAs<Jar> {
+tasks.named<Jar>("jar") {
     into("org/gradle/api/internal/runtimeshaded") {
         from(generateGradleApiPackageList)
         from(generateTestKitPackageList)

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -73,7 +73,7 @@ testFixtures {
 
 apply(from = "buildship.gradle")
 
-tasks.named("sourceJar").configureAs<Jar> {
+tasks.named<Jar>("sourceJar") {
     configurations.compile.allDependencies.withType<ProjectDependency>().forEach {
         from(it.dependencyProject.java.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].groovy.srcDirs)
         from(it.dependencyProject.java.sourceSets[SourceSet.MAIN_SOURCE_SET_NAME].java.srcDirs)


### PR DESCRIPTION
`configureAs<T>` was introduced before  `named<T>` was available.