### PR TITLE
Merge long classpath on Windows when necessary

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ClassPathMerger.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ClassPathMerger.java
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures.executer;
 
 import com.google.common.io.ByteStreams;
+import org.apache.commons.io.IOUtils;
 import org.gradle.api.Transformer;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.os.OperatingSystem;
@@ -68,13 +69,17 @@ interface ClassPathMerger {
 
         private File jar(String manifestContent) throws IOException {
             File jar = Files.createTempFile("classpath.jar", null).toFile();
+            ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(jar));
 
-            try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(jar))) {
+            try {
                 ZipEntry entry = new ZipEntry("META-INF/MANIFEST.MF");
                 zipOutputStream.putNextEntry(entry);
                 ByteStreams.copy(new ByteArrayInputStream(manifestContent.getBytes()), zipOutputStream);
                 zipOutputStream.closeEntry();
+            } finally {
+                IOUtils.closeQuietly(zipOutputStream);
             }
+
             return jar;
         }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ClassPathMerger.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ClassPathMerger.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer;
+
+import com.google.common.io.ByteStreams;
+import org.gradle.api.Transformer;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.os.OperatingSystem;
+import org.gradle.util.CollectionUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+interface ClassPathMerger {
+    ClassPathMerger INSTANCE = OperatingSystem.current().isWindows() ? new WindowsClassPathMerger() : new DoNothingClassPathMerger();
+    // Actually 32KB, let's leave some margin
+    int WINDOWS_CLASSPATH_LENGTH_LIMITATION = 1000;
+
+    List<File> mergeClassPathIfNecessary(List<File> classPath);
+
+    class WindowsClassPathMerger implements ClassPathMerger {
+        @Override
+        public List<File> mergeClassPathIfNecessary(List<File> classPath) {
+            if (CollectionUtils.join(File.pathSeparator, classPath).length() < WINDOWS_CLASSPATH_LENGTH_LIMITATION) {
+                return classPath;
+            }
+            return mergedClassPath(classPath);
+        }
+
+        private List<File> mergedClassPath(List<File> classPath) {
+            try {
+                String maneifestContent = generateManifestContent(classPath);
+                File jar = jar(maneifestContent);
+                return Collections.singletonList(jar);
+            } catch (IOException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            }
+        }
+
+        private File jar(String manifestContent) throws IOException {
+            File jar = Files.createTempFile("classpath.jar", null).toFile();
+
+            try (ZipOutputStream zipOutputStream = new ZipOutputStream(new FileOutputStream(jar))) {
+                ZipEntry entry = new ZipEntry("META-INF/MANIFEST.MF");
+                zipOutputStream.putNextEntry(entry);
+                ByteStreams.copy(new ByteArrayInputStream(manifestContent.getBytes()), zipOutputStream);
+                zipOutputStream.closeEntry();
+            }
+            return jar;
+        }
+
+        /**
+         * Build the entry for classpath in jar MANIFEST.MF file, spaces in path should be escaped since
+         * it's the delimiter.
+         */
+        private String generateManifestContent(List<File> classPath) throws IOException {
+            List<URI> uri = CollectionUtils.collect(classPath, new Transformer<URI, File>() {
+                @Override
+                public URI transform(File file) {
+                    return file.toURI();
+                }
+            });
+
+            return make72Safe("Class-Path: " + CollectionUtils.join(" ", uri) + "\r\n");
+        }
+
+        private String make72Safe(String line) {
+            StringBuilder result = new StringBuilder();
+            int length = line.length();
+            for (int i = 0; i < length; i += 69) {
+                result.append(line, i, Math.min(i + 69, length));
+                result.append("\r\n ");
+            }
+            return result.toString();
+        }
+    }
+
+    class DoNothingClassPathMerger implements ClassPathMerger {
+        @Override
+        public List<File> mergeClassPathIfNecessary(List<File> classPath) {
+            return classPath;
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ClassPathMerger.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/ClassPathMerger.java
@@ -44,7 +44,7 @@ import java.util.zip.ZipOutputStream;
 interface ClassPathMerger {
     ClassPathMerger INSTANCE = OperatingSystem.current().isWindows() ? new WindowsClassPathMerger() : new DoNothingClassPathMerger();
     // Actually 32KB, let's leave some margin
-    int WINDOWS_CLASSPATH_LENGTH_LIMITATION = 1000;
+    int WINDOWS_CLASSPATH_LENGTH_LIMITATION = 30000;
 
     List<File> mergeClassPathIfNecessary(List<File> classPath);
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -76,7 +76,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -202,8 +201,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
                 JavaExecHandleBuilder builder = TestFiles.execFactory().newJavaExec();
                 builder.workingDir(getWorkingDir());
                 builder.setExecutable(new File(getJavaHome(), "bin/java"));
-                Collection<File> classpath = cleanup(GLOBAL_SERVICES.get(ModuleRegistry.class).getAdditionalClassPath().getAsFiles());
-                builder.classpath(classpath);
+                builder.classpath(getClassPath());
                 builder.jvmArgs(invocation.launcherJvmArgs);
                 builder.environment(invocation.environmentVars);
 
@@ -216,7 +214,12 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         };
     }
 
-    private Collection<File> cleanup(List<File> files) {
+    private List<File> getClassPath() {
+        List<File> classPath = GLOBAL_SERVICES.get(ModuleRegistry.class).getAdditionalClassPath().getAsFiles();
+        return ClassPathMerger.INSTANCE.mergeClassPathIfNecessary(cleanup(classPath));
+    }
+
+    private List<File> cleanup(List<File> files) {
         List<File> result = new LinkedList<File>();
         String prefix = Jvm.current().getJavaHome().getPath() + File.separator;
         for (File file : files) {

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/WindowsClassPathMergerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/executer/WindowsClassPathMergerTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.executer
+
+import org.gradle.integtests.fixtures.executer.ClassPathMerger.WindowsClassPathMerger
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Specification
+import spock.lang.Subject
+
+import java.util.zip.ZipFile
+
+@Requires(TestPrecondition.WINDOWS)
+class WindowsClassPathMergerTest extends Specification {
+    @Subject
+    WindowsClassPathMerger windowsClassPathMerger = new WindowsClassPathMerger()
+
+    def 'can merge long classpath list into one jar'() {
+        when:
+        List<File> classPath = generateLongClassPath()
+        List<File> mergedClassPath = windowsClassPathMerger.mergeClassPathIfNecessary(classPath)
+        ZipFile zipFile = new ZipFile(mergedClassPath[0])
+        String manifest = zipFile.entries().findAll { !it.directory }.collect { zipFile.getInputStream(it).text }.first()
+
+        then:
+        manifest.length() > WindowsClassPathMerger.WINDOWS_CLASSPATH_LENGTH_LIMITATION
+        manifest.startsWith('Class-Path:')
+        (manifest - 'Class-Path: ').replaceAll(/\r\n /, '').split(' ').every { it.startsWith('file:') }
+    }
+
+    List<File> generateLongClassPath() {
+        int totalLength = 0
+        String userDir = System.getProperty('user.dir')
+        int fileCounter = 0
+        List<File> files = []
+
+        while (totalLength < WindowsClassPathMerger.WINDOWS_CLASSPATH_LENGTH_LIMITATION) {
+            File file = new File(userDir, fileCounter.toString())
+            files.add(file)
+
+            fileCounter += 1
+            totalLength += (file.absolutePath.length() + 1)
+        }
+        return files
+    }
+}


### PR DESCRIPTION
### Context

Sometimes we saw `CreateProcess error=206, The filename or extension is too long` on Windows: https://builds.gradle.org/viewLog.html?buildId=15391832&tab=buildResultsDiv&buildTypeId=Gradle_Check_Quick_Java7_Oracle_Windows_integTest due to Windows' limitation on command line arguments list. This PR checks the length of classpath list on windows and merges them into one empty jar with `Class-Path` entry when the original classpath is too long. Bazel did [similar things](https://github.com/bazelbuild/bazel/commit/d9a7d3a789be559bd6972208af21adae871d7a44) before. Currently this only works in integration tests, and we probably can move this to production code in the future.

This PR has been tested on CI with `WINDOWS_CLASSPATH_LENGTH_LIMITATION` set to 1000 deliberately.

Also add a limitation of 128K for Unix.

