### PR TITLE
Fix double "Example"

### DIFF
--- a/subprojects/docs/src/docs/userguide/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle_wrapper.adoc
@@ -170,8 +170,8 @@ Let’s assume you grew tired of defining the `-all` distribution type on the co
 
 .Customizing the Wrapper task
 ====
-include::sample[dir="userguide/wrapper/customized-task/groovy",files="build.gradle[tag=customized-wrapper-task]"]
-include::sample[dir="userguide/wrapper/customized-task/kotlin",files="build.gradle.kts[tag=customized-wrapper-task]"]
+include::sample[dir="userguide/wrapper/customized-task/groovy",files="build.gradle[tags=customized-wrapper-task]"]
+include::sample[dir="userguide/wrapper/customized-task/kotlin",files="build.gradle.kts[tags=customized-wrapper-task]"]
 ====
 
 With the configuration in place running `./gradlew wrapper --gradle-version {gradleVersion}` is enough to produce a `distributionUrl` value in the Wrapper properties file that will request the `-all` distribution.

--- a/subprojects/docs/src/docs/userguide/gradle_wrapper.adoc
+++ b/subprojects/docs/src/docs/userguide/gradle_wrapper.adoc
@@ -168,7 +168,7 @@ Most users of Gradle are happy with the default runtime behavior of the Wrapper.
 
 Let’s assume you grew tired of defining the `-all` distribution type on the command line every time you upgrade the Wrapper. You can save yourself some keyboard strokes by re-configuring the `wrapper` task.
 
-.Example: Customizing the Wrapper task
+.Customizing the Wrapper task
 ====
 include::sample[dir="userguide/wrapper/customized-task/groovy",files="build.gradle[tag=customized-wrapper-task]"]
 include::sample[dir="userguide/wrapper/customized-task/kotlin",files="build.gradle.kts[tag=customized-wrapper-task]"]


### PR DESCRIPTION
### Context
I found out that the (asciidoc plugin?!) will automatically add the "Example X" to the doc.
Means the current version shows "Example 1. Example...":
<img width="359" alt="bildschirmfoto 2018-08-23 um 15 18 17" src="https://user-images.githubusercontent.com/10229883/44527659-ca826700-a6e7-11e8-939f-55572e7fb869.png">
This PR fix this...
<img width="316" alt="bildschirmfoto 2018-08-23 um 15 15 16" src="https://user-images.githubusercontent.com/10229883/44527644-c1919580-a6e7-11e8-9736-53552d55d453.png">

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
