### PR TITLE
Make dependency locking errors lenient

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -180,8 +180,8 @@ dependencies {
 
         then:
         failure.assertHasCause("Could not resolve all dependencies for configuration ':lockedConf'.")
-        failure.assertHasCause("Did not resolve 'org:bar:1.0' which is part of the lock state")
-        failure.assertHasCause("Did not resolve 'org:baz:1.0' which is part of the lock state")
+        failure.assertHasCause("Did not resolve 'org:bar:1.0' which is part of the dependency lock state")
+        failure.assertHasCause("Did not resolve 'org:baz:1.0' which is part of the dependency lock state")
     }
 
     def 'fails when lock file does not contain entry for module in resolution result'() {
@@ -216,7 +216,7 @@ dependencies {
 
         then:
         failure.assertHasCause("Could not resolve all dependencies for configuration ':lockedConf'.")
-        failure.assertHasCause("Resolved 'org:bar:1.0' which is not part of the lock state")
+        failure.assertHasCause("Resolved 'org:bar:1.0' which is not part of the dependency lock state")
     }
 
     def 'fails when resolution result is empty and lock file contains entries'() {
@@ -239,10 +239,11 @@ configurations {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
-        fails 'dependencies'
+        fails 'checkDeps'
 
         then:
-        failure.assertHasCause('Dependency lock state for configuration \'lockedConf\' is out of date: Did not resolve \'org:foo:1.0\' which is part of the lock state')
+        failure.assertHasCause('Could not resolve all dependencies for configuration \':lockedConf\'.')
+        failure.assertHasCause('Did not resolve \'org:foo:1.0\' which is part of the dependency lock state')
     }
 
     def 'succeeds without lock file present and does not create one'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -173,13 +173,15 @@ dependencies {
 }
 """
 
-        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
+        lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0', 'org:baz:1.0'])
 
         when:
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("Dependency lock state for configuration 'lockedConf' is out of date: Did not resolve 'org:bar:1.0' which is part of the lock state")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':lockedConf'.")
+        failure.assertHasCause("Did not resolve 'org:bar:1.0' which is part of the lock state")
+        failure.assertHasCause("Did not resolve 'org:baz:1.0' which is part of the lock state")
     }
 
     def 'fails when lock file does not contain entry for module in resolution result'() {
@@ -210,10 +212,11 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:foo:1.0'])
 
         when:
-        fails 'dependencies'
+        fails 'checkDeps'
 
         then:
-        failure.assertHasCause("Dependency lock state for configuration 'lockedConf' is out of date: Resolved 'org:bar:1.0' which is not part of the lock state")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':lockedConf'.")
+        failure.assertHasCause("Resolved 'org:bar:1.0' which is not part of the lock state")
     }
 
     def 'fails when resolution result is empty and lock file contains entries'() {
@@ -374,7 +377,9 @@ dependencies {
         outputContains """lockedConf
 +--- org:foo:[1.0, 1.1] FAILED
 +--- org:foo:1.1 FAILED
-\\--- org:foo:1.0 FAILED"""
++--- org:foo:1.0 FAILED
+\\--- org:bar:1.0 FAILED
+"""
     }
 
     def 'writes dependency lock file when requested'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -173,7 +173,7 @@ buildscript {
         fails 'buildEnvironment'
 
         then:
-        failureCauseContains('Dependency lock state for configuration \'classpath\' is out of date')
+        failureCauseContains('Did not resolve \'org.foo:foo-plugin:1.0\' which is part of the dependency lock state')
     }
 
     def 'same name buildscript and project configurations result in different lock files'() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -68,6 +68,7 @@ import org.gradle.internal.locking.DependencyLockingArtifactVisitor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.util.CollectionUtils;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -125,7 +126,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
         DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(currentBuild, buildProjectDependencies, resolutionStrategy.getSortOrder());
         resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, failureCollector, artifactsVisitor, attributesSchema, artifactTypeRegistry);
