### PR TITLE
Provide a typesafe API for configuring pattern layout

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -97,10 +97,40 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
     void ivyPattern(String pattern);
 
     /**
-     * Specifies the layout to use with this repository, based on the root url.
-     * See {@link #layout(String, Closure)}.
+     * Specifies how the items of the repository are organized.
+     * <p>
+     * Recognised values are as follows:
+     * </p>
+     * <h4>'gradle'</h4>
+     * <p>
+     * A Repository Layout that applies the following patterns:
+     * </p>
+     * <ul>
+     *     <li>Artifacts: <code>$baseUri/{@value #GRADLE_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value #GRADLE_IVY_PATTERN}</code></li>
+     * </ul>
+     * <h4>'maven'</h4>
+     * <p>
+     * A Repository Layout that applies the following patterns:
+     * </p>
+     * <ul>
+     *     <li>Artifacts: <code>$baseUri/{@value #MAVEN_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value #MAVEN_IVY_PATTERN}</code></li>
+     * </ul>
+     * <p>
+     * Following the Maven convention, the 'organisation' value is further processed by replacing '.' with '/'.
+     * </p>
+     * <h4>'ivy'</h4>
+     * <p>
+     * A Repository Layout that applies the following patterns:
+     * </p>
+     * <ul>
+     *     <li>Artifacts: <code>$baseUri/{@value #IVY_ARTIFACT_PATTERN}</code></li>
+     *     <li>Ivy: <code>$baseUri/{@value #IVY_ARTIFACT_PATTERN}</code></li>
+     * </ul>
      *
      * @param layoutName The name of the layout to use.
+     * @see #patternLayout(Action)
      */
     void layout(String layoutName);
 
@@ -143,7 +173,7 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * <p>
      * A repository layout that allows custom patterns to be defined. eg:
      * </p>
