### PR TITLE
fix: remove the double "Example" prefix in base_plugin doc

### DIFF
--- a/subprojects/docs/src/docs/userguide/base_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/base_plugin.adoc
@@ -21,7 +21,7 @@ The Base Plugin provides some tasks and conventions that are common to most buil
 == Usage
 
 
-.Example: Applying the Base Plugin
+.Applying the Base Plugin
 ====
 include::sample[dir="userguide/basePlugin/groovy",files="build.gradle[tags=apply-base-plugin]"]
 include::sample[dir="userguide/basePlugin/kotlin",files="build.gradle.kts[tags=apply-base-plugin]"]


### PR DESCRIPTION
Issue #6442

Signed-off-by: jnizet <jb@ninja-squad.com>
### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
