### PR TITLE
Fix samples which resolve configuration eagerly

### DIFF
--- a/subprojects/docs/src/samples/userguide/bestPractices/logicDuringConfiguration/dont/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/bestPractices/logicDuringConfiguration/dont/groovy/build.gradle
@@ -6,6 +6,12 @@ repositories {
     jcenter()
 }
 
+configurations.all {
+    incoming.beforeResolve {
+        throw new IllegalStateException("You shouldn't resolve configurations during configuration phase!")
+    }
+}
+
 // tag::config-logic[]
 dependencies {
     implementation 'log4j:log4j:1.2.17'
@@ -20,3 +26,4 @@ task printArtifactNames {
     }
 }
 // end::config-logic[]
+

--- a/subprojects/docs/src/samples/userguide/bestPractices/logicDuringConfiguration/dont/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/bestPractices/logicDuringConfiguration/dont/kotlin/build.gradle.kts
@@ -6,6 +6,12 @@ repositories {
     jcenter()
 }
 
+
+configurations.all {
+    incoming.beforeResolve {
+        throw IllegalStateException("You shouldn't resolve configurations during configuration phase!")
+    }
+}
 // tag::config-logic[]
 dependencies {
     implementation("log4j:log4j:1.2.17")

--- a/subprojects/docs/src/samples/userguide/bestPractices/logicDuringConfiguration/dont/logicDuringConfigurationPhase.sample.conf
+++ b/subprojects/docs/src/samples/userguide/bestPractices/logicDuringConfiguration/dont/logicDuringConfigurationPhase.sample.conf
@@ -1,9 +1,11 @@
 commands: [{
     execution-subdirectory: groovy
     executable: gradle
-    args: tasks
+    args: tasks,
+    expect-failure: true
 }, {
     execution-subdirectory: kotlin
     executable: gradle
-    args: tasks
+    args: tasks,
+    expect-failure: true
 }]

--- a/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/groovy/build.gradle
@@ -17,8 +17,11 @@ task uberJar(type: Jar) {
     appendix = 'uber'
 
     from sourceSets.main.output
-    from configurations.runtimeClasspath.
-                                         findAll { it.name.endsWith('jar') }.
-                                         collect { zipTree(it) }
+    from {
+        // Make it lazy
+        configurations.runtimeClasspath.
+            findAll { it.name.endsWith('jar') }.
+            collect { zipTree(it) }
+    }
 }
 // end::create-uber-jar-example[]

--- a/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
@@ -17,10 +17,11 @@ task<Jar>("uberJar") {
     appendix = "uber"
 
     from(sourceSets["main"].output)
-    from(
+    from(provider {
+        // Make it lazy
         configurations.runtimeClasspath
             .filter { it.name.endsWith("jar") }
             .map { zipTree(it) }
-    )
+    })
 }
 // end::create-uber-jar-example[]

--- a/subprojects/docs/src/samples/userguide/java/basic/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/java/basic/groovy/build.gradle
@@ -58,8 +58,11 @@ dependencies {
 }
 
 javadoc {
-    options.docletpath = configurations.asciidoclet.files.toList()
+    dependsOn configurations.asciidoclet
     options.doclet = 'org.asciidoctor.Asciidoclet'
+    doFirst {
+        options.docletpath = configurations.asciidoclet.files.toList()
+    }
 }
 // end::using-custom-doclet[]
 

--- a/subprojects/docs/src/samples/userguide/java/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/java/basic/kotlin/build.gradle.kts
@@ -60,8 +60,11 @@ dependencies {
 }
 
 tasks.getByName<Javadoc>("javadoc") {
-    options.docletpath = asciidoclet.files.toList()
+    dependsOn(configurations.getByName("asciidoclet"))
     options.doclet = "org.asciidoctor.Asciidoclet"
+    doFirst {
+        options.docletpath = asciidoclet.files.toList()
+    }
 }
 // end::using-custom-doclet[]
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/bestpractices/SamplesAuthoringMaintainableBuildsIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/bestpractices/SamplesAuthoringMaintainableBuildsIntegrationTest.groovy
@@ -65,7 +65,7 @@ generateDocs - Generates the HTML documentation for this project.""")
 
     @Unroll
     @UsesSample('userguide/bestPractices/logicDuringConfiguration')
-    def "can execute logic during #lifecyclePhase with #dsl dsl"() {
+    def "can execute logic during execution phase with #dsl dsl"() {
         executer.inDirectory(sample.dir.file("$subDirName/$dsl"))
 
         when:
@@ -75,11 +75,26 @@ generateDocs - Generates the HTML documentation for this project.""")
         outputContains('log4j-1.2.17.jar')
 
         where:
-        dsl      | subDirName | lifecyclePhase
-        'groovy' | 'dont'     | 'configuration phase'
-        'kotlin' | 'dont'     | 'configuration phase'
-        'groovy' | 'do'       | 'execution phase'
-        'kotlin' | 'do'       | 'execution phase'
+        dsl      | subDirName
+        'groovy' | 'do'
+        'kotlin' | 'do'
+    }
+
+    @Unroll
+    @UsesSample('userguide/bestPractices/logicDuringConfiguration')
+    def "throw exception when executing logic during configuration phrase with #dsl dsl"() {
+        executer.inDirectory(sample.dir.file("$subDirName/$dsl"))
+
+        when:
+        fails 'printArtifactNames'
+
+        then:
+        failureCauseContains("You shouldn't resolve configurations during configuration phase")
+
+        where:
+        dsl      | subDirName
+        'groovy' | 'dont'
+        'kotlin' | 'dont'
     }
 
     @Unroll

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsWithJMockitLoadedWithJavaAgent/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsWithJMockitLoadedWithJavaAgent/build.gradle
@@ -15,5 +15,5 @@ dependencies {
 }
 
 test {
-    jvmArgs "-javaagent:${configurations.jmockit.singleFile.absolutePath}"
+    jvmArgumentProviders.add({ ["-javaagent:${configurations.jmockit.singleFile.absolutePath}".toString()] } as CommandLineArgumentProvider)
 }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitIntegrationTest/executesTestsInCorrectEnvironment/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitIntegrationTest/executesTestsInCorrectEnvironment/build.gradle
@@ -4,6 +4,6 @@ dependencies { testCompile 'junit:junit:4.12', 'ant:ant:1.6.1', 'ant:ant-launche
 test {
     systemProperties.testSysProperty = 'value'
     systemProperties.projectDir = projectDir
-    systemProperties.expectedClassPath = sourceSets.test.runtimeClasspath.asPath
+    jvmArgumentProviders.add({ ["-DexpectedClassPath=${sourceSets.test.runtimeClasspath.asPath}".toString()] } as CommandLineArgumentProvider)
     environment.TEST_ENV_VAR = 'value'
 }


### PR DESCRIPTION
### Context

Previously we have several samples which resolve configurations eagerly at configuration phase. This is extremely terrible given that people usually copy code snippets from our samples. This PR fixes them by resolving these configurations lazily. Also, these samples can't benefit from our mirror infrastructure because mirrors take effect in `afterEvaluate{}` block.