### PR TITLE
Upgrade default tool version of Checkstyle to 8.12

### DIFF
--- a/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
+++ b/gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts
@@ -37,6 +37,7 @@ fun Project.configureCheckstyle(codeQualityConfigDir: File) {
     val checkStyleConfigDir = codeQualityConfigDir.resolve("checkstyle")
     configure<CheckstyleExtension> {
         configDir = checkStyleConfigDir
+        toolVersion = "6.19"
 
         plugins.withType<GroovyBasePlugin> {
             java.sourceSets.all {

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
@@ -16,9 +16,12 @@
 package org.gradle.api.plugins.quality.checkstyle
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import static org.gradle.util.TextUtil.getPlatformLineSeparator
 
+@Requires(TestPrecondition.JDK8_OR_LATER)
 class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
 
     private static final EXPECTED_DEPRECATION_MESSAGE = "Setting the Checkstyle configuration file under 'config/checkstyle' of a sub project has been deprecated.";

--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstyleRelocationIntegrationTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstyleRelocationIntegrationTest.groovy
@@ -18,9 +18,12 @@ package org.gradle.api.plugins.quality.checkstyle
 
 import org.gradle.integtests.fixtures.AbstractProjectRelocationIntegrationTest
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 
 import java.util.regex.Pattern
 
+@Requires(TestPrecondition.JDK8_OR_LATER)
 class CheckstyleRelocationIntegrationTest extends AbstractProjectRelocationIntegrationTest {
 
     @Override

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -37,7 +37,7 @@ import java.util.concurrent.Callable;
  */
 public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
 
-    public static final String DEFAULT_CHECKSTYLE_VERSION = "6.19";
+    public static final String DEFAULT_CHECKSTYLE_VERSION = "8.12";
     private static final String CONFIG_DIR_NAME = "config/checkstyle";
     private CheckstyleExtension extension;
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.plugins.quality.CheckstyleExtension.xml
@@ -10,7 +10,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>6.19</literal></td>
+                <td><literal>8.12</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -170,6 +170,7 @@ See [above](#jacoco-plugin-now-works-with-the-build-cache-and-parallel-test-exec
 
 The default tool versions of the following code quality plugins have been updated:
 
+- The Checkstyle plugin now uses 8.12 instead of 6.19 by default.
 - The CodeNarc plugin now uses 1.2.1 instead of 1.1 by default.
 
 ### `CopySpec.duplicatesStrategy` is no longer nullable

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IsolatedAntBuilderMemoryLeakIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/IsolatedAntBuilderMemoryLeakIntegrationTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.integtests
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.*
 
+@Requires(TestPrecondition.JDK8_OR_LATER)
 class IsolatedAntBuilderMemoryLeakIntegrationTest extends AbstractIntegrationSpec {
 
     private void goodCode(String groovyVersion, TestFile root = testDirectory) {


### PR DESCRIPTION
Since Checkstyle 7.0 no longer supports running on JDK 7, tests now
require JDK 8 or later.

Resolves #6622.