### PR TITLE
Polish build scripts and plugins

### DIFF
--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/TaskPropertyValidationPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/TaskPropertyValidationPlugin.kt
@@ -76,7 +76,7 @@ fun Project.addValidateTask() =
         // This block gets called twice for the core project as core applies the base as well as the library plugin. That is why we need to check
         // whether the task already exists.
         if (tasks.findByName(validateTaskName) == null) {
-            val validateTask = tasks.register(validateTaskName, ValidateTaskProperties::class.java) {
+            val validateTask = tasks.register(validateTaskName, ValidateTaskProperties::class) {
                 val main by java.sourceSets
                 dependsOn(main.output)
                 classes = main.output.classesDirs
@@ -88,7 +88,7 @@ fun Project.addValidateTask() =
             tasks.named("codeQuality").configure {
                 dependsOn(validateTask)
             }
-            tasks.withType(Test::class.java).configureEach {
+            tasks.withType(Test::class).configureEach {
                 shouldRunAfter(validateTask)
             }
         }

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanupPlugin.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/CleanupPlugin.kt
@@ -24,12 +24,12 @@ import org.gradle.kotlin.dsl.*
 class CleanupPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-        tasks.register("cleanUpCaches", CleanUpCaches::class.java) {
+        tasks.register("cleanUpCaches", CleanUpCaches::class) {
             dependsOn(":createBuildReceipt")
         }
-        tasks.register("cleanUpDaemons", CleanUpDaemons::class.java)
+        tasks.register("cleanUpDaemons", CleanUpDaemons::class)
 
-        val killExistingProcessesStartedByGradle = tasks.register("killExistingProcessesStartedByGradle", KillLeakingJavaProcesses::class.java)
+        val killExistingProcessesStartedByGradle = tasks.register("killExistingProcessesStartedByGradle", KillLeakingJavaProcesses::class)
 
         if (BuildEnvironment.isCiServer) {
             tasks {

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/EmptyDirectoryCheck.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/EmptyDirectoryCheck.kt
@@ -26,6 +26,7 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.internal.logging.ConsoleRenderer
+import org.gradle.kotlin.dsl.*
 import java.io.File
 import javax.inject.Inject
 
@@ -43,7 +44,7 @@ open class EmptyDirectoryCheck @Inject constructor(objects: ObjectFactory) : Def
     val reportFile: RegularFileProperty = newOutputFile()
 
     @get:Input
-    val policy: Property<WhenNotEmpty> = objects.property(WhenNotEmpty::class.java)
+    val policy: Property<WhenNotEmpty> = objects.property(WhenNotEmpty::class)
 
     @TaskAction
     fun ensureDirectoryEmpty() {
@@ -67,5 +68,5 @@ open class EmptyDirectoryCheck @Inject constructor(objects: ObjectFactory) : Def
 
     private
     fun createMessage(targetDir: File, report: File) =
-            "The directory $targetDir was not empty. Report: ${ConsoleRenderer().asClickableFileUrl(report)}\n${report.readText()}"
+        "The directory $targetDir was not empty. Report: ${ConsoleRenderer().asClickableFileUrl(report)}\n${report.readText()}"
 }

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/EmptyDirectoryCheck.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/EmptyDirectoryCheck.kt
@@ -44,7 +44,7 @@ open class EmptyDirectoryCheck @Inject constructor(objects: ObjectFactory) : Def
     val reportFile: RegularFileProperty = newOutputFile()
 
     @get:Input
-    val policy: Property<WhenNotEmpty> = objects.property(WhenNotEmpty::class)
+    val policy: Property<WhenNotEmpty> = objects.property()
 
     @TaskAction
     fun ensureDirectoryEmpty() {

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/TestFileCleanUpExtension.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/TestFileCleanUpExtension.kt
@@ -22,5 +22,5 @@ import org.gradle.kotlin.dsl.*
 
 
 open class TestFileCleanUpExtension(objects: ObjectFactory) {
-    val policy: Property<WhenNotEmpty> = objects.property(WhenNotEmpty::class)
+    val policy: Property<WhenNotEmpty> = objects.property()
 }

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/TestFileCleanUpExtension.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/TestFileCleanUpExtension.kt
@@ -18,8 +18,9 @@ package org.gradle.gradlebuild.testing.integrationtests.cleanup
 
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.*
 
 
 open class TestFileCleanUpExtension(objects: ObjectFactory) {
-    val policy: Property<WhenNotEmpty> = objects.property(WhenNotEmpty::class.java)
+    val policy: Property<WhenNotEmpty> = objects.property(WhenNotEmpty::class)
 }

--- a/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/TestFilesCleanUpPlugin.kt
+++ b/buildSrc/subprojects/cleanup/src/main/kotlin/org/gradle/gradlebuild/testing/integrationtests/cleanup/TestFilesCleanUpPlugin.kt
@@ -18,7 +18,7 @@ package org.gradle.gradlebuild.testing.integrationtests.cleanup
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.*
 
 
 /**
@@ -30,7 +30,7 @@ open class TestFilesCleanUpPlugin : Plugin<Project> {
         val testFilesCleanup = extensions.create<TestFileCleanUpExtension>("testFilesCleanup", objects)
         testFilesCleanup.policy.set(WhenNotEmpty.FAIL)
 
-        tasks.register("verifyTestFilesCleanup", EmptyDirectoryCheck::class.java) {
+        tasks.register("verifyTestFilesCleanup", EmptyDirectoryCheck::class) {
             targetDirectory.set(layout.buildDirectory.dir("tmp/test files"))
             reportFile.set(layout.buildDirectory.file("reports/remains.txt"))
             policy.set(testFilesCleanup.policy)

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -72,6 +72,7 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
         val extra = gradle.rootProject.extra
         val capabilities: List<CapabilitySpec>
         if (extra.has("capabilities")) {
+            @Suppress("unchecked_cast")
             capabilities = extra.get("capabilities") as List<CapabilitySpec>
         } else {
             val capabilitiesFile = gradle.rootProject.file("gradle/dependency-management/capabilities.json")

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/dependencies/DependenciesMetadataRulesPlugin.kt
@@ -73,7 +73,7 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
         val capabilities: List<CapabilitySpec>
         if (extra.has("capabilities")) {
             @Suppress("unchecked_cast")
-            capabilities = extra.get("capabilities") as List<CapabilitySpec>
+            capabilities = extra["capabilities"] as List<CapabilitySpec>
         } else {
             val capabilitiesFile = gradle.rootProject.file("gradle/dependency-management/capabilities.json")
             if (capabilitiesFile.exists()) {
@@ -81,7 +81,7 @@ open class DependenciesMetadataRulesPlugin : Plugin<Project> {
             } else {
                 capabilities = emptyList()
             }
-            extra.set("capabilities", capabilities)
+            extra["capabilities"] = capabilities
         }
         capabilities.forEach {
             it.configure(dependencies.components, configurations)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/IntTestImagePlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/IntTestImagePlugin.kt
@@ -114,7 +114,10 @@ open class IntTestImagePlugin : Plugin<Project> {
                     }
 
                     into("samples") {
-                        from(Callable { (project(":docs").extra.get("outputs") as Map<String, FileCollection>)["samples"] })
+                        from(Callable {
+                            val outputs: Map<String, FileCollection> by project(":docs").extra
+                            outputs["samples"]
+                        })
                     }
 
                     doLast {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/IntTestImagePlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/IntTestImagePlugin.kt
@@ -52,7 +52,7 @@ open class IntTestImagePlugin : Plugin<Project> {
 
         val partialDistribution by configurations.creating {
             attributes {
-                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class, Usage.JAVA_RUNTIME))
+                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
             }
             isCanBeResolved = true
             isCanBeConsumed = false
@@ -79,7 +79,7 @@ open class IntTestImagePlugin : Plugin<Project> {
         } else {
             val selfRuntime by configurations.creating {
                 attributes {
-                    attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class, Usage.JAVA_RUNTIME))
+                    attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage.JAVA_RUNTIME))
                 }
                 isCanBeResolved = true
                 isCanBeConsumed = false

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/IntTestImagePlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/IntTestImagePlugin.kt
@@ -41,7 +41,7 @@ import java.util.concurrent.Callable
 open class IntTestImagePlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-        val intTestImage = tasks.register("intTestImage", Sync::class.java) {
+        val intTestImage = tasks.register("intTestImage", Sync::class) {
             group = "Verification"
             into(file("$buildDir/integ test"))
         }
@@ -52,7 +52,7 @@ open class IntTestImagePlugin : Plugin<Project> {
 
         val partialDistribution by configurations.creating {
             attributes {
-                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class, Usage.JAVA_RUNTIME))
             }
             isCanBeResolved = true
             isCanBeConsumed = false
@@ -61,7 +61,7 @@ open class IntTestImagePlugin : Plugin<Project> {
         if (useAllDistribution) {
             val unpackedPath = layout.buildDirectory.dir("tmp/unpacked-all-distribution")
 
-            val unpackAllDistribution = tasks.register("unpackAllDistribution", Sync::class.java) {
+            val unpackAllDistribution = tasks.register("unpackAllDistribution", Sync::class) {
                 dependsOn(":distributions:allZip")
                 // TODO: This should be modelled as a publication
                 from(Callable {
@@ -79,7 +79,7 @@ open class IntTestImagePlugin : Plugin<Project> {
         } else {
             val selfRuntime by configurations.creating {
                 attributes {
-                    attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+                    attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage::class, Usage.JAVA_RUNTIME))
                 }
                 isCanBeResolved = true
                 isCanBeConsumed = false

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -64,7 +64,7 @@ open class TestFixturesPlugin : Plugin<Project> {
     fun Project.configureAsProducer() {
 
         configurations {
-            create("outputDirs") {}
+            create("outputDirs")
 
             create("testFixturesCompile") { extendsFrom(configurations["compile"]) }
             create("testFixturesImplementation") { extendsFrom(configurations["implementation"]) }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -83,10 +83,10 @@ open class TestFixturesPlugin : Plugin<Project> {
             "testRuntime" { extendsFrom(configurations["testFixturesUsageRuntime"]) }
         }
 
-        val outputDirs by configurations.getting
-        val testFixturesCompile by configurations.getting
-        val testFixturesRuntime by configurations.getting
-        val testFixturesUsageCompile by configurations.getting
+        val outputDirs by configurations
+        val testFixturesCompile by configurations
+        val testFixturesRuntime by configurations
+        val testFixturesUsageCompile by configurations
 
         val main by java.sourceSets
         val testFixtures by java.sourceSets.creating {

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTest.kt
@@ -55,7 +55,7 @@ open class IntegrationTest : DistributionTest() {
 
     private
     fun determineTimeoutMillis(): Long {
-        return if ("embedded" == getSystemProperties().get("org.gradle.integtest.executer")) {
+        return if ("embedded" == getSystemProperties()["org.gradle.integtest.executer"]) {
             TimeUnit.MINUTES.toMillis(30)
         } else {
             TimeUnit.HOURS.toMillis(2)

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTestsPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/IntegrationTestsPlugin.kt
@@ -28,6 +28,7 @@ class IntegrationTestsPlugin : Plugin<Project> {
         configureIde(TestType.INTEGRATION)
 
         // TODO Model as an extension object. The name is also misleading, as this applies to integration tests as well as cross version tests.
+        @Suppress("unused_variable")
         val integTestTasks by extra { tasks.withType<IntegrationTest>() }
     }
 }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -74,8 +74,8 @@ fun Project.createTasks(sourceSet: SourceSet, testType: TestType) {
 
 
 internal
-fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet, testType: TestType, extraConfig: Action<IntegrationTest>): TaskProvider<IntegrationTest> {
-    return tasks.register(name, IntegrationTest::class.java) {
+fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet, testType: TestType, extraConfig: Action<IntegrationTest>): TaskProvider<IntegrationTest> =
+    tasks.register(name, IntegrationTest::class) {
         description = "Runs ${testType.prefix} with $executer executer"
         systemProperties["org.gradle.integtest.executer"] = executer
         addDebugProperties()
@@ -84,7 +84,6 @@ fun Project.createTestTask(name: String, executer: String, sourceSet: SourceSet,
         libsRepository.required = testType.libRepoRequired
         extraConfig.execute(this)
     }
-}
 
 
 private

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataPlugin.kt
@@ -66,17 +66,17 @@ open class ApiMetadataPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
 
         val extension =
-            extensions.create("apiMetadata", ApiMetadataExtension::class.java, project)
+            extensions.create("apiMetadata", ApiMetadataExtension::class, project)
 
         val apiDeclarationTask =
-            tasks.register("apiDeclarationResource", WriteProperties::class.java) {
+            tasks.register("apiDeclarationResource", WriteProperties::class) {
                 property("includes", extension.includes.get().joinToString(":"))
                 property("excludes", extension.excludes.get().joinToString(":"))
                 outputFile = generatedPropertiesFileFor(apiDeclarationFilename).get().asFile
             }
 
         val apiParameterNamesTask =
-            tasks.register("apiParameterNamesResource", ParameterNamesResourceTask::class.java) {
+            tasks.register("apiParameterNamesResource", ParameterNamesResourceTask::class) {
                 sources.from(extension.sources.asFileTree.matching {
                     include(extension.includes.get())
                     exclude(extension.excludes.get())

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyPlugin.kt
@@ -60,7 +60,7 @@ open class MinifyPlugin : Plugin<Project> {
                          */
                         from.attribute(minified, false).attribute(artifactType, "jar")
                         to.attribute(minified, true).attribute(artifactType, "jar")
-                        artifactTransform(MinifyTransform::class.java) {
+                        artifactTransform(MinifyTransform::class) {
                             params(keepPatterns)
                         }
                     }

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
@@ -113,7 +113,7 @@ open class ShadedJarPlugin : Plugin<Project> {
         }
 
         return configurations.create(configurationName) {
-            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class, Usage.JAVA_RUNTIME))
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
             isCanBeResolved = true
             isCanBeConsumed = false
         }

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
@@ -86,7 +86,7 @@ open class ShadedJarPlugin : Plugin<Project> {
                         .attribute(artifactType, "jar")
                         .attribute(minified, true)
                     to.attribute(artifactType, relocatedClassesAndAnalysisType)
-                    artifactTransform(ShadeClassesTransform::class.java) {
+                    artifactTransform(ShadeClassesTransform::class) {
                         params(
                             "org.gradle.internal.impldep",
                             shadedJarExtension.keepPackages.get(),
@@ -113,7 +113,7 @@ open class ShadedJarPlugin : Plugin<Project> {
         }
 
         return configurations.create(configurationName) {
-            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class, Usage.JAVA_RUNTIME))
             isCanBeResolved = true
             isCanBeConsumed = false
         }
@@ -123,9 +123,9 @@ open class ShadedJarPlugin : Plugin<Project> {
     fun Project.addShadedJarTask(shadedJarExtension: ShadedJarExtension): TaskProvider<ShadedJar> {
         val configurationToShade = shadedJarExtension.shadedConfiguration
         val baseVersion: String by rootProject.extra
-        val jar: TaskProvider<Jar> = tasks.withType(Jar::class.java).named("jar")
+        val jar: TaskProvider<Jar> = tasks.withType(Jar::class).named("jar")
 
-        return tasks.register("${project.name}ShadedJar", ShadedJar::class.java) {
+        return tasks.register("${project.name}ShadedJar", ShadedJar::class) {
             dependsOn(jar)
             jarFile.set(layout.buildDirectory.file("shaded-jar/${base.archivesBaseName}-shaded-$baseVersion.jar"))
             classTreesConfiguration.from(configurationToShade.artifactViewForType(classTreesType))
@@ -156,7 +156,7 @@ open class ShadedJarPlugin : Plugin<Project> {
         registerTransform {
             from.attribute(artifactType, fromType)
             to.attribute(artifactType, toType)
-            artifactTransform(T::class.java, action)
+            artifactTransform(T::class, action)
         }
 }
 
@@ -173,15 +173,15 @@ open class ShadedJarExtension(layout: ProjectLayout, objects: ObjectFactory, val
     /**
      * Retain only those classes in the keep package hierarchies, plus any classes that are reachable from these classes.
      */
-    val keepPackages = objects.setProperty(String::class.java)!!
+    val keepPackages = objects.setProperty(String::class)
 
     /**
      * Do not rename classes in the unshaded package hierarchies. Always includes 'java'.
      */
-    val unshadedPackages = objects.setProperty(String::class.java)!!
+    val unshadedPackages = objects.setProperty(String::class)
 
     /**
      * Do not retain classes in the ignore packages hierarchies, unless reachable from some other retained class.
      */
-    val ignoredPackages = objects.setProperty(String::class.java)!!
+    val ignoredPackages = objects.setProperty(String::class)
 }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/publish-public-libraries.gradle.kts
@@ -72,7 +72,7 @@ fun Project.configureUploadArchivesTask(generatePom: TaskProvider<GeneratePom>) 
 
         repositories {
             ivy {
-                artifactPattern(createArtifactPattern(rootProject.extra.get("isSnapshot") as Boolean, project.group.toString(), base.archivesBaseName))
+                artifactPattern(createArtifactPattern(rootProject.extra["isSnapshot"] as Boolean, project.group.toString(), base.archivesBaseName))
                 credentials {
                     username = artifactoryUserName
                     password = artifactoryUserPassword

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -106,7 +106,7 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
 
     private
     fun Project.addGeneratedResources(gradlebuildJava: UnitTestAndCompileExtension) {
-        val classpathManifest = tasks.register("classpathManifest", ClasspathManifest::class.java)
+        val classpathManifest = tasks.register("classpathManifest", ClasspathManifest::class)
         java.sourceSets["main"].output.dir(mapOf("builtBy" to classpathManifest), gradlebuildJava.generatedResourcesDir)
     }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/buildtypes/BuildTypesPlugin.kt
@@ -10,7 +10,7 @@ import org.gradle.kotlin.dsl.*
 class BuildTypesPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-        val buildTypes = container(BuildType::class.java)
+        val buildTypes = container(BuildType::class)
         extensions.add("buildTypes", buildTypes)
         buildTypes.all {
             register(this)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -104,7 +104,7 @@ class PerformanceTestPlugin : Plugin<Project> {
 
     private
     fun Project.createRebaselineTask(performanceTestSourceSet: SourceSet) {
-        project.tasks.register("rebaselinePerformanceTests", RebaselinePerformanceTests::class.java) {
+        project.tasks.register("rebaselinePerformanceTests", RebaselinePerformanceTests::class) {
             source(performanceTestSourceSet.allSource)
         }
     }
@@ -211,7 +211,7 @@ class PerformanceTestPlugin : Plugin<Project> {
 
     private
     fun Project.createCleanSamplesTask() =
-        tasks.register("cleanSamples", Delete::class.java) {
+        tasks.register("cleanSamples", Delete::class) {
             delete(deferred { tasks.withType<ProjectGeneratorTask>().map { it.outputs } })
             delete(deferred { tasks.withType<RemoteProject>().map { it.outputDirectory } })
             delete(deferred { tasks.withType<JavaExecProjectGeneratorTask>().map { it.outputs } })
@@ -306,7 +306,7 @@ class PerformanceTestPlugin : Plugin<Project> {
         prepareSamplesTask: TaskProvider<Task>
     ): TaskProvider<DistributedPerformanceTest> {
 
-        val result = tasks.register(name, DistributedPerformanceTest::class.java) {
+        val result = tasks.register(name, DistributedPerformanceTest::class) {
             configureReportProperties()
             configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask)
             scenarioList = buildDir / Config.performanceTestScenarioListFileName
@@ -338,7 +338,7 @@ class PerformanceTestPlugin : Plugin<Project> {
         prepareSamplesTask: TaskProvider<Task>
     ): TaskProvider<PerformanceTest> {
 
-        val performanceTest = tasks.register(name, PerformanceTest::class.java) {
+        val performanceTest = tasks.register(name, PerformanceTest::class) {
             configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask)
 
             if (project.hasProperty(PropertyNames.performanceTestVerbose)) {
@@ -362,8 +362,8 @@ class PerformanceTestPlugin : Plugin<Project> {
     }
 
     private
-    fun Project.testResultsZipTaskFor(performanceTest: TaskProvider<PerformanceTest>, name: String): TaskProvider<Zip> {
-        return tasks.register("${name}ResultsZip", Zip::class.java) {
+    fun Project.testResultsZipTaskFor(performanceTest: TaskProvider<PerformanceTest>, name: String): TaskProvider<Zip> =
+        tasks.register("${name}ResultsZip", Zip::class) {
             val junitXmlDir = performanceTest.get().reports.junitXml.destination
             from(junitXmlDir) {
                 include("**/TEST-*.xml")
@@ -383,7 +383,6 @@ class PerformanceTestPlugin : Plugin<Project> {
             destinationDir = buildDir
             archiveName = "test-results-${junitXmlDir.name}.zip"
         }
-    }
 
     private
     fun Project.configureForAnyPerformanceTestTask(

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -18,13 +18,13 @@ package org.gradle.gradlebuild.profiling.buildscan
 import com.gradle.scan.plugin.BuildScanExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.internal.GradleInternal
 import org.gradle.api.plugins.quality.Checkstyle
 import org.gradle.api.plugins.quality.CodeNarc
 import org.gradle.api.reporting.Reporting
 import org.gradle.gradlebuild.BuildEnvironment.isCiServer
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.serviceOf
 import org.jsoup.Jsoup
 import org.jsoup.parser.Parser
 
@@ -146,7 +146,7 @@ open class BuildScanPlugin : Plugin<Project> {
                     gradle.taskGraph.allTasks
                         .filter { it.state.executed && it.path in tasksToInvestigate }
                         .forEach { task ->
-                            val hasher = (gradle as GradleInternal).services.get(ClassLoaderHierarchyHasher::class.java)
+                            val hasher = gradle.serviceOf<ClassLoaderHierarchyHasher>()
                             Visitor(buildScan, hasher, task).visit(task::class.java.classLoader)
                         }
                 }

--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/UpdateVersionsPlugin.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/UpdateVersionsPlugin.kt
@@ -36,7 +36,7 @@ class UpdateVersionsPlugin : Plugin<Project> {
             group = "Versioning"
         }
 
-        tasks.register("updateReleasedVersions", UpdateReleasedVersions::class.java) {
+        tasks.register("updateReleasedVersions", UpdateReleasedVersions::class) {
             // TODO
             val currentReleasedVersionProperty = project.findProperty("currentReleasedVersion")
             val value =
@@ -45,7 +45,7 @@ class UpdateVersionsPlugin : Plugin<Project> {
             currentReleasedVersion.set(value)
         }
 
-        tasks.register("updateReleasedVersionsToLatestNightly", UpdateReleasedVersions::class.java) {
+        tasks.register("updateReleasedVersionsToLatestNightly", UpdateReleasedVersions::class) {
             currentReleasedVersion.set(project.providers.provider(Callable {
                 val jsonText = URL("https://services.gradle.org/versions/${VersionType.NIGHTLY.type}").readText()
                 println(jsonText)

--- a/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/WrapperPlugin.kt
+++ b/buildSrc/subprojects/versioning/src/main/kotlin/org/gradle/gradlebuild/versioning/WrapperPlugin.kt
@@ -48,7 +48,7 @@ class WrapperPlugin : Plugin<Project> {
         val wrapperTaskName = "${name}Wrapper"
         val configureWrapperTaskName = "configure${wrapperTaskName.capitalize()}"
 
-        val wrapperTask = tasks.register(wrapperTaskName, Wrapper::class.java) {
+        val wrapperTask = tasks.register(wrapperTaskName, Wrapper::class) {
             dependsOn(configureWrapperTaskName)
             group = "wrapper"
         }

--- a/subprojects/build-comparison/build-comparison.gradle.kts
+++ b/subprojects/build-comparison/build-comparison.gradle.kts
@@ -20,7 +20,7 @@ val css by configurations.creating {
     // define a configuration that, when resolved, will look in
     // the producer for a publication that exposes CSS resources
     attributes {
-        attribute(Usage.USAGE_ATTRIBUTE, (project.objects.named(Usage::class.java, "css-resources")))
+        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named("css-resources"))
     }
     isCanBeResolved = true
     isCanBeConsumed = false


### PR DESCRIPTION
- Prefer `KClass` based overloads over `Class` based ones
- Remove redundant `.getting` delegates
- Reuse `Gradle.serviceOf`