### PR TITLE
Name task correctly for example

### DIFF
--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -1161,7 +1161,7 @@ include::{samplesPath}/userguide/tasks/incrementalBuild/incrementalBuildAdvanced
 include::{samplesPath}/userguide/tasks/incrementalBuild/incrementalBuildAdvanced/incrementalBuildUpToDateWhenAgain.out[]
 ----
 
-The `{ false }` closure ensures that `copyResources` will always perform the copy, irrespective of whether there is no change in the inputs or outputs.
+The `{ false }` closure ensures that `alwaysInstrumentClasses` will always be executed, irrespective of whether there is no change in the inputs or outputs.
 
 You can of course put more complex logic into the closure. You could check whether a particular record in a database table exists or has changed for example. Just be aware that up-to-date checks should _save_ you time. Don’t add checks that cost as much or more time than the standard execution of the task. In fact, if a task ends up running frequently anyway, because it’s rarely up to date, then it may not be worth having an up-to-date check at all. Remember that your checks will always run if the task is in the execution task graph.
 


### PR DESCRIPTION
The current documentation seems to have an updated sample but the text wasn't updated correctly.
Before:
![bildschirmfoto 2018-08-31 um 08 30 40](https://user-images.githubusercontent.com/10229883/44896346-3bcda580-acf8-11e8-9ddc-c3a49852992b.png)
The `copyResources` is only named once in this doc. 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [ ] ~Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [ ] ~Ensure that tests pass locally: `./gradlew <changed-subproject>:check`~

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
