### PR TITLE
Mention build scans in 4.10 release notes 

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -55,13 +55,13 @@ Caching has always been one of the strong suits of Gradle. Over time, more and m
 ### Kotlin DSL 1.0 RC
 
 [Kotlin DSL version 1.0 RC](https://github.com/gradle/kotlin-dsl/releases/tag/v1.0-RC3) is now available. Major updates from v0.18 include:
- 
+
  * API Documentation in IDE and reference forms
  * Script compilation build cache
  * IDE integration improvements
  * Support for configuration avoidance
  * `buildSrc` refactoring propagation to the IDE
- 
+
 This version includes the last set of backward compatibility-breaking DSL changes until Gradle 6.0.
 
 Please give it a go and file issues in the [gradle/kotlin-dsl](https://github.com/gradle/kotlin-dsl) project.
@@ -103,6 +103,21 @@ However, we strongly recommend that build and plugin authors use Gradle properti
 
 Memory usage for up-to-date checking has been improved.
 For the gradle/gradle build, heap usage dropped by 60 MB to 450 MB, that is a 12% reduction.
+
+### More build insights with Gradle build scan plugin 1.16
+
+Using build scan plugin version >= 1.16 and Gradle 4.10 provides you deeper insights of your build, for example   
+
+- Sources of slow configuration lifecycle callbacks
+- Build script compilation
+- Build deprecation warnings
+- Dependency repositories
+
+in your build scans.
+
+You can enable build scans by running your build with `--scan`.
+
+For further details and getting started with Gradle build scans check the [Build Scan Plugin User Manual](https://docs.gradle.com/build-scan-plugin/).
 
 ## Promoted features
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -106,29 +106,9 @@ For the gradle/gradle build, heap usage dropped by 60 MB to 450 MB, that is a 12
 
 ### Build Scan Plugin default version updated to 1.16
 
-The default build scan plugin version has been updated to. This version provides you new insights of your build, for example:
+The built-in build scan plugin version has been updated to 1.16. When used with Gradle Enterprise 2018.4 or [scans.gradle.com](https://scans.gradle.com/), this provides deeper configuration time profiling, dependency repository insights, deprecated Gradle functionality usage analysis, and more.
 
-- Sources of slow configuration lifecycle callbacks
-- Build script compilation
-- Build deprecation warnings
-- Dependency repositories
-
-in build scans.
-
-You can enable build scans by running your build with `--scan`.
-
-For further details and getting started with Gradle build scans check the [Build Scan Plugin User Manual](https://docs.gradle.com/build-scan-plugin/).
-
-## Promoted features
-
-Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
-See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
-
-The following are the features that have been promoted in this Gradle release.
-
-<!--
-### Example promoted
--->
+For more information on how to use build scans, see [https://scans.gradle.com/](https://scans.gradle.com/). For more information on new features in Gradle Enterprise 2018.4, see the [Gradle Enterprise 2018.4 Release Notes](https://gradle.com/enterprise/releases/2018.4/).
 
 ## Fixed issues
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -104,16 +104,16 @@ However, we strongly recommend that build and plugin authors use Gradle properti
 Memory usage for up-to-date checking has been improved.
 For the gradle/gradle build, heap usage dropped by 60 MB to 450 MB, that is a 12% reduction.
 
-### More build insights with Gradle build scan plugin 1.16
+### Build Scan Plugin default version updated to 1.16
 
-Using build scan plugin version >= 1.16 and Gradle 4.10 provides you deeper insights of your build, for example   
+The default build scan plugin version has been updated to. This version provides you new insights of your build, for example:
 
 - Sources of slow configuration lifecycle callbacks
 - Build script compilation
 - Build deprecation warnings
 - Dependency repositories
 
-in your build scans.
+in build scans.
 
 You can enable build scans by running your build with `--scan`.
 


### PR DESCRIPTION
### Context

Added a section to the release notes mentioning the new defaulit build scan plugin version 1.16.