### PR TITLE
Add type-safe overload for Manifest.from(mergePath, configurationAction)

### DIFF
--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -37,6 +37,14 @@
             "changes": [
                 "Method return type has changed"
             ]
+        },
+        {
+            "type": "org.gradle.api.java.archives.Manifest",
+            "member": "Method org.gradle.api.java.archives.Manifest.from(java.lang.Object,org.gradle.api.Action)",
+            "acceptation": "Support type-safe manifest merging",
+            "changes": [
+                "Method added to interface"
+            ]
         }
     ]
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/Manifest.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/Manifest.java
@@ -16,6 +16,7 @@
 package org.gradle.api.java.archives;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.Map;
@@ -101,4 +102,16 @@ public interface Manifest {
      * @return this
      */
     Manifest from(Object mergePath, Closure<?> closure);
+
+    /**
+     * Specifies other manifests to be merged into this manifest. A merge path is interpreted as described in
+     * {@link #from(Object...)}.
+     *
+     * The merge is not happening instantaneously. It happens either before writing or when {@link #getEffectiveManifest()}
+     * is called.
+     *
+     * @return this
+     * @since 5.0
+     */
+    Manifest from(Object mergePath, Action<ManifestMergeSpec> action);
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/CustomManifestInternalWrapper.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/CustomManifestInternalWrapper.java
@@ -17,9 +17,11 @@
 package org.gradle.api.java.archives.internal;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.java.archives.ManifestException;
+import org.gradle.api.java.archives.ManifestMergeSpec;
 
 import java.io.OutputStream;
 import java.util.Map;
@@ -86,5 +88,10 @@ public class CustomManifestInternalWrapper implements ManifestInternal {
     @Override
     public Manifest from(Object mergePath, Closure<?> closure) {
         return delegate.from(mergePath, closure);
+    }
+
+    @Override
+    public Manifest from(Object mergePath, Action<ManifestMergeSpec> action) {
+        return delegate.from(mergePath, action);
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifest.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/api/java/archives/internal/DefaultManifest.java
@@ -23,9 +23,10 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.java.archives.Attributes;
 import org.gradle.api.java.archives.ManifestMergeSpec;
+import org.gradle.internal.Actions;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.file.PathToFileResolver;
-import org.gradle.util.ConfigureUtil;
+import org.gradle.util.ClosureBackedAction;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -160,16 +161,20 @@ public class DefaultManifest implements ManifestInternal {
 
     @Override
     public DefaultManifest from(Object... mergePaths) {
-        from(mergePaths, null);
-        return this;
+        return from(mergePaths, Actions.<ManifestMergeSpec>doNothing());
     }
 
     @Override
     public DefaultManifest from(Object mergePaths, Closure<?> closure) {
+        return from(mergePaths, ClosureBackedAction.<ManifestMergeSpec>of(closure));
+    }
+
+    @Override
+    public DefaultManifest from(Object mergePath, Action<ManifestMergeSpec> action) {
         DefaultManifestMergeSpec mergeSpec = new DefaultManifestMergeSpec();
-        mergeSpec.from(mergePaths);
+        mergeSpec.from(mergePath);
         manifestMergeSpecs.add(mergeSpec);
-        ConfigureUtil.configure(closure, mergeSpec);
+        action.execute(mergeSpec);
         return this;
     }
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/api/java/archives/internal/DefaultManifestTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.api.java.archives.internal
 
 import org.apache.tools.ant.taskdefs.Manifest
 import org.apache.tools.ant.taskdefs.Manifest.Attribute
+import org.gradle.api.Action
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.java.archives.ManifestMergeSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
@@ -118,10 +120,21 @@ class DefaultManifestTest extends Specification {
                 }
             }
         }
-        gradleManifest.from(new DefaultManifest(fileResolver).attributes(key4: 'value4'))
+        gradleManifest.from(new DefaultManifest(fileResolver).attributes(key4: 'value4', key5: 'value5'), new Action<ManifestMergeSpec>() {
+            @Override
+            void execute(ManifestMergeSpec spec) {
+                spec.eachEntry { details ->
+                    if (details.key == 'key5') {
+                        details.exclude()
+                    }
+
+                }
+            }
+        })
+        gradleManifest.from(new DefaultManifest(fileResolver).attributes(key6: 'value6'))
 
         expect:
-        gradleManifest.effectiveManifest.getAttributes() == [key1: 'value1', key2: 'value2', key4: 'value4'] + MANIFEST_VERSION_MAP
+        gradleManifest.effectiveManifest.getAttributes() == [key1: 'value1', key2: 'value2', key4: 'value4', key6: 'value6'] + MANIFEST_VERSION_MAP
     }
 
     def writeWithPath() {


### PR DESCRIPTION
In order to make it easier to use from statically compiled languages such as Java and Kotlin.

See #6574 