### PR TITLE
Cleanup realization of pending provider

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CompositeDomainObjectSet.java
@@ -278,6 +278,11 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
 
         @Override
+        public void realizePending(ProviderInternal<?> provider) {
+
+        }
+
+        @Override
         public boolean addPending(ProviderInternal<? extends T> provider) {
             throw new UnsupportedOperationException();
         }
@@ -298,8 +303,8 @@ public class CompositeDomainObjectSet<T> extends DelegatingDomainObjectSet<T> im
         }
 
         @Override
-        public void onRealize(Action<T> action) {
-
+        public Action<T> onRealize(Action<T> action) {
+            return null;
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -250,7 +250,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         }
     }
 
-    private <I extends T> boolean doAddRealized(I toAdd, Action<? super I> notification) {
+    protected <I extends T> boolean doAddRealized(I toAdd, Action<? super I> notification) {
         if (getStore().addRealized(toAdd)) {
             didAdd(toAdd);
             notification.execute(toAdd);
@@ -266,7 +266,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         ProviderInternal<? extends T> providerInternal = Cast.uncheckedCast(provider);
         store.addPending(providerInternal);
         if (eventRegister.isSubscribed(providerInternal.getType())) {
-            doAddRealized(provider.get(), eventRegister.getAddActions());
+            doRealize(providerInternal);
         }
     }
 
@@ -276,10 +276,12 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         CollectionProviderInternal<T, ? extends Iterable<T>> providerInternal = Cast.uncheckedCast(provider);
         store.addPendingCollection(providerInternal);
         if (eventRegister.isSubscribed(providerInternal.getElementType())) {
-            for (T value : provider.get()) {
-                doAddRealized(value, eventRegister.getAddActions());
-            }
+            doRealize(providerInternal);
         }
+    }
+
+    protected void doRealize(ProviderInternal<?> provider) {
+        store.realizePending(provider);
     }
 
     protected void didAdd(T toAdd) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -467,6 +467,14 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         });
     }
 
