### PR TITLE
Use JUnitXml data model instead of plain xml processing

### DIFF
--- a/buildSrc/subprojects/performance/performance.gradle.kts
+++ b/buildSrc/subprojects/performance/performance.gradle.kts
@@ -3,8 +3,15 @@ apply(plugin = "org.gradle.kotlin.kotlin-dsl")
 dependencies {
     api(project(":integrationTesting"))
     implementation(project(":build"))
+    implementation("org.openmbee.junit:junit-xml-parser:1.0.0")
     implementation("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2") {
         // Xerces on the runtime classpath is breaking some of our doc tasks
         exclude(group = "xerces")
+    }
+}
+
+tasks.withType<Test>().configureEach {
+    if (JavaVersion.current().isJava9Compatible) {
+        jvmArgs("--add-modules", "java.xml.bind")
     }
 }

--- a/buildSrc/subprojects/performance/performance.gradle.kts
+++ b/buildSrc/subprojects/performance/performance.gradle.kts
@@ -8,10 +8,10 @@ dependencies {
         // Xerces on the runtime classpath is breaking some of our doc tasks
         exclude(group = "xerces")
     }
-}
-
-tasks.withType<Test>().configureEach {
     if (JavaVersion.current().isJava9Compatible) {
-        jvmArgs("--add-modules", "java.xml.bind")
+        // Java 9 throws ClassNotFoundException
+        implementation("javax.activation:activation:1.1.1")
+        // only high version of lombok supports Java 9
+        implementation("org.projectlombok:lombok:1.18.2")
     }
 }

