### PR TITLE
Use global init script to set mirrors for buildSrc

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/AbstractInitIntegrationSpec.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/AbstractInitIntegrationSpec.groovy
@@ -26,7 +26,7 @@ class AbstractInitIntegrationSpec extends AbstractIntegrationSpec {
     final def targetDir = testDirectory.createDir("some-thing")
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
         executer.beforeExecute {
             executer.inDirectory(targetDir)
         }

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/MavenConversionIntegrationTest.groovy
@@ -51,7 +51,7 @@ class MavenConversionIntegrationTest extends AbstractIntegrationSpec {
          * */
         m2.generateUserSettingsFile(m2.mavenRepo())
         using m2
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "multiModule"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/SamplesCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/SamplesCompositeBuildIntegrationTest.groovy
@@ -17,7 +17,7 @@
 
 package org.gradle.integtests.composite
 
-import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.util.Requires
@@ -27,7 +27,7 @@ import spock.lang.Unroll
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
 @Requires(KOTLIN_SCRIPT)
-class SamplesCompositeBuildIntegrationTest extends AbstractSampleIntegrationTest {
+class SamplesCompositeBuildIntegrationTest extends AbstractIntegrationSpec {
 
     @Rule
     public final Sample sample = new Sample(temporaryFolder)
@@ -39,6 +39,9 @@ class SamplesCompositeBuildIntegrationTest extends AbstractSampleIntegrationTest
     @Unroll
     @UsesSample('compositeBuilds/basic')
     def "can run app with command-line composite with #dsl dsl"() {
+        given:
+        executer.withRepositoryMirrors()
+
         when:
         executer.inDirectory(sample.dir.file("$dsl/my-app")).withArguments("--include-build", "../my-utils")
         succeeds(':run')
@@ -54,6 +57,9 @@ class SamplesCompositeBuildIntegrationTest extends AbstractSampleIntegrationTest
     @Unroll
     @UsesSample('compositeBuilds/basic')
     def "can run app when modified to be a composite with #dsl dsl"() {
+        given:
+        executer.withRepositoryMirrors()
+
         when:
         executer.inDirectory(sample.dir.file("$dsl/my-app"))
             .withArguments("--settings-file", "settings-composite.$extension")
@@ -72,6 +78,9 @@ class SamplesCompositeBuildIntegrationTest extends AbstractSampleIntegrationTest
     @Unroll
     @UsesSample('compositeBuilds/basic')
     def "can run app when included in a composite with #dsl dsl"() {
+        given:
+        executer.withRepositoryMirrors()
+
         when:
         executer.inDirectory(sample.dir.file("$dsl/composite"))
         succeeds(':run')
@@ -87,6 +96,9 @@ class SamplesCompositeBuildIntegrationTest extends AbstractSampleIntegrationTest
     @Unroll
     @UsesSample('compositeBuilds/hierarchical-multirepo')
     def "can run app in hierarchical composite with #dsl dsl"() {
+        given:
+        executer.withRepositoryMirrors()
+
         when:
         executer.inDirectory(sample.dir.file("multirepo-app/$dsl"))
         succeeds(':run')
@@ -104,6 +116,7 @@ class SamplesCompositeBuildIntegrationTest extends AbstractSampleIntegrationTest
     def "can publish locally and remove submodule from hierarchical composite with #dsl dsl"() {
         given:
         def multiRepoAppDir = sample.dir.file("multirepo-app/$dsl")
+        executer.withRepositoryMirrors()
 
         when:
         executer.inDirectory(multiRepoAppDir)

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeIntegrationTest.groovy
@@ -28,7 +28,7 @@ import org.junit.Before
 abstract class AbstractIdeIntegrationTest extends AbstractIntegrationTest {
     @Before
     void setUp() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     protected ExecutionResult runTask(taskName, settingsScript = "rootProject.name = 'root'", buildScript) {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLayoutIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setUp() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesApplicationIntegrationTest.groovy
@@ -31,7 +31,7 @@ class SamplesApplicationIntegrationTest extends AbstractIntegrationSpec {
     @Rule Sample sample = new Sample(temporaryFolder, 'application')
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Unroll

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesClientModuleDependenciesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesClientModuleDependenciesIntegrationTest.groovy
@@ -24,7 +24,7 @@ class SamplesClientModuleDependenciesIntegrationTest extends AbstractIntegration
     @Rule Sample sample = new Sample(temporaryFolder, "clientModuleDependencies")
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "resolve shared"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomBuildLanguageIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesCustomBuildLanguageIntegrationTest.groovy
@@ -28,7 +28,7 @@ class SamplesCustomBuildLanguageIntegrationTest extends AbstractIntegrationTest 
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJUnitIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJUnitIntegrationTest.groovy
@@ -33,7 +33,7 @@ class SamplesJUnitIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaApiAndImplIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaApiAndImplIntegrationTest.groovy
@@ -28,7 +28,7 @@ class SamplesJavaApiAndImplIntegrationTest extends AbstractIntegrationSpec {
     static impl = "-impl"
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "test classpath contains impl and api classes"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaBaseIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaBaseIntegrationTest.groovy
@@ -31,7 +31,7 @@ class SamplesJavaBaseIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaCustomizedLayoutIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaCustomizedLayoutIntegrationTest.groovy
@@ -33,6 +33,10 @@ class SamplesJavaCustomizedLayoutIntegrationTest extends AbstractSampleIntegrati
     @Rule
     Sample sample = new Sample(testDirectoryProvider)
 
+    def setup() {
+        executer.withRepositoryMirrors()
+    }
+
     @Unroll
     @UsesSample('java/customizedLayout')
     def "can build and upload jar with #dsl dsl"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -18,7 +18,7 @@
 
 package org.gradle.integtests.samples
 
-import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.test.fixtures.file.TestFile
@@ -30,9 +30,7 @@ import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 import static org.hamcrest.Matchers.containsString
 
 @Requires(KOTLIN_SCRIPT)
-class SamplesJavaMultiProjectIntegrationTest extends AbstractSampleIntegrationTest {
-
-    static final String JAVA_PROJECT_NAME = 'java/multiproject'
+class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationSpec {
     static final String SHARED_NAME = 'shared'
     static final String API_NAME = 'api'
     static final String WEBAPP_NAME = 'webservice'
@@ -40,6 +38,10 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractSampleIntegrationTe
     static final String WEBAPP_PATH = "$SERVICES_NAME/$WEBAPP_NAME" as String
 
     @Rule public final Sample sample = new Sample(testDirectoryProvider, 'java/multiproject')
+
+    def setup() {
+        executer.withGlobalRepositoryMirrors()
+    }
 
     @Unroll
     def "multi project Java project sample with #dsl dsl"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -40,6 +40,7 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationSpec {
     @Rule public final Sample sample = new Sample(testDirectoryProvider, 'java/multiproject')
 
     def setup() {
+        // java/multiproject sample contains buildSrc, which needs global init script to make mirror work
         executer.withGlobalRepositoryMirrors()
     }
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -21,6 +21,7 @@ package org.gradle.integtests.samples
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.integtests.fixtures.Sample
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.junit.Rule
@@ -30,6 +31,7 @@ import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 import static org.hamcrest.Matchers.containsString
 
 @Requires(KOTLIN_SCRIPT)
+@LeaksFileHandles
 class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationSpec {
     static final String SHARED_NAME = 'shared'
     static final String API_NAME = 'api'

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaOnlyIfIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaOnlyIfIntegrationTest.groovy
@@ -30,7 +30,7 @@ class SamplesJavaOnlyIfIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     /**

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaProjectWithIntTestsIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaProjectWithIntTestsIntegrationTest.groovy
@@ -30,7 +30,7 @@ class SamplesJavaProjectWithIntTestsIntegrationTest extends AbstractIntegrationT
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaQuickstartIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaQuickstartIntegrationTest.groovy
@@ -37,7 +37,7 @@ class SamplesJavaQuickstartIntegrationTest extends AbstractIntegrationSpec {
     public final Sample sample = new Sample(testDirectoryProvider, 'java/quickstart')
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Unroll

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaTestListenerIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaTestListenerIntegrationTest.groovy
@@ -31,7 +31,7 @@ class SamplesJavaTestListenerIntegrationTest extends  AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesMixedJavaAndGroovyIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesMixedJavaAndGroovyIntegrationTest.groovy
@@ -32,7 +32,7 @@ class SamplesMixedJavaAndGroovyIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebProjectIntegrationTest.groovy
@@ -27,7 +27,7 @@ class SamplesWebProjectIntegrationTest extends AbstractIntegrationSpec {
     @Rule ReleasingPortAllocator portAllocator = new ReleasingPortAllocator()
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "can build war"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebQuickstartIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesWebQuickstartIntegrationTest.groovy
@@ -27,7 +27,7 @@ class SamplesWebQuickstartIntegrationTest extends AbstractPluginIntegrationTest 
     @Rule ReleasingPortAllocator portFinder = new ReleasingPortAllocator()
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "can build a war"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringRepositoriesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringRepositoriesIntegrationTest.groovy
@@ -27,7 +27,7 @@ class SamplesDeclaringRepositoriesIntegrationTest extends AbstractIntegrationSpe
     Sample sample = new Sample(testDirectoryProvider)
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @UsesSample("userguide/dependencyManagement/declaringRepositories/publicRepository/groovy")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDefiningUsingConfigurationsIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDefiningUsingConfigurationsIntegrationTest.groovy
@@ -32,7 +32,7 @@ class SamplesDefiningUsingConfigurationsIntegrationTest extends AbstractIntegrat
     Sample sample = new Sample(testDirectoryProvider)
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Unroll

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesManagingTransitiveDependenciesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesManagingTransitiveDependenciesIntegrationTest.groovy
@@ -36,7 +36,7 @@ class SamplesManagingTransitiveDependenciesIntegrationTest extends AbstractInteg
     Sample sample = new Sample(testDirectoryProvider)
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Unroll

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesWorkingWithDependenciesIntegrationTest.groovy
@@ -33,7 +33,7 @@ class SamplesWorkingWithDependenciesIntegrationTest extends AbstractIntegrationS
     Sample sample = new Sample(testDirectoryProvider)
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Unroll

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -392,18 +392,6 @@ class AbstractIntegrationSpec extends Specification {
         result.assertHasPostBuildOutput(string.trim())
     }
 
-    void useRepositoryMirrors() {
-        executer.beforeExecute {
-            executer.usingInitScript(RepoScriptBlockUtil.createMirrorInitScript())
-        }
-    }
-
-    void usePluginRepositoryMirror() {
-        executer.beforeExecute {
-            executer.withArgument("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")
-        }
-    }
-
     void outputDoesNotContain(String string) {
         assertHasResult()
         result.assertNotOutput(string.trim())

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -42,8 +42,6 @@ import org.hamcrest.CoreMatchers
 import org.hamcrest.Matcher
 import org.junit.Rule
 
-import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY
-import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl
 import static org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout.DEFAULT_TIMEOUT_SECONDS
 import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
 import static org.gradle.util.Matchers.normalizedLineSeparators

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -33,9 +33,6 @@ import org.junit.Rule;
 
 import java.io.File;
 
-import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY;
-import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl;
-
 public abstract class AbstractIntegrationTest {
     @Rule
     public final TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationTest.java
@@ -143,22 +143,4 @@ public abstract class AbstractIntegrationTest {
     public static String mavenCentralRepository() {
         return RepoScriptBlockUtil.mavenCentralRepository();
     }
-
-    public void useRepositoryMirrors() {
-        executer.beforeExecute(new Action<GradleExecuter>() {
-            @Override
-            public void execute(GradleExecuter gradleExecuter) {
-                executer.usingInitScript(RepoScriptBlockUtil.createMirrorInitScript());
-            }
-        });
-    }
-
-    public void usePluginRepositoryMirror() {
-        executer.beforeExecute(new Action<GradleExecuter>() {
-            @Override
-            public void execute(GradleExecuter gradleExecuter) {
-                executer.withArgument("-D" + PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY + "=" + gradlePluginRepositoryMirrorUrl());
-            }
-        });
-    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractSampleIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractSampleIntegrationTest.groovy
@@ -18,6 +18,6 @@ package org.gradle.integtests.fixtures
 
 abstract class AbstractSampleIntegrationTest extends AbstractIntegrationSpec {
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -165,6 +165,11 @@ class RepoScriptBlockUtil {
     static File createMirrorInitScript() {
         File mirrors = File.createTempFile("mirrors", ".gradle")
         mirrors.deleteOnExit()
+        mirrors << mirrorInitScript()
+        return mirrors
+    }
+
+    static String mirrorInitScript() {
         def mirrorConditions = MirroredRepository.values().collect { MirroredRepository mirror ->
             """
                 if (normalizeUrl(repo.url) == normalizeUrl('${mirror.originalUrl}')) {
@@ -172,7 +177,7 @@ class RepoScriptBlockUtil {
                 }
             """
         }.join("")
-        mirrors << """
+        return """
             import groovy.transform.CompileStatic
             import groovy.transform.CompileDynamic
             
@@ -227,6 +232,5 @@ class RepoScriptBlockUtil {
                 }
             }
         """
-        mirrors
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -33,6 +33,7 @@ import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.logging.configuration.WarningMode;
 import org.gradle.cache.internal.DefaultGeneratedGradleJarCache;
 import org.gradle.initialization.BuildLayoutParameters;
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil;
 import org.gradle.integtests.fixtures.daemon.DaemonLogsAnalyzer;
 import org.gradle.internal.ImmutableActionSet;
 import org.gradle.internal.MutableActionSet;
@@ -74,6 +75,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
+import static org.gradle.api.internal.artifacts.BaseRepositoryFactory.PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY;
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.gradlePluginRepositoryMirrorUrl;
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.DAEMON;
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.FOREGROUND;
 import static org.gradle.integtests.fixtures.executer.AbstractGradleExecuter.CliDaemonArgument.NOT_DEFINED;
@@ -779,6 +782,41 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
     @Override
     public GradleExecuter withWelcomeMessageEnabled() {
         renderWelcomeMessage = true;
+        return this;
+    }
+
+    @Override
+    public GradleExecuter withRepositoryMirrors() {
+        beforeExecute(new Action<GradleExecuter>() {
+            @Override
+            public void execute(GradleExecuter gradleExecuter) {
+                usingInitScript(RepoScriptBlockUtil.createMirrorInitScript());
+            }
+        });
+        return this;
+    }
+
+    @Override
+    public GradleExecuter withGlobalRepositoryMirrors() {
+        beforeExecute(new Action<GradleExecuter>() {
+            @Override
+            public void execute(GradleExecuter gradleExecuter) {
+                TestFile userHome = testDirectoryProvider.getTestDirectory().file("user-home");
+                withGradleUserHomeDir(userHome);
+                userHome.file("init.d/mirrors.gradle").write(RepoScriptBlockUtil.mirrorInitScript());
+            }
+        });
+        return this;
+    }
+
+    @Override
+    public GradleExecuter withPluginRepositoryMirror() {
+        beforeExecute(new Action<GradleExecuter>() {
+            @Override
+            public void execute(GradleExecuter gradleExecuter) {
+                withArgument("-D" + PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY + "=" + gradlePluginRepositoryMirrorUrl());
+            }
+        });
         return this;
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleExecuter.java
@@ -454,4 +454,28 @@ public interface GradleExecuter extends Stoppable {
      * Specifies we should use a test console that only has stdout attached.
      */
     GradleExecuter withTestConsoleAttached(ConsoleAttachment consoleAttachment);
+
+    /**
+     * Apply an init script which replaces all external repositories with inner mirrors.
+     * Note this doesn't work for buildSrc and composite build.
+     *
+     * @see org.gradle.integtests.fixtures.RepoScriptBlockUtil
+     */
+    GradleExecuter withRepositoryMirrors();
+
+    /**
+     * Requires an isolated gradle user home and put an init script which replaces all external repositories with inner mirrors.
+     * This works for all scenarios.
+     *
+     * @see org.gradle.integtests.fixtures.RepoScriptBlockUtil
+     */
+    GradleExecuter withGlobalRepositoryMirrors();
+
+    /**
+     * Start the build with {@link org.gradle.api.internal.artifacts.BaseRepositoryFactory#PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}
+     * set to our inner mirror.
+     *
+     * @see org.gradle.integtests.fixtures.RepoScriptBlockUtil
+     */
+    GradleExecuter withPluginRepositoryMirror();
 }

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/SamplesIvyPublishIntegrationTest.groovy
@@ -28,7 +28,7 @@ class SamplesIvyPublishIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/SampleScalaLanguageIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/SampleScalaLanguageIntegrationTest.groovy
@@ -27,7 +27,7 @@ class SampleScalaLanguageIntegrationTest extends AbstractIntegrationSpec {
     Sample sample = new Sample(temporaryFolder, "jvmComponents/scala")
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "can build scala based jvm component"() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
     }
 
     def setup() {
-        usePluginRepositoryMirror()
+        executer.withPluginRepositoryMirror()
         file("buildSrc/settings.gradle") << """
             include("plugin")
         """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -53,7 +53,7 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
     }
 
     def setup() {
-        executer.withPluginRepositoryMirror()
+        executer.withGlobalRepositoryMirrors()
         file("buildSrc/settings.gradle") << """
             include("plugin")
         """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -53,7 +53,8 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
     }
 
     def setup() {
-        executer.withGlobalRepositoryMirrors()
+        executer.withRepositoryMirrors()
+        executer.withPluginRepositoryMirror()
         file("buildSrc/settings.gradle") << """
             include("plugin")
         """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -21,12 +21,14 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import javax.inject.Inject
 
 @Requires(TestPrecondition.KOTLIN_SCRIPT)
+@LeaksFileHandles
 class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInterOpIntegrationTest {
     def setup() {
         usesKotlin(pluginDir)

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -21,14 +21,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import javax.inject.Inject
 
 @Requires(TestPrecondition.KOTLIN_SCRIPT)
-@LeaksFileHandles
 class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInterOpIntegrationTest {
     def setup() {
         usesKotlin(pluginDir)

--- a/subprojects/osgi/src/integTest/groovy/org/gradle/integtests/OsgiProjectSampleIntegrationTest.groovy
+++ b/subprojects/osgi/src/integTest/groovy/org/gradle/integtests/OsgiProjectSampleIntegrationTest.groovy
@@ -31,10 +31,10 @@ class OsgiProjectSampleIntegrationTest extends AbstractIntegrationSpec {
     @Rule public final Sample sample = new Sample(testDirectoryProvider, 'osgi/groovy')
 
     def setup() {
-        useRepositoryMirrors()
         executer.beforeExecute {
             expectDeprecationWarning()
         }
+        executer.withRepositoryMirrors()
     }
 
     def "OSGi project samples"() {

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
@@ -16,16 +16,20 @@
 
 package org.gradle.language.base
 
-import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
 
 @Requires(TestPrecondition.ONLINE)
-class LanguageTypeSampleIntegrationTest extends AbstractSampleIntegrationTest {
+class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec {
     @Rule
     Sample languageTypeSample = new Sample(temporaryFolder, "customModel/languageType")
+
+    def setup() {
+        executer.withGlobalRepositoryMirrors()
+    }
 
     def "shows custom language sourcesets in component"() {
         given:

--- a/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
+++ b/subprojects/platform-base/src/integTest/groovy/org/gradle/language/base/LanguageTypeSampleIntegrationTest.groovy
@@ -28,6 +28,7 @@ class LanguageTypeSampleIntegrationTest extends AbstractIntegrationSpec {
     Sample languageTypeSample = new Sample(temporaryFolder, "customModel/languageType")
 
     def setup() {
+        //  customModel/languageType sample contains buildSrc, which needs global init script to make mirror work
         executer.withGlobalRepositoryMirrors()
     }
 

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/AbstractPlaySampleIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/AbstractPlaySampleIntegrationTest.groovy
@@ -43,7 +43,7 @@ abstract class AbstractPlaySampleIntegrationTest extends AbstractSampleIntegrati
     }
 
     def setup() {
-        usePluginRepositoryMirror()
+        executer.withPluginRepositoryMirror()
         initScript = file("initFile") << """
             gradle.allprojects {
                 tasks.withType(PlayRun) {

--- a/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/UserGuidePlaySamplesIntegrationTest.groovy
+++ b/subprojects/platform-play/src/integTest/groovy/org/gradle/play/integtest/samples/UserGuidePlaySamplesIntegrationTest.groovy
@@ -37,7 +37,7 @@ class UserGuidePlaySamplesIntegrationTest extends AbstractIntegrationSpec {
     @Rule Sample play26Sample = new Sample(temporaryFolder, "play/play-2.6")
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "sourcesets sample is buildable" () {

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayContinuousBuildIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/AbstractMultiVersionPlayContinuousBuildIntegrationTest.groovy
@@ -35,6 +35,6 @@ abstract class AbstractMultiVersionPlayContinuousBuildIntegrationTest extends Ab
 
     def setup() {
         buildFile << PlayMultiVersionApplicationIntegrationTest.playPlatformConfiguration(version.toString())
-        usePluginRepositoryMirror()
+        executer.withPluginRepositoryMirror()
     }
 }

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionApplicationIntegrationTest.groovy
@@ -32,7 +32,7 @@ abstract class PlayMultiVersionApplicationIntegrationTest extends PlayMultiVersi
         settingsFile << """
             rootProject.name = '${playApp.name}'
         """
-        usePluginRepositoryMirror()
+        executer.withPluginRepositoryMirror()
     }
 
     static String playPlatformConfiguration(String version) {

--- a/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionRunApplicationIntegrationTest.groovy
+++ b/subprojects/platform-play/src/testFixtures/groovy/org/gradle/play/integtest/fixtures/PlayMultiVersionRunApplicationIntegrationTest.groovy
@@ -26,7 +26,7 @@ abstract class PlayMultiVersionRunApplicationIntegrationTest extends PlayMultiVe
 
     def setup() {
         runningApp = new RunningPlayApp(testDirectory)
-        usePluginRepositoryMirror()
+        executer.withPluginRepositoryMirror()
     }
 
     def startBuild(tasks) {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -44,7 +44,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
     def setup() {
         // necessary for picking up some of the output/errorOutput when forked executer is used
         executer.withArgument("-i")
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "compileGoodCode"() {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/integtests/samples/SamplesMixedJavaAndScalaIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/integtests/samples/SamplesMixedJavaAndScalaIntegrationTest.groovy
@@ -36,7 +36,7 @@ class SamplesMixedJavaAndScalaIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/IncrementalScalaCompileIntegrationTest.groovy
@@ -27,7 +27,7 @@ class IncrementalScalaCompileIntegrationTest extends AbstractIntegrationSpec {
     @Rule public final ZincScalaCompileFixture zincScalaCompileFixture = new ZincScalaCompileFixture(executer, temporaryFolder)
 
     void setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def recompilesSourceWhenPropertiesChange() {

--- a/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
+++ b/subprojects/scala/src/integTest/groovy/org/gradle/scala/compile/ZincScalaCompilerIntegrationTest.groovy
@@ -37,7 +37,7 @@ class ZincScalaCompilerIntegrationTest extends MultiVersionIntegrationSpec {
     def setup() {
         args("-PscalaVersion=$version")
         buildFile << buildScript()
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def compileGoodCode() {

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/enduser/GradleRunnerSamplesEndUserIntegrationTest.groovy
@@ -39,7 +39,7 @@ class GradleRunnerSamplesEndUserIntegrationTest extends BaseTestKitEndUserIntegr
     Sample sample = new Sample(testDirectoryProvider)
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Unroll

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsContinousIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsContinousIntegrationTest.groovy
@@ -50,7 +50,7 @@ class TestExecutionBuildOperationsContinousIntegrationTest extends AbstractConti
     }
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "emits test operations for continuous builds"() {

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
@@ -92,7 +92,6 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
     def "emits test operations as expected for composite builds"() {
         given:
-        executer.withRepositoryMirrors()
         resources.maybeCopy('TestExecutionBuildOperationsIntegrationTest')
         settingsFile.text = """
             rootProject.name = "composite"

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsIntegrationTest.groovy
@@ -33,6 +33,9 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
     def operations = new BuildOperationsFixture(executer, temporaryFolder)
 
     def "emitsBuildOperationsForJUnitTests"() {
+        given:
+        executer.withRepositoryMirrors()
+
         when:
         run "test"
 
@@ -46,6 +49,9 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
     }
 
     def "emitsBuildOperationsForTestNgTests"() {
+        given:
+        executer.withRepositoryMirrors()
+
         when:
         run "test"
 
@@ -61,6 +67,7 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
     def "emits test operations as expected for two builds in a row"() {
         given:
+        executer.withRepositoryMirrors()
         resources.maybeCopy('TestExecutionBuildOperationsIntegrationTest/emitsBuildOperationsForJUnitTests')
 
         when:
@@ -85,6 +92,7 @@ class TestExecutionBuildOperationsIntegrationTest extends AbstractIntegrationSpe
 
     def "emits test operations as expected for composite builds"() {
         given:
+        executer.withRepositoryMirrors()
         resources.maybeCopy('TestExecutionBuildOperationsIntegrationTest')
         settingsFile.text = """
             rootProject.name = "composite"

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
@@ -31,7 +31,7 @@ class IncrementalTestIntegrationTest extends MultiVersionIntegrationSpec {
 
     def setup() {
         executer.noExtraLogging()
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def doesNotRunStaleTests() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitMultiVersionIntegrationSpec.groovy
@@ -41,7 +41,7 @@ abstract class JUnitMultiVersionIntegrationSpec extends MultiVersionIntegrationS
     private static final Pattern TEST_CASE_RESULT_PATTERN = ~/(.*)(\w+)\(\) (PASSED|FAILED|SKIPPED|STANDARD_OUT)/
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Override

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitTestFilteringSamplesIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitTestFilteringSamplesIntegrationTest.groovy
@@ -32,7 +32,7 @@ class JUnitTestFilteringSamplesIntegrationTest extends MultiVersionIntegrationSp
     @Rule Sample sample = new Sample(temporaryFolder, 'testing/filtering/groovy')
 
     def setup() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     def "uses test filter"() {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/testng/SampleTestNGIntegrationTest.groovy
@@ -30,7 +30,7 @@ public class SampleTestNGIntegrationTest extends AbstractIntegrationTest {
 
     @Before
     void setUp() {
-        useRepositoryMirrors()
+        executer.withRepositoryMirrors()
     }
 
     @Test @UsesSample('testing/testng/suitexmlbuilder')


### PR DESCRIPTION
### Context

We've set up mirrors for most integration tests, except for:

- tests containing `buildSrc`: https://github.com/gradle/gradle-private/issues/1403

For this case, this PR uses global init script to set up mirrors.