### PR TITLE
Platform edges shouldn't be transitive

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -49,14 +49,16 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     private final ModuleComponentIdentifier componentId;
     private final ComponentIdentifier platformId; // just for reporting
     private final boolean force;
+    private final boolean transitive;
 
-    LenientPlatformDependencyMetadata(ResolveState resolveState, NodeState from, ModuleComponentSelector cs, ModuleComponentIdentifier componentId, ComponentIdentifier platformId, boolean force) {
+    LenientPlatformDependencyMetadata(ResolveState resolveState, NodeState from, ModuleComponentSelector cs, ModuleComponentIdentifier componentId, ComponentIdentifier platformId, boolean force, boolean transitive) {
         this.resolveState = resolveState;
         this.from = from;
         this.cs = cs;
         this.componentId = componentId;
         this.platformId = platformId;
         this.force = force;
+        this.transitive = transitive;
     }
 
     @Override
@@ -106,7 +108,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
 
     @Override
     public boolean isTransitive() {
-        return true;
+        return transitive;
     }
 
     @Override
@@ -159,7 +161,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
                         }
                         if (!componentVersion.equals(target)) {
                             // We will only add dependencies to the leaves if there is such a published module
-                            PotentialEdge potentialEdge = PotentialEdge.of(resolveState, from, leafId, leafSelector, platformId, platformState.isForced());
+                            PotentialEdge potentialEdge = PotentialEdge.of(resolveState, from, leafId, leafSelector, platformId, platformState.isForced(), false);
                             if (potentialEdge.metadata != null) {
                                 result = registerPlatformEdge(result, modules, leafId, leafSelector, platformId, platformState.isForced());
                                 break;
@@ -185,7 +187,8 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
                 leafSelector,
                 leafId,
                 platformId,
-                force
+                force,
+                false
             ));
             return result;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PotentialEdge.java
@@ -44,11 +44,11 @@ class PotentialEdge {
     }
 
     static PotentialEdge of(ResolveState resolveState, NodeState from, ModuleComponentIdentifier toComponent, ModuleComponentSelector toSelector, ComponentIdentifier owner) {
-        return of(resolveState, from, toComponent, toSelector, owner, false);
+        return of(resolveState, from, toComponent, toSelector, owner, false, true);
     }
 
-    static PotentialEdge of(ResolveState resolveState, NodeState from, ModuleComponentIdentifier toComponent, ModuleComponentSelector toSelector, ComponentIdentifier owner, boolean force) {
-        DependencyState dependencyState = new DependencyState(new LenientPlatformDependencyMetadata(resolveState, from, toSelector, toComponent, owner, force || isForce(from)), resolveState.getComponentSelectorConverter());
+    static PotentialEdge of(ResolveState resolveState, NodeState from, ModuleComponentIdentifier toComponent, ModuleComponentSelector toSelector, ComponentIdentifier owner, boolean force, boolean transitive) {
+        DependencyState dependencyState = new DependencyState(new LenientPlatformDependencyMetadata(resolveState, from, toSelector, toComponent, owner, force || isForce(from), transitive), resolveState.getComponentSelectorConverter());
         dependencyState = NodeState.maybeSubstitute(dependencyState, resolveState.getDependencySubstitutionApplicator());
         EdgeState edge = new EdgeState(from, dependencyState, from.previousTraversalExclusions, resolveState);
         ModuleVersionIdentifier toModuleVersionId = DefaultModuleVersionIdentifier.newId(toSelector.getModuleIdentifier(), toSelector.getVersion());


### PR DESCRIPTION
### Context

This commit fixes the transitivity of virtual platform edges, by
making them non transitive.

Fixes nebula-plugins/gradle-nebula-integration#26
