### PR TITLE
Use actual template project as input to performance tests

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
@@ -282,7 +282,7 @@ abstract class AbstractProjectGeneratorTask extends TemplateProjectGeneratorTask
         destFile.parentFile.mkdirs()
         destFile.withWriter { Writer writer ->
             if (templateName.endsWith('.gradle')) {
-                writer << "// Generated ${UUID.randomUUID()}\n"
+                writer << "// Generated from template\n"
             }
             getTemplate(templateFiles.last()).make(templateArgs).writeTo(writer)
         }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskCollection
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.api.tasks.testing.junit.JUnitOptions
@@ -204,17 +205,25 @@ class PerformanceTestPlugin : Plugin<Project> {
         tasks.register("prepareSamples") {
             group = "Project Setup"
             description = "Generates all sample projects for automated performance tests"
-            dependsOn(tasks.withType<ProjectGeneratorTask>())
-            dependsOn(tasks.withType<RemoteProject>())
-            dependsOn(tasks.withType<JavaExecProjectGeneratorTask>())
+            configureSampleGenerators {
+                this@register.dependsOn(this)
+            }
         }
+
+    private
+    fun Project.configureSampleGenerators(action: TaskCollection<*>.() -> Unit) {
+        tasks.withType<ProjectGeneratorTask>().action()
+        tasks.withType<RemoteProject>().action()
+        tasks.withType<JavaExecProjectGeneratorTask>().action()
+    }
+
 
     private
     fun Project.createCleanSamplesTask() =
         tasks.register("cleanSamples", Delete::class) {
-            delete(deferred { tasks.withType<ProjectGeneratorTask>().map { it.outputs } })
-            delete(deferred { tasks.withType<RemoteProject>().map { it.outputDirectory } })
-            delete(deferred { tasks.withType<JavaExecProjectGeneratorTask>().map { it.outputs } })
+            configureSampleGenerators {
+                this@register.delete(deferred { map { it.outputs } })
+            }
         }
 
 
@@ -411,9 +420,9 @@ class PerformanceTestPlugin : Plugin<Project> {
 
             registerTemplateInputsToPerformanceTest()
 
-            mustRunAfter(tasks.withType<ProjectGeneratorTask>())
-            mustRunAfter(tasks.withType<RemoteProject>())
-            mustRunAfter(tasks.withType<JavaExecProjectGeneratorTask>())
+            configureSampleGenerators {
+                this@apply.mustRunAfter(this)
+            }
         }
     }
 
@@ -428,9 +437,9 @@ class PerformanceTestPlugin : Plugin<Project> {
             val prepareSampleTaskInputs = prepareSampleTask.inputs.properties.mapKeys { entry -> "${prepareSampleTask.name}_${entry.key}" }
             inputs.properties(prepareSampleTaskInputs)
         }
