### PR TITLE
Remove getting-started.html as input

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/GradleDistribution.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/GradleDistribution.groovy
@@ -50,6 +50,7 @@ class GradleDistribution {
         staticContent.exclude 'samples/**'
         staticContent.exclude 'src/**'
         staticContent.exclude 'docs/**'
+        staticContent.exclude 'getting-started.html'
         libs = project.fileTree(gradleHomeDir.dir('lib'))
         libs.include('*.jar')
         libs.exclude('plugins/**')


### PR DESCRIPTION
to all the distribution tests. We have that file due to unpacking
the all distribution and it contains the version number of the version
under test.

This caused all our no daemon tests to rerun on any change.