### PR TITLE
Support exclusions for imported BOM modules

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -50,7 +50,8 @@ public enum CacheLayout {
         .changedTo(53, "4.6-rc-1")
         .changedTo(56, "4.7-rc-1")
         .changedTo(58, "4.8-rc-1")
-        .changedTo(63, "4.10-rc-1")),
+        .changedTo(63, "4.10-rc-1")
+        .changedTo(66, "5.0-rc-1")),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -34,6 +34,7 @@ import org.gradle.internal.component.external.descriptor.MavenScope;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
+import org.gradle.internal.component.external.model.maven.MavenDependencyType;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
@@ -101,16 +102,17 @@ public class GradlePomModuleDescriptorBuilder {
     }
 
     public void addDependency(PomDependencyData dep) {
-        doAddDependency(dep, dep.isOptional(), false);
+        MavenDependencyType type = dep.isOptional() ? MavenDependencyType.OPTIONAL_DEPENDENCY : MavenDependencyType.DEPENDENCY;
+        doAddDependency(dep, type);
     }
 
     public void addConstraint(PomDependencyMgt dep) {
-        doAddDependency(dep, true, true);
+        doAddDependency(dep, MavenDependencyType.DEPENDENCY_MANAGEMENT);
     }
 
-    private void doAddDependency(PomDependencyMgt dep, boolean optional, boolean useCompileScope) {
+    private void doAddDependency(PomDependencyMgt dep, MavenDependencyType dependencyType) {
         MavenScope scope;
-        if (useCompileScope) {
+        if (dependencyType == MavenDependencyType.DEPENDENCY_MANAGEMENT) {
             scope = MavenScope.Compile;
         } else {
             String scopeString = dep.getScope();
@@ -164,7 +166,7 @@ public class GradlePomModuleDescriptorBuilder {
             excludes.add(rule);
         }
 
-        dependencies.add(new MavenDependencyDescriptor(scope, optional, selector, dependencyArtifact, excludes));
+        dependencies.add(new MavenDependencyDescriptor(scope, dependencyType, selector, dependencyArtifact, excludes));
     }
 
     private String convertVersionFromMavenSyntax(String version) {
@@ -251,7 +253,7 @@ public class GradlePomModuleDescriptorBuilder {
             return;
         }
 
-        dependencies.add(new MavenDependencyDescriptor(MavenScope.Runtime, false, selector, null, ImmutableList.<ExcludeMetadata>of()));
+        dependencies.add(new MavenDependencyDescriptor(MavenScope.Runtime, MavenDependencyType.RELOCATION, selector, null, ImmutableList.<ExcludeMetadata>of()));
     }
 
     private String getDefaultVersion(PomDependencyMgt dep) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -43,6 +43,7 @@ import org.gradle.internal.component.external.model.DefaultModuleComponentIdenti
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor;
 import org.gradle.internal.component.external.model.ivy.IvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
+import org.gradle.internal.component.external.model.maven.MavenDependencyType;
 import org.gradle.internal.component.external.model.maven.MavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
@@ -300,7 +301,7 @@ public class ModuleMetadataSerializer {
             writeNullableArtifact(mavenDependency.getDependencyArtifact());
             writeMavenExcludeRules(mavenDependency.getAllExcludes());
             encoder.writeSmallInt(mavenDependency.getScope().ordinal());
-            encoder.writeBoolean(mavenDependency.isOptional());
+            encoder.writeSmallInt(mavenDependency.getType().ordinal());
         }
 
         private void writeNullableArtifact(IvyArtifactName artifact) throws IOException {
@@ -647,8 +648,8 @@ public class ModuleMetadataSerializer {
             IvyArtifactName artifactName = readNullableArtifact();
             List<ExcludeMetadata> mavenExcludes = readMavenDependencyExcludes();
             MavenScope scope = MavenScope.values()[decoder.readSmallInt()];
-            boolean optional = decoder.readBoolean();
-            return new MavenDependencyDescriptor(scope, optional, requested, artifactName, mavenExcludes);
+            MavenDependencyType type = MavenDependencyType.values()[decoder.readSmallInt()];
+            return new MavenDependencyDescriptor(scope, type, requested, artifactName, mavenExcludes);
         }
 
         private List<ExcludeMetadata> readMavenDependencyExcludes() throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultPendingDependenciesHandler.java
@@ -37,7 +37,7 @@ class DefaultPendingDependenciesHandler implements PendingDependenciesHandler {
 
         public boolean maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState) {
             ModuleIdentifier key = dependencyState.getModuleIdentifier();
-            boolean isOptionalDependency = dependencyState.getDependency().isPending();
+            boolean isOptionalDependency = dependencyState.getDependency().isConstraint();
             if (!isOptionalDependency) {
                 // Mark as not pending. If we saw pending dependencies before, mark them as no longer pending
                 PendingDependencies priorPendingDependencies = pendingDependencies.notPending(key);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -195,7 +195,7 @@ class EdgeState implements DependencyGraphEdge {
 
     @Override
     public boolean contributesArtifacts() {
-        return !dependencyMetadata.isPending();
+        return !dependencyMetadata.isConstraint();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -185,6 +185,14 @@ class EdgeState implements DependencyGraphEdge {
         return resolveState.getModuleExclusions().intersect(edgeExclusions, transitiveExclusions);
     }
 
+    public ModuleExclusion getEdgeExclusions() {
+        List<ExcludeMetadata> excludes = dependencyMetadata.getExcludes();
+        if (excludes.isEmpty()) {
+            return null;
+        }
+        return resolveState.getModuleExclusions().excludeAny(ImmutableList.copyOf(excludes));
+    }
+
     @Override
     public boolean contributesArtifacts() {
         return !dependencyMetadata.isPending();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -112,7 +112,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     }
 
     @Override
-    public boolean isPending() {
+    public boolean isConstraint() {
         return true;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/MessageBuilderHelper.java
@@ -37,7 +37,7 @@ abstract class MessageBuilderHelper {
         for (List<EdgeState> path : acc) {
             EdgeState target = Iterators.getLast(path.iterator());
             StringBuilder sb = new StringBuilder();
-            if (target.getSelector().getDependencyMetadata().isPending()) {
+            if (target.getSelector().getDependencyMetadata().isConstraint()) {
                 sb.append("Constraint path ");
             } else {
                 sb.append("Dependency path ");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -374,7 +374,7 @@ class NodeState implements DependencyGraphNode {
             if (dependencyEdge.isTransitive()) {
                 // Transitive dependency
                 edgeExclusions = excludedByBoth(edgeExclusions, dependencyEdge.getExclusions());
-            } else if (dependencyEdge.getDependencyMetadata().isPending()) {
+            } else if (dependencyEdge.getDependencyMetadata().isConstraint()) {
                 // Constraint: only consider explicit exclusions declared for this constraint
                 ModuleExclusion constraintExclusions = dependencyEdge.getEdgeExclusions();
                 nodeExclusions = excludedByEither(nodeExclusions, constraintExclusions);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -181,7 +181,6 @@ class NodeState implements DependencyGraphNode {
         }
 
         // Check if this node is still included in the graph, by looking at incoming edges.
-        boolean hasIncomingEdges = !incomingEdges.isEmpty();
         List<EdgeState> transitiveIncoming = getTransitiveIncomingEdges();
 
         // Check if there are any transitive incoming edges at all. Don't traverse if not.
@@ -190,6 +189,7 @@ class NodeState implements DependencyGraphNode {
             if (previousTraversalExclusions != null) {
                 removeOutgoingEdges();
             }
+            boolean hasIncomingEdges = !incomingEdges.isEmpty();
             if (hasIncomingEdges) {
                 LOGGER.debug("{} has no transitive incoming edges. ignoring outgoing edges.", this);
             } else {
@@ -199,7 +199,7 @@ class NodeState implements DependencyGraphNode {
         }
 
         // Determine the net exclusion for this node, by inspecting all transitive incoming edges
-        ModuleExclusion resolutionFilter = getModuleResolutionFilter(transitiveIncoming);
+        ModuleExclusion resolutionFilter = getModuleResolutionFilter(incomingEdges);
 
         // Check if the was previously traversed with the same net exclusion
         if (previousTraversalExclusions != null && previousTraversalExclusions.excludesSameModulesAs(resolutionFilter)) {
@@ -367,12 +367,40 @@ class NodeState implements DependencyGraphNode {
         if (incomingEdges.isEmpty()) {
             return nodeExclusions;
         }
-        ModuleExclusion edgeExclusions = incomingEdges.get(0).getExclusions();
-        for (int i = 1; i < incomingEdges.size(); i++) {
-            EdgeState dependencyEdge = incomingEdges.get(i);
-            edgeExclusions = moduleExclusions.union(edgeExclusions, dependencyEdge.getExclusions());
+
+        ModuleExclusion edgeExclusions = null;
+
+        for (EdgeState dependencyEdge : incomingEdges) {
+            if (dependencyEdge.isTransitive()) {
+                // Transitive dependency
+                edgeExclusions = excludedByBoth(edgeExclusions, dependencyEdge.getExclusions());
+            } else if (dependencyEdge.getDependencyMetadata().isPending()) {
+                // Constraint: only consider explicit exclusions declared for this constraint
+                ModuleExclusion constraintExclusions = dependencyEdge.getEdgeExclusions();
+                nodeExclusions = excludedByEither(nodeExclusions, constraintExclusions);
+            }
         }
-        return moduleExclusions.intersect(edgeExclusions, nodeExclusions);
+        return excludedByEither(edgeExclusions, nodeExclusions);
+    }
+
+    private ModuleExclusion excludedByBoth(ModuleExclusion one, ModuleExclusion two) {
+        if (one == null) {
+            return two;
+        }
+        if (two == null) {
+            return one;
+        }
+        return resolveState.getModuleExclusions().union(one, two);
+    }
+
+    private ModuleExclusion excludedByEither(ModuleExclusion one, ModuleExclusion two) {
+        if (one == null) {
+            return two;
+        }
+        if (two == null) {
+            return one;
+        }
+        return resolveState.getModuleExclusions().intersect(one, two);
     }
 
     private void removeOutgoingEdges() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -114,7 +114,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
 
     private void addDependencyMetadata(DependencyMetadata dependencyMetadata) {
         String reason = dependencyMetadata.getReason();
-        ComponentSelectionDescriptorInternal dependencyDescriptor = dependencyMetadata.isPending() ? CONSTRAINT : REQUESTED;
+        ComponentSelectionDescriptorInternal dependencyDescriptor = dependencyMetadata.isConstraint() ? CONSTRAINT : REQUESTED;
         if (reason != null) {
             dependencyDescriptor = dependencyDescriptor.withReason(Describables.of(reason));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -52,7 +52,7 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     protected abstract Class<? extends T> adapterImplementationType();
 
-    protected abstract boolean isPending();
+    protected abstract boolean isConstraint();
 
     @Override
     public T get(int index) {
@@ -112,6 +112,6 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes());
-        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isPending(), details.getReason());
+        return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), details.getReason());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DependencyConstraintsMetadataAdapter.java
@@ -39,7 +39,7 @@ public class DependencyConstraintsMetadataAdapter extends AbstractDependenciesMe
     }
 
     @Override
-    protected boolean isPending() {
+    protected boolean isConstraint() {
         return true;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/DirectDependenciesMetadataAdapter.java
@@ -38,7 +38,7 @@ public class DirectDependenciesMetadataAdapter extends AbstractDependenciesMetad
     }
 
     @Override
-    protected boolean isPending() {
+    protected boolean isConstraint() {
         return false;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/MavenScope.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/descriptor/MavenScope.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.component.external.descriptor;
 
+/**
+ * A "scope" taken from a Maven POM. Note that the order of this enum is important for the module metadata cache.
+ */
 public enum MavenScope {
     Compile("compile"),
     Runtime("runtime"),

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -111,9 +111,9 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
     protected GradleDependencyMetadata readDependencyMetadata(Decoder decoder) throws IOException {
         ModuleComponentSelector selector = componentSelectorSerializer.read(decoder);
         List<ExcludeMetadata> excludes = readMavenExcludes(decoder);
-        boolean pending = decoder.readBoolean();
+        boolean constraint = decoder.readBoolean();
         String reason = decoder.readNullableString();
-        return new GradleDependencyMetadata(selector, excludes, pending, reason);
+        return new GradleDependencyMetadata(selector, excludes, constraint, reason);
     }
 
     protected List<ExcludeMetadata> readMavenExcludes(Decoder decoder) throws IOException {
@@ -151,7 +151,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         componentSelectorSerializer.write(encoder, dependencyMetadata.getSelector());
         List<ExcludeMetadata> excludes = dependencyMetadata.getExcludes();
         writeMavenExcludeRules(encoder, excludes);
-        encoder.writeBoolean(dependencyMetadata.isPending());
+        encoder.writeBoolean(dependencyMetadata.isConstraint());
         encoder.writeNullableString(dependencyMetadata.getReason());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -154,7 +154,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     }
 
     @Override
-    public boolean isPending() {
+    public boolean isConstraint() {
         return dependencyDescriptor.isOptional();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -37,14 +37,14 @@ import java.util.List;
 public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     private final ModuleComponentSelector selector;
     private final List<ExcludeMetadata> excludes;
-    private final boolean pending;
+    private final boolean constraint;
     private final String reason;
 
-    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean pending, String reason) {
+    public GradleDependencyMetadata(ModuleComponentSelector selector, List<ExcludeMetadata> excludes, boolean constraint, String reason) {
         this.selector = selector;
         this.excludes = excludes;
         this.reason = reason;
-        this.pending = pending;
+        this.constraint = constraint;
     }
 
     @Override
@@ -57,7 +57,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes()), excludes, pending, reason);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes()), excludes, constraint, reason);
     }
 
     @Override
@@ -65,13 +65,13 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
         if (Objects.equal(reason, this.reason)) {
             return this;
         }
-        return new GradleDependencyMetadata(selector, excludes, pending, reason);
+        return new GradleDependencyMetadata(selector, excludes, constraint, reason);
     }
 
     @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
-            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, pending, reason);
+            return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, constraint, reason);
         }
         return new DefaultProjectDependencyMetadata((ProjectComponentSelector) target, this);
     }
@@ -105,8 +105,8 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata {
     }
 
     @Override
-    public boolean isPending() {
-        return pending;
+    public boolean isConstraint() {
+        return constraint;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -85,8 +85,8 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
-    public boolean isPending() {
-        return delegate.isPending();
+    public boolean isConstraint() {
+        return delegate.isConstraint();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -277,7 +277,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
          * Dependencies in the "optional" configuration are never 'pending'.
          */
         @Override
-        public boolean isPending() {
+        public boolean isConstraint() {
             return false;
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyDescriptor.java
@@ -30,6 +30,7 @@ import org.gradle.internal.component.model.IvyArtifactName;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -38,18 +39,18 @@ import java.util.List;
 public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
     private final ModuleComponentSelector selector;
     private final MavenScope scope;
-    private final boolean optional;
+    private final MavenDependencyType type;
     private final ImmutableList<ExcludeMetadata> excludes;
 
     // A dependency artifact will be defined if the descriptor specified a classifier or non-default type attribute.
     @Nullable
     private final IvyArtifactName dependencyArtifact;
 
-    public MavenDependencyDescriptor(MavenScope scope, boolean optional, ModuleComponentSelector selector,
+    public MavenDependencyDescriptor(MavenScope scope, MavenDependencyType type, ModuleComponentSelector selector,
                                      @Nullable IvyArtifactName dependencyArtifact, List<ExcludeMetadata> excludes) {
         this.scope = scope;
         this.selector = selector;
-        this.optional = optional;
+        this.type = type;
         this.dependencyArtifact = dependencyArtifact;
         this.excludes = ImmutableList.copyOf(excludes);
     }
@@ -112,15 +113,23 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
 
     @Override
     protected ExternalDependencyDescriptor withRequested(ModuleComponentSelector newRequested) {
-        return new MavenDependencyDescriptor(scope, isOptional(), newRequested, dependencyArtifact, excludes);
+        return new MavenDependencyDescriptor(scope, type, newRequested, dependencyArtifact, excludes);
     }
 
     public List<ExcludeMetadata> getAllExcludes() {
         return excludes;
     }
 
+    public MavenDependencyType getType() {
+        return type;
+    }
+
     @Override
     public List<ExcludeMetadata> getConfigurationExcludes(Collection<String> configurations) {
+        // Ignore exclusions for dependencies with `<optional>true</optional>`, but not for <dependencyManagement>.
+        if (type == MavenDependencyType.OPTIONAL_DEPENDENCY) {
+            return Collections.emptyList();
+        }
         return excludes;
     }
 
@@ -172,7 +181,7 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
 
     @Override
     public boolean isOptional() {
-        return optional;
+        return type.optional;
     }
 
     @Override
@@ -185,7 +194,7 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
         }
 
         MavenDependencyDescriptor that = (MavenDependencyDescriptor) o;
-        return optional == that.optional
+        return type == that.type
             && Objects.equal(selector, that.selector)
             && scope == that.scope
             && Objects.equal(excludes, that.excludes)
@@ -197,7 +206,7 @@ public class MavenDependencyDescriptor extends ExternalDependencyDescriptor {
         return Objects.hashCode(
             selector,
             scope,
-            optional,
+            type,
             excludes,
             dependencyArtifact);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyType.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyType.java
@@ -16,8 +16,14 @@
 
 package org.gradle.internal.component.external.model.maven;
 
+/**
+ * The context for a dependency parsed from a Maven POM. Note that the order of this enum is important for the module metadata cache.
+ */
 public enum MavenDependencyType {
-    DEPENDENCY(false), RELOCATION(false), OPTIONAL_DEPENDENCY(true), DEPENDENCY_MANAGEMENT(true);
+    DEPENDENCY(false),
+    RELOCATION(false),
+    OPTIONAL_DEPENDENCY(true),
+    DEPENDENCY_MANAGEMENT(true);
 
     public final boolean optional;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyType.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/MavenDependencyType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model.maven;
+
+public enum MavenDependencyType {
+    DEPENDENCY(false), RELOCATION(false), OPTIONAL_DEPENDENCY(true), DEPENDENCY_MANAGEMENT(true);
+
+    public final boolean optional;
+
+    MavenDependencyType(boolean optional) {
+        this.optional = optional;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
@@ -171,8 +171,8 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         IvyArtifactName artifactName = readNullableArtifact(decoder);
         List<ExcludeMetadata> mavenExcludes = readMavenExcludes(decoder);
         MavenScope scope = MavenScope.values()[decoder.readSmallInt()];
-        boolean optional = decoder.readBoolean();
-        return new MavenDependencyDescriptor(scope, optional, requested, artifactName, mavenExcludes);
+        MavenDependencyType type = MavenDependencyType.values()[decoder.readSmallInt()];
+        return new MavenDependencyDescriptor(scope, type, requested, artifactName, mavenExcludes);
     }
 
     private void writeMavenDependency(Encoder encoder, MavenDependencyDescriptor mavenDependency) throws IOException {
@@ -180,7 +180,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
         writeNullableArtifact(encoder, mavenDependency.getDependencyArtifact());
         writeMavenExcludeRules(encoder, mavenDependency.getAllExcludes());
         encoder.writeSmallInt(mavenDependency.getScope().ordinal());
-        encoder.writeBoolean(mavenDependency.isOptional());
+        encoder.writeSmallInt(mavenDependency.getType().ordinal());
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -64,7 +64,7 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     }
 
     @Override
-    public boolean isPending() {
+    public boolean isConstraint() {
         return false;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -86,8 +86,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public boolean isPending() {
-        return delegate.isPending();
+    public boolean isConstraint() {
+        return delegate.isConstraint();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -71,7 +71,7 @@ public interface DependencyMetadata {
      * Is this a strong dependency, does it is merely a constraint on the module to select if brought in
      * by another dependency? ("Optional" dependencies are "constraints")
      */
-    boolean isPending();
+    boolean isConstraint();
 
     /**
      * An optional human readable reason why this dependency is used.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -46,13 +46,13 @@ public class DependencyMetadataRules {
     private static final Spec<ModuleDependencyMetadata> DEPENDENCY_FILTER = new Spec<ModuleDependencyMetadata>() {
         @Override
         public boolean isSatisfiedBy(ModuleDependencyMetadata dep) {
-            return !dep.isPending();
+            return !dep.isConstraint();
         }
     };
     private static final Spec<ModuleDependencyMetadata> DEPENDENCY_CONSTRAINT_FILTER = new Spec<ModuleDependencyMetadata>() {
         @Override
         public boolean isSatisfiedBy(ModuleDependencyMetadata dep) {
-            return dep.isPending();
+            return dep.isConstraint();
         }
     };
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -42,7 +42,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     private final boolean force;
     private final boolean changing;
     private final boolean transitive;
-    private final boolean pending;
+    private final boolean constraint;
     private final String reason;
 
     private final AttributeContainer moduleAttributes;
@@ -56,7 +56,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             String dependencyConfiguration,
                                             List<IvyArtifactName> artifactNames,
                                             List<ExcludeMetadata> excludes,
-                                            boolean force, boolean changing, boolean transitive, boolean pending,
+                                            boolean force, boolean changing, boolean transitive, boolean constraint,
                                             String reason) {
         this.componentId = componentId;
         this.selector = selector;
@@ -69,7 +69,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         this.force = force;
         this.changing = changing;
         this.transitive = transitive;
-        this.pending = pending;
+        this.constraint = constraint;
         this.reason = reason;
     }
 
@@ -157,8 +157,8 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     @Override
-    public boolean isPending() {
-        return pending;
+    public boolean isConstraint() {
+        return constraint;
     }
 
     @Override
@@ -188,11 +188,11 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
     }
 
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, reason);
     }
 
     private LocalOriginDependencyMetadata copyWithReason(String reason) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, pending, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, reason);
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,10 +54,10 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.63'
-        cacheLayout.version == CacheVersion.parse("2.63")
-        cacheLayout.version.toString() == '2.63'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.63')
+        cacheLayout.key == 'metadata-2.66'
+        cacheLayout.version == CacheVersion.parse("2.66")
+        cacheLayout.version.toString() == '2.66'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.66')
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactoryTest.groovy
@@ -75,7 +75,7 @@ class DefaultDependencyDescriptorFactoryTest extends Specification {
         def selector = created.selector as ModuleComponentSelector
 
         then:
-        created.pending
+        created.constraint
         selector.group == "g"
         selector.module == "m"
         selector.version == "1"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/DependenciesMetadataAdapterTest.groovy
@@ -210,7 +210,7 @@ class DependenciesMetadataAdapterTest extends Specification {
         }
 
         @Override
-        protected boolean isPending() {
+        protected boolean isConstraint() {
             return false
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -177,8 +177,8 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         then:
         if (supportedInMetadata(metadataType)) {
             assert dependencies.size() == 2
-            assert dependencies[0].pending == addAllDependenciesAsConstraints()
-            assert dependencies[1].pending == addAllDependenciesAsConstraints()
+            assert dependencies[0].constraint == addAllDependenciesAsConstraints()
+            assert dependencies[1].constraint == addAllDependenciesAsConstraints()
         } else {
             assert dependencies.empty
         }
@@ -214,7 +214,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
             assert dependencies[0].selector.version == "2.0"
             assert dependencies[0].selector.versionConstraint.strictVersion == "2.0"
             assert dependencies[0].selector.versionConstraint.rejectedVersions[0] == "[3.0,)"
-            assert dependencies[0].pending == addAllDependenciesAsConstraints()
+            assert dependencies[0].constraint == addAllDependenciesAsConstraints()
         } else {
             assert dependencies.empty
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.ivy.IvyDependencyDescriptor
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.ComponentAttributeMatcher
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata
 import org.gradle.internal.component.model.VariantResolveMetadata
@@ -87,7 +88,8 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     }
     private mavenComponentMetadata(String[] deps) {
         def dependencies = deps.collect { name ->
-            new MavenDependencyDescriptor(MavenScope.Compile, addAllDependenciesAsConstraints(), newSelector(DefaultModuleIdentifier.newId("org.test", name), "1.0"), null, [])
+            MavenDependencyType type = addAllDependenciesAsConstraints() ? MavenDependencyType.OPTIONAL_DEPENDENCY : MavenDependencyType.DEPENDENCY
+            new MavenDependencyDescriptor(MavenScope.Compile, type, newSelector(DefaultModuleIdentifier.newId("org.test", name), "1.0"), null, [])
         }
         mavenMetadataFactory.create(componentIdentifier, dependencies)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.internal.component.external.descriptor.Configuration
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.maven.DefaultMutableMavenModuleResolveMetadata
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.ModuleSource
 import org.gradle.util.TestUtil
 import spock.lang.Unroll
@@ -178,7 +179,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
 
     def dependency(String org, String module, String version, String scope) {
         def selector = newSelector(DefaultModuleIdentifier.newId(org, module), new DefaultMutableVersionConstraint(version))
-        dependencies.add(new MavenDependencyDescriptor(MavenScope.valueOf(scope), false, selector, null, []))
+        dependencies.add(new MavenDependencyDescriptor(MavenScope.valueOf(scope), MavenDependencyType.DEPENDENCY, selector, null, []))
     }
 
     private void assertHasOnlyStatusAttribute(AttributeContainer attributes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -62,7 +62,7 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
         then:
         def dependencies = selectTargetConfigurationMetadata(mavenMetadata).dependencies
         dependencies.size() == 2
-        !dependencies[0].pending
-        dependencies[1].pending
+        !dependencies[0].constraint
+        dependencies[1].constraint
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.util.TestUtil
 
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
@@ -45,8 +46,8 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
     def "maven optional dependencies are accessible as dependency constraints"() {
         given:
         def mavenMetadata = mavenMetadataFactory.create(componentIdentifier, [
-            new MavenDependencyDescriptor(MavenScope.Compile, false, newSelector(DefaultModuleIdentifier.newId("org", "notOptional"), "1.0"), null, []),
-            new MavenDependencyDescriptor(MavenScope.Compile, true, newSelector(DefaultModuleIdentifier.newId("org", "optional"), "1.0"), null, [])
+            new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.DEPENDENCY, newSelector(DefaultModuleIdentifier.newId("org", "notOptional"), "1.0"), null, []),
+            new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.OPTIONAL_DEPENDENCY, newSelector(DefaultModuleIdentifier.newId("org", "optional"), "1.0"), null, [])
         ])
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/MavenDependencyDescriptorTest.groovy
@@ -40,6 +40,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Patte
 import org.gradle.internal.component.external.descriptor.DefaultExclude
 import org.gradle.internal.component.external.descriptor.MavenScope
 import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor
+import org.gradle.internal.component.external.model.maven.MavenDependencyType
 import org.gradle.internal.component.model.ComponentArtifactMetadata
 import org.gradle.internal.component.model.ComponentResolveMetadata
 import org.gradle.internal.component.model.ConfigurationMetadata
@@ -52,11 +53,11 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
 
     @Override
     ExternalDependencyDescriptor create(ModuleComponentSelector selector) {
-        return mavenDependencyMetadata(MavenScope.Compile, false, selector, [])
+        return mavenDependencyMetadata(MavenScope.Compile, selector, [])
     }
 
     ExternalDependencyDescriptor createWithExcludes(ModuleComponentSelector selector, List<Exclude> excludes) {
-        return mavenDependencyMetadata(MavenScope.Compile, false, selector, excludes)
+        return mavenDependencyMetadata(MavenScope.Compile, selector, excludes)
     }
 
     def "excludes nothing when no exclude rules provided"() {
@@ -90,7 +91,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("master") >> toMaster
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent) as List == [toCompile, toMaster]
@@ -111,7 +112,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("master") >> toMaster
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime, toCompile, toMaster]
@@ -132,7 +133,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toRuntime.hierarchy >> ["runtime", "compile"]
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime, toMaster]
@@ -149,7 +150,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("master") >> null
         toRuntime.hierarchy >> ["compile", "runtime"]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime]
@@ -166,7 +167,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("master") >> toMaster
         toRuntime.hierarchy >> ["compile", "runtime"]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent) as List == [toRuntime]
@@ -184,7 +185,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("master") >> toMaster
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent) as List == [toDefault, toMaster]
@@ -203,7 +204,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toDefault.hierarchy >> ["compile", "default"]
         toMaster.artifacts >> [Stub(ComponentArtifactMetadata)]
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         expect:
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent) as List == [toDefault, toMaster]
@@ -218,7 +219,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("default") >> null
         toComponent.getConfiguration("master") >> null
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         when:
         dep.selectLegacyConfigurations(fromComponent, fromCompile, toComponent)
@@ -236,7 +237,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         toComponent.getConfiguration("default") >> null
         toComponent.getConfiguration("master") >> null
 
-        def dep = mavenDependencyMetadata(MavenScope.Compile, false, Stub(ModuleComponentSelector), [])
+        def dep = mavenDependencyMetadata(MavenScope.Compile, Stub(ModuleComponentSelector), [])
 
         when:
         dep.selectLegacyConfigurations(fromComponent, fromRuntime, toComponent)
@@ -245,7 +246,7 @@ class MavenDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         thrown(ConfigurationNotFoundException)
     }
 
-    private static MavenDependencyDescriptor mavenDependencyMetadata(MavenScope scope, boolean optional, ModuleComponentSelector selector, List<ExcludeMetadata> excludes) {
-        return new MavenDependencyDescriptor(scope, optional, selector, null, excludes)
+    private static MavenDependencyDescriptor mavenDependencyMetadata(MavenScope scope, ModuleComponentSelector selector, List<ExcludeMetadata> excludes) {
+        return new MavenDependencyDescriptor(scope, MavenDependencyType.DEPENDENCY, selector, null, excludes)
     }
 }


### PR DESCRIPTION
When a BOM is imported, we create dependency constraint for each
dependency declared in a `<dependencyManagement>` section. These
entries may define a set of `<exclusions>` for the target module.
We were already parsing and caching these constraint exclusions,
but they were being ignored when building the graph, due to the
non-transitive nature of dependency constraints.

With this PR, we consider any `exclude` defined for a constraint as applying to the _node_ of the target module, and not tied to the edge that brings in the constraint. This makes BOM import function in a more Maven-like way, since these exclusions will not be ignored when another dependency (with no define excludes) points at the same module.

At this stage, it is not possible to define `excludes` for a dependency defined in a build script, nor can they be persisted to a .module metadata file. For now, constraint exclusions are exlusive to BOM import.