### PR TITLE
[WIP] Recompute selected component when removing a selector 

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.integtests.resolve
 
-import groovy.transform.NotYetImplemented
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
@@ -1491,10 +1490,10 @@ task checkDeps(dependsOn: configurations.compile) {
         noExceptionThrown()
     }
 
-    @NotYetImplemented
     def "evicted hard dependency shouldn't add constraint on range"() {
         given:
-        4.times { mavenRepo.module("org", "a", "${it+1}").publish() }
+        4.times { mavenRepo.module("org", "e", "${it+1}").publish() }
+        4.times { mavenRepo.module("org", "a", "${it+1}").dependsOn('org', 'e', "${it+1}").publish() }
         mavenRepo.module("org", "b", "1").dependsOn('org', 'a', '4').publish() // this will be evicted
         mavenRepo.module('org', 'c', '1').dependsOn('org', 'd', '1').publish()
         mavenRepo.module('org', 'd', '1').dependsOn('org', 'b', '2').publish()
@@ -1513,7 +1512,7 @@ task checkDeps(dependsOn: configurations.compile) {
             task checkDeps {
                 doLast {
                     def files = configurations.conf*.name.sort()
-                    assert files == ['a-3.jar', 'b-2.jar', 'c-1.jar', 'd-1.jar']
+                    assert files == ['a-3.jar', 'b-2.jar', 'c-1.jar', 'd-1.jar', 'e-3.jar']
                 }
             }
         """
@@ -1525,7 +1524,6 @@ task checkDeps(dependsOn: configurations.compile) {
         noExceptionThrown()
     }
 
-    @NotYetImplemented
     def "doesn't include evicted version from branch which has been deselected"() {
         given:
         mavenRepo.module('org', 'a', '1').dependsOn('org', 'b', '2').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -403,7 +403,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') alignsTo('2.9.4') byPublishedPlatform()
             module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
-            module('annotations') tries('2.7.9', '2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
             module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
 
             doesNotGetPlatform("org", "platform", "2.9.0") // because of conflict resolution
@@ -967,7 +967,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         expectAlignment {
             module('core') alignsTo('2.9.4') byPublishedPlatform()
             module('databind') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
-            module('annotations') tries('2.7.9', '2.9.0') alignsTo('2.9.4') byPublishedPlatform()
+            module('annotations') tries('2.7.9') alignsTo('2.9.4') byPublishedPlatform()
             module('kt') alignsTo('2.9.4.1') byPublishedPlatform()
 
             doesNotGetPlatform("org", "platform", "2.9.0") // because of conflict resolution

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -222,7 +222,7 @@ public class DependencyGraphBuilder {
             SelectorState selector = dependency.getSelector();
             ModuleResolveState module = selector.getTargetModule();
 
-            if (!selector.isResolved()) {
+            if (selector.canResolve()) {
                 // Have an unprocessed/new selector for this module. Need to re-select the target version.
                 performSelection(resolveState, module);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -63,6 +63,7 @@ class ModuleResolveState implements CandidateModule {
     private ImmutableAttributes mergedAttributes = ImmutableAttributes.EMPTY;
     private AttributeMergingException attributeMergingError;
     private VirtualPlatformState platformState;
+    private boolean replaced = false;
 
     ModuleResolveState(IdGenerator<Long> idGenerator,
                        ModuleIdentifier id,
@@ -141,6 +142,7 @@ class ModuleResolveState implements CandidateModule {
     public void select(ComponentState selected) {
         assert this.selected == null;
         this.selected = selected;
+        this.replaced = false;
 
         selectComponentAndEvictOthers(selected);
     }
@@ -155,7 +157,7 @@ class ModuleResolveState implements CandidateModule {
     /**
      * Changes the selected target component for this module.
      */
-    public void changeSelection(ComponentState newSelection) {
+    private void changeSelection(ComponentState newSelection) {
         assert this.selected != null;
         assert newSelection != null;
         assert this.selected != newSelection;
@@ -165,6 +167,7 @@ class ModuleResolveState implements CandidateModule {
         selected.removeOutgoingEdges();
 
         this.selected = newSelection;
+        this.replaced = false;
 
         doRestart(newSelection);
     }
@@ -185,12 +188,13 @@ class ModuleResolveState implements CandidateModule {
         }
 
         selected = null;
+        replaced = false;
     }
 
     /**
      * Overrides the component selection for this module, when this module has been replaced by another.
      */
-    public void restart(ComponentState selected) {
+    public void replaceBy(ComponentState selected) {
         if (this.selected != null) {
             clearSelection();
         }
@@ -199,8 +203,14 @@ class ModuleResolveState implements CandidateModule {
         assert selected != null;
 
         this.selected = selected;
+        this.replaced = computeReplaced(selected);
 
         doRestart(selected);
+    }
+
+    private boolean computeReplaced(ComponentState selected) {
+        // This module might be resolved to a different module, through replacedBy
+        return !selected.getId().getModule().equals(getId());
     }
 
     private void doRestart(ComponentState selected) {
@@ -253,9 +263,13 @@ class ModuleResolveState implements CandidateModule {
 
     void removeSelector(SelectorState selector) {
         selectors.remove(selector);
+        selector.markForReuse();
         mergedAttributes = ImmutableAttributes.EMPTY;
         for (SelectorState selectorState : selectors) {
             mergedAttributes = appendAttributes(mergedAttributes, selectorState);
+        }
+        if (!selectors.isEmpty()) {
+            maybeUpdateSelection();
         }
     }
 
@@ -323,16 +337,17 @@ class ModuleResolveState implements CandidateModule {
     }
 
 
-    public boolean maybeUpdateSelection() {
+    public void maybeUpdateSelection() {
+        if (replaced) {
+            // Never update selection for a replaced module
+            return;
+        }
         ComponentState newSelected = selectorStateResolver.selectBest(getId(), getSelectors());
         if (selected == null) {
             select(newSelected);
-            return true;
         } else if (newSelected != selected) {
             changeSelection(newSelected);
-            return true;
         }
-        return false;
     }
 
     boolean hasCompetingForceSelectors() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
@@ -33,7 +33,7 @@ class ReplaceSelectionWithConflictResultAction implements Action<ConflictResolut
             public void execute(ModuleIdentifier moduleIdentifier) {
                 // Restart each configuration. For the evicted configuration, this means moving incoming dependencies across to the
                 // matching selected configuration. For the select configuration, this mean traversing its dependencies.
-                resolveState.getModule(moduleIdentifier).restart(selected);
+                resolveState.getModule(moduleIdentifier).replaceBy(selected);
             }
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -78,6 +78,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     private boolean resolved;
     private boolean forced;
     private boolean fromLock;
+    private boolean reusable;
 
     // An internal counter used to track the number of outgoing edges
     // that use this selector. Since a module resolve state tracks all selectors
@@ -210,6 +211,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     private boolean requiresResolve(ComponentIdResolveResult previousResult, VersionSelector allRejects) {
+        this.reusable = false;
         // If we've never resolved, must resolve
         if (previousResult == null) {
             return true;
@@ -243,11 +245,33 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     /**
+     * Marks a selector for reuse,
+     * indicating it could be used again for resolution
+     */
+    void markForReuse() {
+        assert resolved;
+        this.reusable = true;
+    }
+
+    /**
+     * Checks if the selector can be used for resolution.
+     *
+     * @return {@code true} if the selector can resolve, {@code false} otherwise
+     */
+    boolean canResolve() {
+        if (reusable) {
+            return true;
+        }
+        return !resolved;
+    }
+
+    /**
      * Overrides the component that is the chosen for this selector.
      * This happens when the `ModuleResolveState` is restarted, during conflict resolution or version range merging.
      */
     public void overrideSelection(ComponentState selected) {
         this.resolved = true;
+        this.reusable = false;
 
         // Target module can change, if this is called as the result of a module replacement conflict.
         this.targetModule = selected.getModule();


### PR DESCRIPTION
Previously, once a component was selected, removing a selector would not
change the resolution result, potentially keeping a selection that no
longer applied.
Now upon removal of a selector, the selected component may be updated.