### PR TITLE
Simplify discovery of file property factory methods

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.java
@@ -42,7 +42,7 @@ public class CheckstyleExtension extends CodeQualityExtension {
 
     public CheckstyleExtension(Project project) {
         this.project = project;
-        configDir = project.getLayout().directoryProperty();
+        configDir = project.getObjects().directoryProperty();
     }
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
@@ -17,6 +17,7 @@
 package org.gradle.api.file;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 
@@ -25,7 +26,7 @@ import java.io.File;
 /**
  * Represents some configurable directory location, whose value is mutable and is not necessarily currently known until later.
  * <p>
- * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created using the {@link ProjectLayout#directoryProperty()} method.
+ * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created using the {@link ObjectFactory#directoryProperty()} method.
  *
  * @since 4.3
  */

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 
 import java.io.File;
@@ -47,6 +48,7 @@ public interface ProjectLayout {
      * Creates a new {@link DirectoryProperty} that uses the project directory to resolve relative paths, if required. The property has no initial value.
      *
      * @since 4.3
+     * @deprecated Replaced by {@link ObjectFactory#directoryProperty()}
      */
     DirectoryProperty directoryProperty();
 
@@ -55,6 +57,7 @@ public interface ProjectLayout {
      *
      * @param initialProvider initial provider for the property
      * @since 4.4
+     * @deprecated Replaced by {@link ObjectFactory#directoryProperty()}
      */
     DirectoryProperty directoryProperty(Provider<? extends Directory> initialProvider);
 
@@ -62,6 +65,7 @@ public interface ProjectLayout {
      * Creates a new {@link RegularFileProperty} that uses the project directory to resolve relative paths, if required. The property has no initial value.
      *
      * @since 4.3
+     * @deprecated Replaced by {@link ObjectFactory#fileProperty()}
      */
     RegularFileProperty fileProperty();
 
@@ -70,6 +74,7 @@ public interface ProjectLayout {
      *
      * @param initialProvider initial provider for the property
      * @since 4.4
+     * @deprecated Replaced by {@link ObjectFactory#fileProperty()}
      */
     RegularFileProperty fileProperty(Provider<? extends RegularFile> initialProvider);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ProjectLayout.java
@@ -44,14 +44,14 @@ public interface ProjectLayout {
     DirectoryProperty getBuildDirectory();
 
     /**
-     * Creates a new {@link DirectoryProperty} that uses the project directory to resolve paths, if required. The property has no initial value.
+     * Creates a new {@link DirectoryProperty} that uses the project directory to resolve relative paths, if required. The property has no initial value.
      *
      * @since 4.3
      */
     DirectoryProperty directoryProperty();
 
     /**
-     * Creates a new {@link DirectoryProperty} that uses the project directory to resolve paths, if required. The property has the initial provider specified.
+     * Creates a new {@link DirectoryProperty} that uses the project directory to resolve relative paths, if required. The property has the initial provider specified.
      *
      * @param initialProvider initial provider for the property
      * @since 4.4
@@ -59,14 +59,14 @@ public interface ProjectLayout {
     DirectoryProperty directoryProperty(Provider<? extends Directory> initialProvider);
 
     /**
-     * Creates a new {@link RegularFileProperty} that uses the project directory to resolve paths, if required. The property has no initial value.
+     * Creates a new {@link RegularFileProperty} that uses the project directory to resolve relative paths, if required. The property has no initial value.
      *
      * @since 4.3
      */
     RegularFileProperty fileProperty();
 
     /**
-     * Creates a new {@link RegularFileProperty} that uses the project directory to resolve paths, if required. The property has the initial provider specified.
+     * Creates a new {@link RegularFileProperty} that uses the project directory to resolve relative paths, if required. The property has the initial provider specified.
      *
      * @param initialProvider initial provider for the property
      * @since 4.4

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
@@ -25,7 +25,7 @@ import java.io.File;
 /**
  * Represents some configurable regular file location, whose value is mutable and not necessarily currently known until later.
  * <p>
- * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created using the {@link ProjectLayout#fileProperty()} method.
+ * <b>Note:</b> This interface is not intended for implementation by build script or plugin authors. An instance of this class can be created using the {@link org.gradle.api.model.ObjectFactory#fileProperty()} method.
  *
  * @since 4.3
  */

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -18,6 +18,8 @@ package org.gradle.api.model;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
@@ -122,4 +124,18 @@ public interface ObjectFactory {
      * @since 4.5
      */
     <T> SetProperty<T> setProperty(Class<T> elementType);
+
+    /**
+     * Creates a new {@link DirectoryProperty} that uses the project directory to resolve relative paths, if required. The property has no initial value.
+     *
+     * @since 5.0
+     */
+    DirectoryProperty directoryProperty();
+
+    /**
+     * Creates a new {@link RegularFileProperty} that uses the project directory to resolve relative paths, if required. The property has no initial value.
+     *
+     * @since 5.0
+     */
+    RegularFileProperty fileProperty();
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FilePropertiesIntegrationTest.groovy
@@ -459,13 +459,13 @@ task useDirProviderApi {
     }
 
     @Unroll
-    def "can wire the output of a task as a dependency of another task via #fileMethod"() {
+    def "can wire the output of a task created using #outputFileMethod and #outputDirMethod as a dependency of another task via #fileMethod"() {
         buildFile << """
             class DirOutputTask extends DefaultTask {
                 @InputFile
                 final RegularFileProperty inputFile = newInputFile()
                 @OutputDirectory
-                final DirectoryProperty outputDir = newOutputDirectory()
+                final DirectoryProperty outputDir = ${outputDirMethod}
                 
                 @TaskAction
                 void go() {
@@ -478,7 +478,7 @@ task useDirProviderApi {
                 @InputFile
                 final RegularFileProperty inputFile = newInputFile()
                 @OutputFile
-                final RegularFileProperty outputFile = newOutputFile()
+                final RegularFileProperty outputFile = ${outputFileMethod}
                 
                 @TaskAction
                 void go() {
@@ -512,9 +512,13 @@ task useDirProviderApi {
         result.assertTasksExecuted(":createDir", ":createFile1", ":otherTask")
 
         where:
-        fileMethod    | dirMethod
-        'dependsOn'   | 'dependsOn'
-        'inputs.file' | 'inputs.dir'
+        fileMethod    | dirMethod    | outputDirMethod        | outputFileMethod
+        'dependsOn'   | 'dependsOn'  | "newOutputDirectory()" | "newOutputFile()"
+        'inputs.file' | 'inputs.dir' | "newOutputDirectory()" | "newOutputFile()"
+        'dependsOn'   | 'dependsOn'  | "project.layout.directoryProperty()" | "project.layout.fileProperty()"
+        'inputs.file' | 'inputs.dir' | "project.layout.directoryProperty()" | "project.layout.fileProperty()"
+        'dependsOn'   | 'dependsOn'  | "project.objects.directoryProperty()" | "project.objects.fileProperty()"
+        'inputs.file' | 'inputs.dir' | "project.objects.directoryProperty()" | "project.objects.fileProperty()"
     }
 
     def "can use @Optional on properties with type Property"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FilePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FilePropertiesIntegrationTest.groovy
@@ -112,7 +112,7 @@ task useFileProviderApi {
 
         then:
         failure.assertHasDescription("Execution failed for task ':useFileTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using an instance of type org.gradle.api.internal.file.DefaultProjectLayout\$FixedFile.")
+        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.Directory using an instance of type org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedFile.")
 
         when:
         fails("useFileProviderDsl")
@@ -282,7 +282,7 @@ task useDirProviderApi {
 
         then:
         failure.assertHasDescription("Execution failed for task ':useDirTypeDsl'.")
-        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using an instance of type org.gradle.api.internal.file.DefaultProjectLayout\$FixedDirectory.")
+        failure.assertHasCause("Cannot set the value of a property of type org.gradle.api.file.RegularFile using an instance of type org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedDirectory.")
 
         when:
         fails("useDirProviderDsl")
@@ -373,9 +373,10 @@ task useDirProviderApi {
         file("output/merged.txt").text == 'new-file1,file2'
 
         where:
-        outputFileMethod                | inputFileMethod
-        "newOutputFile()"               | "newInputFile()"
-        "project.layout.fileProperty()" | "project.layout.fileProperty()"
+        outputFileMethod                 | inputFileMethod
+        "newOutputFile()"                | "newInputFile()"
+        "project.layout.fileProperty()"  | "project.layout.fileProperty()"
+        "project.objects.fileProperty()" | "project.objects.fileProperty()"
     }
 
     @Unroll
@@ -451,9 +452,10 @@ task useDirProviderApi {
         file("output/merged.txt").text == 'new-dir1,dir2'
 
         where:
-        outputDirMethod                      | inputDirMethod
-        "newOutputDirectory()"               | "newInputDirectory()"
-        "project.layout.directoryProperty()" | "project.layout.directoryProperty()"
+        outputDirMethod                       | inputDirMethod
+        "newOutputDirectory()"                | "newInputDirectory()"
+        "project.layout.directoryProperty()"  | "project.layout.directoryProperty()"
+        "project.objects.directoryProperty()" | "project.objects.directoryProperty()"
     }
 
     @Unroll

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/NestedInputIntegrationTest.groovy
@@ -41,7 +41,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             
             class GeneratorTask extends DefaultTask {
                 @Output${kind}
-                ${type.name} output = newOutput${kind}()
+                ${type.name} output = project.objects.${factory}()
                 
                 @TaskAction
                 void doStuff() {
@@ -50,11 +50,11 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             }
             
             task generator(type: GeneratorTask) {
-                output.set(project.layout.buildDirectory.${kind == 'Directory' ? 'dir' : 'file'}('output'))
+                output.set(project.layout.buildDirectory.${lookup}('output'))
             }
             
             task consumer(type: TaskWithNestedProperty) {
-                bean = new NestedBeanWithInput(input: newInput${kind}())
+                bean = new NestedBeanWithInput(input: project.objects.${factory}())
                 bean.input.set(generator.output)
             }
         """
@@ -65,9 +65,9 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped(':generator', ':consumer')
 
         where:
-        kind        | type                | generatorAction
-        'File'      | RegularFileProperty | '.getAsFile().get().text = "Hello"'
-        'Directory' | DirectoryProperty   | '''.file('output.txt').get().getAsFile().text = "Hello"'''
+        kind        | type                | factory             | lookup | generatorAction
+        'File'      | RegularFileProperty | 'fileProperty'      | 'file' | '.getAsFile().get().text = "Hello"'
+        'Directory' | DirectoryProperty   | 'directoryProperty' | 'dir'  | '''.file('output.txt').get().getAsFile().text = "Hello"'''
     }
 
     def "nested FileCollection input adds a task dependency"() {
@@ -84,7 +84,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             
             class GeneratorTask extends DefaultTask {
                 @OutputFile
-                RegularFileProperty outputFile = newOutputFile()
+                RegularFileProperty outputFile = project.objects.fileProperty()
                 
                 @TaskAction
                 void doStuff() {
@@ -93,7 +93,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             }
             
             task generator(type: GeneratorTask) {
-                outputFile.set(project.layout.buildDirectory.file('output'))
+                outputFile = project.layout.buildDirectory.file('output')
             }
             
             task consumer(type: TaskWithNestedProperty) {
@@ -122,7 +122,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             
             class GeneratorTask extends DefaultTask {
                 @OutputFile
-                RegularFileProperty outputFile = newOutputFile()
+                RegularFileProperty outputFile = project.objects.fileProperty()
                 
                 @TaskAction
                 void doStuff() {
@@ -131,7 +131,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             }
             
             task generator(type: GeneratorTask) {
-                outputFile.set(project.layout.buildDirectory.file('output'))
+                outputFile = project.layout.buildDirectory.file('output')
             }
             
             task consumer(type: TaskWithNestedProperty) {
@@ -348,7 +348,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
                 Object bean
     
                 @OutputFile
-                RegularFileProperty outputFile = newOutputFile()
+                RegularFileProperty outputFile = project.objects.fileProperty()
     
                 @TaskAction
                 void writeInputToFile() {
@@ -897,6 +897,7 @@ class NestedInputIntegrationTest extends AbstractIntegrationSpec {
             }
         """
     }
+
     private TestFile taskWithNestedBeanWithAction() {
         nestedBeanWithAction()
         return file("buildSrc/src/main/java/TaskWithNestedBeanWithAction.java") << """

--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -34,7 +34,7 @@ public class DefaultTask extends AbstractTask {
      * @since 4.4
      */
     @Incubating
-    protected DirectoryProperty newOutputDirectory() {
+    protected final DirectoryProperty newOutputDirectory() {
         return getServices().get(TaskFileVarFactory.class).newOutputDirectory(this);
     }
 
@@ -45,7 +45,7 @@ public class DefaultTask extends AbstractTask {
      * @since 4.4
      */
     @Incubating
-    protected RegularFileProperty newOutputFile() {
+    protected final RegularFileProperty newOutputFile() {
         return getServices().get(TaskFileVarFactory.class).newOutputFile(this);
     }
 
@@ -56,7 +56,7 @@ public class DefaultTask extends AbstractTask {
      * @since 4.4
      */
     @Incubating
-    protected RegularFileProperty newInputFile() {
+    protected final RegularFileProperty newInputFile() {
         return getServices().get(TaskFileVarFactory.class).newInputFile(this);
     }
 
@@ -67,7 +67,7 @@ public class DefaultTask extends AbstractTask {
      * @since 4.4
      */
     @Incubating
-    protected DirectoryProperty newInputDirectory() {
+    protected final DirectoryProperty newInputDirectory() {
         return getServices().get(TaskFileVarFactory.class).newInputDirectory(this);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -20,7 +20,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.internal.NoConventionMapping;
-import org.gradle.api.internal.file.TaskFileVarFactory;
+import org.gradle.api.model.ObjectFactory;
 
 /**
  * {@code DefaultTask} is the standard {@link Task} implementation. You can extend this to implement your own task types.
@@ -35,7 +35,7 @@ public class DefaultTask extends AbstractTask {
      */
     @Incubating
     protected final DirectoryProperty newOutputDirectory() {
-        return getServices().get(TaskFileVarFactory.class).newOutputDirectory(this);
+        return getServices().get(ObjectFactory.class).directoryProperty();
     }
 
     /**
@@ -46,7 +46,7 @@ public class DefaultTask extends AbstractTask {
      */
     @Incubating
     protected final RegularFileProperty newOutputFile() {
-        return getServices().get(TaskFileVarFactory.class).newOutputFile(this);
+        return getServices().get(ObjectFactory.class).fileProperty();
     }
 
     /**
@@ -57,7 +57,7 @@ public class DefaultTask extends AbstractTask {
      */
     @Incubating
     protected final RegularFileProperty newInputFile() {
-        return getServices().get(TaskFileVarFactory.class).newInputFile(this);
+        return getServices().get(ObjectFactory.class).fileProperty();
     }
 
     /**
@@ -68,6 +68,6 @@ public class DefaultTask extends AbstractTask {
      */
     @Incubating
     protected final DirectoryProperty newInputDirectory() {
-        return getServices().get(TaskFileVarFactory.class).newInputDirectory(this);
+        return getServices().get(ObjectFactory.class).directoryProperty();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/DefaultTask.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.internal.NoConventionMapping;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.util.DeprecationLogger;
 
 /**
  * {@code DefaultTask} is the standard {@link Task} implementation. You can extend this to implement your own task types.
@@ -32,9 +33,11 @@ public class DefaultTask extends AbstractTask {
      *
      * @return The property.
      * @since 4.4
+     * @deprecated Replaced by {@link ObjectFactory#directoryProperty()}
      */
-    @Incubating
+    @Deprecated
     protected final DirectoryProperty newOutputDirectory() {
+        DeprecationLogger.nagUserOfReplacedMethod("DefaultTask.newOutputDirectory()", "ObjectFactory.directoryProperty()");
         return getServices().get(ObjectFactory.class).directoryProperty();
     }
 
@@ -43,9 +46,11 @@ public class DefaultTask extends AbstractTask {
      *
      * @return The property.
      * @since 4.4
+     * @deprecated Replaced by {@link ObjectFactory#fileProperty()}
      */
-    @Incubating
+    @Deprecated
     protected final RegularFileProperty newOutputFile() {
+        DeprecationLogger.nagUserOfReplacedMethod("DefaultTask.newOutputFile()", "ObjectFactory.fileProperty()");
         return getServices().get(ObjectFactory.class).fileProperty();
     }
 
@@ -54,9 +59,11 @@ public class DefaultTask extends AbstractTask {
      *
      * @return The property.
      * @since 4.4
+     * @deprecated Replaced by {@link ObjectFactory#fileProperty()}
      */
-    @Incubating
+    @Deprecated
     protected final RegularFileProperty newInputFile() {
+        DeprecationLogger.nagUserOfReplacedMethod("DefaultTask.newInputFile()", "ObjectFactory.fileProperty()");
         return getServices().get(ObjectFactory.class).fileProperty();
     }
 
@@ -65,9 +72,11 @@ public class DefaultTask extends AbstractTask {
      *
      * @return The property.
      * @since 4.4
+     * @deprecated Replaced by {@link ObjectFactory#directoryProperty()}
      */
-    @Incubating
+    @Deprecated
     protected final DirectoryProperty newInputDirectory() {
+        DeprecationLogger.nagUserOfReplacedMethod("DefaultTask.newInputDirectory()", "ObjectFactory.directoryProperty()");
         return getServices().get(ObjectFactory.class).directoryProperty();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -1,0 +1,338 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.Task;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.provider.AbstractCombiningProvider;
+import org.gradle.api.internal.provider.AbstractMappingProvider;
+import org.gradle.api.internal.provider.AbstractProvider;
+import org.gradle.api.internal.provider.DefaultPropertyState;
+import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.provider.Provider;
+import org.gradle.internal.file.PathToFileResolver;
+
+import javax.annotation.Nullable;
+import java.io.File;
+
+public class DefaultFilePropertyFactory implements FilePropertyFactory {
+    private final FileResolver fileResolver;
+
+    public DefaultFilePropertyFactory(FileResolver resolver) {
+        this.fileResolver = resolver;
+    }
+
+    @Override
+    public DirectoryProperty directoryProperty() {
+        return new DefaultDirectoryVar(fileResolver);
+    }
+
+    @Override
+    public RegularFileProperty fileProperty() {
+        return new DefaultRegularFileVar(fileResolver);
+    }
+
+    static class FixedDirectory implements Directory, FileSystemLocation {
+        private final File value;
+        final FileResolver fileResolver;
+
+        FixedDirectory(File value, FileResolver fileResolver) {
+            this.value = value;
+            this.fileResolver = fileResolver;
+        }
+
+        @Override
+        public String toString() {
+            return value.toString();
+        }
+
+        @Override
+        public File getAsFile() {
+            return value;
+        }
+
+        @Override
+        public Directory dir(String path) {
+            File newDir = fileResolver.resolve(path);
+            return new FixedDirectory(newDir, fileResolver.newResolver(newDir));
+        }
+
+        @Override
+        public FileTree getAsFileTree() {
+            return fileResolver.resolveFilesAsTree(this);
+        }
+
+        @Override
+        public Provider<Directory> dir(Provider<? extends CharSequence> path) {
+            return new ResolvingDirectory(fileResolver, path);
+        }
+
+        @Override
+        public RegularFile file(String path) {
+            return new FixedFile(fileResolver.resolve(path));
+        }
+
+        @Override
+        public Provider<RegularFile> file(Provider<? extends CharSequence> path) {
+            return new ResolvingFile(fileResolver, path);
+        }
+    }
+
+    static class FixedFile implements RegularFile, FileSystemLocation {
+        private final File file;
+
+        FixedFile(File file) {
+            this.file = file;
+        }
+
+        @Override
+        public String toString() {
+            return file.toString();
+        }
+
+        @Override
+        public File getAsFile() {
+            return file;
+        }
+    }
+
+    static class ResolvingFile extends AbstractMappingProvider<RegularFile, CharSequence> implements TaskDependencyContainer {
+        private final PathToFileResolver resolver;
+
+        ResolvingFile(PathToFileResolver resolver, Provider<? extends CharSequence> path) {
+            super(RegularFile.class, path);
+            this.resolver = resolver;
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            // No dependencies
+        }
+
+        @Override
+        protected RegularFile map(CharSequence path) {
+            return new FixedFile(resolver.resolve(path));
+        }
+    }
+
+    static class DefaultRegularFileVar extends DefaultPropertyState<RegularFile> implements RegularFileProperty, TaskDependencyContainer, ProducerAwareProperty {
+        private Task producer;
+        private final PathToFileResolver fileResolver;
+
+        DefaultRegularFileVar(PathToFileResolver fileResolver) {
+            super(RegularFile.class);
+            this.fileResolver = fileResolver;
+        }
+
+        @Override
+        public void attachProducer(Task task) {
+            if (this.producer != null && this.producer != task) {
+                throw new IllegalStateException("This property already has a producer task associated with it.");
+            }
+            this.producer = task;
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            if (producer != null) {
+                context.add(producer);
+            } else if (getProvider() instanceof TaskDependencyContainer) {
+                context.add(getProvider());
+            }
+        }
+
+        @Override
+        public void setFromAnyValue(Object object) {
+            if (object instanceof File) {
+                set((File) object);
+            } else {
+                super.setFromAnyValue(object);
+            }
+        }
+
+        @Override
+        public Provider<File> getAsFile() {
+            return new ToFileProvider(this);
+        }
+
+        @Override
+        public void set(File file) {
+            set(new FixedFile(fileResolver.resolve(file)));
+        }
+    }
+
+    static class ResolvingDirectory extends AbstractProvider<Directory> implements TaskDependencyContainer {
+        private final FileResolver resolver;
+        private final Provider<?> valueProvider;
+
+        ResolvingDirectory(FileResolver resolver, Provider<?> valueProvider) {
+            this.resolver = resolver;
+            this.valueProvider = valueProvider;
+        }
+
+        @Nullable
+        @Override
+        public Class<Directory> getType() {
+            return Directory.class;
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            // No dependencies
+        }
+
+        @Override
+        public boolean isPresent() {
+            return valueProvider.isPresent();
+        }
+
+        @Override
+        public Directory getOrNull() {
+            if (!isPresent()) {
+                return null;
+            }
+            File dir = resolver.resolve(valueProvider);
+            return new FixedDirectory(dir, resolver.newResolver(dir));
+        }
+
+        @Override
+        public String toString() {
+            return String.format("provider(%s, %s)", getType(), valueProvider);
+        }
+    }
+
+    static class DefaultDirectoryVar extends DefaultPropertyState<Directory> implements DirectoryProperty, TaskDependencyContainer, ProducerAwareProperty {
+        private final FileResolver resolver;
+        private Task producer;
+
+        DefaultDirectoryVar(FileResolver resolver) {
+            super(Directory.class);
+            this.resolver = resolver;
+        }
+
+        DefaultDirectoryVar(FileResolver resolver, Object value) {
+            super(Directory.class);
+            this.resolver = resolver;
+            resolveAndSet(value);
+        }
+
+        @Override
+        public void attachProducer(Task producer) {
+            if (this.producer != null && this.producer != producer) {
+                throw new IllegalStateException("This property already has a producer task associated with it.");
+            }
+            this.producer = producer;
+        }
+
+        @Override
+        public void setFromAnyValue(Object object) {
+            if (object instanceof File) {
+                File file = (File) object;
+                set(file);
+            } else {
+                super.setFromAnyValue(object);
+            }
+        }
+
+        @Override
+        public void visitDependencies(TaskDependencyResolveContext context) {
+            if (producer != null) {
+                context.add(producer);
+            } else if (getProvider() instanceof TaskDependencyContainer) {
+                context.add(getProvider());
+            }
+        }
+
+        @Override
+        public FileTree getAsFileTree() {
+            return resolver.resolveFilesAsTree(this);
+        }
+
+        @Override
+        public Provider<File> getAsFile() {
+            return new ToFileProvider(this);
+        }
+
+        void resolveAndSet(Object value) {
+            File resolved = resolver.resolve(value);
+            set(new FixedDirectory(resolved, resolver.newResolver(resolved)));
+        }
+
+        @Override
+        public void set(File dir) {
+            File resolved = resolver.resolve(dir);
+            set(new FixedDirectory(resolved, resolver.newResolver(resolved)));
+        }
+
+        @Override
+        public Provider<Directory> dir(final String path) {
+            return new AbstractMappingProvider<Directory, Directory>(Directory.class, this) {
+                @Override
+                protected Directory map(Directory dir) {
+                    return dir.dir(path);
+                }
+            };
+        }
+
+        @Override
+        public Provider<Directory> dir(final Provider<? extends CharSequence> path) {
+            return new AbstractCombiningProvider<Directory, Directory, CharSequence>(Directory.class, this, path) {
+                @Override
+                protected Directory map(Directory b, CharSequence v) {
+                    return b.dir(v.toString());
+                }
+            };
+        }
+
+        @Override
+        public Provider<RegularFile> file(final String path) {
+            return new AbstractMappingProvider<RegularFile, Directory>(RegularFile.class, this) {
+                @Override
+                protected RegularFile map(Directory dir) {
+                    return dir.file(path);
+                }
+            };
+        }
+
+        @Override
+        public Provider<RegularFile> file(final Provider<? extends CharSequence> path) {
+            return new AbstractCombiningProvider<RegularFile, Directory, CharSequence>(RegularFile.class, this, path) {
+                @Override
+                protected RegularFile map(Directory b, CharSequence v) {
+                    return b.file(v.toString());
+                }
+            };
+        }
+    }
+
+    static class ToFileProvider extends AbstractMappingProvider<File, FileSystemLocation> {
+        ToFileProvider(Provider<? extends FileSystemLocation> provider) {
+            super(File.class, provider);
+        }
+
+        @Override
+        protected File map(FileSystemLocation provider) {
+            return provider.getAsFile();
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -43,12 +43,12 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
     }
 
     @Override
-    public DirectoryProperty directoryProperty() {
+    public DirectoryProperty newDirectoryProperty() {
         return new DefaultDirectoryVar(fileResolver);
     }
 
     @Override
-    public RegularFileProperty fileProperty() {
+    public RegularFileProperty newFileProperty() {
         return new DefaultRegularFileVar(fileResolver);
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -22,35 +22,28 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
-import org.gradle.api.internal.provider.AbstractCombiningProvider;
 import org.gradle.api.internal.provider.AbstractMappingProvider;
-import org.gradle.api.internal.provider.AbstractProvider;
-import org.gradle.api.internal.provider.DefaultPropertyState;
 import org.gradle.api.internal.tasks.AbstractTaskDependency;
-import org.gradle.api.internal.tasks.TaskDependencyContainer;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.provider.Provider;
-import org.gradle.internal.file.PathToFileResolver;
 
-import javax.annotation.Nullable;
 import java.io.File;
 
-public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
+public class DefaultProjectLayout extends DefaultFilePropertyFactory implements ProjectLayout, TaskFileVarFactory {
     private final FixedDirectory projectDir;
     private final DefaultDirectoryVar buildDir;
     private final TaskResolver taskResolver;
     private final FileResolver fileResolver;
 
     public DefaultProjectLayout(File projectDir, FileResolver resolver, TaskResolver taskResolver) {
+        super(resolver);
         this.taskResolver = taskResolver;
         this.fileResolver = resolver;
         this.projectDir = new FixedDirectory(projectDir, resolver);
@@ -68,20 +61,10 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
     }
 
     @Override
-    public DirectoryProperty directoryProperty() {
-        return new DefaultDirectoryVar(projectDir.fileResolver);
-    }
-
-    @Override
     public DirectoryProperty directoryProperty(Provider<? extends Directory> initialProvider) {
         DirectoryProperty result = directoryProperty();
         result.set(initialProvider);
         return result;
-    }
-
-    @Override
-    public RegularFileProperty fileProperty() {
-        return new DefaultRegularFileVar(projectDir.fileResolver);
     }
 
     @Override
@@ -164,289 +147,5 @@ public class DefaultProjectLayout implements ProjectLayout, TaskFileVarFactory {
      */
     public void setBuildDirectory(Object value) {
         buildDir.resolveAndSet(value);
-    }
-
-    private static class FixedDirectory implements Directory, FileSystemLocation {
-        private final File value;
-        private final FileResolver fileResolver;
-
-        FixedDirectory(File value, FileResolver fileResolver) {
-            this.value = value;
-            this.fileResolver = fileResolver;
-        }
-
-        @Override
-        public String toString() {
-            return value.toString();
-        }
-
-        @Override
-        public File getAsFile() {
-            return value;
-        }
-
-        @Override
-        public Directory dir(String path) {
-            File newDir = fileResolver.resolve(path);
-            return new FixedDirectory(newDir, fileResolver.newResolver(newDir));
-        }
-
-        @Override
-        public FileTree getAsFileTree() {
-            return fileResolver.resolveFilesAsTree(this);
-        }
-
-        @Override
-        public Provider<Directory> dir(Provider<? extends CharSequence> path) {
-            return new ResolvingDirectory(fileResolver, path);
-        }
-
-        @Override
-        public RegularFile file(String path) {
-            return new FixedFile(fileResolver.resolve(path));
-        }
-
-        @Override
-        public Provider<RegularFile> file(Provider<? extends CharSequence> path) {
-            return new ResolvingFile(fileResolver, path);
-        }
-    }
-
-    private static class FixedFile implements RegularFile, FileSystemLocation {
-        private final File file;
-
-        FixedFile(File file) {
-            this.file = file;
-        }
-
-        @Override
-        public String toString() {
-            return file.toString();
-        }
-
-        @Override
-        public File getAsFile() {
-            return file;
-        }
-    }
-
-    private static class ResolvingFile extends AbstractMappingProvider<RegularFile, CharSequence> implements TaskDependencyContainer {
-        private final PathToFileResolver resolver;
-
-        ResolvingFile(PathToFileResolver resolver, Provider<? extends CharSequence> path) {
-            super(RegularFile.class, path);
-            this.resolver = resolver;
-        }
-
-        @Override
-        public void visitDependencies(TaskDependencyResolveContext context) {
-            // No dependencies
-        }
-
-        @Override
-        protected RegularFile map(CharSequence path) {
-            return new FixedFile(resolver.resolve(path));
-        }
-    }
-
-    private static class DefaultRegularFileVar extends DefaultPropertyState<RegularFile> implements RegularFileProperty, TaskDependencyContainer, ProducerAwareProperty {
-        private Task producer;
-        private final PathToFileResolver fileResolver;
-
-        DefaultRegularFileVar(PathToFileResolver fileResolver) {
-            super(RegularFile.class);
-            this.fileResolver = fileResolver;
-        }
-
-        @Override
-        public void attachProducer(Task task) {
-            if (this.producer != null && this.producer != task) {
-                throw new IllegalStateException("This property already has a producer task associated with it.");
-            }
-            this.producer = task;
-        }
-
-        @Override
-        public void visitDependencies(TaskDependencyResolveContext context) {
-            if (producer != null) {
-                context.add(producer);
-            } else if (getProvider() instanceof TaskDependencyContainer) {
-                context.add(getProvider());
-            }
-        }
-
-        @Override
-        public void setFromAnyValue(Object object) {
-            if (object instanceof File) {
-                set((File) object);
-            } else {
-                super.setFromAnyValue(object);
-            }
-        }
-
-        @Override
-        public Provider<File> getAsFile() {
-            return new ToFileProvider(this);
-        }
-
-        @Override
-        public void set(File file) {
-            set(new FixedFile(fileResolver.resolve(file)));
-        }
-    }
-
-    private static class ResolvingDirectory extends AbstractProvider<Directory> implements TaskDependencyContainer {
-        private final FileResolver resolver;
-        private final Provider<?> valueProvider;
-
-        ResolvingDirectory(FileResolver resolver, Provider<?> valueProvider) {
-            this.resolver = resolver;
-            this.valueProvider = valueProvider;
-        }
-
-        @Nullable
-        @Override
-        public Class<Directory> getType() {
-            return Directory.class;
-        }
-
-        @Override
-        public void visitDependencies(TaskDependencyResolveContext context) {
-            // No dependencies
-        }
-
-        @Override
-        public boolean isPresent() {
-            return valueProvider.isPresent();
-        }
-
-        @Override
-        public Directory getOrNull() {
-            if (!isPresent()) {
-                return null;
-            }
-            File dir = resolver.resolve(valueProvider);
-            return new FixedDirectory(dir, resolver.newResolver(dir));
-        }
-
-        @Override
-        public String toString() {
-            return String.format("provider(%s, %s)", getType(), valueProvider);
-        }
-    }
-
-    private static class DefaultDirectoryVar extends DefaultPropertyState<Directory> implements DirectoryProperty, TaskDependencyContainer, ProducerAwareProperty {
-        private final FileResolver resolver;
-        private Task producer;
-
-        DefaultDirectoryVar(FileResolver resolver) {
-            super(Directory.class);
-            this.resolver = resolver;
-        }
-
-        DefaultDirectoryVar(FileResolver resolver, Object value) {
-            super(Directory.class);
-            this.resolver = resolver;
-            resolveAndSet(value);
-        }
-
-        @Override
-        public void attachProducer(Task producer) {
-            if (this.producer != null && this.producer != producer) {
-                throw new IllegalStateException("This property already has a producer task associated with it.");
-            }
-            this.producer = producer;
-        }
-
-        @Override
-        public void setFromAnyValue(Object object) {
-            if (object instanceof File) {
-                File file = (File) object;
-                set(file);
-            } else {
-                super.setFromAnyValue(object);
-            }
-        }
-
-        @Override
-        public void visitDependencies(TaskDependencyResolveContext context) {
-            if (producer != null) {
-                context.add(producer);
-            } else if (getProvider() instanceof TaskDependencyContainer) {
-                context.add(getProvider());
-            }
-        }
-
-        @Override
-        public FileTree getAsFileTree() {
-            return resolver.resolveFilesAsTree(this);
-        }
-
-        @Override
-        public Provider<File> getAsFile() {
-            return new ToFileProvider(this);
-        }
-
-        void resolveAndSet(Object value) {
-            File resolved = resolver.resolve(value);
-            set(new FixedDirectory(resolved, resolver.newResolver(resolved)));
-        }
-
-        @Override
-        public void set(File dir) {
-            File resolved = resolver.resolve(dir);
-            set(new FixedDirectory(resolved, resolver.newResolver(resolved)));
-        }
-
-        @Override
-        public Provider<Directory> dir(final String path) {
-            return new AbstractMappingProvider<Directory, Directory>(Directory.class, this) {
-                @Override
-                protected Directory map(Directory dir) {
-                    return dir.dir(path);
-                }
-            };
-        }
-
-        @Override
-        public Provider<Directory> dir(final Provider<? extends CharSequence> path) {
-            return new AbstractCombiningProvider<Directory, Directory, CharSequence>(Directory.class, this, path) {
-                @Override
-                protected Directory map(Directory b, CharSequence v) {
-                    return b.dir(v.toString());
-                }
-            };
-        }
-
-        @Override
-        public Provider<RegularFile> file(final String path) {
-            return new AbstractMappingProvider<RegularFile, Directory>(RegularFile.class, this) {
-                @Override
-                protected RegularFile map(Directory dir) {
-                    return dir.file(path);
-                }
-            };
-        }
-
-        @Override
-        public Provider<RegularFile> file(final Provider<? extends CharSequence> path) {
-            return new AbstractCombiningProvider<RegularFile, Directory, CharSequence>(RegularFile.class, this, path) {
-                @Override
-                protected RegularFile map(Directory b, CharSequence v) {
-                    return b.file(v.toString());
-                }
-            };
-        }
-    }
-
-    private static class ToFileProvider extends AbstractMappingProvider<File, FileSystemLocation> {
-        ToFileProvider(Provider<? extends FileSystemLocation> provider) {
-            super(File.class, provider);
-        }
-
-        @Override
-        protected File map(FileSystemLocation provider) {
-            return provider.getAsFile();
-        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -29,8 +29,6 @@ import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollectio
 import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.provider.AbstractMappingProvider;
-import org.gradle.api.internal.tasks.AbstractTaskDependency;
-import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.provider.Provider;
 
@@ -72,44 +70,6 @@ public class DefaultProjectLayout extends DefaultFilePropertyFactory implements 
         RegularFileProperty result = fileProperty();
         result.set(initialProvider);
         return result;
-    }
-
-    @Override
-    public DirectoryProperty newOutputDirectory(Task producer) {
-        DefaultDirectoryVar property = new DefaultDirectoryVar(projectDir.fileResolver);
-        property.attachProducer(producer);
-        return property;
-    }
-
-    @Override
-    public RegularFileProperty newOutputFile(Task producer) {
-        DefaultRegularFileVar property = new DefaultRegularFileVar(projectDir.fileResolver);
-        property.attachProducer(producer);
-        return property;
-    }
-
-    @Override
-    public RegularFileProperty newInputFile(final Task consumer) {
-        final DefaultRegularFileVar fileVar = new DefaultRegularFileVar(projectDir.fileResolver);
-        consumer.dependsOn(new AbstractTaskDependency() {
-            @Override
-            public void visitDependencies(TaskDependencyResolveContext context) {
-                fileVar.visitDependencies(context);
-            }
-        });
-        return fileVar;
-    }
-
-    @Override
-    public DirectoryProperty newInputDirectory(final Task consumer) {
-        final DefaultDirectoryVar directoryVar = new DefaultDirectoryVar(projectDir.fileResolver);
-        consumer.dependsOn(new AbstractTaskDependency() {
-            @Override
-            public void visitDependencies(TaskDependencyResolveContext context) {
-                directoryVar.visitDependencies(context);
-            }
-        });
-        return directoryVar;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultProjectLayout.java
@@ -31,6 +31,7 @@ import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.provider.AbstractMappingProvider;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.provider.Provider;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
@@ -59,10 +60,22 @@ public class DefaultProjectLayout extends DefaultFilePropertyFactory implements 
     }
 
     @Override
+    public DirectoryProperty directoryProperty() {
+        DeprecationLogger.nagUserOfReplacedMethod("ProjectLayout.directoryProperty()", "ObjectFactory.directoryProperty()");
+        return newDirectoryProperty();
+    }
+
+    @Override
     public DirectoryProperty directoryProperty(Provider<? extends Directory> initialProvider) {
         DirectoryProperty result = directoryProperty();
         result.set(initialProvider);
         return result;
+    }
+
+    @Override
+    public RegularFileProperty fileProperty() {
+        DeprecationLogger.nagUserOfReplacedMethod("ProjectLayout.fileProperty()", "ObjectFactory.fileProperty()");
+        return newFileProperty();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -20,7 +20,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 
 public interface FilePropertyFactory {
-    DirectoryProperty directoryProperty();
+    DirectoryProperty newDirectoryProperty();
 
-    RegularFileProperty fileProperty();
+    RegularFileProperty newFileProperty();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FilePropertyFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.file;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
+
+public interface FilePropertyFactory {
+    DirectoryProperty directoryProperty();
+
+    RegularFileProperty fileProperty();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/TaskFileVarFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/TaskFileVarFactory.java
@@ -18,20 +18,10 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 
 public interface TaskFileVarFactory {
-    DirectoryProperty newOutputDirectory(Task producer);
-
-    RegularFileProperty newOutputFile(Task producer);
-
-    RegularFileProperty newInputFile(Task consumer);
-
-    DirectoryProperty newInputDirectory(Task consumer);
-
     /**
      * Creates a {@link ConfigurableFileCollection} that can be used as a task input.
      *

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -17,8 +17,11 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.Named;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.DefaultSourceDirectorySet;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.provider.DefaultListProperty;
@@ -43,12 +46,14 @@ public class DefaultObjectFactory implements ObjectFactory {
     private final NamedObjectInstantiator namedObjectInstantiator;
     private final FileResolver fileResolver;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
+    private final FilePropertyFactory filePropertyFactory;
 
-    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory) {
         this.instantiator = instantiator;
         this.namedObjectInstantiator = namedObjectInstantiator;
         this.fileResolver = fileResolver;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
+        this.filePropertyFactory = filePropertyFactory;
     }
 
     @Override
@@ -70,6 +75,16 @@ public class DefaultObjectFactory implements ObjectFactory {
                 return new DefaultSourceDirectorySet(name, displayName, fileResolver, directoryFileTreeFactory, DefaultObjectFactory.this);
             }
         });
+    }
+
+    @Override
+    public DirectoryProperty directoryProperty() {
+        return filePropertyFactory.directoryProperty();
+    }
+
+    @Override
+    public RegularFileProperty fileProperty() {
+        return filePropertyFactory.fileProperty();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -79,12 +79,12 @@ public class DefaultObjectFactory implements ObjectFactory {
 
     @Override
     public DirectoryProperty directoryProperty() {
-        return filePropertyFactory.directoryProperty();
+        return filePropertyFactory.newDirectoryProperty();
     }
 
     @Override
     public RegularFileProperty fileProperty() {
-        return filePropertyFactory.fileProperty();
+        return filePropertyFactory.newFileProperty();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -16,6 +16,8 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.Named;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.provider.DefaultPropertyState;
 import org.gradle.api.model.ObjectFactory;
@@ -54,6 +56,16 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
 
     @Override
     public <T> SetProperty<T> setProperty(Class<T> elementType) {
+        return broken();
+    }
+
+    @Override
+    public DirectoryProperty directoryProperty() {
+        return broken();
+    }
+
+    @Override
+    public RegularFileProperty fileProperty() {
         return broken();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.TaskOutputCachingState;
 import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.file.CompositeFileCollection;
+import org.gradle.api.internal.file.ProducerAwareProperty;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.tasks.execution.SelfDescribingSpec;
 import org.gradle.api.internal.tasks.execution.TaskProperties;
@@ -219,6 +220,9 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
         return taskMutator.mutate("TaskOutputs.file(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
             @Override
             public TaskOutputFilePropertyBuilder call() {
+                if (path instanceof ProducerAwareProperty) {
+                    ((ProducerAwareProperty) path).attachProducer(task);
+                }
                 StaticValue value = new StaticValue(path);
                 DeclaredTaskOutputFileProperty outputFileSpec = specFactory.createOutputFileSpec(value);
                 registeredFileProperties.add(outputFileSpec);
@@ -232,6 +236,9 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
         return taskMutator.mutate("TaskOutputs.dir(Object)", new Callable<TaskOutputFilePropertyBuilder>() {
             @Override
             public TaskOutputFilePropertyBuilder call() {
+                if (path instanceof ProducerAwareProperty) {
+                    ((ProducerAwareProperty) path).attachProducer(task);
+                }
                 StaticValue value = new StaticValue(path);
                 DeclaredTaskOutputFileProperty outputDirSpec = specFactory.createOutputDirSpec(value);
                 registeredFileProperties.add(outputDirSpec);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.classpath.DefaultPluginModuleRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
 import org.gradle.api.internal.classpath.PluginModuleRegistry;
 import org.gradle.api.internal.file.DefaultFileCollectionFactory;
+import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
@@ -322,7 +323,12 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
     }
 
     ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
-        return new DefaultObjectFactory(instantiatorFactory.injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory);
+        return new DefaultObjectFactory(
+            instantiatorFactory.injectAndDecorate(services),
+            NamedObjectInstantiator.INSTANCE,
+            fileResolver,
+            directoryFileTreeFactory,
+            new DefaultFilePropertyFactory(fileResolver));
     }
 
     ProviderFactory createProviderFactory() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.file.DefaultProjectLayout;
 import org.gradle.api.internal.file.DefaultSourceDirectorySetFactory;
 import org.gradle.api.internal.file.DefaultTemporaryFileProvider;
 import org.gradle.api.internal.file.FileLookup;
+import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.SourceDirectorySetFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
@@ -298,9 +299,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return ConfigurationTargetIdentifier.of(project);
     }
 
-    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory) {
         Instantiator instantiator = instantiatorFactory.injectAndDecorate(ProjectScopeServices.this);
-        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory);
+        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory);
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.model
 
+import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.internal.reflect.Instantiator
@@ -24,7 +25,7 @@ import spock.lang.Unroll
 
 
 class DefaultObjectFactoryTest extends Specification {
-    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory))
+    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory))
 
     def "can create a property"() {
         expect:

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.attributes.DefaultImmutableAttributesFactory
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter
+import org.gradle.api.internal.file.DefaultFilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.model.DefaultObjectFactory
@@ -78,7 +79,7 @@ class TestUtil {
     private static ObjectFactory objFactory(FileResolver fileResolver) {
         DefaultServiceRegistry services = new DefaultServiceRegistry()
         services.add(ProviderFactory, new DefaultProviderFactory())
-        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory())
+        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver))
     }
 
     static ValueSnapshotter valueSnapshotter() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
@@ -383,7 +383,8 @@ task checkArtifacts {
         buildFile << """
             project(':a') {
                 task classes {
-                    ext.outputDir = newOutputDirectory()
+                    ext.outputDir = objects.directoryProperty()
+                    outputs.dir(outputDir)
                     outputDir.set(layout.buildDirectory.dir("classes"))
                 }
                 artifacts {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactDeclarationIntegrationTest.groovy
@@ -351,7 +351,8 @@ task checkArtifacts {
         buildFile << """
             project(':a') {
                 task classes {
-                    ext.outputFile = newOutputFile()
+                    ext.outputFile = project.objects.fileProperty()
+                    outputs.file(outputFile)
                     outputFile.set(layout.buildDirectory.file("a.jar"))
                 }
                 artifacts {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -83,7 +83,7 @@ The following are the features that have been promoted in this Gradle release.
 ## Deprecations
 
 Features that have become superseded or irrelevant due to the natural evolution of Gradle become *deprecated*, and scheduled to be removed
-in the next major Gradle version (Gradle 5.0). See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
+in the next major Gradle version (Gradle 6.0). See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
 
@@ -97,7 +97,7 @@ The `interactive` flag is deprecated and will be removed in Gradle 6.0.
 
 ### Removing tasks from TaskContainer
 
-Removing tasks from the `TaskContainer` using the following methods has been deprecated:
+Removing tasks from the `TaskContainer` using the following methods has been deprecated and will be an error in Gradle 6.0.
 
 - `remove(Object)`
 - `removeAll(Collection)`
@@ -105,13 +105,13 @@ Removing tasks from the `TaskContainer` using the following methods has been dep
 - `clear()`
 - `Iterator#remove()` via `TaskContainer#iterator()`
 
-With the deprecation of every method for removing a task, registering a callback when an object is removed is also deprecated (`whenObjectRemoved(Closure/Action)`).
+With the deprecation of every method for removing a task, registering a callback when an object is removed is also deprecated (`whenObjectRemoved(Closure/Action)`). These methods will be removed in Gradle 6.0
 
 ### Replacing tasks 
 
 It is only safe to replace an unrealized tasks registered with the new Task API because this task has not been used by anything else.
 
-In the future, these behaviors will be treated as errors.
+In Gradle 6.0, these behaviors will be treated as errors.
 
 #### Replacing tasks that may still be used by other tasks 
 
@@ -165,10 +165,13 @@ to reset the property back to its default value. Use `DuplicatesStrategy.INHERIT
 
 For easier configurability from statically compiled languages such as Java or Kotlin.
 
+### Property factory methods on `DefaultTask` are final
+
+The property factory methods such as `newInputFile()` are intended to be called from the constructor of a type that extends `DefaultTask`. These methods are now final to avoid subclasses overriding these methods and using state that is not initialized.
+
 ### Source and test source dirs in `IdeaModule` no longer contain resources
 
 The `IdeaModule` Tooling API model element contains methods to retrieve resources and test resources so those elements were removed from the result of  `IdeaModule#getSourceDirs()` and `IdeaModule#getTestSourceDirs()`.
-
 
 ### Changes to previously deprecated APIs
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -47,6 +47,10 @@ The `SourceDirectorySet` type is often used by plugins to represent some set of 
 
 In this release of Gradle, the `ObjectFactory` service, which is part of the public API, now includes a method to create `SourceDirectorySet` instances. A plugin can now use this method instead of the internal types.
 
+### Changes to file property construction
+
+TBD - `ObjectFactory` is now used to create file and directory `Property` instances, similar to other `Property` types.
+
 ### JaCoCo plugin now works with the build cache and parallel test execution
 
 The [JaCoCo plugin](userguide/jacoco_plugin.html) plugin now works seamlessly with the build cache.

--- a/subprojects/docs/src/docs/userguide/lazy_configuration.adoc
+++ b/subprojects/docs/src/docs/userguide/lazy_configuration.adoc
@@ -27,18 +27,20 @@ The Provider API is currently <<feature_lifecycle.adoc#feature_lifecycle,incubat
 
 ====
 
-Gradle provides lazy properties, which delay the calculation of a property’s value until it’s absolutely required. Lazy types are faster, more understandable and better instrumented than the internal convention mapping mechanisms. This provides two main benefits to build script and plugin authors:
+Gradle provides lazy properties, which delay the calculation of a property’s value until it’s actually required. These provide three main benefits to build script and plugin authors:
 
-1. Build authors can wire together Gradle models without worrying when a particular property’s value will be known. For example, when you want to map properties in an extension to task properties but the values aren't known until the build script configures them.
-2. Build authors can avoid resource intensive work during the configuration phase, which can have a direct impact on maximum build performance. For example, when a property value comes from parsing a file.
+1. Build authors can wire together Gradle models without worrying when a particular property’s value will be known. For example, you may want to set the input source files of a task based on the source directories property of an extension but the extension property value isn't known until the build script or some other plugin configures them.
+2. Build authors can wire an output property of a task into an input property of some other task and Gradle automatically determines the task dependencies based on this connection. Property instances carry information about which task, if any, produces their value.
+3. Build authors can avoid resource intensive work during the configuration phase, which can have a large impact on build performance. For example, when a property value comes from parsing a file but is only used when functional tests are run, using a property to capture this means that the file is parsed only when the functional tests are run, but not when `clean` is run.
 
 Gradle represents lazy properties with two interfaces:
 
-* link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider] are properties that can only be queried and cannot be changed.
+* link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider] represents a value that can only be queried and cannot be changed.
 ** Properties with these types are read-only.
 ** The method link:{javadocPath}/org/gradle/api/provider/Provider.html#get--[Provider.get()] returns the current value of the property.
 ** A `Provider` can be created by the factory method link:{javadocPath}/org/gradle/api/provider/ProviderFactory.html#provider-java.util.concurrent.Callable-[ProviderFactory.provider(java.util.concurrent.Callable)].
-* link:{javadocPath}/org/gradle/api/provider/Property.html[Property] are properties that can be queried and overwritten.
+** Many other types extend `Provider` and can be used where-ever a lazy value is required.
+* link:{javadocPath}/org/gradle/api/provider/Property.html[Property] represents a value that can be queried and also changed.
 ** Properties with these types are configurable.
 ** `Property` implements the `Provider` interface.
 ** The method link:{javadocPath}/org/gradle/api/provider/Property.html#set-T-[Property.set(T)] specifies a value for the property, overwriting whatever value may have been present.
@@ -47,7 +49,7 @@ Gradle represents lazy properties with two interfaces:
 
 Neither of these types nor their subtypes are intended to be implemented by a build script or plugin author.  Gradle provides several factory methods to create instances of these types. See the <<#sec:lazy_configuration_reference,Quick Reference>> for all of the types and factories available.
 
-Lazy properties are intended to be passed around and only evaluated when required (usually, during the execution phase). For more information about the Gradle build phases, please see <<build_lifecycle.adoc#sec:build_phases,Build Lifecycle>>.
+Lazy properties are intended to be passed around and only queried when required (usually, during the execution phase). For more information about the Gradle build phases, please see <<build_lifecycle.adoc#sec:build_phases,Build Lifecycle>>.
 
 The following demonstrates a task with a read-only property and a configurable property:
 
@@ -64,12 +66,14 @@ include::sample[dir="providers/propertyAndProvider/kotlin",files="build.gradle.k
 include::{samplesPath}/providers/propertyAndProvider/usePropertyAndProvider.out[]
 ----
 
-The `Greeting` task has a `Property<String>` for the mutable part of the message and a `Provider<String>` for the calculated, read-only, message.
+The `Greeting` task has a property of type `Property<String>` for the configurable part of the message and a property of type `Provider<String>` for the calculated, read-only, message.
 
 [NOTE]
 ====
 
-Note that Groovy Gradle DSL will generate setter methods for each `Property`-typed property in a task implementation. These setter methods allow you to configure the property using the assignment (`=`) operator as a convenience.
+Note that Gradle Groovy DSL will generate setter methods for each `Property`-typed property in a task implementation. These setter methods allow you to configure the property using the assignment (`=`) operator as a convenience.
+
+Kotlin DSL conveniences will be added in a future release.
 
 ====
 
@@ -84,7 +88,7 @@ If provider types are not intended to be implemented directly by build script or
 [NOTE]
 ====
 
-link:{groovyDslPath}/org.gradle.api.Project.html[Project] does not provide a specific method signature for creating a provider from a `groovy.lang.Closure`. When writing a plugin with Groovy, you can use the method signature accepting a `java.util.concurrent.Callable` parameter. Groovy's http://docs.groovy-lang.org/next/html/documentation/core-semantics.html#_assigning_a_closure_to_a_sam_type[Closure to type coercion] will take care of the rest.
+There are no specific methods for creating a provider from a `groovy.lang.Closure`. When writing a plugin with Groovy, you can use the method that accepts a `java.util.concurrent.Callable` parameter. Groovy's `Closure` type extends `Callable`.
 
 ====
 
@@ -105,13 +109,13 @@ In <<working_with_files.adoc#working_with_files,Working with Files>>, we introdu
 | link:{javadocPath}/org/gradle/api/file/ConfigurableFileTree.html[ConfigurableFileTree]
 |===
 
-All of these types are also considered `Provider` types.
+All of these types are also considered lazy types.
 
 In this section, we are going to introduce more strongly typed models for a link:{javadocPath}/org/gradle/api/file/FileSystemLocation.html[FileSystemLocation]: link:{javadocPath}/org/gradle/api/file/Directory.html[Directory] and link:{javadocPath}/org/gradle/api/file/RegularFile.html[RegularFile]. These types shouldn't be confused with the standard Java https://docs.oracle.com/javase/7/docs/api/java/io/File.html[java.io.File] type as they tell Gradle to expect more specific values (a directory or a non-directory, regular file).
 
-Gradle provides two specialized `Property` subtypes for dealing with these types: link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty] and link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]. link:{javadocPath}/org/gradle/api/file/ProjectLayout.html[ProjectLayout] has methods to create these: link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#fileProperty--[ProjectLayout.fileProperty()] and link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#directoryProperty--[ProjectLayout.directoryProperty()].
+Gradle provides two specialized `Property` subtypes for dealing with these types: link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty] and link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]. link:{javadocPath}/org/gradle/api/model/ObjectFactory.html[ObjectFactory] has methods to create these: link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#fileProperty--[ObjectFactory.fileProperty()] and link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#directoryProperty--[ObjectFactory.directoryProperty()].
 
-A `DirectoryProperty` can also be used to create a lazily evaluated `Provider` for a `Directory` and `RegularFile` via link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#dir-java.lang.String-[DirectoryProperty.dir(java.lang.String)] and link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#file-java.lang.String-[DirectoryProperty.file(java.lang.String)] respectively. These methods create paths that are relative to the location set for the original `DirectoryProperty`.
+A `DirectoryProperty` can also be used to create a lazily evaluated `Provider` for a `Directory` and `RegularFile` via link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#dir-java.lang.String-[DirectoryProperty.dir(java.lang.String)] and link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#file-java.lang.String-[DirectoryProperty.file(java.lang.String)] respectively. These methods create providers whose values are calculated relative to the location for the `DirectoryProperty` they were created from. The values returned from these providers will reflect changes to the `DirectoryProperty`.
 
 .Using file and directory property
 ====
@@ -135,7 +139,7 @@ include::{samplesPath}/providers/fileAndDirectoryProperty/workingWithFilesKotlin
 This example shows how `Provider` types can be used inside an extension. Lazy values for link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:buildDir[Project.getBuildDir()] and link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:projectDir[Project.getProjectDir()] can be accessed through link:{javadocPath}/org/gradle/api/Project.html#getLayout--[Project.getLayout()] with link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#getBuildDirectory--[ProjectLayout.getBuildDirectory()] and link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#getProjectDirectory--[ProjectLayout.getProjectDirectory()].
 
 [[sec:working_with_task_dependencies_in_lazy_properties]]
-== Working with task dependencies and Providers
+== Working with task input and outputs and Providers
 
 Many builds have several tasks that depend on each other. This usually means that one task processes the outputs of another task as an input. For these outputs and inputs, we need to know their locations on the file system and appropriately configure each task to know where to look. This can be cumbersome if any of these values are configurable by a user or configured by multiple plugins.
 
@@ -160,14 +164,14 @@ include::{samplesPath}/providers/implicitTaskDependency/implicitTaskDependencyGr
 include::{samplesPath}/providers/implicitTaskDependency/implicitTaskDependencyKotlin.out[]
 ----
 
-In the example above, the task outputs and inputs are connected before any location is defined. This is possible because the input and output properties use the `Provider` API. The output property is created with link:{javadocPath}/org/gradle/api/DefaultTask.html#newOutputFile--[DefaultTask.newOutputFile()] and the input property is created with link:{javadocPath}/org/gradle/api/DefaultTask.html#newInputFile--[DefaultTask.newInputFile()]. Values are only resolved when they are needed during execution. The setters can be called at any time before the task is executed and the change will automatically affect all related input and output properties.
+In the example above, the task outputs and inputs are connected before any location is defined. This is possible because the input and output properties use the `Provider` API. The output property and input property are created with link:{javadocPath}/org/gradle/api/mode/ObjectFactory.html#fileProperty--[ObjectFactory.fileProperty()] method. Values are only resolved when they are queried during task execution. The setters can be called at any time before the task is executed and the change will automatically affect all related input and output properties.
 
-Another thing to note is the absence of any explicit task dependency. Properties created via `newOutputFile()` and `newOutputDirectory()` bring knowledge about which task is generating them, so using them as task input will implicitly link tasks together.
+Another thing to note is the absence of any explicit task dependency. Task outputs represented using `Providers` bring knowledge about which task is generating them, so using them as task inputs will implicitly add the correct task dependencies.
 
 [[sec:working_with_collection]]
 == Working with collection Providers
 
-In this section, we are going to explore lazy collections. They work exactly like any other `Provider` and, just like `FileSystemLocation` providers, they have additional modeling around them. There are two provider interfaces available, one for `List` values and another for `Set` values:
+In this section, we are going to explore lazy collections. They work exactly like any other `Provider` and, just like file providers, they have additional modeling around them. There are two provider interfaces available, one for `List` values and another for `Set` values:
 
 * For `List` values the interface is called link:{javadocPath}/org/gradle/api/provider/ListProperty.html[ListProperty]. You can create a new `ListProperty` using link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#listProperty-java.lang.Class-[ObjectFactory.listProperty(java.lang.Class)] and specifying the element's type.
 * For `Set` values the interface is called link:{javadocPath}/org/gradle/api/provider/SetProperty.html[SetProperty]. You can create a new `SetProperty` using link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#setProperty-java.lang.Class-[ObjectFactory.setProperty(java.lang.Class)] and specifying the element's type.
@@ -220,12 +224,12 @@ Use these types for _read-only_ values:
 
 link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider]<link:{javadocPath}/org/gradle/api/file/RegularFile.html[RegularFile]>:: File on disk
   Factories;;
-    * link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#fileProperty--[ProjectLayout.fileProperty()]
+    * link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#fileProperty--[ObjectFactory.fileProperty()]
     * link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#file-java.lang.String-[DirectoryProperty.file(java.lang.String)]
 
 link:{javadocPath}/org/gradle/api/provider/Provider.html[Provider]<link:{javadocPath}/org/gradle/api/file/Directory.html[Directory]>:: Directory on disk
   Factories;;
-    * link:{javadocPath}/org/gradle/api/file/ProjectLayout.html#directoryProperty--[ProjectLayout.directoryProperty()]
+    * link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#directoryProperty--[ObjectFactory.directoryProperty()]
     * link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html#dir-java.lang.String-[DirectoryProperty.dir(java.lang.String)]
 
 link:{javadocPath}/org/gradle/api/file/FileCollection.html[FileCollection]:: Unstructured collection of files
@@ -243,13 +247,13 @@ Use these types for _mutable_ values:
 
 link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty]:: File on disk
   Factories;;
-    * link:{javadocPath}/org/gradle/api/DefaultTask.html#newInputFile--[DefaultTask.newInputFile()] and link:{javadocPath}/org/gradle/api/DefaultTask.html#newOutputFile--[DefaultTask.newOutputFile()] if used as task input/output
-    * link:{javadocPath}/org/gradle/api/file/Directory.html#file-java.lang.String-[Directory.file(java.lang.String)] otherwise
+    * link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#fileProperty--[ObjectFactory.fileProperty()]
+    * link:{javadocPath}/org/gradle/api/file/Directory.html#file-java.lang.String-[Directory.file(java.lang.String)]
 
 link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]:: Directory on disk
   Factories;;
-    * link:{javadocPath}/org/gradle/api/DefaultTask.html#newInputDirectory--[DefaultTask.newInputDirectory()] and link:{javadocPath}/org/gradle/api/DefaultTask.html#newOutputDirectory--[DefaultTask.newOutputDirectory()] if used as task input/output
-    * link:{javadocPath}/org/gradle/api/file/Directory.html#dir-java.lang.String-[Directory.dir(java.lang.String)] otherwise
+    * link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#directoryProperty--[ObjectFactory.directoryProperty()]
+    * link:{javadocPath}/org/gradle/api/file/Directory.html#dir-java.lang.String-[Directory.dir(java.lang.String)]
 
 link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[ConfigurableFileCollection]:: Unstructured collection of files
   Factories;;

--- a/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/groovy/build.gradle
@@ -1,31 +1,35 @@
 class FooExtension {
+    // A directory
     final DirectoryProperty someDirectory
+    //  A file
     final RegularFileProperty someFile
+    // A collection of files or directories
     final ConfigurableFileCollection someFiles
 
-    FooExtension(Project project) {
-        someDirectory = project.objects.directoryProperty()
-        someFile = project.objects.fileProperty()
-        someFiles = project.layout.configurableFiles()
+    FooExtension(ObjectFactory objects, ProjectLayout layout) {
+        someDirectory = objects.directoryProperty()
+        someFile = objects.fileProperty()
+        someFiles = layout.configurableFiles()
     }
 }
 
-project.extensions.create('foo', FooExtension, project)
+project.extensions.create('foo', FooExtension, project.objects, project.layout)
 
 foo {
+    // Configure the locations
     someDirectory = project.layout.projectDirectory.dir('some-directory')
     someFile = project.layout.buildDirectory.file('some-file')
-    someFiles.from project.layout.configurableFiles(someDirectory, someFile)
+    someFiles.from(someDirectory, someFile)
 }
 
 task print {
     doLast {
-        def someDirectory = project.foo.someDirectory.get().asFile
+        def someDirectory = foo.someDirectory.get().asFile
         logger.quiet("foo.someDirectory = " + someDirectory)
-        logger.quiet("foo.someFiles contains someDirectory? " + project.foo.someFiles.contains(someDirectory))
+        logger.quiet("foo.someFiles contains someDirectory? " + foo.someFiles.contains(someDirectory))
 
-        def someFile = project.foo.someFile.get().asFile
+        def someFile = foo.someFile.get().asFile
         logger.quiet("foo.someFile = " + someFile)
-        logger.quiet("foo.someFiles contains someFile? " + project.foo.someFiles.contains(someFile))
+        logger.quiet("foo.someFiles contains someFile? " + foo.someFiles.contains(someFile))
     }
 }

--- a/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/groovy/build.gradle
@@ -4,8 +4,8 @@ class FooExtension {
     final ConfigurableFileCollection someFiles
 
     FooExtension(Project project) {
-        someDirectory = project.layout.directoryProperty()
-        someFile = project.layout.fileProperty()
+        someDirectory = project.objects.directoryProperty()
+        someFile = project.objects.fileProperty()
         someFiles = project.layout.configurableFiles()
     }
 }

--- a/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/kotlin/build.gradle.kts
@@ -1,31 +1,19 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-open class FooExtension(project: Project) {
-    val someDirectory: DirectoryProperty = project.layout.directoryProperty()
-    val someFile: RegularFileProperty = project.layout.fileProperty()
-    val someFiles: ConfigurableFileCollection = project.layout.configurableFiles()
+open class FooExtension(objects: ObjectFactory, layout: ProjectLayout) {
+    // A directory
+    val someDirectory: DirectoryProperty = objects.directoryProperty()
+    //  A file
+    val someFile: RegularFileProperty = objects.fileProperty()
+    // A collection of files or directories
+    val someFiles: ConfigurableFileCollection = layout.configurableFiles()
 }
 
-project.extensions.create("foo", FooExtension::class, project)
+project.extensions.create("foo", FooExtension::class, project.objects, project.layout)
 
 configure<FooExtension> {
+    // Configure the locations
     someDirectory.set(project.layout.projectDirectory.dir("some-directory"))
     someFile.set(project.layout.buildDirectory.file("some-file"))
-    someFiles.from(project.layout.configurableFiles(someDirectory, someFile))
+    someFiles.from(someDirectory, someFile)
 }
 
 task("print") {

--- a/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/providers/fileAndDirectoryProperty/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "file-and-directory-property"

--- a/subprojects/docs/src/samples/providers/implicitTaskDependency/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/implicitTaskDependency/groovy/build.gradle
@@ -1,7 +1,7 @@
 
 class Producer extends DefaultTask {
     @OutputFile
-    final RegularFileProperty outputFile = newOutputFile()
+    final RegularFileProperty outputFile = project.objects.fileProperty()
 
     @TaskAction
     void produce() {
@@ -14,7 +14,7 @@ class Producer extends DefaultTask {
 
 class Consumer extends DefaultTask {
     @InputFile
-    final RegularFileProperty inputFile = newInputFile()
+    final RegularFileProperty inputFile = project.objects.fileProperty()
 
     @TaskAction
     void consume() {

--- a/subprojects/docs/src/samples/providers/implicitTaskDependency/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/implicitTaskDependency/groovy/build.gradle
@@ -28,12 +28,13 @@ task producer(type: Producer)
 task consumer(type: Consumer)
 
 // Wire property from producer to consumer task
+// Don't need to add a task dependency to the consumer task, this is automatically added
 consumer.inputFile = producer.outputFile
 
 // Set values for the producer lazily
-// Note that the consumer does not need to be changed again.
+// Don't need to update the consumer.inputFile property, this is automatically updated
 producer.outputFile = layout.buildDirectory.file('file.txt')
 
 // Change the base output directory.
-// Note that this automatically changes producer.outputFile and consumer.inputFile
+// Don't need to update producer.outputFile and consumer.inputFile, these are automatically updated
 buildDir = 'output'

--- a/subprojects/docs/src/samples/providers/implicitTaskDependency/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/implicitTaskDependency/kotlin/build.gradle.kts
@@ -1,23 +1,6 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-
 open class Producer : DefaultTask() {
     @get:OutputFile
-    val outputFile: RegularFileProperty = newOutputFile()
+    val outputFile: RegularFileProperty = project.objects.fileProperty()
 
     @TaskAction
     fun produce() {
@@ -30,7 +13,7 @@ open class Producer : DefaultTask() {
 
 open class Consumer : DefaultTask() {
     @get:InputFile
-    val inputFile: RegularFileProperty = newInputFile()
+    val inputFile: RegularFileProperty = project.objects.fileProperty()
 
     @TaskAction
     fun consume() {
@@ -44,12 +27,13 @@ val producer by tasks.creating(Producer::class)
 val consumer by tasks.creating(Consumer::class)
 
 // Wire property from producer to consumer task
+// Don't need to add a task dependency to the consumer task, this is automatically added
 consumer.inputFile.set(producer.outputFile)
 
 // Set values for the producer lazily
-// Note that the consumer does not need to be changed again.
+// Don't need to update the consumer.inputFile property, this is automatically updated
 producer.outputFile.set(layout.buildDirectory.file("file.txt"))
 
 // Change the base output directory.
-// Note that this automatically changes producer.outputFile and consumer.inputFile
+// Don't need to update producer.outputFile and consumer.inputFile, these are automatically updated
 setBuildDir("output")

--- a/subprojects/docs/src/samples/providers/listProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/listProperty/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 task("print") {
     doLast {
         val list: ListProperty<String> = project.objects.listProperty()

--- a/subprojects/docs/src/samples/providers/listProperty/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/providers/listProperty/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "list-property"

--- a/subprojects/docs/src/samples/providers/propertyAndProvider/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/propertyAndProvider/groovy/build.gradle
@@ -14,6 +14,9 @@ class Greeting extends DefaultTask {
 }
 
 task greeting(type: Greeting) {
-    // Note that this is effectively calling Property.set()
+    // Configure the greeting
+    message.set('Hi')
+
+    // Note that an assignment statement can be used instead of calling Property.set()
     message = 'Hi'
 }

--- a/subprojects/docs/src/samples/providers/propertyAndProvider/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/propertyAndProvider/kotlin/build.gradle.kts
@@ -1,19 +1,3 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 open class Greeting : DefaultTask() {
     // Configurable by the user
     @get:Input
@@ -30,5 +14,6 @@ open class Greeting : DefaultTask() {
 }
 
 task<Greeting>("greeting") {
+    // Configure the greeting
     message.set("Hi")
 }

--- a/subprojects/docs/src/samples/providers/propertyAndProvider/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/providers/propertyAndProvider/kotlin/settings.gradle.kts
@@ -1,17 +1,1 @@
-/*
- * Copyright 2018 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 rootProject.name = "property-and-provider"

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/DefaultXcodeWorkspace.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/xcode/internal/DefaultXcodeWorkspace.java
@@ -17,7 +17,7 @@
 package org.gradle.ide.xcode.internal;
 
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.ide.xcode.XcodeWorkspace;
 
 import javax.inject.Inject;
@@ -26,8 +26,8 @@ public class DefaultXcodeWorkspace implements XcodeWorkspace {
     private final DirectoryProperty workspaceDir;
 
     @Inject
-    public DefaultXcodeWorkspace(ProjectLayout projectLayout) {
-        workspaceDir = projectLayout.directoryProperty();
+    public DefaultXcodeWorkspace(ObjectFactory objectFactory) {
+        workspaceDir = objectFactory.directoryProperty();
     }
 
     @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaProject.java
@@ -135,7 +135,7 @@ public class IdeaProject implements IdeWorkspace {
         ServiceRegistry services = ((ProjectInternal) project).getServices();
         this.projectPathRegistry = services.get(ProjectStateRegistry.class);
         this.artifactRegistry = services.get(IdeArtifactRegistry.class);
-        this.outputFile = project.getLayout().fileProperty();
+        this.outputFile = project.getObjects().fileProperty();
     }
 
     @Override

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishArtifactCustomizationIntegTest.groovy
@@ -411,7 +411,8 @@ The following types/formats are supported:
             }
 
             task regularFileTask {
-                ext.outputFile = newOutputFile()
+                ext.outputFile = project.objects.fileProperty()
+                outputs.file(outputFile)
                 outputFile.set(file('regularFile-1.0.reg'))
                 doLast {
                     outputFile.get().getAsFile() << 'foo'

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/compile/CompileOptions.java
@@ -94,7 +94,7 @@ public class CompileOptions extends AbstractOptions {
     @Inject
     public CompileOptions(ProjectLayout projectLayout, ObjectFactory objectFactory) {
         this.annotationProcessorGeneratedSourcesDirectory = objectFactory.property(File.class);
-        this.headerOutputDirectory = projectLayout.directoryProperty();
+        this.headerOutputDirectory = objectFactory.directoryProperty();
     }
 
     /**

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -410,9 +410,11 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         buildFile << """
             apply plugin: 'cpp-application'
             
+            def headerDirectory = objects.directoryProperty()
+            
             task generateHeader {
-                ext.headerDirectory = newOutputDirectory()
-                headerDirectory.set(project.layout.buildDirectory.dir("headers"))
+                outputs.dir(headerDirectory)
+                headerDirectory.set(layout.buildDirectory.dir("headers"))
                 doLast {
                     def fooH = headerDirectory.file("foo.h").get().asFile
                     fooH.parentFile.mkdirs()
@@ -423,7 +425,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             }
             
             application.binaries.whenElementFinalized { binary ->
-                def dependency = project.dependencies.create(files(generateHeader.headerDirectory))
+                def dependency = project.dependencies.create(files(headerDirectory))
                 binary.getIncludePathConfiguration().dependencies.add(dependency)
             }
          """

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppBinary.java
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.file.collections.FileCollectionAdapter;
@@ -60,8 +59,8 @@ public class DefaultCppBinary extends DefaultNativeBinary implements CppBinary {
     private final Property<CppCompile> compileTaskProperty;
     private final NativeVariantIdentity identity;
 
-    public DefaultCppBinary(Names names, ProjectLayout projectLayout, ObjectFactory objects, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration componentImplementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, objects, projectLayout, componentImplementation);
+    public DefaultCppBinary(Names names, ObjectFactory objects, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration componentImplementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objects, componentImplementation);
         this.baseName = baseName;
         this.sourceFiles = sourceFiles;
         this.targetPlatform = targetPlatform;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppExecutable.java
@@ -23,7 +23,6 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
@@ -58,11 +57,11 @@ public class DefaultCppExecutable extends DefaultCppBinary implements CppExecuta
     private final RegularFileProperty debuggerExecutableFile;
 
     @Inject
-    public DefaultCppExecutable(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.executableFile = projectLayout.fileProperty();
-        this.debuggerExecutableFile = projectLayout.fileProperty();
-        this.installationDirectory = projectLayout.directoryProperty();
+    public DefaultCppExecutable(Names names, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.executableFile = objectFactory.fileProperty();
+        this.debuggerExecutableFile = objectFactory.fileProperty();
+        this.installationDirectory = objectFactory.directoryProperty();
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
         this.runtimeElementsProperty = objectFactory.property(Configuration.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppSharedLibrary.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -55,10 +54,10 @@ public class DefaultCppSharedLibrary extends DefaultCppBinary implements CppShar
     private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultCppSharedLibrary(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.linkFile = projectLayout.fileProperty();
-        this.runtimeFile = projectLayout.fileProperty();
+    public DefaultCppSharedLibrary(Names names, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.linkFile = objectFactory.fileProperty();
+        this.runtimeFile = objectFactory.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppStaticLibrary.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
@@ -56,9 +55,9 @@ public class DefaultCppStaticLibrary extends DefaultCppBinary implements CppStat
     private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultCppStaticLibrary(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.linkFile = projectLayout.fileProperty();
+    public DefaultCppStaticLibrary(Names names, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, ConfigurationContainer configurations, Configuration implementation, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.linkFile = objectFactory.fileProperty();
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultNativeBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/internal/DefaultNativeBinary.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.language.ComponentDependencies;
@@ -34,10 +33,10 @@ public abstract class DefaultNativeBinary implements ComponentWithNames, Compone
     private final DirectoryProperty objectsDir;
     private final DefaultComponentDependencies dependencies;
 
-    public DefaultNativeBinary(Names names, ObjectFactory objectFactory, ProjectLayout projectLayout, Configuration componentImplementation) {
+    public DefaultNativeBinary(Names names, ObjectFactory objectFactory, Configuration componentImplementation) {
         this.names = names;
 
-        this.objectsDir = projectLayout.directoryProperty();
+        this.objectsDir = objectFactory.directoryProperty();
         dependencies = objectFactory.newInstance(DefaultComponentDependencies.class, names.getName() + "Implementation");
         dependencies.getImplementationDependencies().extendsFrom(componentImplementation);
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -81,7 +81,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
         dependsOn(systemIncludes);
 
         this.source = getTaskFileVarFactory().newInputFileCollection(this);
-        this.objectFileDir = newOutputDirectory();
+        this.objectFileDir = objectFactory.directoryProperty();
         this.compilerArgs = getProject().getObjects().listProperty(String.class);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftBinary.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.collections.FileCollectionAdapter;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
@@ -73,12 +72,12 @@ public class DefaultSwiftBinary extends DefaultNativeBinary implements SwiftBina
     private final Property<SwiftVersion> sourceCompatibility;
     private final Configuration importPathConfiguration;
 
-    public DefaultSwiftBinary(Names names, ProjectLayout projectLayout, final ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration componentImplementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, objectFactory, projectLayout, componentImplementation);
+    public DefaultSwiftBinary(Names names, final ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration componentImplementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, componentImplementation);
         this.module = module;
         this.testable = testable;
         this.source = source;
-        this.moduleFile = projectLayout.fileProperty();
+        this.moduleFile = objectFactory.fileProperty();
         this.compileTaskProperty = objectFactory.property(SwiftCompile.class);
         this.targetPlatform = targetPlatform;
         this.toolChain = toolChain;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftExecutable.java
@@ -22,7 +22,6 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
@@ -59,13 +58,13 @@ public class DefaultSwiftExecutable extends DefaultSwiftBinary implements SwiftE
     private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultSwiftExecutable(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.executableFile = projectLayout.fileProperty();
-        this.installDirectory = projectLayout.directoryProperty();
+    public DefaultSwiftExecutable(Names names, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.executableFile = objectFactory.fileProperty();
+        this.installDirectory = objectFactory.directoryProperty();
         this.linkTaskProperty = objectFactory.property(LinkExecutable.class);
         this.installTaskProperty = objectFactory.property(InstallExecutable.class);
-        this.debuggerExecutableFile = projectLayout.fileProperty();
+        this.debuggerExecutableFile = objectFactory.fileProperty();
         this.runtimeElementsProperty = objectFactory.property(Configuration.class);
         this.outputs = fileOperations.configurableFiles();
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftSharedLibrary.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -56,10 +55,10 @@ public class DefaultSwiftSharedLibrary extends DefaultSwiftBinary implements Swi
     private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultSwiftSharedLibrary(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.linkFile = projectLayout.fileProperty();
-        this.runtimeFile = projectLayout.fileProperty();
+    public DefaultSwiftSharedLibrary(Names names, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.linkFile = objectFactory.fileProperty();
+        this.runtimeFile = objectFactory.fileProperty();
         this.linkTaskProperty = objectFactory.property(LinkSharedLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/internal/DefaultSwiftStaticLibrary.java
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
@@ -57,9 +56,9 @@ public class DefaultSwiftStaticLibrary extends DefaultSwiftBinary implements Swi
     private final ConfigurableFileCollection outputs;
 
     @Inject
-    public DefaultSwiftStaticLibrary(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.linkFile = projectLayout.fileProperty();
+    public DefaultSwiftStaticLibrary(Names names, ObjectFactory objectFactory, FileOperations fileOperations, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.linkFile = objectFactory.fileProperty();
         this.createTaskProperty = objectFactory.property(CreateStaticLibrary.class);
         this.linkElements = objectFactory.property(Configuration.class);
         this.runtimeElements = objectFactory.property(Configuration.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -97,10 +97,10 @@ public class SwiftCompile extends DefaultTask {
 
         ObjectFactory objectFactory = getProject().getObjects();
         this.moduleName = objectFactory.property(String.class);
-        this.moduleFile = newOutputFile();
+        this.moduleFile = objectFactory.fileProperty();
         this.modules = getProject().files();
         this.compilerArgs = objectFactory.listProperty(String.class);
-        this.objectFileDir = newOutputDirectory();
+        this.objectFileDir = objectFactory.directoryProperty();
         this.source = getProject().files();
         this.sourceCompatibility = objectFactory.property(SwiftVersion.class);
         this.macros = objectFactory.listProperty(String.class);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -44,7 +44,7 @@ import java.io.File;
 @CacheableTask
 public class UnexportMainSymbol extends DefaultTask {
     private final ConfigurableFileCollection source = getProject().files();
-    private final DirectoryProperty outputDirectory = newOutputDirectory();
+    private final DirectoryProperty outputDirectory = getProject().getObjects().directoryProperty();
 
     /**
      * The object files to relocate.

--- a/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
+++ b/subprojects/language-native/src/main/java/org/gradle/swiftpm/tasks/GenerateSwiftPackageManagerManifest.java
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
@@ -50,8 +51,14 @@ import java.util.TreeSet;
  */
 @Incubating
 public class GenerateSwiftPackageManagerManifest extends DefaultTask {
-    private final RegularFileProperty manifestFile = newOutputFile();
-    private final Property<Package> packageProperty = getProject().getObjects().property(Package.class);
+    private final RegularFileProperty manifestFile;
+    private final Property<Package> packageProperty;
+
+    public GenerateSwiftPackageManagerManifest() {
+        ObjectFactory objectFactory = getProject().getObjects();
+        manifestFile = objectFactory.fileProperty();
+        packageProperty = objectFactory.property(Package.class);
+    }
 
     @Input
     public Property<Package> getPackage() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppBinaryTest.groovy
@@ -50,7 +50,7 @@ class DefaultCppBinaryTest extends Specification {
         _ * configurations.create("nativeRuntimeDebug") >> runtime
         _ * componentHeaders.plus(_) >> headerDirs
 
-        binary = new DefaultCppBinary(Names.of("mainDebug"), project.layout, project.objects, Stub(Provider), Stub(FileCollection), componentHeaders, configurations, implementation, Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider), Stub(NativeVariantIdentity))
+        binary = new DefaultCppBinary(Names.of("mainDebug"), project.objects, Stub(Provider), Stub(FileCollection), componentHeaders, configurations, implementation, Stub(CppPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider), Stub(NativeVariantIdentity))
     }
 
     def "creates configurations for the binary"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppBasePluginTest.groovy
@@ -75,7 +75,7 @@ class CppBasePluginTest extends Specification {
         def baseName = project.objects.property(String)
         baseName.set("test_app")
         def executable = Stub(DefaultCppExecutable)
-        def executableFile = project.layout.fileProperty()
+        def executableFile = project.objects.fileProperty()
         executable.name >> name
         executable.names >> Names.of(name)
         executable.baseName >> baseName

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultNativeBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/internal/DefaultNativeBinaryTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language.internal
 
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
@@ -39,7 +38,7 @@ class DefaultNativeBinaryTest extends Specification {
 
     def "has implementation dependencies"() {
         given:
-        def binary = new TestBinary("binary", project.objects, project.layout, implementation)
+        def binary = new TestBinary("binary", project.objects, implementation)
 
         expect:
         binary.implementationDependencies == project.configurations.binaryImplementation
@@ -48,7 +47,7 @@ class DefaultNativeBinaryTest extends Specification {
 
     def "can add implementation dependency"() {
         given:
-        def binary = new TestBinary("binary", project.objects, project.layout, implementation)
+        def binary = new TestBinary("binary", project.objects, implementation)
         binary.dependencies.implementation("a:b:c:")
 
         expect:
@@ -57,8 +56,8 @@ class DefaultNativeBinaryTest extends Specification {
 
     class TestBinary extends DefaultNativeBinary {
         @Inject
-        TestBinary(String name, ObjectFactory objectFactory, ProjectLayout projectLayout, Configuration componentImplementation) {
-            super(Names.of(name), objectFactory, projectLayout, componentImplementation)
+        TestBinary(String name, ObjectFactory objectFactory, Configuration componentImplementation) {
+            super(Names.of(name), objectFactory, componentImplementation)
         }
 
         @Override

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftBinaryTest.groovy
@@ -50,7 +50,7 @@ class DefaultSwiftBinaryTest extends Specification {
         _ * configurations.create("nativeLinkDebug") >> link
         _ * configurations.create("nativeRuntimeDebug") >> runtime
 
-        binary = new DefaultSwiftBinary(Names.of("mainDebug"), project.layout, project.objects, Stub(Provider), false, Stub(FileCollection),  configurations, implementation, Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider), Stub(NativeVariantIdentity))
+        binary = new DefaultSwiftBinary(Names.of("mainDebug"), project.objects, Stub(Provider), false, Stub(FileCollection),  configurations, implementation, Stub(SwiftPlatform), Stub(NativeToolChainInternal), Stub(PlatformToolProvider), Stub(NativeVariantIdentity))
     }
 
     def "compileModules is a transformed view of compile"() {

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/plugins/SwiftBasePluginTest.groovy
@@ -82,7 +82,7 @@ class SwiftBasePluginTest extends Specification {
 
     def "adds link and install task for executable"() {
         def executable = Stub(DefaultSwiftExecutable)
-        def executableFile = project.layout.fileProperty()
+        def executableFile = project.objects.fileProperty()
         executable.name >> name
         executable.names >> Names.of(name)
         executable.module >> Providers.of("TestApp")

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishArtifactCustomizationIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishArtifactCustomizationIntegTest.groovy
@@ -411,7 +411,8 @@ class MavenPublishArtifactCustomizationIntegTest extends AbstractMavenPublishInt
             }
 
             task regularFileTask {
-                ext.outputFile = newOutputFile()
+                ext.outputFile = project.objects.fileProperty()
+                outputs.file(outputFile)
                 outputFile.set(file('regularFile-1.0.reg'))
                 doLast {
                     outputFile.get().getAsFile() << 'foo'

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -27,7 +27,7 @@ class SomeTask extends DefaultTask {
     final Property<String> prop = project.objects.property(String)
     
     @OutputFile
-    final Property<RegularFile> outputFile = newOutputFile()
+    final Property<RegularFile> outputFile = project.objects.fileProperty()
     
     @TaskAction
     void go() { 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -68,17 +68,17 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
     private final Property<NativeToolChain> toolChain;
 
     public AbstractLinkTask() {
-        ObjectFactory objectFactory = getProject().getObjects();
+        final ObjectFactory objectFactory = getProject().getObjects();
         this.libs = getProject().files();
         this.source = getProject().files();
-        this.linkedFile = newOutputFile();
-        this.destinationDirectory = newOutputDirectory();
+        this.linkedFile = objectFactory.fileProperty();
+        this.destinationDirectory = objectFactory.directoryProperty();
         destinationDirectory.set(linkedFile.map(new Transformer<Directory, RegularFile>() {
             @Override
             public Directory transform(RegularFile regularFile) {
                 // TODO: Get rid of destinationDirectory entirely and replace it with a
                 // collection of link outputs
-                DirectoryProperty dirProp = getProject().getLayout().directoryProperty();
+                DirectoryProperty dirProp = objectFactory.directoryProperty();
                 dirProp.set(regularFile.getAsFile().getParentFile());
                 return dirProp.get();
             }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -61,7 +61,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
     public CreateStaticLibrary() {
         ObjectFactory objectFactory = getProject().getObjects();
         this.source = getProject().files();
-        this.outputFile = newOutputFile();
+        this.outputFile = objectFactory.fileProperty();
         this.staticLibArgs = getProject().getObjects().listProperty(String.class);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/ExtractSymbols.java
@@ -55,8 +55,8 @@ public class ExtractSymbols extends DefaultTask {
     public ExtractSymbols() {
         ObjectFactory objectFactory = getProject().getObjects();
 
-        this.binaryFile = newInputFile();
-        this.symbolFile = newOutputFile();
+        this.binaryFile = objectFactory.fileProperty();
+        this.symbolFile = objectFactory.fileProperty();
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/InstallExecutable.java
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
@@ -73,15 +74,17 @@ public class InstallExecutable extends DefaultTask {
         ObjectFactory objectFactory = getProject().getObjects();
         this.workerLeaseService = workerLeaseService;
         this.libs = getProject().files();
-        this.installDirectory = newOutputDirectory();
-        this.installedExecutable = newOutputFile();
+        this.installDirectory = objectFactory.directoryProperty();
+        this.installedExecutable = objectFactory.fileProperty();
         this.installedExecutable.set(getLibDirectory().map(new Transformer<RegularFile, Directory>() {
             @Override
             public RegularFile transform(Directory directory) {
                 return directory.file(executable.getAsFile().get().getName());
             }
         }));
-        this.executable = newInputFile();
+        this.executable = objectFactory.fileProperty();
+        // A further work around for missing ability to skip task when input file is missing (see #getInputFileIfExists below)
+        dependsOn(executable);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
     }
@@ -132,7 +135,7 @@ public class InstallExecutable extends DefaultTask {
      *
      * @since 4.7
      */
-    @Internal
+    @OutputFile
     public RegularFileProperty getInstalledExecutable() {
         return installedExecutable;
     }
@@ -142,6 +145,7 @@ public class InstallExecutable extends DefaultTask {
      *
      * @since 4.3
      */
+    // TODO - allow @InputFile and @SkipWhenEmpty to be attached to getExecutableFile()
     @SkipWhenEmpty
     @Nullable
     @Optional

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/LinkSharedLibrary.java
@@ -38,7 +38,7 @@ import java.util.concurrent.Callable;
 @Incubating
 public class LinkSharedLibrary extends AbstractLinkTask {
     private String installName;
-    private final RegularFileProperty importLibrary = newOutputFile();
+    private final RegularFileProperty importLibrary = getProject().getObjects().fileProperty();
 
     public LinkSharedLibrary() {
         importLibrary.set(getProject().getLayout().getProjectDirectory().file(getProject().getProviders().provider(new Callable<String>() {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/StripSymbols.java
@@ -55,8 +55,8 @@ public class StripSymbols extends DefaultTask {
     public StripSymbols() {
         ObjectFactory objectFactory = getProject().getObjects();
 
-        this.binaryFile = newInputFile();
-        this.outputFile = newOutputFile();
+        this.binaryFile = objectFactory.fileProperty();
+        this.outputFile = objectFactory.fileProperty();
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
     }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/tasks/PlayRun.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/tasks/PlayRun.java
@@ -50,7 +50,7 @@ public class PlayRun extends ConventionTask {
 
     private int httpPort;
 
-    private final DirectoryProperty workingDir = getProject().getLayout().directoryProperty();
+    private final DirectoryProperty workingDir = getProject().getObjects().directoryProperty();
 
     @InputFile
     private File applicationJar;

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -21,6 +21,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.Incubating;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
@@ -38,8 +39,14 @@ import java.util.Properties;
 @Incubating
 public class GeneratePluginDescriptors extends DefaultTask {
 
-    private final ListProperty<PluginDeclaration> declarations = getProject().getObjects().listProperty(PluginDeclaration.class);
-    private final DirectoryProperty outputDirectory = newOutputDirectory();
+    private final ListProperty<PluginDeclaration> declarations;
+    private final DirectoryProperty outputDirectory;
+
+    public GeneratePluginDescriptors() {
+        ObjectFactory objectFactory = getProject().getObjects();
+        declarations = objectFactory.listProperty(PluginDeclaration.class);
+        outputDirectory = objectFactory.directoryProperty();
+    }
 
     @Input
     public ListProperty<PluginDeclaration> getDeclarations() {

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/PluginUnderTestMetadata.java
@@ -47,7 +47,7 @@ public class PluginUnderTestMetadata extends DefaultTask {
     public static final String IMPLEMENTATION_CLASSPATH_PROP_KEY = "implementation-classpath";
     public static final String METADATA_FILE_NAME = "plugin-under-test-metadata.properties";
     private final ConfigurableFileCollection pluginClasspath = getProject().files();
-    private final DirectoryProperty outputDirectory = newOutputDirectory();
+    private final DirectoryProperty outputDirectory = getProject().getObjects().directoryProperty();
 
     /**
      * The code under test. Defaults to {@code sourceSets.main.runtimeClasspath}.

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -35,7 +35,6 @@ import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.DocumentationRegistry;
-import org.gradle.internal.classanalysis.AsmConstants;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -49,6 +48,7 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.TaskValidationException;
 import org.gradle.api.tasks.VerificationTask;
 import org.gradle.internal.Cast;
+import org.gradle.internal.classanalysis.AsmConstants;
 import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classpath.ClassPath;
@@ -111,7 +111,7 @@ import java.util.Map;
 public class ValidateTaskProperties extends ConventionTask implements VerificationTask {
     private FileCollection classes;
     private FileCollection classpath;
-    private RegularFileProperty outputFile = newOutputFile();
+    private RegularFileProperty outputFile = getProject().getObjects().fileProperty();
     private boolean ignoreFailures;
     private boolean failOnWarning;
 

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -25,16 +25,17 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.tasks.DefaultTaskDependency;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.internal.ModuleMetadataFileGenerator;
-import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -69,9 +70,10 @@ public class GenerateModuleMetadata extends DefaultTask {
     private final RegularFileProperty outputFile;
 
     public GenerateModuleMetadata() {
-        publication = getProject().getObjects().property(Publication.class);
-        publications = getProject().getObjects().listProperty(Publication.class);
-        outputFile = newOutputFile();
+        ObjectFactory objectFactory = getProject().getObjects();
+        publication = objectFactory.property(Publication.class);
+        publications = objectFactory.listProperty(Publication.class);
+        outputFile = objectFactory.fileProperty();
         // TODO - should be incremental
         getOutputs().upToDateWhen(Specs.<Task>satisfyNone());
         mustHaveAttachedComponent();

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/ReportingExtension.java
@@ -56,7 +56,8 @@ public class ReportingExtension {
 
     public ReportingExtension(Project project) {
         this.project = (ProjectInternal)project;
-        this.baseDirectory = project.getLayout().directoryProperty(project.getLayout().getBuildDirectory().dir(DEFAULT_REPORTS_DIR_NAME));
+        this.baseDirectory = project.getObjects().directoryProperty();
+        baseDirectory.set(project.getLayout().getBuildDirectory().dir(DEFAULT_REPORTS_DIR_NAME));
     }
 
     /**
@@ -91,7 +92,7 @@ public class ReportingExtension {
         this.baseDirectory.set(project.provider(new Callable<Directory>() {
             @Override
             public Directory call() throws Exception {
-                DirectoryProperty result = project.getLayout().directoryProperty();
+                DirectoryProperty result = project.getObjects().directoryProperty();
                 result.set(project.file(baseDir));
                 return result.get();
             }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -115,7 +115,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         testListenerInternalBroadcaster = listenerManager.createAnonymousBroadcaster(TestListenerInternal.class);
         testOutputListenerBroadcaster = listenerManager.createAnonymousBroadcaster(TestOutputListener.class);
         testListenerBroadcaster = listenerManager.createAnonymousBroadcaster(TestListener.class);
-        binaryResultsDirectory = newOutputDirectory();
+        binaryResultsDirectory = getProject().getObjects().directoryProperty();
 
         reports = instantiator.newInstance(DefaultTestTaskReports.class, this);
         reports.getJunitXml().setEnabled(true);

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/internal/DefaultCppTestExecutable.java
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
@@ -58,13 +57,12 @@ public class DefaultCppTestExecutable extends DefaultCppBinary implements CppTes
 
     @Inject
     public DefaultCppTestExecutable(Names names, Provider<String> baseName, FileCollection sourceFiles, FileCollection componentHeaderDirs, Configuration implementation,
-                                    Provider<CppComponent> testedComponent, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity,
-                                    ConfigurationContainer configurations, ProjectLayout projectLayout, ObjectFactory objects, FileOperations fileOperations) {
-        super(names, projectLayout, objects, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+                                    Provider<CppComponent> testedComponent, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity, ConfigurationContainer configurations, ObjectFactory objects, FileOperations fileOperations) {
+        super(names, objects, baseName, sourceFiles, componentHeaderDirs, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
         this.testedComponent = testedComponent;
-        this.executableFile = projectLayout.fileProperty();
-        this.debuggerExecutableFile = projectLayout.fileProperty();
-        this.installationDirectory = projectLayout.directoryProperty();
+        this.executableFile = objects.fileProperty();
+        this.debuggerExecutableFile = objects.fileProperty();
+        this.installationDirectory = objects.directoryProperty();
         this.linkTaskProperty = objects.property(LinkExecutable.class);
         this.installTaskProperty = objects.property(InstallExecutable.class);
         this.outputs = fileOperations.configurableFiles();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBinary.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBinary.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -46,11 +45,11 @@ public abstract class DefaultSwiftXCTestBinary extends DefaultSwiftBinary implem
     private final RegularFileProperty runScriptFile;
     private final Property<XCTest> runTaskProperty;
 
-    public DefaultSwiftXCTestBinary(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        this.executableFile = projectLayout.fileProperty();
-        this.installDirectory = projectLayout.directoryProperty();
-        this.runScriptFile = projectLayout.fileProperty();
+    public DefaultSwiftXCTestBinary(Names names, ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        this.executableFile = objectFactory.fileProperty();
+        this.installDirectory = objectFactory.directoryProperty();
+        this.runScriptFile = objectFactory.fileProperty();
         this.runTaskProperty = objectFactory.property(XCTest.class);
     }
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestBundle.java
@@ -19,7 +19,6 @@ package org.gradle.nativeplatform.test.xctest.internal;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -37,8 +36,8 @@ public class DefaultSwiftXCTestBundle extends DefaultSwiftXCTestBinary implement
     private final Property<LinkMachOBundle> linkTask;
 
     @Inject
-    public DefaultSwiftXCTestBundle(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+    public DefaultSwiftXCTestBundle(Names names, ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
         linkTask = objectFactory.property(LinkMachOBundle.class);
     }
 

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/internal/DefaultSwiftXCTestExecutable.java
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
@@ -46,9 +45,9 @@ public class DefaultSwiftXCTestExecutable extends DefaultSwiftXCTestBinary imple
     private final RegularFileProperty debuggerExecutableFile;
 
     @Inject
-    public DefaultSwiftXCTestExecutable(Names names, ProjectLayout projectLayout, ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, FileOperations fileOperations, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
-        super(names, projectLayout, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
-        debuggerExecutableFile = projectLayout.fileProperty();
+    public DefaultSwiftXCTestExecutable(Names names, ObjectFactory objectFactory, Provider<String> module, boolean testable, FileCollection source, FileOperations fileOperations, ConfigurationContainer configurations, Configuration implementation, SwiftPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider, NativeVariantIdentity identity) {
+        super(names, objectFactory, module, testable, source, configurations, implementation, targetPlatform, toolChain, platformToolProvider, identity);
+        debuggerExecutableFile = objectFactory.fileProperty();
         linkTask = objectFactory.property(LinkExecutable.class);
         installTask = objectFactory.property(InstallExecutable.class);
         files = fileOperations.configurableFiles();

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/InstallXCTestBundle.java
@@ -26,6 +26,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.file.FileOperations;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
@@ -52,8 +53,16 @@ import java.util.concurrent.Callable;
  */
 @Incubating
 public class InstallXCTestBundle extends DefaultTask {
-    private final DirectoryProperty installDirectory = newOutputDirectory();
-    private final RegularFileProperty bundleBinaryFile = newInputFile();
+    private final DirectoryProperty installDirectory;
+    private final RegularFileProperty bundleBinaryFile;
+
+    public InstallXCTestBundle() {
+        ObjectFactory objectFactory = getProject().getObjects();
+        installDirectory = objectFactory.directoryProperty();
+        bundleBinaryFile = objectFactory.fileProperty();
+        // A work around for not being able to skip the task when an input _file_ does not exist
+        dependsOn(bundleBinaryFile);
+    }
 
     @Inject
     protected SwiftStdlibToolLocator getSwiftStdlibToolLocator() {

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XCTest.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/tasks/XCTest.java
@@ -22,6 +22,7 @@ import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.tasks.testing.TestExecuter;
 import org.gradle.api.internal.tasks.testing.filter.DefaultTestFilter;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
@@ -43,9 +44,16 @@ import java.util.List;
  */
 @Incubating
 public class XCTest extends AbstractTestTask {
-    private final DirectoryProperty workingDirectory = getProject().getLayout().directoryProperty();
-    private final DirectoryProperty testInstallDirectory = newInputDirectory();
-    private final RegularFileProperty runScriptFile = newInputFile();
+    private final DirectoryProperty workingDirectory;
+    private final DirectoryProperty testInstallDirectory;
+    private final RegularFileProperty runScriptFile;
+
+    public XCTest() {
+        ObjectFactory objectFactory = getProject().getObjects();
+        workingDirectory = objectFactory.directoryProperty();
+        testInstallDirectory = objectFactory.directoryProperty();
+        runScriptFile = objectFactory.fileProperty();
+    }
 
     @Override
     protected XCTestTestExecutionSpec createTestExecutionSpec() {


### PR DESCRIPTION
### Context

Previously, there were 2 ways to create file `Property` instances: using methods on `DefaultTask` for task inputs and outputs, and methods on `ProjectLayout` for use in project extensions (and nowhere for other things outside of project scope). Both of these locations are different to the locations where the factory methods for other kinds of properties and domain object values live, making it harder to locate the correct factory method that works for the intended purpose.

This PR moves these factory methods to `ObjectFactory` to live with the other factory methods. It deprecates the factory methods in the old locations and also removes the differences in their behaviour, so that these property implementations all behave the same way regardless of how they were created. 

This PR also adds some initial support for task dependency inference for an output file `Property`  registered using the `task.outputs.file()` or `task.outputs.dir()` runtime API.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
