### PR TITLE
Use our own lock for SystemProperties methods

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/SystemProperties.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/SystemProperties.java
@@ -69,6 +69,9 @@ public class SystemProperties {
         return INSTANCE;
     }
 
+    private SystemProperties() {
+    }
+
     @SuppressWarnings("unchecked")
     public Map<String, String> asMap() {
         return (Map) System.getProperties();
@@ -122,19 +125,17 @@ public class SystemProperties {
      * @param value The value to temporarily set the property to
      * @param factory Instance created by the Factory implementation
      */
-    public <T> T withSystemProperty(String propertyName, String value, Factory<T> factory) {
-        synchronized (System.getProperties()) {
-            String originalValue = System.getProperty(propertyName);
-            System.setProperty(propertyName, value);
+    public synchronized  <T> T withSystemProperty(String propertyName, String value, Factory<T> factory) {
+        String originalValue = System.getProperty(propertyName);
+        System.setProperty(propertyName, value);
 
-            try {
-                return factory.create();
-            } finally {
-                if (originalValue != null) {
-                    System.setProperty(propertyName, originalValue);
-                } else {
-                    System.clearProperty(propertyName);
-                }
+        try {
+            return factory.create();
+        } finally {
+            if (originalValue != null) {
+                System.setProperty(propertyName, originalValue);
+            } else {
+                System.clearProperty(propertyName);
             }
         }
     }
@@ -143,10 +144,8 @@ public class SystemProperties {
      * Provides safe access to the system properties, preventing concurrent {@link #withSystemProperty(String, String, Factory)} calls.
      * This can be used to wrap 3rd party APIs that iterate over the system properties, so they won't result in {@link java.util.ConcurrentModificationException}s.
      */
-    public <T> T withSystemProperties(Factory<T> factory) {
-        synchronized (System.getProperties()) {
-            return factory.create();
-        }
+    public synchronized  <T> T withSystemProperties(Factory<T> factory) {
+        return factory.create();
     }
 
     /**


### PR DESCRIPTION
We attempted to coordinate all access to system properties
for maximum security, but that didn't work out because it
also prevented reads from other threads while someone was
holding the lock. This is no longer a problem on Java 9,
but a deadlock is possible on Java 8.

We now only coordinate our own writes and accept that some
3rd party code may use `setProperty()` and bypass our checks
that way.

Fixes https://github.com/gradle/gradle-private/issues/1460