-        project.tasks.withType<ProjectGeneratorTask>().forEach(registerInputs)
-        project.tasks.withType<RemoteProject>().forEach(registerInputs)
-        project.tasks.withType<JavaExecProjectGeneratorTask>().forEach(registerInputs)
+        project.configureSampleGenerators {
+            configureEach(registerInputs)
+        }
     }
 
     private

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -86,11 +86,11 @@ class PerformanceTestPlugin : Plugin<Project> {
         createCheckNoIdenticalBuildFilesTask()
         configureGeneratorTasks()
 
-        val prepareSamplesTask = createPrepareSamplesTask()
+        createPrepareSamplesTask()
         createCleanSamplesTask()
 
-        createLocalPerformanceTestTasks(performanceTestSourceSet, prepareSamplesTask)
-        createDistributedPerformanceTestTasks(performanceTestSourceSet, prepareSamplesTask)
+        createLocalPerformanceTestTasks(performanceTestSourceSet)
+        createDistributedPerformanceTestTasks(performanceTestSourceSet)
 
         createRebaselineTask(performanceTestSourceSet)
 
@@ -230,12 +230,11 @@ class PerformanceTestPlugin : Plugin<Project> {
 
     private
     fun Project.createLocalPerformanceTestTasks(
-        performanceSourceSet: SourceSet,
-        prepareSamplesTask: TaskProvider<Task>
+        performanceSourceSet: SourceSet
     ) {
 
         fun create(name: String, configure: PerformanceTest.() -> Unit = {}) {
-            createLocalPerformanceTestTask(name, performanceSourceSet, prepareSamplesTask).configure(configure)
+            createLocalPerformanceTestTask(name, performanceSourceSet).configure(configure)
         }
 
         create("performanceTest") {
@@ -257,12 +256,11 @@ class PerformanceTestPlugin : Plugin<Project> {
 
     private
     fun Project.createDistributedPerformanceTestTasks(
-        performanceSourceSet: SourceSet,
-        prepareSamplesTask: TaskProvider<Task>
+        performanceSourceSet: SourceSet
     ) {
 
         fun create(name: String, configure: PerformanceTest.() -> Unit = {}) {
-            createDistributedPerformanceTestTask(name, performanceSourceSet, prepareSamplesTask).configure(configure)
+            createDistributedPerformanceTestTask(name, performanceSourceSet).configure(configure)
         }
 
         create("distributedPerformanceTest") {
@@ -312,13 +310,12 @@ class PerformanceTestPlugin : Plugin<Project> {
     private
     fun Project.createDistributedPerformanceTestTask(
         name: String,
-        performanceSourceSet: SourceSet,
-        prepareSamplesTask: TaskProvider<Task>
+        performanceSourceSet: SourceSet
     ): TaskProvider<DistributedPerformanceTest> {
 
         val result = tasks.register(name, DistributedPerformanceTest::class) {
             configureReportProperties()
-            configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask)
+            configureForAnyPerformanceTestTask(this, performanceSourceSet)
             configureSampleGenerators {
                 this@register.dependsOn(this)
             }
@@ -347,12 +344,11 @@ class PerformanceTestPlugin : Plugin<Project> {
     private
     fun Project.createLocalPerformanceTestTask(
         name: String,
-        performanceSourceSet: SourceSet,
-        prepareSamplesTask: TaskProvider<Task>
+        performanceSourceSet: SourceSet
     ): TaskProvider<PerformanceTest> {
 
         val performanceTest = tasks.register(name, PerformanceTest::class) {
-            configureForAnyPerformanceTestTask(this, performanceSourceSet, prepareSamplesTask)
+            configureForAnyPerformanceTestTask(this, performanceSourceSet)
 
             if (project.hasProperty(PropertyNames.performanceTestVerbose)) {
                 testLogging.showStandardStreams = true
@@ -400,8 +396,7 @@ class PerformanceTestPlugin : Plugin<Project> {
     private
     fun Project.configureForAnyPerformanceTestTask(
         task: PerformanceTest,
-        performanceSourceSet: SourceSet,
-        prepareSamplesTask: TaskProvider<Task>
+        performanceSourceSet: SourceSet
     ) {
 
         task.apply {
@@ -419,8 +414,6 @@ class PerformanceTestPlugin : Plugin<Project> {
             }
 
             jvmArgs("-Xmx3g", "-XX:+HeapDumpOnOutOfMemoryError")
-
-            dependsOn(prepareSamplesTask)
 
             registerTemplateInputsToPerformanceTest()
 

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -369,7 +369,6 @@ tasks.register("springBootApp", RemoteProject) {
 tasks.register("largeNativeBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/perf-native-large'
     branch = 'master'
-    finalizedBy 'largeNativeBuildPrebuilt'
 }
 
 tasks.register("largeNativeBuildPrebuilt", GradleBuild) {


### PR DESCRIPTION
This makes the inputs for the performance tests more stable and relocatable.

The downside is that we need to generate all the template projects for the distributed performance test. That currently takes about 6 minutes on our CI infrastructure. We can improve on that by adding more parallelism and more caching to the project generation tasks. Especially java project generation takes quite a considerable amount of time: https://e.grdev.net/s/5wvl2bwxbznpc/timeline?sort=duration&task=eizj7di2vq46c
Given that the [task is already cacheable](https://github.com/gradle/gradle/blob/533cf9fb405500279dbc599e54ca2fd22e215f70/subprojects/performance/templates.gradle#L39), we need to work on getting more cache hits for that template generation.