### PR TITLE
Upgrade default tool version of PMD to 6.7.0

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/pmd/AbstractPmdPluginVersionIntegrationTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.integtests.fixtures.TargetVersions
 import org.gradle.util.TestPrecondition
 import org.gradle.util.VersionNumber
 
-@TargetVersions(['4.3', '5.0.5', '5.1.1', '5.3.3', PmdPlugin.DEFAULT_PMD_VERSION])
+@TargetVersions(['4.3', '5.0.5', '5.1.1', '5.3.3', '5.6.1', PmdPlugin.DEFAULT_PMD_VERSION])
 class AbstractPmdPluginVersionIntegrationTest extends MultiVersionIntegrationSpec {
     String calculateDefaultDependencyNotation() {
         if (versionNumber < VersionNumber.version(5)) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -152,7 +152,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     }
 
     /**
-     * The built-in rule sets to be used. See the <a href="http://pmd.sourceforge.net/rules/index.html">official list</a> of built-in rule sets.
+     * The built-in rule sets to be used. See the <a href="https://pmd.github.io/pmd-6.7.0/pmd_rules_java.html">official list</a> of built-in rule sets.
      *
      * Example: ruleSets = ["basic", "braces"]
      */
@@ -162,7 +162,7 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
     }
 
     /**
-     * The built-in rule sets to be used. See the <a href="http://pmd.sourceforge.net/rules/index.html">official list</a> of built-in rule sets.
+     * The built-in rule sets to be used. See the <a href="https://pmd.github.io/pmd-6.7.0/pmd_rules_java.html">official list</a> of built-in rule sets.
      *
      * Example: ruleSets = ["basic", "braces"]
      */

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdExtension.java
@@ -46,18 +46,18 @@ public class PmdExtension extends CodeQualityExtension {
     }
 
     /**
-     * The built-in rule sets to be used. See the <a href="http://pmd.sourceforge.net/rules/index.html">official list</a> of built-in rule sets.
+     * The built-in rule sets to be used. See the <a href="https://pmd.github.io/pmd-6.7.0/pmd_rules_java.html">official list</a> of built-in rule sets.
      *
-     * Example: ruleSets = ["basic", "braces"]
+     * Example: ruleSets = ["category/java/errorprone.xml", "category/java/bestpractices.xml"]
      */
     public List<String> getRuleSets() {
         return ruleSets;
     }
 
     /**
-     * The built-in rule sets to be used. See the <a href="http://pmd.sourceforge.net/rules/index.html">official list</a> of built-in rule sets.
+     * The built-in rule sets to be used. See the <a href="https://pmd.github.io/pmd-6.7.0/pmd_rules_java.html">official list</a> of built-in rule sets.
      *
-     * Example: ruleSets = ["basic", "braces"]
+     * Example: ruleSets = ["category/java/errorprone.xml", "category/java/bestpractices.xml"]
      */
     public void setRuleSets(List<String> ruleSets) {
         this.ruleSets = ruleSets;
@@ -66,7 +66,7 @@ public class PmdExtension extends CodeQualityExtension {
     /**
      * Convenience method for adding rule sets.
      *
-     * Example: ruleSets "basic", "braces"
+     * Example: ruleSets "category/java/errorprone.xml", "category/java/bestpractices.xml"
      *
      * @param ruleSets the rule sets to be added
      */

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -48,7 +48,7 @@ import java.util.concurrent.Callable;
  */
 public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
 
-    public static final String DEFAULT_PMD_VERSION = "5.6.1";
+    public static final String DEFAULT_PMD_VERSION = "6.7.0";
     private PmdExtension extension;
 
     @Override
@@ -65,7 +65,7 @@ public class PmdPlugin extends AbstractCodeQualityPlugin<Pmd> {
     protected CodeQualityExtension createExtension() {
         extension = project.getExtensions().create("pmd", PmdExtension.class, project);
         extension.setToolVersion(DEFAULT_PMD_VERSION);
-        extension.setRuleSets(new ArrayList<String>(Arrays.asList("java-basic")));
+        extension.setRuleSets(new ArrayList<String>(Arrays.asList("category/java/errorprone.xml")));
         extension.setRuleSetFiles(project.getLayout().files());
         conventionMappingOf(extension).map("targetJdk", new Callable<Object>() {
             @Override

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdInvoker.groovy
@@ -41,6 +41,9 @@ abstract class PmdInvoker {
         def prePmd5 = pmdClasspath.any {
             it.name ==~ /pmd-([1-4]\.[0-9\.]+)\.jar/
         }
+        def prePmd6 = prePmd5 || pmdClasspath.any {
+            it.name ==~ /pmd-(java-)?(5\.[0-9\.]+)\.jar/
+        }
         def antPmdArgs = [failOnRuleViolation: false, failuresPropertyName: "pmdFailureCount"]
         if (prePmd5) {
             // NOTE: PMD 5.0.2 apparently introduces an element called "language" that serves the same purpose
@@ -49,8 +52,13 @@ abstract class PmdInvoker {
             antPmdArgs["targetjdk"] = targetJdk.name
 
             // fallback to basic on pre 5.0 for backwards compatible
-            if (ruleSets == ["java-basic"]) {
+            if (ruleSets == ["java-basic"] || ruleSets == ["category/java/errorprone.xml"]) {
                 ruleSets = ['basic']
+                pmdTask.setRuleSets(ruleSets)
+            }
+        } else if (prePmd6) {
+            if (ruleSets == ["category/java/errorprone.xml"]) {
+                ruleSets = ['java-basic']
                 pmdTask.setRuleSets(ruleSets)
             }
         }

--- a/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
+++ b/subprojects/code-quality/src/test/groovy/org/gradle/api/plugins/quality/PmdPluginTest.groovy
@@ -48,7 +48,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
     def "configures pmd extension"() {
         expect:
         PmdExtension extension = project.extensions.pmd
-        extension.ruleSets == ["java-basic"]
+        extension.ruleSets == ["category/java/errorprone.xml"]
         extension.ruleSetConfig == null
         extension.ruleSetFiles.empty
         extension.reportsDir == project.file("build/reports/pmd")
@@ -100,7 +100,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
             assert description == "Run PMD analysis for ${sourceSet.name} classes"
             source as List == sourceSet.allJava as List
             assert pmdClasspath == project.configurations.pmd
-            assert ruleSets == ["java-basic"]
+            assert ruleSets == ["category/java/errorprone.xml"]
             assert ruleSetConfig == null
             assert ruleSetFiles.empty
             assert reports.xml.destination == project.file("build/reports/pmd/${sourceSet.name}.xml")
@@ -117,7 +117,7 @@ class PmdPluginTest extends AbstractProjectBuilderSpec {
         task.description == null
         task.source.empty
         task.pmdClasspath == project.configurations.pmd
-        task.ruleSets == ["java-basic"]
+        task.ruleSets == ["category/java/errorprone.xml"]
         task.ruleSetConfig == null
         task.ruleSetFiles.empty
         task.reports.xml.destination == project.file("build/reports/pmd/custom.xml")

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.PmdExtension.xml
@@ -10,7 +10,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>5.2.3</literal></td>
+                <td><literal>6.7.0</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>
@@ -18,7 +18,7 @@
             </tr>
             <tr>
                 <td>ruleSets</td>
-                <td><literal>["basic"]</literal></td>
+                <td><literal>["category/java/errorprone.xml"]</literal></td>
             </tr>
             <tr>
                 <td>ruleSetConfig</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -171,6 +171,9 @@ See [above](#jacoco-plugin-now-works-with-the-build-cache-and-parallel-test-exec
 The default tool versions of the following code quality plugins have been updated:
 
 - The CodeNarc plugin now uses 1.2.1 instead of 1.1 by default.
+- The PMD plugin now uses 6.7.0 instead of 5.6.1 by default.
+  In addition, the default ruleset was changed from the now deprecated `java-basic` to `category/java/errorprone.xml`.
+  We recommend configuring a ruleset explicitly, though.
 
 ### `CopySpec.duplicatesStrategy` is no longer nullable
 


### PR DESCRIPTION
The default ruleset has been changed from the now deprecated
`java-basic` to `category/java/errorprone.xml`.

Resolves #6625.