### PR TITLE
Disallow build scan plugin < 1.13

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/config/BuildScanConfigIntegrationTest.groovy
@@ -189,34 +189,9 @@ class BuildScanConfigIntegrationTest extends AbstractIntegrationSpec {
         description = applied ? "applied" : "not applied"
     }
 
-    def "fails when VCS mappings are being used and plugin is too old"() {
-        given:
-        scanPlugin.runtimeVersion = "1.10"
-        installVcsMappings()
-
-        when:
-        fails "t"
-
-        then:
-        failureCauseContains(BuildScanPluginCompatibility.UNSUPPORTED_VCS_MAPPINGS_MESSAGE)
-    }
-
-    def "conveys when VCS mappings are being used and plugin is not too old"() {
-        given:
-        scanPlugin.runtimeVersion = "1.11"
-        installVcsMappings()
-
-        when:
-        succeeds "t"
-
-        then:
-        scanPlugin.assertUnsupportedMessage(output, null)
-        scanPlugin.attributes(output).rootProjectHasVcsMappings
-    }
-
     def "can convey unsupported to plugin that supports it"() {
         given:
-        scanPlugin.runtimeVersion = "1.11"
+        scanPlugin.runtimeVersion = "1.13"
         when:
         succeeds "t", "-D${BuildScanPluginCompatibility.UNSUPPORTED_TOGGLE}=true"
 

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
@@ -20,14 +20,10 @@ import org.gradle.util.VersionNumber;
 
 class BuildScanPluginCompatibility {
 
-    public static final VersionNumber MIN_SUPPORTED_VERSION = VersionNumber.parse("1.8");
+    public static final VersionNumber MIN_SUPPORTED_VERSION = VersionNumber.parse("1.13");
     public static final String UNSUPPORTED_PLUGIN_VERSION_MESSAGE =
         "This version of Gradle requires version " + MIN_SUPPORTED_VERSION + " of the build scan plugin or later.\n"
             + "Please see https://gradle.com/scans/help/gradle-incompatible-plugin-version for more information.";
-
-    public static final VersionNumber MIN_VERSION_AWARE_OF_VCS_MAPPINGS = VersionNumber.parse("1.11");
-    public static final String UNSUPPORTED_VCS_MAPPINGS_MESSAGE =
-        "Build scans are not supported when using VCS mappings. It may be supported when using newer versions of the build scan plugin.";
 
     public static final VersionNumber MIN_VERSION_FOR_KOTLIN_SCRIPT_BUILD_CACHING = VersionNumber.parse("1.15.2");
     public static final String UNSUPPORTED_KOTLIN_SCRIPT_BUILD_CACHING_MESSAGE =
@@ -41,10 +37,6 @@ class BuildScanPluginCompatibility {
     String unsupportedReason(VersionNumber pluginVersion, BuildScanConfig.Attributes attributes) {
         if (isEarlierThan(pluginVersion, MIN_SUPPORTED_VERSION)) {
             return UNSUPPORTED_PLUGIN_VERSION_MESSAGE;
-        }
-
-        if (isEarlierThan(pluginVersion, MIN_VERSION_AWARE_OF_VCS_MAPPINGS) && attributes.isRootProjectHasVcsMappings()) {
-            return UNSUPPORTED_VCS_MAPPINGS_MESSAGE;
         }
 
         if (isEarlierThan(pluginVersion, MIN_VERSION_FOR_KOTLIN_SCRIPT_BUILD_CACHING) && isKotlinBuildCachingEnabled()) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
@@ -72,13 +72,13 @@ class BuildScanConfigManagerTest extends Specification {
         thrown UnsupportedBuildScanPluginVersionException
 
         when:
-        config("1.9")
+        config("1.13")
 
         then:
         notThrown UnsupportedBuildScanPluginVersionException
 
         when:
-        config("1.8-TIMESTAMP")
+        config("1.13-TIMESTAMP")
 
         then:
         notThrown UnsupportedBuildScanPluginVersionException
@@ -144,7 +144,7 @@ class BuildScanConfigManagerTest extends Specification {
         System.setProperty(BuildScanPluginCompatibility.UNSUPPORTED_TOGGLE, "true")
 
         then:
-        with(config(BuildScanConfigManager.FIRST_VERSION_AWARE_OF_UNSUPPORTED.toString())) {
+        with(config()) {
             !enabled
             !disabled
             unsupportedMessage == BuildScanPluginCompatibility.UNSUPPORTED_TOGGLE_MESSAGE
@@ -154,7 +154,7 @@ class BuildScanConfigManagerTest extends Specification {
         scanEnabled = true
 
         then:
-        with(config(BuildScanConfigManager.FIRST_VERSION_AWARE_OF_UNSUPPORTED.toString())) {
+        with(config()) {
             enabled
             !disabled
             unsupportedMessage == BuildScanPluginCompatibility.UNSUPPORTED_TOGGLE_MESSAGE

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -26,19 +26,22 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         "1.6",
         "1.7",
         "1.7.4",
-    ]
-
-    private static final List<String> SUPPORTED = [
         "1.8",
         "1.9",
         // "1.9.1", // https://github.com/gradle/dotcom/issues/1213
         "1.10",
         "1.10.1",
         "1.10.2",
-        "1.10.3",
+        "1.10.3"
+    ]
+
+    private static final List<String> GRACEFULLY_UNSUPPORTED_WITHOUT_FAILURE = [
         "1.11",
         "1.12",
-        "1.12.1",
+        "1.12.1"
+    ]
+
+    private static final List<String> SUPPORTED = [
         "1.13",
         "1.13.1",
         "1.13.2",
@@ -62,6 +65,18 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
+    "gracefully succeeds without capturing scan with unsupported version #version"() {
+        when:
+        usePluginVersion version
+
+        then:
+        build("--scan").output.contains("Build scan data will not be captured due to version $version of the build scan plugin being incompatible with Gradle")
+
+        where:
+        version << GRACEFULLY_UNSUPPORTED_WITHOUT_FAILURE
+    }
+
+    @Unroll
     "gracefully fails with unsupported version #version"() {
         when:
         usePluginVersion version
@@ -69,7 +84,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         then:
         buildAndFail("--scan").output.contains("""
 > Failed to apply plugin [id 'com.gradle.build-scan']
-   > This version of Gradle requires version 1.8.0 of the build scan plugin or later.
+   > This version of Gradle requires version 1.13.0 of the build scan plugin or later.
      Please see https://gradle.com/scans/help/gradle-incompatible-plugin-version for more information.
 """)
 


### PR DESCRIPTION
Older scan plugins are currently broken on Gradle nightly builds.

While we still need to make a final compatibility decision on which
versions to support for 5.0, we should immediately stop anyone using
nightly builds from using unsupported versions, as they will experience
UI errors due to missing data when viewing created scans.

Intentionally not cleaning up any APIs at this point (e.g. the
attributes are no longer used) as we should do that as part of a
proper cleanup before 5.0.
