### PR TITLE
Refine the type in ComponentModuleMetadataHandler.module

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentModuleMetadataHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/ComponentModuleMetadataHandler.java
@@ -17,7 +17,7 @@ package org.gradle.api.artifacts.dsl;
 
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
-import org.gradle.api.artifacts.ComponentModuleMetadata;
+import org.gradle.api.artifacts.ComponentModuleMetadataDetails;
 
 /**
  * Allows to modify the metadata of depended-on software components.
@@ -56,5 +56,5 @@ public interface ComponentModuleMetadataHandler {
      * @param rule a rule that applies to the components of the specified module
      * @since 2.2
      */
-    void module(Object moduleNotation, Action<? super ComponentModuleMetadata> rule);
+    void module(Object moduleNotation, Action<? super ComponentModuleMetadataDetails> rule);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentModuleMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentModuleMetadataHandler.java
@@ -16,7 +16,7 @@
 package org.gradle.api.internal.artifacts.dsl;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.ComponentModuleMetadata;
+import org.gradle.api.artifacts.ComponentModuleMetadataDetails;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.internal.artifacts.ComponentModuleMetadataProcessor;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -28,7 +28,7 @@ public class DefaultComponentModuleMetadataHandler implements ComponentModuleMet
         this.moduleMetadataContainer = new ComponentModuleMetadataContainer(moduleIdentifierFactory);
     }
 
-    public void module(Object moduleNotation, Action<? super ComponentModuleMetadata> rule) {
+    public void module(Object moduleNotation, Action<? super ComponentModuleMetadataDetails> rule) {
         rule.execute(moduleMetadataContainer.module(moduleNotation));
     }
 


### PR DESCRIPTION
The action type parameter becomes `? super ComponentModuleMetadataDetails`
as it matches better the type received when the action is applied.

Fixes a comment made in #6596