### PR TITLE
Fix two broken links to old documentation pages

### DIFF
--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/SecurityManagerIntegrationTest.groovy
@@ -59,6 +59,6 @@ public class SecurityManagerTest {
         fails('test')
         failure.assertHasCause("""Process 'Gradle Test Executor 1' finished with non-zero exit value 1
 This problem might be caused by incorrect test process configuration.
-Please refer to the test execution section in the user guide at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_plugin.html#sec:test_execution""")
+Please refer to the test execution section in the user guide at https://docs.gradle.org/${GradleVersion.current().version}/userguide/java_testing.html#sec:test_execution""")
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -155,7 +155,7 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
                     throw new ExecException(e.getMessage()
                         + "\nThis problem might be caused by incorrect test process configuration."
                         + "\nPlease refer to the test execution section in the user guide at "
-                        + documentationRegistry.getDocumentationFor("java_plugin", "sec:test_execution"), e.getCause());
+                        + documentationRegistry.getDocumentationFor("java_testing", "sec:test_execution"), e.getCause());
                 }
             } finally {
                 completion.leaseFinish();


### PR DESCRIPTION
### Context
I noticed that the link that gets spit out when a Gradle Test Executor process dies was pointing to the wrong page, it looks like what was once found at https://docs.gradle.org/current/userguide/java_plugin.html#sec:test_execution is now at https://docs.gradle.org/current/userguide/java_testing.html#sec:test_execution

This updates the places I saw that referenced across the codebase.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective (I'm assuming this is not relevant for this change)
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic (also assuming this is not relevant
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes (nor this)
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
