### PR TITLE
Wrap external provider inside `NamedDomainObjectProvider`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -143,7 +143,12 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
     }
 
     @Override
-    public void addLater(final Provider<? extends T> provider) {
+    public void addLater(Provider<? extends T> provider) {
+        assertMutable();
+        if (provider instanceof Named && !(provider instanceof NamedDomainObjectProvider)) {
+            final Named named = (Named) provider;
+            provider = createExternalProvider(named.getName(), provider);
+        }
         super.addLater(provider);
         if (provider instanceof Named) {
             final Named named = (Named) provider;
@@ -794,6 +799,10 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         return Cast.uncheckedCast(getInstantiator().newInstance(ExistingNamedDomainObjectProvider.class, this, name));
     }
 
+    protected NamedDomainObjectProvider<? extends T> createExternalProvider(String name, Provider<? extends T> object) {
+        return Cast.uncheckedCast(getInstantiator().newInstance(ExternalDomainObjectCreatingProvider.class, this, name, object));
+    }
+
     protected abstract class AbstractNamedDomainObjectProvider<I extends T> extends AbstractProvider<I> implements Named, NamedDomainObjectProvider<I> {
         private final String name;
         private final Class<I> type;
@@ -957,6 +966,20 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         protected RuntimeException domainObjectCreationException(Throwable cause) {
             return new IllegalStateException(String.format("Could not create domain object '%s' (%s)", getName(), getType().getSimpleName()), cause);
+        }
+    }
+
+    public class ExternalDomainObjectCreatingProvider<I extends T> extends AbstractDomainObjectCreatingProvider<I> {
+        private final ProviderInternal<I> provider;
+
+        public ExternalDomainObjectCreatingProvider(String name, ProviderInternal<I> provider) {
+            super(name, provider.getType(), null);
+            this.provider = provider;
+        }
+
+        @Override
+        protected I createDomainObject() {
+            return provider.get();
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectCollectionSpec.groovy
@@ -16,5 +16,129 @@
 
 package org.gradle.api.internal
 
+import org.gradle.api.Named
+import org.gradle.api.NamedDomainObjectCollection
+import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.internal.provider.ProviderInternal
+
+import static org.gradle.util.WrapUtil.toList
+
 abstract class AbstractNamedDomainObjectCollectionSpec<T> extends AbstractDomainObjectCollectionSpec<T> {
+    abstract NamedDomainObjectCollection<T> getContainer()
+
+    def "can reference external named unrealized provider by name without realizing them"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(NamedProviderInternal)
+
+        given:
+        _ * provider.type >> type
+        _ * provider.name >> "a"
+
+        when:
+        container.addLater(provider)
+
+        then:
+        0 * provider.get()
+
+        when:
+        def domainObjectProvider = container.named("a")
+
+        then:
+        domainObjectProvider.name == "a"
+        domainObjectProvider.present
+        domainObjectProvider.type == type
+
+        when:
+        def r = domainObjectProvider.get()
+
+        then:
+        r == a
+
+        and:
+        _ * provider.get() >> a
+
+        when:
+        def result = toList(container)
+
+        then:
+        result == iterationOrder(a)
+
+        and:
+        0 * provider.get()
+    }
+
+    def "cannot reference external non-named unrealized provider by name"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(ProviderInternal)
+
+        given:
+        _ * provider.type >> type
+
+        when:
+        container.addLater(provider)
+
+        then:
+        0 * provider.get()
+
+        when:
+        container.named("a")
+
+        then:
+        def ex = thrown(UnknownDomainObjectException)
+        ex.message == "${container.type.simpleName} with name 'a' not found."
+
+        and:
+        0 * provider.get()
+
+        when:
+        def result = toList(container)
+
+        then:
+        result == iterationOrder(a)
+
+        and:
+        1 * provider.get() >> a
+    }
+
+    def "can iterate through container containing unrealized external named provider"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(NamedProviderInternal)
+
+        given:
+        _ * provider.type >> type
+        _ * provider.name >> "a"
+        container.addLater(provider)
+
+        when:
+        def result = toList(container)
+
+        then:
+        noExceptionThrown()
+        result == iterationOrder(a)
+
+        and:
+        1 * provider.get() >> a
+    }
+
+    def "can iterate through filtered container containing unrealized external named provider"() {
+        containerAllowsExternalProviders()
+        def provider = Mock(NamedProviderInternal)
+
+        given:
+        _ * provider.type >> type
+        _ * provider.name >> "a"
+        container.addLater(provider)
+
+        when:
+        def result = toList(container.withType(type))
+
+        then:
+        noExceptionThrown()
+        result == iterationOrder(a)
+
+        and:
+        1 * provider.get() >> a
+    }
+
+    interface NamedProviderInternal extends Named, ProviderInternal {}
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -18,9 +18,9 @@ package org.gradle.api.internal.tasks
 
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
-import org.gradle.api.DomainObjectCollection
 import org.gradle.api.GradleException
 import org.gradle.api.InvalidUserDataException
+import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Rule
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
@@ -78,7 +78,7 @@ class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<T
     ).create()
 
     @Override
-    final DomainObjectCollection<Task> getContainer() {
+    final NamedDomainObjectCollection<Task> getContainer() {
         return container
     }
 


### PR DESCRIPTION
It allow `NamedDomainObjectCollection#named` to work properly.

### Context
See https://github.com/gradle/gradle-native/issues/709.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fallow-named-to-work-with-external-provider)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