--- a/buildSrc/subprojects/performance/performance.gradle.kts
+++ b/buildSrc/subprojects/performance/performance.gradle.kts
@@ -3,15 +3,13 @@ apply(plugin = "org.gradle.kotlin.kotlin-dsl")
 dependencies {
     api(project(":integrationTesting"))
     implementation(project(":build"))
-    implementation("org.openmbee.junit:junit-xml-parser:1.0.0")
     implementation("org.codehaus.groovy.modules.http-builder:http-builder:0.7.2") {
         // Xerces on the runtime classpath is breaking some of our doc tasks
         exclude(group = "xerces")
     }
-    if (JavaVersion.current().isJava9Compatible) {
-        // Java 9 throws ClassNotFoundException
-        implementation("javax.activation:activation:1.1.1")
-        // only high version of lombok supports Java 9
-        implementation("org.projectlombok:lombok:1.18.2")
+    implementation("org.openmbee.junit:junit-xml-parser:1.0.0") {
+        // don't need it at runtime
+        exclude(module = "lombok")
     }
+    implementation("javax.activation:activation:1.1.1")
 }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -329,7 +329,7 @@ class DistributedPerformanceTest extends PerformanceTest {
 
     @TypeChecked(TypeCheckingMode.SKIP)
     private List<JUnitTestSuite> fetchTestResults(buildData) {
-        def unzippedJUnitXmls = []
+        def junitTestSuites = []
         def artifactsUri = buildData?.artifacts?.@href?.text()
         if (artifactsUri) {
             def resultArtifacts = client.get(path: "${artifactsUri}/results/${project.name}/build/")
@@ -342,12 +342,12 @@ class DistributedPerformanceTest extends PerformanceTest {
                     def contentUri = fileNode.content.@href.text()
                     client.get(path: contentUri, contentType: ContentType.BINARY) {
                         resp, inputStream ->
-                            unzippedJUnitXmls = parseXmlsInZip(inputStream)
+                            junitTestSuites = parseXmlsInZip(inputStream)
                     }
                 }
             }
         }
-        unzippedJUnitXmls
+        junitTestSuites
     }
 
     List<JUnitTestSuite> parseXmlsInZip(InputStream inputStream) {

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -41,6 +41,7 @@ import org.gradle.process.JavaExecSpec
 import groovy.transform.CompileStatic
 import org.openmbee.junit.model.JUnitTestSuite
 import org.openmbee.junit.JUnitMarshalling
+import org.apache.commons.io.input.CloseShieldInputStream
 
 /**
  * Runs each performance test scenario in a dedicated TeamCity job.
@@ -356,14 +357,7 @@ class DistributedPerformanceTest extends PerformanceTest {
             def entry
             while (entry = zipInput.nextEntry) {
                 if (!entry.isDirectory() && entry.name.endsWith('.xml')) {
-                    PipedOutputStream os = new PipedOutputStream()
-                    PipedInputStream is = new PipedInputStream(os)
-                    Thread.start {
-                        os.withStream {
-                            it << zipInput
-                        }
-                    }
-                    parsedXmls.add(JUnitMarshalling.unmarshalTestSuite(is))
+                    parsedXmls.add(JUnitMarshalling.unmarshalTestSuite(new CloseShieldInputStream(zipInput)))
                 }
             }
         }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
@@ -30,6 +30,9 @@ import org.gradle.api.tasks.testing.TestOutputEvent
 import org.gradle.api.tasks.testing.TestOutputListener
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.internal.event.ListenerBroadcast
+import org.openmbee.junit.model.JUnitTestSuite
+import org.openmbee.junit.model.JUnitFailure
+import org.openmbee.junit.model.JUnitTestCase
 
 import javax.xml.datatype.DatatypeFactory
 
@@ -51,41 +54,36 @@ class JUnitXmlTestEventsGenerator {
         this.testListenerBroadcast = testListenerBroadcast
     }
 
-    void processXmlFile(File resultsFile, Object build) {
-        processXml(new XmlSlurper().parse(resultsFile), build)
-    }
-
-    void processXml(GPathResult testResult, Object build) {
-        String suiteName = testResult.@name.text()
-        def testSuiteDescriptor = new DecoratingTestDescriptor(new DefaultTestClassDescriptor(0, suiteName), createWorkerSuite())
+    void processTestSuite(JUnitTestSuite testSuite, Object build) {
+        String suiteName = testSuite.name
+        DecoratingTestDescriptor testSuiteDescriptor = new DecoratingTestDescriptor(new DefaultTestClassDescriptor(0, suiteName), createWorkerSuite())
         testListener.beforeSuite(testSuiteDescriptor.parent.parent)
         testListener.beforeSuite(testSuiteDescriptor.parent)
         testListener.beforeSuite(testSuiteDescriptor)
-        String timestamp = testResult.@timestamp.text()
+        String timestamp = testSuite.timestamp
         long startTime = DatatypeFactory.newInstance().newXMLGregorianCalendar(timestamp).toGregorianCalendar().getTimeInMillis()
-        testResult.testcase.each { testCase ->
-            String testCaseClassName = testCase.@classname.text()
-            String testMethodName = testCase.@name.text()
-            def testCaseDescriptor = new DecoratingTestDescriptor(new DefaultTestMethodDescriptor(0, testCaseClassName, testMethodName), testSuiteDescriptor)
-            def skipped = testCase.skipped
-            def failure = testCase.failure
-            long endTime = startTime + (testCase.@time.toDouble() * 1000).round()
+        testSuite.testCases.each { JUnitTestCase testCase ->
+            String testCaseClassName = testCase.className
+            String testMethodName = testCase.name
+            DecoratingTestDescriptor testCaseDescriptor = new DecoratingTestDescriptor(new DefaultTestMethodDescriptor(0, testCaseClassName, testMethodName), testSuiteDescriptor)
+            List<JUnitFailure> failures = testCase.failures
+            long endTime = startTime + (testCase.time * 1000).round()
 
-            if (failure.size() > 0) {
+            if (failures && failures.size() > 0) {
                 testListener.beforeTest(testCaseDescriptor)
                 publishAdditionalMetadata(testCaseDescriptor, build)
                 try {
-                    String systemErr = testResult."system-err".text()
+                    String systemErr = testSuite.systemOut
                     if (systemErr) {
                         testOutputListener.onOutput(testCaseDescriptor, new DefaultTestOutputEvent(TestOutputEvent.Destination.StdErr, systemErr))
                     }
                 } catch (Exception e) {
                     e.printStackTrace()
                 }
-                String failureText = failure.text()
+                String failureText = failures.collect { it.message } .join('\n')
                 failureText = failureText.replace("java.lang.AssertionError: ", "")
-                testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime, 1, 0, 1, [assertionError(failureText)]))
-            } else if (!(skipped.size() > 0)) {
+                testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime, 1, 0, 1, [new AssertionError(failureText as Object)] as List<Throwable>))
+            } else if (notSkipped(testCase)) {
                 testListener.beforeTest(testCaseDescriptor)
                 publishAdditionalMetadata(testCaseDescriptor, build)
                 testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.SUCCESS, startTime, endTime, 1, 1, 0, []))
@@ -96,10 +94,9 @@ class JUnitXmlTestEventsGenerator {
         testListener.afterSuite(testSuiteDescriptor.parent.parent, new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, []))
     }
 
-    @groovy.transform.CompileStatic
-    // workaround for class org.codehaus.groovy.reflection.CachedConstructor cannot access a member of class java.lang.AssertionError (in module java.base) with modifiers "private"
-    // using Jigsaw
-    AssertionError assertionError(/*must be Object*/Object failureText) { new AssertionError(failureText) }
+    private boolean notSkipped(JUnitTestCase testCase) {
+        return testCase.skipped?.toString() == null
+    }
 
     private void publishAdditionalMetadata(DecoratingTestDescriptor testCaseDescriptor, Object build) {
         List<String> outputs = []

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
@@ -34,6 +34,7 @@ import org.openmbee.junit.model.JUnitFailure
 import org.openmbee.junit.model.JUnitTestCase
 
 import javax.xml.datatype.DatatypeFactory
+import groovy.transform.CompileStatic
 
 /**
  * This class is responsible for publishing events to {@link TestListener} and {@link TestOutputListener}
@@ -53,6 +54,7 @@ class JUnitXmlTestEventsGenerator {
         this.testListenerBroadcast = testListenerBroadcast
     }
 
+    @CompileStatic
     void processTestSuite(JUnitTestSuite testSuite, Object build) {
         String suiteName = testSuite.name
         DecoratingTestDescriptor testSuiteDescriptor = new DecoratingTestDescriptor(new DefaultTestClassDescriptor(0, suiteName), createWorkerSuite())
@@ -81,7 +83,7 @@ class JUnitXmlTestEventsGenerator {
                 }
                 String failureText = failures.collect { it.message } .join('\n')
                 failureText = failureText.replace("java.lang.AssertionError: ", "")
-                testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime, 1, 0, 1, [assertionError(failureText)]))
+                testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime, 1, 0, 1, [assertionError(failureText) as Throwable]))
             } else if (notSkipped(testCase)) {
                 testListener.beforeTest(testCaseDescriptor)
                 publishAdditionalMetadata(testCaseDescriptor, build)
@@ -93,7 +95,7 @@ class JUnitXmlTestEventsGenerator {
         testListener.afterSuite(testSuiteDescriptor.parent.parent, new DefaultTestResult(TestResult.ResultType.SUCCESS, 0, 0, 0, 0, 0, []))
     }
 
-    @groovy.transform.CompileStatic
+    @CompileStatic
     // workaround for class org.codehaus.groovy.reflection.CachedConstructor cannot access a member of class java.lang.AssertionError (in module java.base) with modifiers "private"
     // using Jigsaw
     private AssertionError assertionError(/*must be Object*/Object failureText) { new AssertionError(failureText) }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ScenarioReportRenderer.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ScenarioReportRenderer.groovy
@@ -2,9 +2,10 @@ package org.gradle.testing
 
 import groovy.util.slurpersupport.NodeChildren
 import groovy.xml.MarkupBuilder
+import org.openmbee.junit.model.JUnitTestSuite
 
 class ScenarioReportRenderer {
-    void render(Writer writer, String projectName, List<Object> finishedBuilds, Map<String, List<File>> testResultFilesForBuild) {
+    void render(Writer writer, String projectName, List<Object> finishedBuilds, Map<String, List<JUnitTestSuite>> testResultsForBuild) {
         def markup = new MarkupBuilder(writer)
 
         markup.html {
@@ -18,16 +19,16 @@ class ScenarioReportRenderer {
             def otherBuilds = buildsSuccessOrNot.get(false)
             if (otherBuilds) {
                 h3 "${otherBuilds.size()} Failed scenarios"
-                renderResultTable(markup, projectName, otherBuilds, testResultFilesForBuild, true)
+                renderResultTable(markup, projectName, otherBuilds, testResultsForBuild, true)
             }
             if (successfullBuilds) {
                 h3 "${successfullBuilds.size()} Successful scenarios"
-                renderResultTable(markup, projectName, successfullBuilds, testResultFilesForBuild)
+                renderResultTable(markup, projectName, successfullBuilds, testResultsForBuild)
             }
         }
     }
 
-    private renderResultTable(markup, projectName, builds, Map<String, List<File>> testResultFilesForBuild, failed = false) {
+    private renderResultTable(markup, projectName, builds, Map<String, List<JUnitTestSuite>> testResultsForBuild, failed = false) {
         def closure = {
             table {
                 thead {
@@ -42,8 +43,7 @@ class ScenarioReportRenderer {
                 }
                 builds.eachWithIndex { build, idx ->
                     def rowClass = build.@status.toString().toLowerCase()
-                    def testResultFiles = testResultFilesForBuild.get(build.@id.text())
-                    def xmlResultFiles = testResultFiles.findAll { it.name.endsWith('.xml') }
+                    def testResults = testResultsForBuild.get(build.@id.text())
                     tr(class: rowClass) {
                         td("${idx+1}. ${this.getScenarioId(build)}")
                         td {
@@ -59,14 +59,13 @@ class ScenarioReportRenderer {
                         }
                     }
                     if (failed) {
-                        if (xmlResultFiles) {
-                            for (File testResultXmlFile : xmlResultFiles) {
-                                def testresult = new XmlSlurper().parse(testResultXmlFile)
-                                testresult.testcase.failure.each { failure ->
+                        testResults?.each { testSuite ->
+                            testSuite?.testCases?.each { testCase ->
+                                testCase?.failures?.each { failure ->
                                     tr(class: rowClass) {
                                         td(colspan: 4) {
                                             span(class: 'code') {
-                                                pre(failure.text())
+                                                pre(failure.message)
                                             }
                                         }
                                     }

--- a/buildSrc/subprojects/performance/src/test/groovy/org/gradle/testing/JUnitXmlTestEventsGeneratorTest.groovy
+++ b/buildSrc/subprojects/performance/src/test/groovy/org/gradle/testing/JUnitXmlTestEventsGeneratorTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.api.tasks.testing.TestOutputListener
 import org.gradle.api.tasks.testing.TestResult
 import org.gradle.internal.event.ListenerBroadcast
 import spock.lang.Specification
+import org.openmbee.junit.JUnitMarshalling
+import org.openmbee.junit.model.JUnitTestSuite
 
 class JUnitXmlTestEventsGeneratorTest extends Specification {
     def "uses correct failure message"() {
@@ -53,7 +55,7 @@ class JUnitXmlTestEventsGeneratorTest extends Specification {
                 </failure>
                 </testcase>
             </testsuite>""".stripIndent()
-        def gpath = new XmlSlurper().parseText(xml)
+        JUnitTestSuite testSuite = JUnitMarshalling.unmarshalTestSuite(new ByteArrayInputStream(xml.bytes))
         ListenerBroadcast<TestListener> testListenerBroadcast = Mock()
         TestListener testListener = Mock()
         ListenerBroadcast<TestOutputListener> testOutputListenerBroadcast = Mock()
@@ -63,7 +65,7 @@ class JUnitXmlTestEventsGeneratorTest extends Specification {
         Object build = new XmlSlurper().parseText("""<build webUrl="http://some.url"><properties><property name="scenario" value="configuration of ktsManyProjects (--recompile-scripts)" inherited="false"/></properties></build>""")
 
         when:
-        new JUnitXmlTestEventsGenerator(testListenerBroadcast, testOutputListenerBroadcast).processXml(gpath, build)
+        new JUnitXmlTestEventsGenerator(testListenerBroadcast, testOutputListenerBroadcast).processTestSuite(testSuite, build)
 
         then:
         _ * testListenerBroadcast.getSource() >> testListener

--- a/buildSrc/subprojects/performance/src/test/groovy/org/gradle/testing/ScenarioReportRendererTest.groovy
+++ b/buildSrc/subprojects/performance/src/test/groovy/org/gradle/testing/ScenarioReportRendererTest.groovy
@@ -5,6 +5,7 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 import spock.lang.Subject
+import org.openmbee.junit.JUnitMarshalling
 
 
 class ScenarioReportRendererTest extends Specification {
@@ -41,7 +42,7 @@ class ScenarioReportRendererTest extends Specification {
         def successfulBuild = getSampleBuild("sample-build-result-success.xml")
         def testResultXmlFile = copyResource("TEST-sample.xml")
         def testResultFilesForBuild = [:]
-        testResultFilesForBuild.put(failedBuild.@id.text(), [testResultXmlFile])
+        testResultFilesForBuild.put(failedBuild.@id.text(), [JUnitMarshalling.unmarshalTestSuite(new FileInputStream(testResultXmlFile))])
 
         when:
         htmlFile.withWriter { Writer writer ->


### PR DESCRIPTION
This PR uses JUnit xml library to replace the previously used plain xml processing.