### PR TITLE
Allow having extra modules in lock-file

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.util.ToBeImplemented
 import spock.lang.Unroll
+import spock.lang.Issue
 
 class DependencyLockingIntegrationTest extends AbstractDependencyResolutionTest {
 
@@ -892,6 +893,7 @@ configurations {
         lockfileFixture.verifyLockfile('lockedConf', [])
     }
 
+    @Issue("gradle/gradle#6472")
     def 'update with selective modules allow extra modules to remain in the lockfile'() {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.0').publish()
@@ -925,6 +927,7 @@ dependencies {
         lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
     }
 
+    @Issue("gradle/gradle#6472")
     def 'write-locks removes any extra modules in the lockfile'() {
         mavenRepo.module('org', 'bar', '1.0').publish()
         mavenRepo.module('org', 'foo', '1.0').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -149,7 +149,7 @@ dependencies {
    Constraint path ':depLock:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'"""
     }
 
-    def 'fails when lock file contains entry that is not in resolution result'() {
+    def 'succeeds when lock file contains entry that is not in resolution result'() {
         mavenRepo.module('org', 'foo', '1.0').publish()
         mavenRepo.module('org', 'bar', '1.0').publish()
 
@@ -176,10 +176,15 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf',['org:bar:1.0', 'org:foo:1.0'])
 
         when:
-        fails 'checkDeps'
+        succeeds 'checkDeps'
 
         then:
-        failure.assertHasCause("Dependency lock state for configuration 'lockedConf' is out of date: Did not resolve 'org:bar:1.0' which is part of the lock state")
+        resolve.expectGraph {
+            root(":", ":depLock:") {
+                edge("org:foo:1.+", "org:foo:1.0")
+                edge("org:foo:1.0", "org:foo:1.0")
+            }
+        }
     }
 
     def 'fails when lock file does not contain entry for module in resolution result'() {
@@ -885,5 +890,71 @@ configurations {
 
         then:
         lockfileFixture.verifyLockfile('lockedConf', [])
+    }
+
+    def 'update with selective modules allow extra modules to remain in the lockfile'() {
+        mavenRepo.module('org', 'bar', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.0').publish()
+
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf 'org:bar:1.0'
+}
+"""
+
+        when:
+        succeeds 'dependencies', '--update-locks', 'org:bar'
+
+        then:
+        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+    }
+
+    def 'write-locks removes any extra modules in the lockfile'() {
+        mavenRepo.module('org', 'bar', '1.0').publish()
+        mavenRepo.module('org', 'foo', '1.0').publish()
+
+        lockfileFixture.createLockfile('lockedConf', ['org:bar:1.0', 'org:foo:1.0'])
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf 'org:bar:1.0'
+}
+"""
+
+        when:
+        succeeds 'dependencies', '--write-locks'
+
+        then:
+        lockfileFixture.verifyLockfile('lockedConf', ['org:bar:1.0'])
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/locking/DependencyLockingArtifactVisitor.java
@@ -62,19 +62,19 @@ public class DependencyLockingArtifactVisitor implements ValidatingArtifactsVisi
     public void startArtifacts(RootGraphNode root) {
         RootConfigurationMetadata metadata = root.getMetadata();
         dependencyLockingState = metadata.getDependencyLockingState();
-        if (dependencyLockingState.mustValidateLockState()) {
-            Set<ModuleComponentIdentifier> lockedModules = dependencyLockingState.getLockedDependencies();
+
+        Set<ModuleComponentIdentifier> lockedModules = dependencyLockingState.getLockedDependencies();
+        if (lockedModules != null) {
             modulesToBeLocked = Maps.newHashMapWithExpectedSize(lockedModules.size());
             for (ModuleComponentIdentifier lockedModule : lockedModules) {
                 modulesToBeLocked.put(lockedModule.getModuleIdentifier(), lockedModule);
             }
-            allResolvedModules = Sets.newHashSetWithExpectedSize(this.modulesToBeLocked.size());
-            extraModules = Sets.newHashSet();
-            incorrectModules = Sets.newHashSet();
         } else {
-            modulesToBeLocked = Collections.emptyMap();
-            allResolvedModules = Sets.newHashSet();
+            modulesToBeLocked = Maps.newHashMap();
         }
+        allResolvedModules = Sets.newHashSetWithExpectedSize(this.modulesToBeLocked.size());
+        extraModules = Sets.newHashSet();
+        incorrectModules = Sets.newHashSet();
     }
 
     @Override
@@ -95,14 +95,12 @@ public class DependencyLockingArtifactVisitor implements ValidatingArtifactsVisi
                     if (changing) {
                         addChangingModule(id);
                     }
-                    if (dependencyLockingState.mustValidateLockState()) {
-                        ModuleComponentIdentifier lockedId = modulesToBeLocked.remove(id.getModuleIdentifier());
-                        if (lockedId == null) {
-                            extraModules.add(id);
-                        } else if (!lockedId.getVersion().equals(id.getVersion())) {
-                            node.getIncomingEdges();
-                            incorrectModules.add(lockedId);
-                        }
+                    ModuleComponentIdentifier lockedId = modulesToBeLocked.remove(id.getModuleIdentifier());
+                    if (lockedId == null) {
+                        extraModules.add(id);
+                    } else if (!lockedId.getVersion().equals(id.getVersion())) {
+                        node.getIncomingEdges();
+                        incorrectModules.add(lockedId);
                     }
                 }
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -152,7 +152,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         ex.message.contains("Resolved 'org:foo:1.0' which is not part of the lock state")
     }
 
-    def 'throws when module not visited'() {
+    def 'finishes without error module not visited'() {
         given:
         startWithState([newId(mid, '1.1')])
 
@@ -160,8 +160,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         visitor.complete()
 
         then:
-        def ex = thrown(LockOutOfDateException)
-        ex.message.contains("Did not resolve 'org:foo:1.1' which is part of the lock state")
+        notThrown(LockOutOfDateException)
     }
 
     def 'invokes locking provider on complete with visited modules'() {
@@ -196,6 +195,18 @@ class DependencyLockingArtifactVisitorTest extends Specification {
 
     }
 
+    def 'invokes locking provider on complete with visited modules and any extra modules from starting state'() {
+        given:
+        def identifier = newId(mid, '1.1')
+        startWithState([identifier])
+
+        when: 'No modules are visited/resolved'
+        visitor.complete()
+
+        then:
+        1 * dependencyLockingProvider.persistResolvedDependencies(configuration, singleton(identifier), emptySet())
+
+    }
 
     private void addVisitedNode(ModuleComponentIdentifier module) {
         DependencyGraphNode node = Mock()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/locking/DependencyLockingArtifactVisitorTest.groovy
@@ -53,8 +53,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         then:
         1 * rootNode.metadata >> metadata
         1 * metadata.dependencyLockingState >> lockState
-        1 * lockState.mustValidateLockState() >> true
-        1 * lockState.lockedDependencies >> Collections.emptySet()
+        1 * lockState.lockedDependencies >> emptySet()
         0 * _
     }
 
@@ -65,7 +64,7 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         then:
         1 * rootNode.metadata >> metadata
         1 * metadata.dependencyLockingState >> lockState
-        1 * lockState.mustValidateLockState() >> false
+        1 * lockState.getLockedDependencies() >> emptySet()
         0 * _
     }
 
@@ -113,7 +112,6 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         DependencyGraphComponent component = Mock()
         ComponentIdentifier identifier = Mock()
 
-
         when:
         visitor.visitNode(node)
 
@@ -128,6 +126,8 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         given:
         def id = newId(mid, '1.1')
         startWithState([id])
+
+        and:
         addVisitedNode(id)
 
         when:
@@ -140,6 +140,8 @@ class DependencyLockingArtifactVisitorTest extends Specification {
     def 'throws when extra modules visited'() {
         given:
         startWithState([])
+
+        and:
         addVisitedNode(newId(mid, '1.0'))
 
         when:
@@ -166,6 +168,8 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         given:
         def identifier = newId(mid, '1.1')
         startWithoutLockState()
+
+        and:
         addVisitedNode(identifier)
 
         when:
@@ -180,6 +184,8 @@ class DependencyLockingArtifactVisitorTest extends Specification {
         given:
         def identifier = newId(mid, '1.1')
         startWithoutLockState()
+
+        and:
         addVisitedChangingNode(identifier)
 
         when:


### PR DESCRIPTION
### Context
This allows having lock files for configurations that dynamically resolve dependencies for different build platforms. 

For example; a configuration might include `abc-linux.jar` for only building in linux platforms and `abc-mac.jar` for building on a mac. As of currently, there's no way to have a lock file that supports this case. If you try to add both, dependency manager will throw an exception. 

I also understand java is platform independent, but we can also look at other use cases. We may have a configuration that looks at a custom flag passed in `gradle build --custom-flag` which might then add an extra dependency (nothing to do with platforms at all). The above example relating to platforms is simply our current use case.

This change allows to have both versions locked down in the lock file, but not throw an error for having an extra module version stated in the lock state.

Only caveat; The original lock file needs to be generated using `--write-lock` but the required dependencies can be then manually modified to allow both.

For more info: https://github.com/gradle/gradle/issues/6472

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
-- N/A
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
