### PR TITLE
Remove depreacted Class.newInstance()

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrExecuter.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/AntlrExecuter.java
@@ -94,7 +94,7 @@ public class AntlrExecuter implements AntlrWorker {
             try {
                 Class<?> toolClass = Class.forName(className); // ok to use caller classloader
                 if (args == null) {
-                    return toolClass.newInstance();
+                    return toolClass.getConstructor().newInstance();
                 } else {
                     Constructor<?> constructor = toolClass.getConstructor(String[].class);
                     return constructor.newInstance(new Object[]{args});

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -244,7 +244,7 @@ public class JavaReflectionUtil {
             handlerClass = fallbackType;
         }
         try {
-            return Cast.uncheckedCast(handlerClass.newInstance());
+            return Cast.uncheckedCast(handlerClass.getConstructor().newInstance());
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/service/DefaultServiceMethodFactory.java
@@ -26,7 +26,7 @@ class DefaultServiceMethodFactory implements ServiceMethodFactory {
     DefaultServiceMethodFactory() {
         ServiceMethodFactory factory;
         try {
-            factory = (ServiceMethodFactory) Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory").newInstance();
+            factory = (ServiceMethodFactory) Class.forName("org.gradle.internal.service.MethodHandleBasedServiceMethodFactory").getConstructor().newInstance();
         } catch (Exception e) {
             factory = new ReflectionBasedServiceMethodFactory();
         }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/DefaultClassLoaderFactoryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/DefaultClassLoaderFactoryTest.groovy
@@ -60,7 +60,7 @@ class DefaultClassLoaderFactoryTest extends Specification {
 
         when:
         Thread.currentThread().contextClassLoader = cl
-        c.newInstance().doStuff()
+        c.getConstructor().newInstance().doStuff()
 
         then:
         notThrown()

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
@@ -330,7 +330,7 @@ class OperatingSystemTest extends Specification {
                 .each { Field field ->
                 if (OperatingSystem.isAssignableFrom(field.getType())) {
                     makeFinalFieldAccessibleForTesting(field)
-                    field.set(null, field.getType().newInstance())
+                    field.set(null, field.getType().getConstructor().newInstance())
                 }
             }
             return true

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultIncludedBuildRegistryTest.groovy
@@ -237,7 +237,7 @@ class DefaultIncludedBuildRegistryTest extends Specification {
     }
 
     def build(File rootDir) {
-        return BuildDefinition.fromStartParameterForBuild(StartParameter.newInstance(), null, rootDir, DefaultPluginRequests.EMPTY, null)
+        return BuildDefinition.fromStartParameterForBuild(StartParameter.getConstructor().newInstance(), null, rootDir, DefaultPluginRequests.EMPTY, null)
     }
 
     def rootBuild() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/DefaultIsolatedAntBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/DefaultIsolatedAntBuilder.java
@@ -162,7 +162,7 @@ public class DefaultIsolatedAntBuilder implements IsolatedAntBuilder, Stoppable 
         // we must use a String literal here, otherwise using things like Foo.class.name will trigger unnecessary
         // loading of classes in the classloader of the DefaultIsolatedAntBuilder, which is not what we want.
         try {
-            return antAdapterLoader.loadClass(className).newInstance();
+            return antAdapterLoader.loadClass(className).getConstructor().newInstance();
         } catch (Exception e) {
             // should never happen
             throw UncheckedException.throwAsUncheckedException(e);

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/BootstrapSecurityManager.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/BootstrapSecurityManager.java
@@ -86,7 +86,7 @@ public class BootstrapSecurityManager extends SecurityManager {
             SecurityManager securityManager;
             try {
                 Class<?> aClass = systemClassLoader.loadClass(securityManagerType);
-                securityManager = (SecurityManager) aClass.newInstance();
+                securityManager = (SecurityManager) aClass.getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException("Could not create an instance of '" + securityManagerType + "' specified for system SecurityManager.", e);
             }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AsmBackedClassGeneratorTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AsmBackedClassGeneratorTest.java
@@ -77,7 +77,7 @@ public class AsmBackedClassGeneratorTest {
         Class<? extends Bean> generatedClass = generator.generate(Bean.class);
         assertTrue(IConventionAware.class.isAssignableFrom(generatedClass));
 
-        Bean bean = generatedClass.newInstance();
+        Bean bean = generatedClass.getConstructor().newInstance();
 
         IConventionAware conventionAware = (IConventionAware) bean;
         assertThat(conventionAware.getConventionMapping(), instanceOf(ConventionAwareHelper.class));
@@ -88,7 +88,7 @@ public class AsmBackedClassGeneratorTest {
     public void mixesInDynamicObjectAwareInterface() throws Exception {
         Class<? extends Bean> generatedClass = generator.generate(Bean.class);
         assertTrue(DynamicObjectAware.class.isAssignableFrom(generatedClass));
-        Bean bean = generatedClass.newInstance();
+        Bean bean = generatedClass.getConstructor().newInstance();
         DynamicObjectAware dynamicBean = (DynamicObjectAware) bean;
 
         dynamicBean.getAsDynamicObject().setProperty("prop", "value");
@@ -100,7 +100,7 @@ public class AsmBackedClassGeneratorTest {
     public void mixesInExtensionAwareInterface() throws Exception {
         Class<? extends Bean> generatedClass = generator.generate(Bean.class);
         assertTrue(ExtensionAware.class.isAssignableFrom(generatedClass));
-        Bean bean = generatedClass.newInstance();
+        Bean bean = generatedClass.getConstructor().newInstance();
         ExtensionAware dynamicBean = (ExtensionAware) bean;
 
         assertThat(dynamicBean.getExtensions(), notNullValue());
@@ -110,7 +110,7 @@ public class AsmBackedClassGeneratorTest {
     public void mixesInGroovyObjectInterface() throws Exception {
         Class<? extends Bean> generatedClass = generator.generate(Bean.class);
         assertTrue(GroovyObject.class.isAssignableFrom(generatedClass));
-        Bean bean = generatedClass.newInstance();
+        Bean bean = generatedClass.getConstructor().newInstance();
         GroovyObject groovyObject = (GroovyObject) bean;
         assertThat(groovyObject.getMetaClass(), notNullValue());
 
@@ -342,7 +342,7 @@ public class AsmBackedClassGeneratorTest {
     public void appliesConventionMappingToEachProperty() throws Exception {
         Class<? extends Bean> generatedClass = generator.generate(Bean.class);
         assertTrue(IConventionAware.class.isAssignableFrom(generatedClass));
-        Bean bean = generatedClass.newInstance();
+        Bean bean = generatedClass.getConstructor().newInstance();
         IConventionAware conventionAware = (IConventionAware) bean;
 
         assertThat(bean.getProp(), nullValue());
@@ -444,7 +444,7 @@ public class AsmBackedClassGeneratorTest {
     @Test
     @Issue("GRADLE-2163")
     public void appliesConventionMappingToGroovyBoolean() throws Exception {
-        BeanWithGroovyBoolean bean = generator.generate(BeanWithGroovyBoolean.class).newInstance();
+        BeanWithGroovyBoolean bean = generator.generate(BeanWithGroovyBoolean.class).getConstructor().newInstance();
 
         assertTrue(bean instanceof IConventionAware);
         assertThat(bean.getSmallB(), equalTo(false));
@@ -489,7 +489,7 @@ public class AsmBackedClassGeneratorTest {
     @Test
     public void appliesConventionMappingToCollectionGetter() throws Exception {
         Class<? extends CollectionBean> generatedClass = generator.generate(CollectionBean.class);
-        CollectionBean bean = generatedClass.newInstance();
+        CollectionBean bean = generatedClass.getConstructor().newInstance();
         IConventionAware conventionAware = (IConventionAware) bean;
         final List<String> conventionValue = toList("value");
 
@@ -515,7 +515,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void handlesVariousPropertyTypes() throws Exception {
-        BeanWithVariousPropertyTypes bean = generator.generate(BeanWithVariousPropertyTypes.class).newInstance();
+        BeanWithVariousPropertyTypes bean = generator.generate(BeanWithVariousPropertyTypes.class).getConstructor().newInstance();
 
         assertThat(bean.getArrayProperty(), notNullValue());
         assertThat(bean.getBooleanProperty(), equalTo(false));
@@ -539,7 +539,7 @@ public class AsmBackedClassGeneratorTest {
     public void doesNotOverrideMethodsFromConventionAwareInterface() throws Exception {
         Class<? extends ConventionAwareBean> generatedClass = generator.generate(ConventionAwareBean.class);
         assertTrue(IConventionAware.class.isAssignableFrom(generatedClass));
-        ConventionAwareBean bean = generatedClass.newInstance();
+        ConventionAwareBean bean = generatedClass.getConstructor().newInstance();
         assertSame(bean, bean.getConventionMapping());
 
         bean.setProp("value");
@@ -548,7 +548,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotOverrideMethodsFromSuperclassesMarkedWithAnnotation() throws Exception {
-        BeanSubClass bean = generator.generate(BeanSubClass.class).newInstance();
+        BeanSubClass bean = generator.generate(BeanSubClass.class).getConstructor().newInstance();
         IConventionAware conventionAware = (IConventionAware) bean;
         conventionAware.getConventionMapping().map("property", new Callable<Object>() {
             public Object call() throws Exception {
@@ -578,7 +578,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotMixInConventionMappingToClassWithAnnotation() throws Exception {
-        NoMappingBean bean = generator.generate(NoMappingBean.class).newInstance();
+        NoMappingBean bean = generator.generate(NoMappingBean.class).getConstructor().newInstance();
         assertFalse(bean instanceof IConventionAware);
         assertNull(bean.getInterfaceProperty());
 
@@ -588,14 +588,14 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotOverrideMethodsFromDynamicObjectAwareInterface() throws Exception {
-        DynamicObjectAwareBean bean = generator.generate(DynamicObjectAwareBean.class).newInstance();
+        DynamicObjectAwareBean bean = generator.generate(DynamicObjectAwareBean.class).getConstructor().newInstance();
         assertThat(bean.getConvention(), sameInstance(bean.conv));
         assertThat(bean.getAsDynamicObject(), sameInstance(bean.conv.getExtensionsAsDynamicObject()));
     }
 
     @Test
     public void canAddDynamicPropertiesAndMethodsToJavaObject() throws Exception {
-        Bean bean = generator.generate(Bean.class).newInstance();
+        Bean bean = generator.generate(Bean.class).getConstructor().newInstance();
         DynamicObjectAware dynamicObjectAware = (DynamicObjectAware) bean;
         ConventionObject conventionObject = new ConventionObject();
         new DslObject(dynamicObjectAware).getConvention().getPlugins().put("plugin", conventionObject);
@@ -610,7 +610,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void canAddDynamicPropertiesAndMethodsToGroovyObject() throws Exception {
-        TestDecoratedGroovyBean bean = generator.generate(TestDecoratedGroovyBean.class).newInstance();
+        TestDecoratedGroovyBean bean = generator.generate(TestDecoratedGroovyBean.class).getConstructor().newInstance();
         DynamicObjectAware dynamicObjectAware = (DynamicObjectAware) bean;
         ConventionObject conventionObject = new ConventionObject();
         new DslObject(dynamicObjectAware).getConvention().getPlugins().put("plugin", conventionObject);
@@ -625,7 +625,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void respectsPropertiesAddedToMetaClassOfJavaObject() throws Exception {
-        Bean bean = generator.generate(Bean.class).newInstance();
+        Bean bean = generator.generate(Bean.class).getConstructor().newInstance();
 
         call("{ it.metaClass.getConventionProperty = { -> 'value'} }", bean);
         assertThat(call("{ it.hasProperty('conventionProperty') }", bean), notNullValue());
@@ -635,7 +635,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void respectsPropertiesAddedToMetaClassOfGroovyObject() throws Exception {
-        TestDecoratedGroovyBean bean = generator.generate(TestDecoratedGroovyBean.class).newInstance();
+        TestDecoratedGroovyBean bean = generator.generate(TestDecoratedGroovyBean.class).getConstructor().newInstance();
 
         call("{ it.metaClass.getConventionProperty = { -> 'value'} }", bean);
         assertThat(call("{ it.hasProperty('conventionProperty') }", bean), notNullValue());
@@ -645,7 +645,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void usesExistingGetAsDynamicObjectMethod() throws Exception {
-        DynamicObjectBean bean = generator.generate(DynamicObjectBean.class).newInstance();
+        DynamicObjectBean bean = generator.generate(DynamicObjectBean.class).getConstructor().newInstance();
 
         call("{ it.prop = 'value' }", bean);
         assertThat(call("{ it.prop }", bean), equalTo((Object) "value"));
@@ -667,7 +667,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void mixesInSetValueMethodForSingleValuedProperty() throws Exception {
-        BeanWithVariousGettersAndSetters bean = generator.generate(BeanWithVariousGettersAndSetters.class).newInstance();
+        BeanWithVariousGettersAndSetters bean = generator.generate(BeanWithVariousGettersAndSetters.class).getConstructor().newInstance();
 
         call("{ it.prop 'value'}", bean);
         assertThat(bean.getProp(), equalTo("value"));
@@ -696,7 +696,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotUseConventionValueOnceSetValueMethodHasBeenCalled() throws Exception {
-        Bean bean = generator.generate(Bean.class).newInstance();
+        Bean bean = generator.generate(Bean.class).getConstructor().newInstance();
         IConventionAware conventionAware = (IConventionAware) bean;
         conventionAware.getConventionMapping().map("prop", new Callable<Object>() {
             public Object call() throws Exception {
@@ -712,7 +712,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotMixInSetValueMethodForReadOnlyProperty() throws Exception {
-        BeanWithReadOnlyProperties bean = generator.generate(BeanWithReadOnlyProperties.class).newInstance();
+        BeanWithReadOnlyProperties bean = generator.generate(BeanWithReadOnlyProperties.class).getConstructor().newInstance();
 
         try {
             call("{ it.prop 'value'}", bean);
@@ -724,7 +724,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotMixInSetValueMethodForMultiValueProperty() throws Exception {
-        CollectionBean bean = generator.generate(CollectionBean.class).newInstance();
+        CollectionBean bean = generator.generate(CollectionBean.class).getConstructor().newInstance();
 
         try {
             call("{ def val = ['value']; it.prop val}", bean);
@@ -736,7 +736,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void overridesExistingSetValueMethod() throws Exception {
-        BeanWithDslMethods bean = generator.generate(BeanWithDslMethods.class).newInstance();
+        BeanWithDslMethods bean = generator.generate(BeanWithDslMethods.class).getConstructor().newInstance();
         IConventionAware conventionAware = (IConventionAware) bean;
         conventionAware.getConventionMapping().map("prop", new Callable<Object>() {
             public Object call() throws Exception {
@@ -769,7 +769,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void addsInsteadOfOverridesSetValueMethodIfOnlyMultiArgMethods() throws Exception {
-        BeanWithMultiArgDslMethods bean = generator.generate(BeanWithMultiArgDslMethods.class).newInstance();
+        BeanWithMultiArgDslMethods bean = generator.generate(BeanWithMultiArgDslMethods.class).getConstructor().newInstance();
         // this method should have been added to the class
         call("{ it.prop 'value'}", bean);
         assertThat(bean.getProp(), equalTo("value"));
@@ -777,26 +777,26 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void doesNotOverrideSetValueMethodForPropertyThatIsNotConventionMappingAware() throws Exception {
-        BeanWithMultiArgDslMethodsAndNoConventionMapping bean = generator.generate(BeanWithMultiArgDslMethodsAndNoConventionMapping.class).newInstance();
+        BeanWithMultiArgDslMethodsAndNoConventionMapping bean = generator.generate(BeanWithMultiArgDslMethodsAndNoConventionMapping.class).getConstructor().newInstance();
         call("{ it.prop 'value'}", bean);
         assertThat(bean.getProp(), equalTo("(value)"));
     }
 
     @Test
     public void mixesInClosureOverloadForActionMethod() throws Exception {
-        Bean bean = generator.generate(Bean.class).newInstance();
+        Bean bean = generator.generate(Bean.class).getConstructor().newInstance();
         bean.prop = "value";
 
         call("{def value; it.doStuff { value = it }; assert value == \'value\' }", bean);
 
-        BeanWithOverriddenMethods subBean = generator.generate(BeanWithOverriddenMethods.class).newInstance();
+        BeanWithOverriddenMethods subBean = generator.generate(BeanWithOverriddenMethods.class).getConstructor().newInstance();
 
         call("{def value; it.doStuff { value = it }; assert value == \'overloaded\' }", subBean);
     }
 
     @Test
-    public void doesNotOverrideExistingClosureOverload() throws IllegalAccessException, InstantiationException {
-        BeanWithDslMethods bean = generator.generate(BeanWithDslMethods.class).newInstance();
+    public void doesNotOverrideExistingClosureOverload() throws Exception {
+        BeanWithDslMethods bean = generator.generate(BeanWithDslMethods.class).getConstructor().newInstance();
         bean.prop = "value";
 
         assertThat(call("{def value; it.doStuff { value = it }; return value }", bean), equalTo((Object) "[value]"));
@@ -804,7 +804,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void generatesDslObjectCompatibleObject() throws Exception {
-        DslObject dslObject = new DslObject(generator.generate(Bean.class).newInstance());
+        DslObject dslObject = new DslObject(generator.generate(Bean.class).getConstructor().newInstance());
         assertEquals(Bean.class, dslObject.getDeclaredType());
         assertEquals(TypeOf.typeOf(Bean.class), dslObject.getPublicType());
         assertNotNull(dslObject.getConventionMapping());
@@ -815,7 +815,7 @@ public class AsmBackedClassGeneratorTest {
 
     @Test
     public void honorsPublicType() throws Exception {
-        DslObject dslObject = new DslObject(generator.generate(BeanWithPublicType.class).newInstance());
+        DslObject dslObject = new DslObject(generator.generate(BeanWithPublicType.class).getConstructor().newInstance());
         assertEquals(TypeOf.typeOf(Bean.class), dslObject.getPublicType());
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -789,7 +789,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
                 if (params.length > 0) {
                     return type.cast(decorated.constructors[0].newInstance(params))
                 } else {
-                    return decorated.newInstance()
+                    return decorated.getConstructor().newInstance()
                 }
             }
         })

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -35,7 +35,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
     def setup() {
         taskFactory = new TaskFactory(generator).createChild(project, instantiator)
         _ * generator.generate(_) >> { Class type -> type }
-        _ * instantiator.newInstance(_) >> { args -> args[0].newInstance() }
+        _ * instantiator.newInstance(_) >> { args -> args[0].getConstructor().newInstance() }
     }
 
     public void injectsProjectAndNameIntoTask() {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -387,7 +387,7 @@ tasks.register("serveDocs", Exec) {
 tasks.register("editReleaseNotes") {
     group = "release notes"
     doLast {
-        Class.forName("java.awt.Desktop").newInstance().edit(file("src/docs/release/notes.md"))
+        Class.forName("java.awt.Desktop").getConstructor().newInstance().edit(file("src/docs/release/notes.md"))
     }
 }
 
@@ -415,7 +415,7 @@ tasks.addRule("view«Doc Task Name» - Opens entry point") { String taskName ->
             tasks.create(taskName) {
                 dependsOn task
                 doLast {
-                    Class.forName("java.awt.Desktop").newInstance().browse(file(task.entryPoint).toURI())
+                    Class.forName("java.awt.Desktop").getConstructor().newInstance().browse(file(task.entryPoint).toURI())
                 }
             }
         }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixtureTest.groovy
@@ -81,7 +81,7 @@ class BuildOperationNotificationsFixtureTest extends Specification {
     BuildOperationNotificationListener2 listener() {
         GroovyClassLoader groovyClassLoader = new GroovyClassLoader(BuildOperationNotificationsFixture.getClassLoader())
         Class theParsedClass = groovyClassLoader.parseClass(BuildOperationNotificationsFixture.EVALUATION_LISTENER_SOURCE)
-        return theParsedClass.newInstance() as BuildOperationNotificationListener2
+        return theParsedClass.getConstructor().newInstance() as BuildOperationNotificationListener2
     }
 
     def progressNotification(Class<SimpleProgress> progressClazz = null) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ReportGenerator.java
@@ -30,7 +30,7 @@ public class ReportGenerator {
     public static void main(String... args) throws Exception {
         Class<?> resultStoreClass = Class.forName(args[0]);
         File outputDirectory = new File(args[1]);
-        ResultsStore resultStore = (ResultsStore) resultStoreClass.newInstance();
+        ResultsStore resultStore = (ResultsStore) resultStoreClass.getConstructor().newInstance();
         try {
             new ReportGenerator().generate(resultStore, outputDirectory);
         } finally {

--- a/subprojects/ivy/src/crossVersionTest/groovy/org/gradle/api/publish/ivy/IvyPublishCrossVersionIntegrationTest.groovy
+++ b/subprojects/ivy/src/crossVersionTest/groovy/org/gradle/api/publish/ivy/IvyPublishCrossVersionIntegrationTest.groovy
@@ -94,7 +94,7 @@ repositories {
     if (${previous.fullySupportsIvyRepository}) {
         ivy { url "${repo.uri}" }
     } else {
-        add(Class.forName('org.apache.ivy.plugins.resolver.FileSystemResolver').newInstance()) {
+        add(Class.forName('org.apache.ivy.plugins.resolver.FileSystemResolver').getConstructor().newInstance()) {
             name = 'repo'
             addIvyPattern("${repoPath}/[organisation]/[module]/[revision]/ivy-[revision].xml")
             addArtifactPattern("${repoPath}/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/bootstrap/ProcessBootstrap.java
@@ -55,7 +55,7 @@ public class ProcessBootstrap {
 
         try {
             Class<?> mainClass = runtimeClassLoader.loadClass(mainClassName);
-            Object entryPoint = mainClass.newInstance();
+            Object entryPoint = mainClass.getConstructor().newInstance();
             Method mainMethod = mainClass.getMethod("run", String[].class);
             mainMethod.invoke(entryPoint, new Object[]{args});
         } finally {

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/serialization/ClasspathInfererTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/serialization/ClasspathInfererTest.groovy
@@ -41,7 +41,7 @@ class ClasspathInfererTest extends AbstractClassGraphSpec {
         def classpath = []
         factory.getClassPathFor(actionClass, classpath)
         def loader = new VisitableURLClassLoader(ClassLoader.systemClassLoader.parent, classpath)
-        def action = loader.loadClass(CustomAction.name).newInstance()
+        def action = loader.loadClass(CustomAction.name).getConstructor().newInstance()
         action.execute(null)
     }
 
@@ -53,7 +53,7 @@ class ClasspathInfererTest extends AbstractClassGraphSpec {
         def classpath = []
         factory.getClassPathFor(actionClass, classpath)
         def loader = new VisitableURLClassLoader(ClassLoader.systemClassLoader.parent, classpath)
-        def action = loader.loadClass(CustomAction.name).newInstance()
+        def action = loader.loadClass(CustomAction.name).getConstructor().newInstance()
         action.execute(null)
     }
 
@@ -66,7 +66,7 @@ class ClasspathInfererTest extends AbstractClassGraphSpec {
         def classpath = []
         factory.getClassPathFor(actionClass, classpath)
         def loader = new VisitableURLClassLoader(ClassLoader.systemClassLoader.parent, classpath)
-        def action = loader.loadClass(CustomAction.name).newInstance()
+        def action = loader.loadClass(CustomAction.name).getConstructor().newInstance()
         action.execute(null)
     }
 
@@ -79,7 +79,7 @@ class ClasspathInfererTest extends AbstractClassGraphSpec {
         def classpath = []
         factory.getClassPathFor(actionClass, classpath)
         def loader = new VisitableURLClassLoader(ClassLoader.systemClassLoader.parent, classpath)
-        def action = loader.loadClass(CustomAction.name).newInstance()
+        def action = loader.loadClass(CustomAction.name).getConstructor().newInstance()
         action.execute(null)
     }
 
@@ -95,7 +95,7 @@ class ClasspathInfererTest extends AbstractClassGraphSpec {
         def loader
         try {
             loader = new VisitableURLClassLoader(ClassLoader.systemClassLoader.parent, classpath)
-            def action = loader.loadClass(CustomAction.name).newInstance()
+            def action = loader.loadClass(CustomAction.name).getConstructor().newInstance()
             action.execute(null)
         } finally {
             loader?.close()

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/DefaultSerializerTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/DefaultSerializerTest.groovy
@@ -21,7 +21,7 @@ class DefaultSerializerTest extends SerializerSpec {
         DefaultSerializer serializer = new DefaultSerializer(classLoader)
 
         Class cl = classLoader.parseClass('package org.gradle.cache; class TestObj implements Serializable { }')
-        Object o = cl.newInstance()
+        Object o = cl.getConstructor().newInstance()
 
         when:
         def r = serialize(o, serializer)

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/model/NamedObjectInstantiator.java
@@ -191,7 +191,7 @@ public class NamedObjectInstantiator {
         visitor.visitEnd();
         Class<Object> factoryClass = generator.define();
         try {
-            return (ClassGeneratingLoader) (factoryClass.newInstance());
+            return (ClassGeneratingLoader) (factoryClass.getConstructor().newInstance());
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/AbstractAnnotationModelRuleExtractorTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/registry/AbstractAnnotationModelRuleExtractorTest.groovy
@@ -66,7 +66,7 @@ public abstract class AbstractAnnotationModelRuleExtractorTest extends ProjectRe
                     getSubject() >> action.subject
                     getInputs() >> action.inputs
                     execute(_, _) >> { MutableModelNode node, List<ModelView<?>> inputs ->
-                        action.execute(new DefaultModelRuleInvoker(rule.ruleDefinition.method, { rule.ruleDefinition.method.method.declaringClass.newInstance() } as Factory), node, inputs) }
+                        action.execute(new DefaultModelRuleInvoker(rule.ruleDefinition.method, { rule.ruleDefinition.method.method.declaringClass.getConstructor().newInstance() } as Factory), node, inputs) }
                 }
             }
             getScope() >> ModelPath.ROOT

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitIgnoreClassMultiVersionIntegrationSpec/canHandleClassLevelIgnoredTests/src/test/java/org/gradle/CustomIgnoredTest.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitIgnoreClassMultiVersionIntegrationSpec/canHandleClassLevelIgnoredTests/src/test/java/org/gradle/CustomIgnoredTest.java
@@ -57,7 +57,7 @@ public class CustomIgnoredTest {
 
         private org.gradle.CustomIgnoredTest reflectMeATestContainingInstance(Class<? extends org.gradle.CustomIgnoredTest> testClass) {
             try {
-                return testClass.newInstance();
+                return testClass.getConstructor().newInstance();
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessor.java
@@ -120,7 +120,7 @@ public class TestNGTestClassProcessor implements TestClassProcessor {
         //this way, custom listeners are more powerful and, for example, they can change test status.
         for (String listenerClass : options.getListeners()) {
             try {
-                testNg.addListener(applicationClassLoader.loadClass(listenerClass).newInstance());
+                testNg.addListener(applicationClassLoader.loadClass(listenerClass).getConstructor().newInstance());
             } catch (Throwable e) {
                 throw new GradleException(String.format("Could not add a test listener with class '%s'.", listenerClass), e);
             }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r22/BuildActionCrossVersionSpec.groovy
@@ -53,7 +53,7 @@ public class ActionImpl implements ${BuildAction.name}<java.io.File> {
         builder.buildJar(implJar)
 
         def cl1 = new URLClassLoader([implJar.toURI().toURL()] as URL[], getClass().classLoader)
-        def action1 = cl1.loadClass("ActionImpl").newInstance()
+        def action1 = cl1.loadClass("ActionImpl").getConstructor().newInstance()
 
         when:
         File actualJar1 = withConnection { ProjectConnection connection ->
@@ -76,7 +76,7 @@ public class ActionImpl implements ${BuildAction.name}<String> {
 """
         builder.buildJar(implJar)
         def cl2 = new URLClassLoader([implJar.toURI().toURL()] as URL[], getClass().classLoader)
-        def action2 = cl2.loadClass("ActionImpl").newInstance()
+        def action2 = cl2.loadClass("ActionImpl").getConstructor().newInstance()
 
         String result2 = withConnection { ProjectConnection connection ->
             connection.action(action2).run()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r32/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r32/BuildActionCrossVersionSpec.groovy
@@ -45,11 +45,11 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         expect:
         def l1 = withConnection { c ->
-            return c.action(action1.newInstance()).run()
+            return c.action(action1.getConstructor().newInstance()).run()
         }
         l1 == ["not broken 1"]
         def l2 = withConnection { c ->
-            return c.action(action2.newInstance()).run()
+            return c.action(action2.getConstructor().newInstance()).run()
         }
         l2 == ["not broken 2"]
     }
@@ -77,11 +77,11 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         expect:
         def l1 = withConnection { c ->
-            return c.action(action1.newInstance()).run()
+            return c.action(action1.getConstructor().newInstance()).run()
         }
         l1 == ["not broken 1"]
         def l2 = withConnection { c ->
-            return c.action(action2.newInstance()).run()
+            return c.action(action2.getConstructor().newInstance()).run()
         }
         l2 == ["not broken 1"]
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r34/BuildActionCrossVersionSpec.groovy
@@ -47,7 +47,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         when:
         def classloader = new URLClassLoader([jar.toURL()] as URL[], getClass().classLoader)
-        def action = classloader.loadClass("ActionImpl").newInstance()
+        def action = classloader.loadClass("ActionImpl").getConstructor().newInstance()
         withConnection { ProjectConnection connection ->
             connection.action(action).run()
         }


### PR DESCRIPTION
### Context

`Class.newInstance()` was deprecated in Java 9. Let's remove it from our code.