### PR TITLE
Ensure plugin bootstrapping in composites works without workarounds

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -132,10 +132,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
 
         applyPlugin(buildA)
 
-        includeBuild pluginBuild, """
-            // Only substitute version 1.0 with project dependency. This allows this project to build with the published dependency.
-            substitute module("org.test:pluginBuild:1.0") with project(":")
-        """
+        includeBuild pluginBuild
 
         when:
         execute(buildA, "tasks")


### PR DESCRIPTION
When a plugin is built inside a composite build and that plugin uses
and older version of itself to build itself, it should not be substituted
into its own `buildscript {}` classpath. This only used to work with some
workarounds, making composites unnecessarily hard to use in that case.
Since Gradle 4.9 this works out of the box. This test change just makes
sure we don't regress again like we did in Gradle 4.1.