### PR TITLE
Adjust source and test source directories in IdeaProject TAPI model

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -17,12 +17,7 @@
             <tr>
                 <td>sourceDirs</td>
                 <td><literal>[]</literal></td>
-                <td>
-                    <itemizedlist>
-                        <listitem>with Gradle &lt; 5.0: source dirs from <literal>project.sourceSets.main.allSource</literal>.</listitem>
-                        <listitem>with Gradle &gt;= 5.0: source dirs from <literal>project.sourceSets.main.allJava</literal>.</listitem>
-                    </itemizedlist>
-                </td>
+                <td>project.sourceSets.main.allJava</td>
             </tr>
             <tr>
                 <td>scopes</td>
@@ -59,12 +54,7 @@
             <tr>
                 <td>testSourceDirs</td>
                 <td><literal>[]</literal></td>
-                <td>
-                    <itemizedlist>
-                        <listitem>with Gradle &lt; 5.0: source dirs from <literal>project.sourceSets.test.allSource</literal>.</listitem>
-                        <listitem>with Gradle &gt;= 5.0: source dirs from <literal>project.sourceSets.test.allJava</literal>.</listitem>
-                    </itemizedlist>
-                </td>
+                <td>project.sourceSets.test.allJava</td>
             </tr>
             <tr>
                 <td>resourceDirs</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -165,6 +165,11 @@ to reset the property back to its default value. Use `DuplicatesStrategy.INHERIT
 
 For easier configurability from statically compiled languages such as Java or Kotlin.
 
+### Source and test source dirs in `IdeaModule` no longer contain resources
+
+The `IdeaModule` Tooling API model element contains methods to retrieve resources and test resources so those elements were removed from the result of  `IdeaModule#getSourceDirs()` and `IdeaModule#getTestSourceDirs()`.
+
+
 ### Changes to previously deprecated APIs
 
 - The `org.gradle.plugins.signing.Signature` methods `getToSignArtifact()` and `setFile(File)` are removed.

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/m5/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -115,6 +115,7 @@ idea.module.testOutputDir = file('someTestDir')
         module.compilerOutput.testOutputDir == file('someTestDir')
     }
 
+    @TargetGradleVersion("<5.0")
     def "provides source dir information"() {
 
         file('build.gradle').text = "apply plugin: 'java'"

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r50/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r50/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -22,8 +22,6 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.tooling.model.idea.IdeaContentRoot
 import org.gradle.tooling.model.idea.IdeaModule
 import org.gradle.tooling.model.idea.IdeaProject
-import org.gradle.util.ToBeImplemented
-import org.junit.Ignore
 
 /**
  * NOTE: Starting with Gradle 5.0 the contract of IdeaModule#sourceDirs and IdeaModule#testSourceDirs changes in
@@ -31,8 +29,6 @@ import org.junit.Ignore
  */
 @ToolingApiVersion(">=5.0")
 @TargetGradleVersion(">=5.0")
-@Ignore
-@ToBeImplemented
 class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
 
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/IdeaPlugin.java
@@ -375,14 +375,14 @@ public class IdeaPlugin extends IdePlugin {
             @Override
             public Set<File> call() {
                 SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-                return sourceSets.getByName("main").getAllSource().getSrcDirs();
+                return sourceSets.getByName("main").getAllJava().getSrcDirs();
             }
         });
         convention.map("testSourceDirs", new Callable<Set<File>>() {
             @Override
             public Set<File> call() {
                 SourceSetContainer sourceSets = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets();
-                return sourceSets.getByName("test").getAllSource().getSrcDirs();
+                return sourceSets.getByName("test").getAllJava().getSrcDirs();
             }
         });
         convention.map("resourceDirs", new Callable<Set<File>>() {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -219,10 +219,7 @@ public class IdeaModule {
 
     /**
      * The directories containing the production sources.
-     * <p>
-     * For backward-compatibility it is set of directories containing the production sources from <tt>project.sourceSets.main.allSource</tt>.
-     * <p>
-     * Starting with Gradle 5.0 it is set of directories containing the production sources from <tt>project.sourceSets.main.allJava</tt>.
+     *
      * For example see docs for {@link IdeaModule}
      */
     public Set<File> getSourceDirs() {
@@ -318,10 +315,7 @@ public class IdeaModule {
 
     /**
      * The directories containing the test sources.
-     * <p>
-     * For backward-compatibility it is set of directories containing the test sources from <tt>project.sourceSets.test.allSource</tt>.
-     * <p>
-     * Starting with Gradle 5.0 it is set of directories containing the test sources from <tt>project.sourceSets.test.allJava</tt>.
+     *
      * For example see docs for {@link IdeaModule}
      */
     public Set<File> getTestSourceDirs() {


### PR DESCRIPTION
This is a follow-up for the [_Add support for resources and test resources in IDEA module_](#3724) story. There we kept the original behaviour for `IdeaModule#getSourceDirs()` and `IdeaModule#getTestSourceDirs()` to maintain backward compatibility.  This PR adjusts the source and test source dirs to contain `allJava` instead of `allSources` for Gradle 5.0.