+    @Override
+    protected void doRealize(ProviderInternal<?> provider) {
+        if ((provider instanceof AbstractDomainObjectCreatingProvider && ((AbstractDomainObjectCreatingProvider) provider).isRealized()) || provider instanceof ExistingNamedDomainObjectProvider) {
+            return;
+        }
+        super.doRealize(provider);
+    }
+
     private static abstract class RuleAdapter implements Rule {
 
         private final String description;
@@ -963,6 +971,10 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         protected RuntimeException domainObjectCreationException(Throwable cause) {
             return new IllegalStateException(String.format("Could not create domain object '%s' (%s)", getName(), getType().getSimpleName()), cause);
+        }
+
+        public boolean isRealized() {
+            return realized;
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -143,7 +143,12 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
     }
 
     @Override
-    public void addLater(final Provider<? extends T> provider) {
+    public void addLater(Provider<? extends T> provider) {
+        assertMutable();
+        if (provider instanceof Named && !(provider instanceof NamedDomainObjectProvider)) {
+            final Named named = (Named) provider;
+            provider = createExternalProvider(named.getName(), provider);
+        }
         super.addLater(provider);
         if (provider instanceof Named) {
             final Named named = (Named) provider;
@@ -794,6 +799,10 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         return Cast.uncheckedCast(getInstantiator().newInstance(ExistingNamedDomainObjectProvider.class, this, name));
     }
 
+    protected NamedDomainObjectProvider<? extends T> createExternalProvider(String name, Provider<? extends T> object) {
+        return Cast.uncheckedCast(getInstantiator().newInstance(ExternalDomainObjectCreatingProvider.class, this, name, object));
+    }
+
     protected abstract class AbstractNamedDomainObjectProvider<I extends T> extends AbstractProvider<I> implements Named, NamedDomainObjectProvider<I> {
         private final String name;
         private final Class<I> type;
@@ -957,6 +966,20 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         protected RuntimeException domainObjectCreationException(Throwable cause) {
             return new IllegalStateException(String.format("Could not create domain object '%s' (%s)", getName(), getType().getSimpleName()), cause);
+        }
+    }
+
+    public class ExternalDomainObjectCreatingProvider<I extends T> extends AbstractDomainObjectCreatingProvider<I> {
+        private final ProviderInternal<I> provider;
+
+        public ExternalDomainObjectCreatingProvider(String name, ProviderInternal<I> provider) {
+            super(name, provider.getType(), null);
+            this.provider = provider;
+        }
+
+        @Override
+        protected I createDomainObject() {
+            return provider.get();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/AbstractIterationOrderRetainingElementSource.java
@@ -131,6 +131,16 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
         }
     }
 
+    @Override
+    public void realizePending(ProviderInternal<?> provider) {
+        for (Element<T> element : inserted) {
+            if (!element.isRealized() && element.isProvidedBy(provider)) {
+                modCount++;
+                element.realize();
+            }
+        }
+    }
+
     protected void clearCachedElement(Element<T> element) {
         modCount++;
         element.clearCache();
@@ -186,8 +196,10 @@ abstract public class AbstractIterationOrderRetainingElementSource<T> implements
     }
 
     @Override
-    public void onRealize(final Action<T> action) {
+    public Action<T> onRealize(final Action<T> action) {
+        Action<T> result = this.realizeAction;
         this.realizeAction = action;
+        return result;
     }
 
     protected class RealizedElementCollectionIterator implements Iterator<T> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultPendingSource.java
@@ -50,6 +50,19 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
         }
     }
 
+    @Override
+    public void realizePending(ProviderInternal<?> provider) {
+        if (!pending.isEmpty()) {
+            List<TypedCollector<T>> copied = Lists.newArrayList();
+            for (TypedCollector<T> collector : pending) {
+                if (collector.isProvidedBy(provider)) {
+                    copied.add(collector);
+                }
+            }
+            realize(copied);
+        }
+    }
+
     private void realize(Iterable<TypedCollector<T>> collectors) {
         for (TypedCollector<T> collector : collectors) {
             if (flushAction != null) {
@@ -98,8 +111,10 @@ public class DefaultPendingSource<T> implements PendingSource<T> {
     }
 
     @Override
-    public void onRealize(Action<T> action) {
+    public Action<T> onRealize(Action<T> action) {
+        Action<T> result = this.flushAction;
         this.flushAction = action;
+        return result;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/FilteredCollection.java
@@ -188,6 +188,13 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     }
 
     @Override
+    public void realizePending(ProviderInternal<?> provider) {
+        if (filter.getType().isAssignableFrom(provider.getType())) {
+            collection.realizePending(provider);
+        }
+    }
+
+    @Override
     public boolean addPending(ProviderInternal<? extends S> provider) {
         return collection.addPending(provider);
     }
@@ -210,7 +217,9 @@ public class FilteredCollection<T, S extends T> implements ElementSource<S> {
     }
 
     @Override
-    public void onRealize(Action<S> action) { }
+    public Action<S> onRealize(Action<S> action) {
+        return null;
+    }
 
     @Override
     public void realizeExternal(ProviderInternal<? extends S> provider) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/PendingSource.java
@@ -25,6 +25,8 @@ public interface PendingSource<T> {
 
     void realizePending(Class<?> type);
 
+    void realizePending(ProviderInternal<?> provider);
+
     boolean addPending(ProviderInternal<? extends T> provider);
 
     boolean removePending(ProviderInternal<? extends T> provider);
@@ -35,7 +37,7 @@ public interface PendingSource<T> {
 
     void realizeExternal(ProviderInternal<? extends T> provider);
 
-    void onRealize(Action<T> action);
+    Action<T> onRealize(Action<T> action);
 
     boolean isEmpty();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/SortedSetElementSource.java
@@ -109,6 +109,11 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     }
 
     @Override
+    public void realizePending(ProviderInternal<?> provider) {
+        pending.realizePending(provider);
+    }
+
+    @Override
     public boolean addPending(final ProviderInternal<? extends T> provider) {
         if (provider instanceof ChangingValue) {
             ((ChangingValue<T>)provider).onValueChange(new Action<T>() {
@@ -149,8 +154,8 @@ public class SortedSetElementSource<T> implements ElementSource<T> {
     }
 
     @Override
-    public void onRealize(Action<T> action) {
-        pending.onRealize(action);
+    public Action<T> onRealize(Action<T> action) {
+        return pending.onRealize(action);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.ITaskFactory;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator;
+import org.gradle.api.internal.provider.ProviderInternal;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskCollection;
 import org.gradle.api.tasks.TaskProvider;
@@ -518,7 +519,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         // @formatter:off
         for (Iterator<TaskProvider<?>> iterator = placeholders.values().iterator(); iterator.hasNext();) {
             // @formatter:on
-            iterator.next().get();
+            doRealizePlaceholder((ProviderInternal<?>) iterator.next());
             iterator.remove();
         }
     }
@@ -537,7 +538,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     private boolean maybeCreateTasks(String name) {
         TaskProvider<?> placeholder = placeholders.remove(name);
         if (placeholder != null) {
-            placeholder.get();
+            doRealizePlaceholder((ProviderInternal<? extends Task>)placeholder);
             return true;
         }
         if (modelNode != null && modelNode.hasLink(name)) {
@@ -686,6 +687,11 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         DeprecationLogger.nagUserWith(String.format("The TaskContainer.%s method has been deprecated.", methodName), "This is scheduled to become an error in Gradle 6.0.", "Prefer disabling the task instead, see Task.setEnabled(boolean).", "");
     }
 
+    private void doRealizePlaceholder(ProviderInternal<?> provider) {
+        getStore().addPending((ProviderInternal<? extends Task>) provider);
+        doRealize(provider);
+    }
+
     // Cannot be private due to reflective instantiation
     public class TaskCreatingProvider<I extends Task> extends AbstractDomainObjectCreatingProvider<I> implements TaskProvider<I> {
         private final TaskIdentity<I> identity;
@@ -715,6 +721,7 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
                 public void run(BuildOperationContext context) {
                     try {
                         TaskCreatingProvider.super.tryCreate();
+                        statistics.lazyTaskRealized(getType());
                         // TODO removing this stuff from the store should be handled through some sort of decoration
                         context.setResult(REALIZE_RESULT);
                     } finally {
@@ -732,11 +739,6 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         @Override
         protected I createDomainObject() {
             return createTask(identity, constructorArgs);
-        }
-
-        @Override
-        protected void onLazyDomainObjectRealized() {
-            statistics.lazyTaskRealized(getType());
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -319,6 +319,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         1 * action.execute(b)
         _ * provider2.elementType >> type
         1 * provider2.get() >> [a, b]
+        _ * provider2.size() >> 2
         0 * _
     }
 
@@ -570,6 +571,7 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         then:
         _ * provider2.elementType >> type
         1 * provider2.get() >> [a, b]
+        _ * provider2.size() >> 2
         1 * action.execute(a)
         1 * action.execute(b)
         0 * _

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectCollectionSpec.groovy
@@ -16,5 +16,129 @@
 
 package org.gradle.api.internal
 
+import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.internal.provider.ProviderInternal
+
+import static org.gradle.util.WrapUtil.toList
+
 abstract class AbstractNamedDomainObjectCollectionSpec<T> extends AbstractDomainObjectCollectionSpec<T> {
+    abstract NamedDomainObjectCollection<T> getContainer()
+
+    def "can reference external named unrealized provider by name without realizing them"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(NamedProviderInternal)
+
+        given:
+        _ * provider.type >> type
+        _ * provider.name >> "a"
+
+        when:
+        container.addLater(provider)
+
+        then:
+        0 * provider.get()
+
+        when:
+        def domainObjectProvider = container.named("a")
+
+        then:
+        domainObjectProvider.name == "a"
+        domainObjectProvider.present
+        domainObjectProvider.type == type
+
+        when:
+        def r = domainObjectProvider.get()
+
+        then:
+        r == a
+
+        and:
+        _ * provider.get() >> a
+
+        when:
+        def result = toList(container)
+
+        then:
+        result == iterationOrder(a)
+
+        and:
+        0 * provider.get()
+    }
+
+    def "cannot reference external non-named unrealized provider by name"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(ProviderInternal)
+
+        given:
+        _ * provider.type >> type
+
+        when:
+        container.addLater(provider)
+
+        then:
+        0 * provider.get()
+
+        when:
+        container.named("a")
+
+        then:
+        def ex = thrown(UnknownDomainObjectException)
+        ex.message == "${container.type.simpleName} with name 'a' not found."
+
+        and:
+        0 * provider.get()
+
+        when:
+        def result = toList(container)
+
+        then:
+        result == iterationOrder(a)
+
+        and:
+        1 * provider.get() >> a
+    }
+
+    def "can iterate through container containing unrealized external named provider"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(NamedProviderInternal)
+
+        given:
+        _ * provider.type >> type
+        _ * provider.name >> "a"
+        container.addLater(provider)
+
+        when:
+        def result = toList(container)
+
+        then:
+        noExceptionThrown()
+        result == iterationOrder(a)
+
+        and:
+        1 * provider.get() >> a
+    }
+
+    def "can iterate through filtered container containing unrealized external named provider"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(NamedProviderInternal)
+
+        given:
+        _ * provider.type >> type
+        _ * provider.name >> "a"
+        container.addLater(provider)
+
+        when:
+        def result = toList(container.withType(type))
+
+        then:
+        noExceptionThrown()
+        result == iterationOrder(a)
+
+        and:
+        1 * provider.get() >> a
+    }
+
+    interface NamedProviderInternal extends Named, ProviderInternal {}
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -290,11 +290,17 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObj
         def bob = container.register("bob", AgeAwarePerson) {
             it.age = 50
         }
+        def john = container.register("john", AgeAwarePerson)
+        john.configure {
+            it.age = 42
+        }
         then:
         fred.present
         fred.get().name == "fred"
         bob.present
         bob.get().age == 50
+        john.present
+        john.get().age == 42
     }
 
     def "can look up objects by name"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/AbstractPendingSourceSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/AbstractPendingSourceSpec.groovy
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections
+
+import org.gradle.api.Action
+import org.gradle.api.internal.provider.AbstractProvider
+import org.gradle.api.internal.provider.ChangingValue
+import org.gradle.api.internal.provider.ChangingValueHandler
+import org.gradle.api.internal.provider.CollectionProviderInternal
+import org.gradle.api.internal.provider.ProviderInternal
+import spock.lang.Specification
+
+abstract class AbstractPendingSourceSpec extends Specification {
+    def realize = Mock(Action)
+
+    Action<CharSequence> defaultRealizeAction = new Action<CharSequence>() {
+        @Override
+        void execute(CharSequence t) {
+            realize.execute(t.toString())
+        }
+    }
+
+    Action<CharSequence> getRealizeAction() {
+        return defaultRealizeAction;
+    }
+
+    abstract PendingSource<CharSequence> getSource()
+
+    def setup() {
+        source.onRealize(realizeAction)
+    }
+
+    def "can add a provider"() {
+        when:
+        source.addPending(provider("foo"))
+
+        then:
+        source.size() == 1
+        !source.isEmpty()
+    }
+
+    def "can add a provider of iterable"() {
+        when:
+        source.addPendingCollection(setProvider("foo", "bar"))
+
+        then:
+        source.size() == 2
+        !source.isEmpty()
+    }
+
+    def "can realize all pending elements"() {
+        given:
+        source.addPending(provider("provider1"))
+        source.addPending(provider(new StringBuffer("provider2")))
+        source.addPending(provider("provider3"))
+        source.addPendingCollection(setProvider("provider4[0]", "provider4[1]"))
+        source.addPendingCollection(setProvider(new StringBuffer("provider5[0]"), new StringBuffer("provider5[1]")))
+
+        when:
+        source.realizePending()
+
+        then:
+        1 * realize.execute("provider1")
+        1 * realize.execute("provider2")
+        1 * realize.execute("provider3")
+        1 * realize.execute("provider4[0]")
+        1 * realize.execute("provider4[1]")
+        1 * realize.execute("provider5[0]")
+        1 * realize.execute("provider5[1]")
+        0 * realize.execute(_)
+    }
+
+    def "can realize all pending elements with a given type"() {
+        given:
+        source.addPending(provider("provider1"))
+        source.addPending(provider(new StringBuffer("provider2")))
+        source.addPending(provider("provider3"))
+        source.addPendingCollection(setProvider("provider4[0]", "provider4[1]"))
+        source.addPendingCollection(setProvider(new StringBuffer("provider5[0]"), new StringBuffer("provider5[1]")))
+
+        when:
+        source.realizePending(String.class)
+
+        then:
+        1 * realize.execute("provider1")
+        0 * realize.execute("provider2")
+        1 * realize.execute("provider3")
+        1 * realize.execute("provider4[0]")
+        1 * realize.execute("provider4[1]")
+        0 * realize.execute("provider5[0]")
+        0 * realize.execute("provider5[1]")
+        0 * realize.execute(_)
+    }
+
+    def "realizes only the specified pending element"() {
+        def provider1 = provider("provider1")
+        def provider5 = setProvider(new StringBuffer("provider5[0]"), new StringBuffer("provider5[1]"))
+
+        given:
+        source.addPending(provider1)
+        source.addPending(provider(new StringBuffer("provider2")))
+        source.addPending(provider("provider3"))
+        source.addPendingCollection(setProvider("provider4[0]", "provider4[1]"))
+        source.addPendingCollection(provider5)
+
+        when:
+        source.realizePending(provider1)
+
+        then:
+        1 * realize.execute("provider1")
+        0 * realize.execute("provider2")
+        0 * realize.execute("provider3")
+        0 * realize.execute("provider4[0]")
+        0 * realize.execute("provider4[1]")
+        0 * realize.execute("provider5[0]")
+        0 * realize.execute("provider5[1]")
+        0 * realize.execute(_)
+
+        when:
+        source.realizePending(provider5)
+
+        then:
+        0 * realize.execute("provider1")
+        0 * realize.execute("provider2")
+        0 * realize.execute("provider3")
+        0 * realize.execute("provider4[0]")
+        0 * realize.execute("provider4[1]")
+        1 * realize.execute("provider5[0]")
+        1 * realize.execute("provider5[1]")
+        0 * realize.execute(_)
+    }
+
+    def "returns previous realize action upon setting a new one"() {
+        when:
+        def action = source.onRealize(Mock(Action))
+
+        then:
+        action == realizeAction
+    }
+
+    def "can remove pending elements"() {
+        def provider1 = provider("provider1")
+        def provider5 = setProvider(new StringBuffer("provider5[0]"), new StringBuffer("provider5[1]"))
+
+        when:
+        source.addPending(provider1)
+        source.addPending(provider(new StringBuffer("provider2")))
+        source.addPending(provider("provider3"))
+        source.addPendingCollection(setProvider("provider4[0]", "provider4[1]"))
+        source.addPendingCollection(provider5)
+
+        then:
+        source.size() == 7
+
+        when:
+        source.removePending(provider1)
+
+        then:
+        source.size() == 6
+
+        when:
+        source.removePending(provider5)
+
+        then:
+        source.size() == 4
+
+        when:
+        source.realizePending()
+
+        then:
+        0 * realize.execute("provider1")
+        1 * realize.execute("provider2")
+        1 * realize.execute("provider3")
+        1 * realize.execute("provider4[0]")
+        1 * realize.execute("provider4[1]")
+        0 * realize.execute("provider5[0]")
+        0 * realize.execute("provider5[1]")
+        0 * realize.execute(_)
+    }
+
+    def "can clear pending elements"() {
+        when:
+        source.addPending(provider("provider1"))
+        source.addPending(provider(new StringBuffer("provider2")))
+        source.addPending(provider("provider3"))
+        source.addPendingCollection(setProvider("provider4[0]", "provider4[1]"))
+        source.addPendingCollection(setProvider(new StringBuffer("provider5[0]"), new StringBuffer("provider5[1]")))
+
+        then:
+        source.size() == 7
+
+        when:
+        source.clear()
+
+        then:
+        source.size() == 0
+        source.isEmpty()
+
+        when:
+        source.realizePending()
+
+        then:
+        0 * realize.execute()
+    }
+
+    ProviderInternal<? extends String> provider(String value) {
+        return new TypedProvider(String, value)
+    }
+
+    ProviderInternal<? extends StringBuffer> provider(StringBuffer value) {
+        return new TypedProvider(StringBuffer, value)
+    }
+
+    CollectionProviderInternal<? extends String, Set<? extends String>> setProvider(String... values) {
+        return new TypedProviderOfSet(String, values as LinkedHashSet)
+    }
+
+    CollectionProviderInternal<? extends StringBuffer, Set<? extends StringBuffer>> setProvider(StringBuffer... values) {
+        return new TypedProviderOfSet(StringBuffer, values as LinkedHashSet)
+    }
+
+    private static class TypedProvider<T> extends AbstractProvider<T> implements ChangingValue<T> {
+        final Class<T> type
+        T value
+        final ChangingValueHandler<T> changingValue = new ChangingValueHandler<T>()
+
+        TypedProvider(Class<T> type, T value) {
+            this.type = type
+            this.value = value
+        }
+
+        @Override
+        Class<T> getType() {
+            return type
+        }
+
+        @Override
+        T getOrNull() {
+            return value
+        }
+
+        void setValue(T value) {
+            T previousValue = this.value
+            this.value = value
+            changingValue.handle(previousValue)
+        }
+
+        @Override
+        void onValueChange(Action<T> action) {
+            changingValue.onValueChange(action)
+        }
+    }
+
+    private static class TypedProviderOfSet<T> extends AbstractProvider<Set<T>> implements CollectionProviderInternal<T, Set<T>>, ChangingValue<Iterable<T>> {
+        final Class<T> type
+        Set<T> value
+        final ChangingValueHandler<Iterable<T>> changingValue = new ChangingValueHandler<Iterable<T>>()
+
+        TypedProviderOfSet(Class<T> type, Set<T> value) {
+            this.type = type
+            this.value = value
+        }
+
+        @Override
+        Class<? extends T> getElementType() {
+            return type
+        }
+
+        @Override
+        Set<T> getOrNull() {
+            return value
+        }
+
+        @Override
+        int size() {
+            return value.size()
+        }
+
+        void setValue(Set<T> value) {
+            Set<T> previousValue = this.value
+            this.value = value
+            changingValue.handle(previousValue)
+        }
+
+        @Override
+        void onValueChange(Action<Iterable<T>> action) {
+            changingValue.onValueChange(action)
+        }
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/IterationOrderRetainingSetElementSourceTest.groovy
@@ -20,15 +20,14 @@ import org.gradle.api.Action
 
 
 class IterationOrderRetainingSetElementSourceTest extends AbstractIterationOrderRetainingElementSourceTest {
-    IterationOrderRetainingSetElementSource<CharSequence> source = new IterationOrderRetainingSetElementSource<>()
+    final ElementSource<CharSequence> source = new IterationOrderRetainingSetElementSource<>()
 
-    def setup() {
-        source.onRealize(new Action<CharSequence>() {
-            @Override
-            void execute(CharSequence t) {
-                source.addRealized(t)
-            }
-        })
+    final Action<CharSequence> realizeAction = new Action<CharSequence>() {
+        @Override
+        void execute(CharSequence t) {
+            realize.execute(t.toString())
+            source.addRealized(t)
+        }
     }
 
     def "can add the same provider twice"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/ListElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/ListElementSourceTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.api.internal.provider.CollectionProviderInternal
 
 
 class ListElementSourceTest extends AbstractIterationOrderRetainingElementSourceTest {
-    ListElementSource<CharSequence> source = new ListElementSource<>()
+    final ElementSource<CharSequence> source = new ListElementSource<>()
 
     def "can add the same provider twice"() {
         def provider = provider("foo")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/SortedSetElementSourceTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/collections/SortedSetElementSourceTest.groovy
@@ -16,19 +16,32 @@
 
 package org.gradle.api.internal.collections
 
+
 import org.gradle.api.Action
 
-
 class SortedSetElementSourceTest extends AbstractElementSourceTest {
-    ElementSource source = new SortedSetElementSource<CharSequence>()
+    final ElementSource source = new SortedSetElementSource<CharSequence>()
 
-    def setup() {
-        source.onRealize(new Action<CharSequence>() {
-            @Override
-            void execute(CharSequence t) {
-                source.addRealized(t)
-            }
-        })
+    final Action<CharSequence> realizeAction = new Action<CharSequence>() {
+        @Override
+        void execute(CharSequence t) {
+            realize.execute(t.toString())
+            source.addRealized(t.toString())
+        }
+    }
+
+    def "cannot realize pending elements when realize action is not set"() {
+        given:
+        source.onRealize(null)
+
+        when:
+        source.addPending(provider("provider1"))
+        source.addPending(provider("provider2"))
+        source.addPending(provider("provider3"))
+        source.realizePending()
+
+        then:
+        thrown(IllegalStateException)
     }
 
     def "can remove elements using iteratorNoFlush"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.api.internal.tasks
 
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.DomainObjectCollection
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Rule
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
@@ -78,7 +78,7 @@ class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<T
     ).create()
 
     @Override
-    final DomainObjectCollection<Task> getContainer() {
+    final NamedDomainObjectCollection<Task> getContainer() {
         return container
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/Collectors.java
@@ -198,26 +198,26 @@ public class Collectors {
     }
 
     public static class ElementsFromCollectionProvider<T> implements ProvidedCollector<T> {
-        private final Provider<? extends Iterable<? extends T>> provider;
+        private final Provider<? extends Iterable<? extends T>> providerOfElements;
 
-        public ElementsFromCollectionProvider(Provider<? extends Iterable<? extends T>> provider) {
-            this.provider = provider;
+        public ElementsFromCollectionProvider(Provider<? extends Iterable<? extends T>> providerOfElements) {
+            this.providerOfElements = providerOfElements;
         }
 
         @Override
         public boolean present() {
-            return provider.isPresent();
+            return providerOfElements.isPresent();
         }
 
         @Override
         public void collectInto(ValueCollector<T> collector, Collection<T> collection) {
-            Iterable<? extends T> value = provider.get();
+            Iterable<? extends T> value = providerOfElements.get();
             collector.addAll(value, collection);
         }
 
         @Override
         public boolean maybeCollectInto(ValueCollector<T> collector, Collection<T> collection) {
-            Iterable<? extends T> value = provider.getOrNull();
+            Iterable<? extends T> value = providerOfElements.getOrNull();
             if (value == null) {
                 return false;
             }
@@ -227,7 +227,7 @@ public class Collectors {
 
         @Override
         public boolean isProvidedBy(Provider<?> provider) {
-            return Objects.equal(provider, provider);
+            return Objects.equal(provider, providerOfElements);
         }
 
         @Override
@@ -239,18 +239,18 @@ public class Collectors {
                 return false;
             }
             ElementsFromCollectionProvider<?> that = (ElementsFromCollectionProvider<?>) o;
-            return Objects.equal(provider, that.provider);
+            return Objects.equal(providerOfElements, that.providerOfElements);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hashCode(provider);
+            return Objects.hashCode(providerOfElements);
         }
 
         @Override
         public int size() {
-            if (provider instanceof CollectionProviderInternal) {
-                return ((CollectionProviderInternal)provider).size();
+            if (providerOfElements instanceof CollectionProviderInternal) {
+                return ((CollectionProviderInternal)providerOfElements).size();
             } else {
                 throw new UnsupportedOperationException();
             }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/JavaPluginIntegrationTest.groovy
@@ -98,4 +98,27 @@ class JavaPluginIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.groupedOutput.task(':printArtifacts').output.contains("jar task created")
     }
+
+    def "can support eager realization of artifacts for archives configuration"() {
+        settingsFile << "rootProject.name = 'root'"
+        buildFile << '''
+            apply plugin: 'base'
+
+            configurations.archives.artifacts.all {
+                println "Realizing eagerly '${it.name}' (${it.class.simpleName}) of type '${it.type}'"
+            }
+
+            apply plugin: 'java'
+
+            task printArchivesArtifacts {
+                doLast {
+                    assert configurations.archives.artifacts.collect { it.type } == ['jar']
+                }
+            }
+        '''
+
+        expect:
+        succeeds "printArchivesArtifacts"
+        outputContains("Realizing eagerly 'root' (LazyPublishArtifact) of type 'jar'")
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/DefaultArtifactPublicationSet.java
@@ -71,6 +71,9 @@ public class DefaultArtifactPublicationSet {
 
         @Override
         public int size() {
+            if (artifacts == null) {
+                return 0;
+            }
             return artifacts.size();
         }
 


### PR DESCRIPTION
It avoids concurrent modification exception where a provider tries to add
to the store while the store is busy realizing the provider. To work around this, we use the `doAddRealized` internal method.

The PR also clean up the realization of a provider by introducing the `realizePending(ProviderInternal)` method to the store. The domain object collections now use this method instead of relying on the side effect of `Provider#get()`.

### Context
See https://github.com/gradle/gradle-native/issues/709

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Favoid-concurrent-modification-when-realizing)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