-     * <pre class='autoTested'>
+     * <pre>
      * repositories {
      *     ivy {
      *         layout 'pattern' , {
@@ -158,8 +188,32 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * @param layoutName The name of the layout to use.
      * @param config The action used to configure the layout.
      * @since 2.3 (feature was already present in Groovy DSL, this particular method introduced in 2.3)
+     * @deprecated use {@link #layout(String)} or {@link #patternLayout(Action)}
      */
+    @Deprecated
     void layout(String layoutName, Action<? extends RepositoryLayout> config);
+
+    /**
+     * Specifies how the items of the repository are organized.
+     * <p>
+     * The layout is configured with the supplied closure.
+     * <pre class='autoTested'>
+     * repositories {
+     *     ivy {
+     *         patternLayout {
+     *             artifact '[module]/[revision]/[artifact](.[ext])'
+     *             ivy '[module]/[revision]/ivy.xml'
+     *         }
+     *     }
+     * }
+     * </pre>
+     * <p>The available pattern tokens are listed as part of <a href="http://ant.apache.org/ivy/history/master/concept.html#patterns">Ivy's Main Concepts documentation</a>.</p>
+     *
+     * @param config The action used to configure the layout.
+     * @since 5.0
+     */
+    @Incubating
+    void patternLayout(Action<? super  IvyPatternRepositoryLayout> config);
 
     /**
      * Specifies how the items of the repository are organized. See {@link #layout(String, org.gradle.api.Action)}
@@ -167,7 +221,9 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
      * @param layoutName The name of the layout to use.
      * @param config The closure used to configure the layout.
      * An instance of {@link RepositoryLayout} is passed as a parameter to the closure.
+     * @deprecated use {@link #layout(String)} or {@link #patternLayout(Action)}
      */
+    @Deprecated
     void layout(String layoutName, Closure config);
 
     /**

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -244,7 +244,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
                     url 'http://myCompanyBucket/ivyrepo'
                     artifactPattern 'http://myCompanyBucket/ivyrepo/[organisation]/[module]/[artifact]-[revision]'
                     ivyPattern 'http://myCompanyBucket/ivyrepo/[organisation]/[module]/ivy-[revision].xml'
-                    layout 'pattern', {
+                    patternLayout {
                         artifact '[module]/[organisation]/[revision]/[artifact]'
                         artifact '3rd-party/[module]/[organisation]/[revision]/[artifact]'
                         ivy '[module]/[organisation]/[revision]/ivy.xml'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleArtifactResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleArtifactResolutionIntegrationTest.groovy
@@ -121,7 +121,7 @@ repositories {
 repositories {
     ivy {
         url '${httpRepo.uri}'
-        layout 'pattern', {
+        patternLayout {
             artifact '[module]/[revision]/[artifact](.[ext])'
             ivy '[module]/[revision]/alternate-ivy.xml'
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepositoryMetaDataProvider;
+import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout;
 import org.gradle.api.artifacts.repositories.RepositoryLayout;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
@@ -70,6 +71,7 @@ import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.local.FileStore;
 import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.DeprecationLogger;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -280,13 +282,26 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
 
     @Override
     public void layout(String layoutName, Closure config) {
-        layout(layoutName, ConfigureUtil.<RepositoryLayout>configureUsing(config));
+        DeprecationLogger.nagUserOfReplacedMethod("IvyArtifactRepository.layout(String, Closure)", "IvyArtifactRepository.patternLayout(Action)");
+        internalLayout(layoutName, ConfigureUtil.<RepositoryLayout>configureUsing(config));
     }
 
     @Override
     public void layout(String layoutName, Action<? extends RepositoryLayout> config) {
+        DeprecationLogger.nagUserOfReplacedMethod("IvyArtifactRepository.layout(String, Action)", "IvyArtifactRepository.patternLayout(Action)");
+        internalLayout(layoutName, config);
+    }
+
+    private void internalLayout(String layoutName, Action config) {
         layout(layoutName);
-        ((Action) config).execute(layout);
+        config.execute(layout);
+    }
+
+    @Override
+    public void patternLayout(Action<? super IvyPatternRepositoryLayout> config) {
+        DefaultIvyPatternRepositoryLayout layout = instantiator.newInstance(DefaultIvyPatternRepositoryLayout.class);
+        this.layout = layout;
+        config.execute(layout);
     }
 
     public IvyArtifactRepositoryMetaDataProvider getResolve() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -45,6 +45,7 @@ import org.gradle.util.TestUtil
 import javax.inject.Inject
 
 class DefaultIvyArtifactRepositoryTest extends Specification {
+    final instantiator = TestUtil.instantiatorFactory().decorate()
     final FileResolver fileResolver = Mock()
     final RepositoryTransportFactory transportFactory = Mock()
     final LocallyAvailableResourceFinder locallyAvailableResourceFinder = Mock()
@@ -58,7 +59,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
 
-    final DefaultIvyArtifactRepository repository = new DefaultIvyArtifactRepository(fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory, TestUtil.valueSnapshotter(), Mock(ObjectFactory))
+    final DefaultIvyArtifactRepository repository = instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory, TestUtil.valueSnapshotter(), Mock(ObjectFactory))
 
     def "default values"() {
         expect:
@@ -184,7 +185,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     def "uses specified base url with configured pattern layout"() {
         repository.name = 'name'
         repository.url = 'http://host'
-        repository.layout 'pattern', {
+        repository.patternLayout {
             artifact '[module]/[revision]/[artifact](.[ext])'
             ivy '[module]/[revision]/ivy.xml'
         }
@@ -210,7 +211,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     def "when requested uses maven patterns with configured pattern layout"() {
         repository.name = 'name'
         repository.url = 'http://host'
-        repository.layout 'pattern', {
+        repository.patternLayout {
             artifact '[module]/[revision]/[artifact](.[ext])'
             ivy '[module]/[revision]/ivy.xml'
             m2compatible = true
@@ -260,7 +261,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     def "uses artifact pattern for ivy files when no ivy pattern provided"() {
         repository.name = 'name'
         repository.url = 'http://host'
-        repository.layout 'pattern', {
+        repository.patternLayout {
             artifact '[layoutPattern]'
         }
         repository.artifactPattern 'http://other/[additionalPattern]'

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/ivy/AbstractIvyRemoteRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/ivy/AbstractIvyRemoteRepoResolveIntegrationTest.groovy
@@ -85,7 +85,7 @@ abstract class AbstractIvyRemoteRepoResolveIntegrationTest extends AbstractInteg
                 ivy {
                     url "${remoteIvyRepo.uri}"
                     $server.validCredentials
-                    layout "pattern", {
+                    patternLayout {
                         artifact "${remoteIvyRepo.baseArtifactPattern}"
                         ivy "${remoteIvyRepo.baseIvyPattern}"
                         m2compatible = $m2Compatible

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/groovy/build.gradle
@@ -200,7 +200,7 @@ repositories {
 repositories {
     ivy {
         url "http://repo.mycompany.com/repo"
-        layout "pattern", {
+        patternLayout {
             artifact "[module]/[revision]/[type]/[artifact].[ext]"
         }
     }
@@ -211,7 +211,7 @@ repositories {
 repositories {
     ivy {
         url "http://repo.mycompany.com/repo"
-        layout "pattern", {
+        patternLayout {
             artifact "[organisation]/[module]/[revision]/[artifact]-[revision].[ext]"
             m2compatible = true
         }
@@ -223,7 +223,7 @@ repositories {
 repositories {
     ivy {
         url "http://repo.mycompany.com/repo"
-        layout "pattern", {
+        patternLayout {
             artifact "3rd-party-artifacts/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]"
             artifact "company-artifacts/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]"
             ivy "ivy-files/[organisation]/[module]/[revision]/ivy.xml"

--- a/subprojects/docs/src/samples/userguide/artifacts/defineRepository/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/artifacts/defineRepository/kotlin/build.gradle.kts
@@ -203,10 +203,8 @@ repositories {
 repositories {
     ivy {
         url = uri("http://repo.mycompany.com/repo")
-        layout("pattern") {
-            (this as IvyPatternRepositoryLayout).apply {
-                artifact("[module]/[revision]/[type]/[artifact].[ext]")
-            }
+        patternLayout {
+            artifact("[module]/[revision]/[type]/[artifact].[ext]")
         }
     }
 }
@@ -216,11 +214,9 @@ repositories {
 repositories {
     ivy {
         url = uri("http://repo.mycompany.com/repo")
-        layout("pattern") {
-            (this as IvyPatternRepositoryLayout).apply {
-                artifact("[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")
-                setM2compatible(true)
-            }
+        patternLayout {
+            artifact("[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")
+            setM2compatible(true)
         }
     }
 }
@@ -230,12 +226,10 @@ repositories {
 repositories {
     ivy {
         url = uri("http://repo.mycompany.com/repo")
-        layout("pattern") {
-            (this as IvyPatternRepositoryLayout).apply {
-                artifact("3rd-party-artifacts/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")
-                artifact("company-artifacts/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")
-                ivy("ivy-files/[organisation]/[module]/[revision]/ivy.xml")
-            }
+        patternLayout {
+            artifact("3rd-party-artifacts/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")
+            artifact("company-artifacts/[organisation]/[module]/[revision]/[artifact]-[revision].[ext]")
+            ivy("ivy-files/[organisation]/[module]/[revision]/ivy.xml")
         }
     }
 }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnly/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnly/groovy/build.gradle
@@ -2,7 +2,7 @@
 repositories {
     ivy {
         url 'https://ajax.googleapis.com/ajax/libs'
-        layout 'pattern', {
+        patternLayout {
             artifact '[organization]/[revision]/[module].[ext]'
         }
     }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnly/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnly/kotlin/build.gradle.kts
@@ -2,9 +2,9 @@
 repositories {
     ivy {
         url = uri("https://ajax.googleapis.com/ajax/libs")
-        layout("pattern", Action<IvyPatternRepositoryLayout> {
+        patternLayout {
             artifact("[organization]/[revision]/[module].[ext]")
-        })
+        }
     }
 }
 

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnlyWithClassifier/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnlyWithClassifier/groovy/build.gradle
@@ -2,7 +2,7 @@
 repositories {
     ivy {
         url 'https://ajax.googleapis.com/ajax/libs'
-        layout 'pattern', {
+        patternLayout {
             artifact '[organization]/[revision]/[module](.[classifier]).[ext]'
         }
     }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnlyWithClassifier/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringDependencies/artifactOnlyWithClassifier/kotlin/build.gradle.kts
@@ -2,9 +2,9 @@
 repositories {
     ivy {
         url = uri("https://ajax.googleapis.com/ajax/libs")
-        layout("pattern", Action<IvyPatternRepositoryLayout> {
+        patternLayout {
             artifact("[organization]/[revision]/[module](.[classifier]).[ext]")
-        })
+        }
     }
 }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/GradleKotlinDslIntegrationTest.groovy
@@ -136,6 +136,9 @@ class GradleKotlinDslIntegrationTest extends AbstractIntegrationSpec {
 
     def 'can query KotlinBuildScriptModel'() {
         given:
+        // TODO Remove this once the Kotlin DSL upgrades 'pattern("layout") {' to 'patternLayout {
+        // Using expectDeprecationWarning did not work as some setup do not trigger one
+        executer.noDeprecationChecks()
         // This test breaks encapsulation a bit in the interest of ensuring Gradle Kotlin DSL use
         // of internal APIs is not broken by refactorings on the Gradle side
         buildFile << """

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/base/JavaScriptRepositoriesExtension.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/base/JavaScriptRepositoriesExtension.java
@@ -66,7 +66,7 @@ public class JavaScriptRepositoriesExtension {
             public void execute(IvyArtifactRepository repo) {
                 repo.setName("googleApisJs");
                 repo.setUrl(GOOGLE_APIS_REPO_URL);
-                repo.layout("pattern", new Action<IvyPatternRepositoryLayout>() {
+                repo.patternLayout(new Action<IvyPatternRepositoryLayout>() {
                     public void execute(IvyPatternRepositoryLayout layout) {
                         layout.artifact("[organization]/[revision]/[module].[ext]");
                         layout.ivy("[organization]/[revision]/[module].xml");

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/PluginManagementDslSpec.groovy
@@ -238,7 +238,7 @@ class PluginManagementDslSpec extends AbstractIntegrationSpec {
                 repositories {
                     ivy {
                         url "http://repo.internal.net/ivy"
-                        layout("pattern") {
+                        patternLayout {
                             ivy '[organisation]/[module]/[revision]/[module]-[revision].ivy'
                             artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]'
                             m2compatible true

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -371,7 +371,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
                 repositories {
                     ivy {
                         url "${repo.uri}"
-                        layout("pattern") {
+                        patternLayout {
                             ivy '[organisation]/[module]/[revision]/[module]-[revision].ivy'
                             artifact '[organisation]/[module]/[revision]/[artifact]-[revision](-[classifier]).[ext]'
                             m2compatible true

--- a/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishSftpIntegrationTest.groovy
+++ b/subprojects/resources-sftp/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishSftpIntegrationTest.groovy
@@ -146,7 +146,7 @@ class IvyPublishSftpIntegrationTest extends AbstractIvyPublishIntegTest {
                             username 'sftp'
                             password 'sftp'
                         }
-                        layout "pattern", {
+                        patternLayout {
                             artifact "${ivySftpRepo.baseArtifactPattern}"
                             ivy "${ivySftpRepo.baseIvyPattern}"
                             m2compatible = $m2Compatible


### PR DESCRIPTION
When an IvyArtifactRepository is configured with a `pattern` layout, it
can be further configured. This change deprecates the older method that
took both the layout name and a configuration closure in favour of a
named method to configure the `pattern` layout since the others cannot
be configured.