-        result.graphResolved(new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(), artifactsVisitor.complete(), artifactTransforms));
+        result.graphResolved(new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.<UnresolvedDependency>emptySet()), artifactsVisitor.complete(), artifactTransforms));
     }
 
     public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) {
@@ -157,8 +158,9 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         if (resolutionStrategy.getConflictResolution() == ConflictResolution.strict) {
             visitors.add(new FailOnVersionConflictArtifactsVisitor(configuration.getModule().getProjectPath(), configuration.getName()));
         }
+        DependencyLockingArtifactVisitor lockingVisitor = null;
         if (resolutionStrategy.isDependencyLockingEnabled()) {
-            DependencyLockingArtifactVisitor lockingVisitor = new DependencyLockingArtifactVisitor(configuration.getName(), resolutionStrategy.getDependencyLockingProvider());
+            lockingVisitor = new DependencyLockingArtifactVisitor(configuration.getName(), resolutionStrategy.getDependencyLockingProvider());
             visitors.add(lockingVisitor);
         }
         ImmutableList<DependencyArtifactsVisitor> allVisitors = visitors.build();
@@ -170,8 +172,13 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         VisitedFileDependencyResults fileDependencyResults = fileDependencyVisitor.complete();
         ResolvedGraphResults graphResults = oldModelBuilder.complete();
 
-        Set<UnresolvedDependency> failures = failureCollector.complete();
-        results.graphResolved(newModelBuilder.complete(), localComponentsVisitor, new BuildDependenciesOnlyVisitedArtifactSet(failures, artifactsResults, artifactTransforms));
+        // Append to failures for locking and fail on version conflict
+        Set<UnresolvedDependency> extraFailures = Collections.emptySet();
+        if (lockingVisitor != null) {
+            extraFailures = lockingVisitor.collectLockingFailures(extraFailures);
+        }
+        Set<UnresolvedDependency> failures = failureCollector.complete(extraFailures);
+        results.graphResolved(newModelBuilder.complete(extraFailures), localComponentsVisitor, new BuildDependenciesOnlyVisitedArtifactSet(failures, artifactsResults, artifactTransforms));
 
         results.retainState(new ArtifactResolveState(graphResults, artifactsResults, fileDependencyResults, failures, oldTransientModelBuilder));
         if (!results.hasError() && failures.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -173,10 +173,9 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolvedGraphResults graphResults = oldModelBuilder.complete();
 
         // Append to failures for locking and fail on version conflict
-        Set<UnresolvedDependency> extraFailures = Collections.emptySet();
-        if (lockingVisitor != null) {
-            extraFailures = lockingVisitor.collectLockingFailures(extraFailures);
-        }
+        Set<UnresolvedDependency> extraFailures = lockingVisitor == null
+            ? Collections.<UnresolvedDependency>emptySet()
+            : lockingVisitor.collectLockingFailures();
         Set<UnresolvedDependency> failures = failureCollector.complete(extraFailures);
         results.graphResolved(newModelBuilder.complete(extraFailures), localComponentsVisitor, new BuildDependenciesOnlyVisitedArtifactSet(failures, artifactsResults, artifactTransforms));
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice;
 
-import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.LenientConfiguration;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
@@ -46,10 +45,8 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Default
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.locking.LockOutOfDateException;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -91,31 +88,27 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
     }
 
     private void emptyGraph(ConfigurationInternal configuration, ResolverResults results, boolean verifyLocking) {
+        if (verifyLocking && configuration.getResolutionStrategy().isDependencyLockingEnabled()) {
+            DependencyLockingProvider dependencyLockingProvider = configuration.getResolutionStrategy().getDependencyLockingProvider();
+            DependencyLockingState lockingState = dependencyLockingProvider.loadLockState(configuration.getName());
+            if (lockingState.mustValidateLockState() && !lockingState.getLockedDependencies().isEmpty()) {
+                // Invalid lock state, need to do a real resolution to gather locking failures
+                delegate.resolveGraph(configuration, results);
+                return;
+            }
+            dependencyLockingProvider.persistResolvedDependencies(configuration.getName(), Collections.<ModuleComponentIdentifier>emptySet(), Collections.<ModuleComponentIdentifier>emptySet());
+        }
         Module module = configuration.getModule();
         ModuleVersionIdentifier id = moduleIdentifierFactory.moduleWithVersion(module);
         ComponentIdentifier componentIdentifier = componentIdentifierFactory.createComponentIdentifier(module);
         ResolutionResult emptyResult = DefaultResolutionResultBuilder.empty(id, componentIdentifier);
         ResolvedLocalComponentsResult emptyProjectResult = new ResolvedLocalComponentsResultGraphVisitor(thisBuild);
-        if (verifyLocking && configuration.getResolutionStrategy().isDependencyLockingEnabled()) {
-            DependencyLockingProvider dependencyLockingProvider = configuration.getResolutionStrategy().getDependencyLockingProvider();
-            DependencyLockingState lockingState = dependencyLockingProvider.loadLockState(configuration.getName());
-            if (lockingState.mustValidateLockState() && !lockingState.getLockedDependencies().isEmpty()) {
-                ArrayList<String> errors = Lists.newArrayListWithCapacity(lockingState.getLockedDependencies().size());
-                for (ModuleComponentIdentifier lockedDependency : lockingState.getLockedDependencies()) {
-                    errors.add("Did not resolve '" + lockedDependency.getGroup() + ":" + lockedDependency.getModule() + ":" + lockedDependency.getVersion() + "' which is part of the lock state");
-                }
-                results.graphResolved(emptyResult, emptyProjectResult, EmptyResults.INSTANCE);
-                // TODO LJA Transform this to be lenient
-                throw LockOutOfDateException.createLockOutOfDateException(configuration.getName(), errors);
-            }
-            dependencyLockingProvider.persistResolvedDependencies(configuration.getName(), Collections.<ModuleComponentIdentifier>emptySet(), Collections.<ModuleComponentIdentifier>emptySet());
-        }
         results.graphResolved(emptyResult, emptyProjectResult, EmptyResults.INSTANCE);
     }
 
     @Override
     public void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
-        if (configuration.getAllDependencies().isEmpty()) {
+        if (configuration.getAllDependencies().isEmpty() && results.getVisitedArtifacts() == EmptyResults.INSTANCE) {
             results.artifactsResolved(new EmptyResolvedConfiguration(), EmptyResults.INSTANCE);
         } else {
             delegate.resolveArtifacts(configuration, results);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolver.java
@@ -105,6 +105,7 @@ public class ShortCircuitEmptyConfigurationResolver implements ConfigurationReso
                     errors.add("Did not resolve '" + lockedDependency.getGroup() + ":" + lockedDependency.getModule() + ":" + lockedDependency.getVersion() + "' which is part of the lock state");
                 }
                 results.graphResolved(emptyResult, emptyProjectResult, EmptyResults.INSTANCE);
+                // TODO LJA Transform this to be lenient
                 throw LockOutOfDateException.createLockOutOfDateException(configuration.getName(), errors);
             }
             dependencyLockingProvider.persistResolvedDependencies(configuration.getName(), Collections.<ModuleComponentIdentifier>emptySet(), Collections.<ModuleComponentIdentifier>emptySet());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
@@ -74,11 +74,12 @@ public class ResolutionFailureCollector implements DependencyGraphVisitor {
     public void finish(DependencyGraphNode root) {
     }
 
-    public Set<UnresolvedDependency> complete() {
-        if (failuresByRevisionId.isEmpty()) {
+    public Set<UnresolvedDependency> complete(Set<UnresolvedDependency> extraFailures) {
+        if (extraFailures.isEmpty() && failuresByRevisionId.isEmpty()) {
             return ImmutableSet.of();
         }
         ImmutableSet.Builder<UnresolvedDependency> builder = ImmutableSet.builder();
+        builder.addAll(extraFailures);
         for (Map.Entry<ComponentSelector, BrokenDependency> entry : failuresByRevisionId.entrySet()) {
             Collection<List<ComponentIdentifier>> paths = DependencyGraphPathResolver.calculatePaths(entry.getValue().requiredBy, root);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -143,22 +143,22 @@ public class DependencyLockingArtifactVisitor implements ValidatingArtifactsVisi
         if (dependencyLockingState.mustValidateLockState()) {
             if (!modulesToBeLocked.isEmpty() || !extraModules.isEmpty()) {
                 lockOutOfDate = true;
-                return createFailures(failures, modulesToBeLocked, extraModules);
+                return createLockingFailures(failures, modulesToBeLocked, extraModules);
             }
         }
         return Collections.emptySet();
     }
 
-    private Set<UnresolvedDependency> createFailures(Set<UnresolvedDependency> extraFailures, Map<ModuleIdentifier, ModuleComponentIdentifier> modulesToBeLocked, Set<ModuleComponentIdentifier> extraModules) {
+    public static Set<UnresolvedDependency> createLockingFailures(Set<UnresolvedDependency> extraFailures, Map<ModuleIdentifier, ModuleComponentIdentifier> modulesToBeLocked, Set<ModuleComponentIdentifier> extraModules) {
         Set<UnresolvedDependency> completedFailures = Sets.newHashSetWithExpectedSize(extraFailures.size() + modulesToBeLocked.values().size() + extraModules.size());
         completedFailures.addAll(extraFailures);
         for (ModuleComponentIdentifier presentInLock : modulesToBeLocked.values()) {
             completedFailures.add(new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector(presentInLock.getModuleIdentifier(), presentInLock.getVersion()),
-                                  new LockOutOfDateException("Did not resolve '" + presentInLock.getDisplayName() + "' which is part of the lock state")));
+                                  new LockOutOfDateException("Did not resolve '" + presentInLock.getDisplayName() + "' which is part of the dependency lock state")));
         }
         for (ModuleComponentIdentifier extraModule : extraModules) {
             completedFailures.add(new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector(extraModule.getModuleIdentifier(), extraModule.getVersion()),
-                new LockOutOfDateException("Resolved '" + extraModule.getDisplayName() + "' which is not part of the lock state")));
+                new LockOutOfDateException("Resolved '" + extraModule.getDisplayName() + "' which is not part of the dependency lock state")));
         }
         return completedFailures;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -135,23 +135,20 @@ public class DependencyLockingArtifactVisitor implements ValidatingArtifactsVisi
      * This will transform any lock out of date result into an {@link UnresolvedDependency} in order to plug into lenient resolution.
      * This happens only if there are no previous failures as otherwise lock state can't be asserted.
      *
-     * @param failures
-     *
      * @return the existing failures augmented with any locking related one
      */
-    public Set<UnresolvedDependency> collectLockingFailures(Set<UnresolvedDependency> failures) {
+    public Set<UnresolvedDependency> collectLockingFailures() {
         if (dependencyLockingState.mustValidateLockState()) {
             if (!modulesToBeLocked.isEmpty() || !extraModules.isEmpty()) {
                 lockOutOfDate = true;
-                return createLockingFailures(failures, modulesToBeLocked, extraModules);
+                return createLockingFailures(modulesToBeLocked, extraModules);
             }
         }
         return Collections.emptySet();
     }
 
-    public static Set<UnresolvedDependency> createLockingFailures(Set<UnresolvedDependency> extraFailures, Map<ModuleIdentifier, ModuleComponentIdentifier> modulesToBeLocked, Set<ModuleComponentIdentifier> extraModules) {
-        Set<UnresolvedDependency> completedFailures = Sets.newHashSetWithExpectedSize(extraFailures.size() + modulesToBeLocked.values().size() + extraModules.size());
-        completedFailures.addAll(extraFailures);
+    private static Set<UnresolvedDependency> createLockingFailures(Map<ModuleIdentifier, ModuleComponentIdentifier> modulesToBeLocked, Set<ModuleComponentIdentifier> extraModules) {
+        Set<UnresolvedDependency> completedFailures = Sets.newHashSetWithExpectedSize(modulesToBeLocked.values().size() + extraModules.size());
         for (ModuleComponentIdentifier presentInLock : modulesToBeLocked.values()) {
             completedFailures.add(new DefaultUnresolvedDependency(DefaultModuleVersionSelector.newSelector(presentInLock.getModuleIdentifier(), presentInLock.getVersion()),
                                   new LockOutOfDateException("Did not resolve '" + presentInLock.getDisplayName() + "' which is part of the dependency lock state")));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockOutOfDateException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/LockOutOfDateException.java
@@ -22,6 +22,8 @@ import org.gradle.internal.text.TreeFormatter;
 
 import java.util.List;
 
+import static java.util.Collections.emptyList;
+
 public class LockOutOfDateException extends GraphValidationException {
 
     private final List<String> errors;
@@ -35,6 +37,11 @@ public class LockOutOfDateException extends GraphValidationException {
         }
         treeFormatter.endChildren();
         return new LockOutOfDateException(treeFormatter.toString(), ImmutableList.copyOf(errors));
+    }
+
+    public LockOutOfDateException(String message) {
+        super(message);
+        this.errors = emptyList();
     }
 
     private LockOutOfDateException(String message, List<String> errors) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilderTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
+import static java.util.Collections.emptySet
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ResolutionResultPrinter.printGraph
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.VersionSelectionReasons.*
 
@@ -49,7 +50,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(rootNode)
 
         when:
-        def result = builder.complete()
+        def result = builder.complete(emptySet())
 
         then:
         with(result) {
@@ -81,7 +82,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete()
+        def result = builder.complete(emptySet())
 
         then:
         printGraph(result.root) == """org:root:1.0
@@ -110,7 +111,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete()
+        def result = builder.complete(emptySet())
 
         then:
         printGraph(result.root) == """org:root:1.0
@@ -150,7 +151,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete()
+        def result = builder.complete(emptySet())
 
         then:
         printGraph(result.root) == """org:root:1.0
@@ -189,7 +190,7 @@ class StreamingResolutionResultBuilderTest extends Specification {
         builder.finish(root)
 
         when:
-        def result = builder.complete()
+        def result = builder.complete(emptySet())
 
         then:
         printGraph(result.root) == """org:root:1.0

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -143,7 +143,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         addVisitedNode(newId(mid, '1.0'))
 
         when:
-        def failures = visitor.collectLockingFailures(emptySet())
+        def failures = visitor.collectLockingFailures()
 
         then:
         failures.size() == 1
@@ -158,7 +158,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         startWithState([newId(mid, '1.1')])
 
         when:
-        def failures = visitor.collectLockingFailures(emptySet())
+        def failures = visitor.collectLockingFailures()
 
         then:
         failures.size() == 1

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -137,29 +137,35 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         notThrown(LockOutOfDateException)
     }
 
-    def 'throws when extra modules visited'() {
+    def 'generates failures when extra modules visited'() {
         given:
         startWithState([])
         addVisitedNode(newId(mid, '1.0'))
 
         when:
-        visitor.complete()
+        def failures = visitor.collectLockingFailures(emptySet())
 
         then:
-        def ex = thrown(LockOutOfDateException)
-        ex.message.contains("Resolved 'org:foo:1.0' which is not part of the lock state")
+        failures.size() == 1
+        failures.each {
+            assert it.problem instanceof LockOutOfDateException
+            assert it.problem.message.contains("Resolved 'org:foo:1.0' which is not part of the lock state")
+        }
     }
 
-    def 'throws when module not visited'() {
+    def 'generates failures when module not visited'() {
         given:
         startWithState([newId(mid, '1.1')])
 
         when:
-        visitor.complete()
+        def failures = visitor.collectLockingFailures(emptySet())
 
         then:
-        def ex = thrown(LockOutOfDateException)
-        ex.message.contains("Did not resolve 'org:foo:1.1' which is part of the lock state")
+        failures.size() == 1
+        failures.each {
+            assert it.problem instanceof LockOutOfDateException
+            assert it.problem.message.contains("Did not resolve 'org:foo:1.1' which is part of the lock state")
+        }
     }
 
     def 'invokes locking provider on complete with visited modules'() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -149,7 +149,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         failures.size() == 1
         failures.each {
             assert it.problem instanceof LockOutOfDateException
-            assert it.problem.message.contains("Resolved 'org:foo:1.0' which is not part of the lock state")
+            assert it.problem.message.contains("Resolved 'org:foo:1.0' which is not part of the dependency lock state")
         }
     }
 
@@ -164,7 +164,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         failures.size() == 1
         failures.each {
             assert it.problem instanceof LockOutOfDateException
-            assert it.problem.message.contains("Did not resolve 'org:foo:1.1' which is part of the lock state")
+            assert it.problem.message.contains("Did not resolve 'org:foo:1.1' which is part of the dependency lock state")
         }
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -453,17 +453,19 @@ dependencies {
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:
-        outputContains """The dependency locks are out-of-date:
-   - Did not resolve 'org:bar:1.0' which is part of the lock state
-   - Resolved 'org:foo:1.1' which is not part of the lock state
+        outputContains """org:foo:1.1 FAILED
+   Selection reasons:
+      - By constraint : Dependency locking
+   Failures:
+      - Dependency lock state out of date:
+          - Resolved 'org:foo:1.1' which is not part of the lock state
 
-org:foo:1.1
-   variant "default" [
-      org.gradle.status = release (not requested)
-   ]
+org:foo:1.1 FAILED
+\\--- lockedConf
 
 org:foo:1.+ -> 1.1
-\\--- lockedConf"""
+\\--- lockedConf
+"""
     }
 
     def "displays a dependency insight report even if locks are out of date because of new constraint"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -458,7 +458,7 @@ dependencies {
       - By constraint : Dependency locking
    Failures:
       - Dependency lock state out of date:
-          - Resolved 'org:foo:1.1' which is not part of the lock state
+          - Resolved 'org:foo:1.1' which is not part of the dependency lock state
 
 org:foo:1.1 FAILED
 \\--- lockedConf

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencyLockingIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencyLockingIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.plugins.ide.eclipse
 
-import org.gradle.util.ToBeImplemented
-import org.junit.Ignore
 import org.junit.Test
 
 class EclipseDependencyLockingIntegrationTest extends AbstractEclipseIntegrationTest {
@@ -58,8 +56,6 @@ dependencies {
         libraries[0].assertHasJar(repoJar)
     }
 
-    @ToBeImplemented
-    @Ignore
     @Test
     void "does not break when extra dependency not in lockfile is defined"() {
         //given
@@ -93,7 +89,7 @@ dependencies {
 
         //then
         def libraries = classpath.libs
-        assert libraries.size() == 2
+        assert libraries.size() == 3
         libraries[0].assertHasJar(artifactOne)
         libraries[1].assertHasJar(artifactTwo)
     }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencyLockingIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseDependencyLockingIntegrationTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse
+
+import org.gradle.util.ToBeImplemented
+import org.junit.Ignore
+import org.junit.Test
+
+class EclipseDependencyLockingIntegrationTest extends AbstractEclipseIntegrationTest {
+
+    @Test
+    void "does not break when lockfile is out of date"() {
+        //given
+        def mvnRepo = maven(file("repo"))
+        mvnRepo.module("groupOne", "artifactTwo").publish()
+        mvnRepo.module("groupOne", "artifactTwo", "1.1").publish()
+        def repoJar = mvnRepo.module("groupOne", "artifactTwo", "2.0").publish().artifactFile
+
+        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactTwo:1.1'
+
+        //when
+        runEclipseTask """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+repositories {
+    maven { url "${mvnRepo.uri}" }
+}
+
+configurations {
+    compileClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+dependencies {
+    compile 'groupOne:artifactTwo:[2.0,3.0)'
+}
+"""
+
+        //then
+        def libraries = classpath.libs
+        assert libraries.size() == 3
+        libraries[0].assertHasJar(repoJar)
+    }
+
+    @ToBeImplemented
+    @Ignore
+    @Test
+    void "does not break when extra dependency not in lockfile is defined"() {
+        //given
+        def mvnRepo = maven(file("repo"))
+        mvnRepo.module("groupOne", "artifactOne").publish()
+        def artifactOne = mvnRepo.module("groupOne", "artifactOne", "1.1").publish().artifactFile
+        def artifactTwo = mvnRepo.module("groupOne", "artifactTwo", "2.0").publish().artifactFile
+
+        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactOne:1.1'
+
+        //when
+        runEclipseTask """
+apply plugin: 'java'
+apply plugin: 'eclipse'
+
+repositories {
+    maven { url "${mvnRepo.uri}" }
+}
+
+configurations {
+    compileClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+dependencies {
+    compile 'groupOne:artifactOne:[1.0,2.0)'
+    compile 'groupOne:artifactTwo:[2.0,3.0)'
+}
+"""
+
+        //then
+        def libraries = classpath.libs
+        assert libraries.size() == 2
+        libraries[0].assertHasJar(artifactOne)
+        libraries[1].assertHasJar(artifactTwo)
+    }
+
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencyLockingIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencyLockingIntegrationTest.groovy
@@ -17,8 +17,6 @@
 package org.gradle.plugins.ide.idea
 
 import org.gradle.plugins.ide.AbstractIdeIntegrationTest
-import org.gradle.util.ToBeImplemented
-import org.junit.Ignore
 import org.junit.Test
 
 class IdeaDependencyLockingIntegrationTest extends AbstractIdeIntegrationTest {
@@ -56,10 +54,9 @@ dependencies {
 
         //then
         assert content.count("artifactTwo-2.0.jar") == 1
+        assert content.count("unresolved dependency - groupOne artifactTwo") >= 1
     }
 
-    @ToBeImplemented
-    @Ignore
     @Test
     void "does not break when extra dependency not in lockfile is defined"() {
         //given
@@ -93,7 +90,9 @@ dependencies {
         def content = getFile([print : true], 'root.iml').text
 
         //then
+        assert content.count("artifactOne-1.1.jar") == 1
         assert content.count("artifactTwo-2.0.jar") == 1
+        assert content.count("unresolved dependency - groupOne artifactTwo 2.0") == 1
     }
 
 }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencyLockingIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaDependencyLockingIntegrationTest.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.idea
+
+import org.gradle.plugins.ide.AbstractIdeIntegrationTest
+import org.gradle.util.ToBeImplemented
+import org.junit.Ignore
+import org.junit.Test
+
+class IdeaDependencyLockingIntegrationTest extends AbstractIdeIntegrationTest {
+
+    @Test
+    void "does not break when lockfile is out of date"() {
+        //given
+        def mvnRepo = maven(file("repo"))
+        mvnRepo.module("groupOne", "artifactTwo").publish()
+        mvnRepo.module("groupOne", "artifactTwo", "1.1").publish()
+        mvnRepo.module("groupOne", "artifactTwo", "2.0").publish()
+
+        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactTwo:1.1'
+
+        //when
+        runIdeaTask """
+apply plugin: 'java'
+apply plugin: 'idea'
+
+repositories {
+    maven { url "${mvnRepo.uri}" }
+}
+
+configurations {
+    compileClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+dependencies {
+    compile 'groupOne:artifactTwo:[2.0,3.0)'
+}
+"""
+        def content = getFile([print : true], 'root.iml').text
+
+        //then
+        assert content.count("artifactTwo-2.0.jar") == 1
+    }
+
+    @ToBeImplemented
+    @Ignore
+    @Test
+    void "does not break when extra dependency not in lockfile is defined"() {
+        //given
+        def mvnRepo = maven(file("repo"))
+        mvnRepo.module("groupOne", "artifactOne").publish()
+        mvnRepo.module("groupOne", "artifactOne", "1.1").publish()
+        mvnRepo.module("groupOne", "artifactTwo", "2.0").publish()
+
+        file('gradle/dependency-locks/compileClasspath.lockfile') << 'groupOne:artifactOne:1.1'
+
+        //when
+        runIdeaTask """
+apply plugin: 'java'
+apply plugin: 'idea'
+
+repositories {
+    maven { url "${mvnRepo.uri}" }
+}
+
+configurations {
+    compileClasspath {
+        resolutionStrategy.activateDependencyLocking()
+    }
+}
+
+dependencies {
+    compile 'groupOne:artifactOne:[1.0,2.0)'
+    compile 'groupOne:artifactTwo:[2.0,3.0)'
+}
+"""
+        def content = getFile([print : true], 'root.iml').text
+
+        //then
+        assert content.count("artifactTwo-2.0.jar") == 1
+    }
+
+}


### PR DESCRIPTION
Dependency resolution has a lenient resolution mode, where resolution failures still allow some interactions with the resolved graph.
Dependency locking was not leveraging that feature and thus caused interaction issues with systems that rely on this feature, such as IDE project import.
This set of changes makes sure that dependency locking errors are now reported in a lenient fashion.