### PR TITLE
Use TCP keep-alive for http connections

### DIFF
--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientConfigurer.java
@@ -73,7 +73,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.HostnameVerifier;
-import java.io.IOException;
 import java.net.ProxySelector;
 import java.util.Collection;
 import java.util.Collections;
@@ -247,7 +246,7 @@ public class HttpClientConfigurer {
 
     private void configureSocketConfig(HttpClientBuilder builder) {
         HttpTimeoutSettings timeoutSettings = httpSettings.getTimeoutSettings();
-        builder.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutSettings.getSocketTimeoutMs()).build());
+        builder.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutSettings.getSocketTimeoutMs()).setSoKeepAlive(true).build());
     }
 
     private void configureRedirectStrategy(HttpClientBuilder builder) {
@@ -281,7 +280,7 @@ public class HttpClientConfigurer {
             this.alwaysSendAuth = alwaysSendAuth;
         }
 
-        public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
+        public void process(final HttpRequest request, final HttpContext context) throws HttpException {
 
             AuthState authState = (AuthState) context.getAttribute(HttpClientContext.TARGET_AUTH_STATE);
 

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
@@ -19,12 +19,12 @@ import org.apache.http.auth.AuthScope
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.ssl.SSLContexts
 import org.gradle.api.artifacts.repositories.PasswordCredentials
-import org.gradle.internal.credentials.DefaultHttpHeaderCredentials
 import org.gradle.internal.authentication.AllSchemesAuthentication
+import org.gradle.internal.credentials.DefaultHttpHeaderCredentials
 import org.gradle.internal.resource.UriTextResource
 import spock.lang.Specification
 
-public class HttpClientConfigurerTest extends Specification {
+class HttpClientConfigurerTest extends Specification {
     HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
 
     PasswordCredentials credentials = Mock()
@@ -151,5 +151,6 @@ public class HttpClientConfigurerTest extends Specification {
         2 * timeoutSettings.socketTimeoutMs >> 30000
         httpClientBuilder.defaultRequestConfig.connectTimeout == 10000
         httpClientBuilder.defaultRequestConfig.socketTimeout == 30000
+        httpClientBuilder.defaultSocketConfig.soKeepAlive
     }
 }


### PR DESCRIPTION
So that a proxy or MITM doesn't terminate the connections so easily.

Fixes #6461