### PR TITLE
Support task-level timeouts

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/UncheckedException.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/UncheckedException.java
@@ -25,7 +25,7 @@ import java.lang.reflect.InvocationTargetException;
  * Wraps a checked exception. Carries no other context.
  */
 public final class UncheckedException extends RuntimeException {
-    public UncheckedException(Throwable cause) {
+    private UncheckedException(Throwable cause) {
         super(cause);
     }
 
@@ -44,6 +44,9 @@ public final class UncheckedException extends RuntimeException {
      * Note: always throws the failure in some form. The return value is to keep the compiler happy.
      */
     public static RuntimeException throwAsUncheckedException(Throwable t, boolean preserveMessage) {
+        if (t instanceof InterruptedException) {
+            Thread.currentThread().interrupt();
+        }
         if (t instanceof RuntimeException) {
             throw (RuntimeException) t;
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/ClasspathUtil.java
@@ -63,7 +63,7 @@ public class ClasspathUtil {
                         try {
                             implementationClassPath.add(new File(toURI(url)));
                         } catch (URISyntaxException e) {
-                            throw new UncheckedException(e);
+                            throw UncheckedException.throwAsUncheckedException(e);
                         }
                     }
                 }
@@ -151,7 +151,7 @@ public class ClasspathUtil {
                                url.getPort(),
                                url.getFile().replace(" ", "%20")).toURI();
             } catch (MalformedURLException e1) {
-                throw new UncheckedException(e1);
+                throw UncheckedException.throwAsUncheckedException(e1);
             }
         }
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/CompositeStoppable.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/CompositeStoppable.java
@@ -104,7 +104,7 @@ public class CompositeStoppable implements Stoppable {
                 } catch (Throwable throwable) {
                     if (failure == null) {
                         failure = throwable;
-                    } else {
+                    } else if (!Thread.currentThread().isInterrupted()) {
                         LOGGER.error(String.format("Could not stop %s.", element), throwable);
                     }
                 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/InterruptibleRunnable.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/InterruptibleRunnable.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.concurrent;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Wraps a runnable so that it can be interrupted. Useful when {@link java.util.concurrent.Future} is not available or its behavior is not desired.
+ *
+ * In contrast to {@link java.util.concurrent.Future#cancel(boolean)}, the delegate Runnable is always called, even if an interrupt was received before this runnable was started.
+ * This can be used to implement guaranteed delivery mechanisms, where proper interrupt handling is up to the delegate.
+ */
+public final class InterruptibleRunnable implements Runnable {
+    private final Lock stateLock = new ReentrantLock();
+    private final Runnable delegate;
+    private boolean interrupted;
+    private Thread thread;
+
+    public InterruptibleRunnable(Runnable delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void run() {
+        beforeRun();
+        try {
+            delegate.run();
+        } finally {
+            afterRun();
+        }
+    }
+
+    private void beforeRun() {
+        stateLock.lock();
+        try {
+            thread = Thread.currentThread();
+            if (interrupted) {
+                thread.interrupt();
+            }
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    private void afterRun() {
+        stateLock.lock();
+        try {
+            Thread.interrupted();
+            thread = null;
+        } finally {
+            stateLock.unlock();
+        }
+    }
+
+    public void interrupt() {
+        stateLock.lock();
+        try {
+            if (thread == null) {
+                interrupted = true;
+            } else {
+                thread.interrupt();
+            }
+        } finally {
+            stateLock.unlock();
+        }
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutorImpl.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/concurrent/ManagedExecutorImpl.java
@@ -83,7 +83,8 @@ class ManagedExecutorImpl extends AbstractDelegatingExecutorService implements M
                 throw new IllegalStateException("Timeout waiting for concurrent jobs to complete.");
             }
         } catch (InterruptedException e) {
-            throw new UncheckedException(e);
+            executor.shutdownNow();
+            throw UncheckedException.throwAsUncheckedException(e);
         }
         executorPolicy.onStop();
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -186,7 +186,7 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
                     try {
                         workAvailable.await();
                     } catch (InterruptedException e) {
-                        throw new UncheckedException(e);
+                        throw UncheckedException.throwAsUncheckedException(e);
                     }
                 }
                 return getNextOperation();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -338,7 +338,7 @@ public class JavaReflectionUtil {
         try {
             return object.getClass().getMethod("toString").getDeclaringClass() == Object.class;
         } catch (java.lang.NoSuchMethodException e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
         }
     }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -141,7 +141,7 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
                     try {
                         workAvailable.await();
                     } catch (InterruptedException e) {
-                        throw new UncheckedException(e);
+                        throw UncheckedException.throwAsUncheckedException(e);
                     }
                 }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -179,7 +179,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
         try {
             return action.call();
         } catch (Exception e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
         } finally {
             if (!coordinationService.withStateLock(tryLock(locks))) {
                 releaseWorkerLeaseAndWaitFor(locks);

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -22,9 +22,11 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.LoggingManager;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskDestroyables;
 import org.gradle.api.tasks.TaskInputs;
@@ -34,6 +36,7 @@ import org.gradle.api.tasks.TaskState;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -746,4 +749,26 @@ public interface Task extends Comparable<Task>, ExtensionAware {
     @Incubating
     @Internal
     TaskDependency getShouldRunAfter();
+
+    /**
+     * <p>The timeout of this task.</p>
+     *
+     * <pre class='autoTested'>
+     *   task myTask {
+     *       timeout = Duration.ofMinutes(10)
+     *   }
+     * </pre>
+     *
+     * <p>
+     * The Thread executing this task will be interrupted if the task takes longer than the specified amount of time to run.
+     * In order for a task to work properly with this feature, it needs to react to interrupts and must clean up any resources it opened.
+     * </p>
+     * <p>By default, tasks never time out.</p>
+     *
+     * @since 5.0
+     */
+    @Internal
+    @Optional
+    @Incubating
+    Property<Duration> getTimeout();
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.workers.IsolationMode
+import spock.lang.Timeout
+import spock.lang.Unroll
+
+class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
+
+    private static final TIMEOUT = 500
+
+    @Timeout(30)
+    def "fails when negative timeout is specified"() {
+        given:
+        buildFile << """
+            task broken() {
+                doLast {
+                    println "Hello"
+                }
+                timeout = Duration.ofMillis(-1)
+            }
+            """
+
+        expect:
+        fails "broken"
+        failure.assertHasDescription("Timeout of task ':broken' must be positive, but was -0.001S")
+        result.assertNotOutput("Hello")
+    }
+
+    @Timeout(30)
+    def "timeout stops long running method call"() {
+        given:
+        buildFile << """
+            task block() {
+                doLast {
+                    Thread.sleep(60000)
+                }
+                timeout = Duration.ofMillis($TIMEOUT)
+            }
+            """
+
+        expect:
+        fails "block"
+        failure.assertHasDescription("task ':block' exceeded its timeout")
+    }
+
+    @Timeout(30)
+    def "other tasks still run after a timeout if --continue is used"() {
+        given:
+        buildFile << """
+            task block() {
+                doLast {
+                    Thread.sleep(60000)
+                }
+                timeout = Duration.ofMillis($TIMEOUT)
+            }
+            
+            task foo() {
+            }
+            """
+
+        expect:
+        fails "block", "foo", "--continue"
+        result.assertTaskExecuted(":foo")
+        failure.assertHasDescription("task ':block' exceeded its timeout")
+    }
+
+    @Timeout(30)
+    def "timeout stops long running exec()"() {
+        given:
+        file('src/main/java/Block.java') << """ 
+            import java.util.concurrent.CountDownLatch;
+
+            public class Block {
+                public static void main(String[] args) throws InterruptedException {
+                    new CountDownLatch(1).await();
+                }
+            }
+        """
+        buildFile << """
+            apply plugin: 'java'
+            task block(type: JavaExec) {
+                classpath = sourceSets.main.output
+                main = 'Block'
+                timeout = Duration.ofMillis($TIMEOUT)
+            }
+            """
+
+        expect:
+        fails "block"
+        failure.assertHasDescription("task ':block' exceeded its timeout")
+    }
+
+    @Timeout(30)
+    def "timeout stops long running tests"() {
+        given:
+        (1..100).each { i ->
+            file("src/test/java/Block${i}.java") << """ 
+                import java.util.concurrent.CountDownLatch;
+                import org.junit.Test;
+    
+                public class Block${i} {
+                    @Test
+                    public void test() throws InterruptedException {
+                        new CountDownLatch(1).await();
+                    }
+                }
+            """
+        }
+        buildFile << """
+            apply plugin: 'java'
+            ${jcenterRepository()}
+            dependencies {
+                testImplementation 'junit:junit:4.12'
+            }
+            test {
+                timeout = Duration.ofMillis($TIMEOUT)
+            }
+            """
+
+        expect:
+        fails "test"
+        failure.assertHasDescription("task ':test' exceeded its timeout")
+    }
+
+    @Timeout(30)
+    @Unroll
+    def "timeout stops long running work items with #isolationMode isolation"() {
+        given:
+        buildFile << """
+            import java.util.concurrent.CountDownLatch;
+            import javax.inject.Inject;
+            
+            task block(type: WorkerTask) {
+                timeout = Duration.ofMillis($TIMEOUT)
+            }
+            
+            class WorkerTask extends DefaultTask {
+
+                @Inject
+                WorkerExecutor getWorkerExecutor() {
+                    throw new UnsupportedOperationException()
+                }
+
+                @TaskAction
+                void executeTask() {
+                    for (int i = 0; i < 100; i++) {
+                        workerExecutor.submit(BlockingRunnable) {
+                            isolationMode = IsolationMode.$isolationMode
+                        }
+                    }
+                }
+            }
+
+            public class BlockingRunnable implements Runnable {
+                @Inject
+                public BlockingRunnable() {
+                }
+
+                public void run() {
+                    new CountDownLatch(1).await();
+                }
+            }
+            """
+
+        expect:
+        fails "block"
+        failure.assertHasDescription("task ':block' exceeded its timeout")
+
+        where:
+        isolationMode << IsolationMode.values()
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -54,6 +54,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.provider.Property;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Internal;
@@ -79,6 +80,7 @@ import javax.annotation.Nullable;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -117,6 +119,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     private String description;
 
     private String group;
+
+    private final Property<Duration> timeout;
 
     private AndSpec<Task> onlyIfSpec = createNewOnlyIfSpec();
 
@@ -177,6 +181,8 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         taskLocalState = new DefaultTaskLocalState(taskMutator);
 
         this._dependencies = new DefaultTaskDependency(tasks, ImmutableSet.<Object>of(taskInputs.getFiles()));
+
+        this.timeout = _project.getObjects().property(Duration.class);
     }
 
     private void assertDynamicObject() {
@@ -922,5 +928,10 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     @Override
     public boolean isHasCustomActions() {
         return hasCustomActions;
+    }
+
+    @Override
+    public Property<Duration> getTimeout() {
+        return timeout;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
@@ -102,7 +102,7 @@ public class Deleter {
         try {
             Thread.sleep(DELETE_RETRY_SLEEP_MILLIS);
         } catch (InterruptedException ex) {
-            // Ignore Exception
+            Thread.currentThread().interrupt();
         }
 
         if (!file.delete() && file.exists()) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/FinalizerThread.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/FinalizerThread.java
@@ -57,7 +57,7 @@ class FinalizerThread extends Thread {
                 removeCacheEntry(key, entry, DONT_CLOSE_CLASSLOADER);
             }
         } catch (InterruptedException ex) {
-            LOG.debug("Shutdown of classloader cache in progress");
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -62,6 +62,11 @@ public class TaskStateInternal implements TaskState {
         this.failure = failure;
     }
 
+    public void setAborted(String message) {
+        this.outcome = TaskExecutionOutcome.EXECUTED;
+        this.failure = new GradleException(message);
+    }
+
     public boolean getExecuting() {
         return executing;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ActionEventFiringTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ActionEventFiringTaskExecuter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.api.execution.TaskActionListener;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.TaskExecuter;
+import org.gradle.api.internal.tasks.TaskExecutionContext;
+import org.gradle.api.internal.tasks.TaskStateInternal;
+
+/**
+ * A {@link TaskExecuter} that notifies listeners interested in the actual actions being executed.
+ */
+public class ActionEventFiringTaskExecuter implements TaskExecuter {
+    private final TaskExecuter delegate;
+    private final TaskOutputChangesListener outputsGenerationListener;
+    private final TaskActionListener listener;
+
+    public ActionEventFiringTaskExecuter(TaskExecuter delegate, TaskOutputChangesListener outputsGenerationListener, TaskActionListener taskActionListener) {
+        this.delegate = delegate;
+        this.outputsGenerationListener = outputsGenerationListener;
+        this.listener = taskActionListener;
+    }
+
+    public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        listener.beforeActions(task);
+        if (task.hasTaskActions()) {
+            outputsGenerationListener.beforeTaskOutputChanged();
+        }
+        try {
+            delegate.execute(task, state, context);
+        } finally {
+            listener.afterActions(task);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SnapshotAfterExecutionTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SnapshotAfterExecutionTaskExecuter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.TaskExecuter;
+import org.gradle.api.internal.tasks.TaskExecutionContext;
+import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.internal.scopeids.id.BuildInvocationScopeId;
+
+/**
+ * A {@link TaskExecuter} which snaphots the task's output after it has executed.
+ */
+public class SnapshotAfterExecutionTaskExecuter implements TaskExecuter {
+    private final TaskExecuter delegate;
+    private final BuildInvocationScopeId buildInvocationScopeId;
+
+    public SnapshotAfterExecutionTaskExecuter(TaskExecuter delegate, BuildInvocationScopeId buildInvocationScopeId) {
+        this.delegate = delegate;
+        this.buildInvocationScopeId = buildInvocationScopeId;
+    }
+
+    public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        try {
+            delegate.execute(task, state, context);
+        } finally {
+            context.getTaskArtifactState().snapshotAfterTaskExecution(state.getFailure(), buildInvocationScopeId.getId(), context);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TimeoutTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/TimeoutTaskExecuter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.TaskInternal;
+import org.gradle.api.internal.tasks.TaskExecuter;
+import org.gradle.api.internal.tasks.TaskExecutionContext;
+import org.gradle.api.internal.tasks.TaskStateInternal;
+import org.gradle.api.internal.tasks.timeout.Timeout;
+import org.gradle.api.internal.tasks.timeout.TimeoutHandler;
+import org.gradle.api.provider.Property;
+
+import java.time.Duration;
+
+/**
+ * A task executer that interrupts a task if it exceeds its timeout.
+ */
+public class TimeoutTaskExecuter implements TaskExecuter {
+    private final TaskExecuter delegate;
+    private final TimeoutHandler timeoutHandler;
+
+    public TimeoutTaskExecuter(TaskExecuter delegate, TimeoutHandler timeoutHandler) {
+        this.delegate = delegate;
+        this.timeoutHandler = timeoutHandler;
+    }
+
+    @Override
+    public void execute(TaskInternal task, TaskStateInternal state, TaskExecutionContext context) {
+        Property<Duration> timeoutProperty = task.getTimeout();
+        if (timeoutProperty.isPresent()) {
+            Duration timeout = timeoutProperty.get();
+            if (timeout.isNegative()) {
+                throw new InvalidUserDataException("Timeout of " + task + " must be positive, but was " + timeout.toString().substring(2));
+            } else {
+                executeWithTimeout(task, state, context, timeout);
+            }
+        } else {
+            delegate.execute(task, state, context);
+        }
+    }
+
+    private void executeWithTimeout(TaskInternal task, TaskStateInternal state, TaskExecutionContext context, Duration timeout) {
+        Timeout taskTimeout = timeoutHandler.start(Thread.currentThread(), timeout);
+        try {
+            delegate.execute(task, state, context);
+        } finally {
+            taskTimeout.stop();
+            if (taskTimeout.timedOut()) {
+                state.setAborted(task + " exceeded its timeout");
+                Thread.interrupted();
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/DefaultTimeoutHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/DefaultTimeoutHandler.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.timeout;
+
+import org.gradle.internal.concurrent.ManagedScheduledExecutor;
+import org.gradle.internal.concurrent.Stoppable;
+
+import java.time.Duration;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
+    private final ManagedScheduledExecutor executor;
+
+    public DefaultTimeoutHandler(ManagedScheduledExecutor executor) {
+        this.executor = executor;
+    }
+
+    @Override
+    public Timeout start(Thread taskExecutionThread, Duration timeout) {
+        long timeoutMillis = timeout.toMillis();
+        long limit = System.currentTimeMillis() + timeoutMillis;
+        InterruptOnTimeout interrupter = new InterruptOnTimeout(taskExecutionThread, limit);
+        ScheduledFuture<?> periodicCheck = executor.scheduleAtFixedRate(interrupter, timeoutMillis, 50, TimeUnit.MILLISECONDS);
+        return new DefaultTimeout(interrupter, periodicCheck);
+    }
+
+    @Override
+    public void stop() {
+        executor.stop();
+    }
+
+    private static final class DefaultTimeout implements Timeout {
+
+        private final InterruptOnTimeout interrupter;
+        private final ScheduledFuture<?> periodicCheck;
+
+        private DefaultTimeout(InterruptOnTimeout interrupter, ScheduledFuture<?> periodicCheck) {
+            this.interrupter = interrupter;
+            this.periodicCheck = periodicCheck;
+        }
+
+        @Override
+        public void stop() {
+            periodicCheck.cancel(true);
+        }
+
+        @Override
+        public boolean timedOut() {
+            return interrupter.timedOut;
+        }
+    }
+
+    private static class InterruptOnTimeout implements Runnable {
+        private final Thread thread;
+        private final long limit;
+
+        private volatile boolean timedOut;
+
+        private InterruptOnTimeout(Thread thread, long limit) {
+            this.thread = thread;
+            this.limit = limit;
+        }
+
+        @Override
+        public void run() {
+            if (timedOut) {
+                return;
+            }
+            if (System.currentTimeMillis() > limit) {
+                timedOut = true;
+                thread.interrupt();
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/Timeout.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/Timeout.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.timeout;
+
+/**
+ * Represents a timeout for some piece of work.
+ */
+public interface Timeout {
+    /**
+     * Returns whether the work did time out.
+     */
+    boolean timedOut();
+
+    /**
+     * Stops the timeout.
+     */
+    void stop();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/TimeoutHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/TimeoutHandler.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.timeout;
+
+import org.gradle.internal.concurrent.Stoppable;
+
+import java.time.Duration;
+
+/**
+ * Manages timeouts for threads, interrupting them if the timeout is exceeded.
+ */
+public interface TimeoutHandler extends Stoppable {
+    /**
+     * Starts a timeout for the given thread. The thread is interrupted if the given timeout is exceeded.
+     * The returned {@link Timeout} object must be used to stop the timeout once the thread has completed
+     * the work that this timeout was supposed to limit, otherwise it may be interrupted doing
+     * some other work later.
+     */
+    Timeout start(Thread taskExecutionThread, Duration timeoutInMillis);
+
+    /**
+     * Stops all {@link Timeout}s created from this handler.
+     */
+    @Override
+    void stop();
+}

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -80,7 +80,7 @@ import java.util.Set;
  */
 public class GradleResolveVisitor extends ResolveVisitor {
     // note: BigInteger and BigDecimal are also imported by default
-    private static final String[] DEFAULT_IMPORTS = {"java.lang.", "java.io.", "java.net.", "java.util.", "groovy.lang.", "groovy.util."};
+    private static final String[] DEFAULT_IMPORTS = {"java.lang.", "java.io.", "java.net.", "java.util.", "groovy.lang.", "groovy.util.", "java.time."};
     private static final String SCRIPTS_PACKAGE = "org.gradle.groovy.scripts";
 
     private ClassNode currentClass;

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceFileWatcherBacking.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceFileWatcherBacking.java
@@ -91,7 +91,7 @@ public class WatchServiceFileWatcherBacking {
                             try {
                                 pumpEvents();
                             } catch (InterruptedException e) {
-                                // just stop
+                                Thread.currentThread().interrupt();
                             } catch (Throwable t) {
                                 if (!(Throwables.getRootCause(t) instanceof InterruptedException)) {
                                     stop();

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/TaskExecutionServices.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.changedetection.state.TaskHistoryStore;
 import org.gradle.api.internal.changedetection.state.TaskOutputFilesRepository;
 import org.gradle.api.internal.changedetection.state.ValueSnapshotter;
 import org.gradle.api.internal.tasks.TaskExecuter;
+import org.gradle.api.internal.tasks.execution.ActionEventFiringTaskExecuter;
 import org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter;
 import org.gradle.api.internal.tasks.execution.CleanupStaleOutputsExecuter;
 import org.gradle.api.internal.tasks.execution.EventFiringTaskExecuter;
@@ -46,10 +47,14 @@ import org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter;
 import org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter;
 import org.gradle.api.internal.tasks.execution.SkipUpToDateTaskExecuter;
+import org.gradle.api.internal.tasks.execution.SnapshotAfterExecutionTaskExecuter;
 import org.gradle.api.internal.tasks.execution.TaskOutputChangesListener;
+import org.gradle.api.internal.tasks.execution.TimeoutTaskExecuter;
 import org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.internal.tasks.properties.annotations.FileFingerprintingPropertyAnnotationHandler;
+import org.gradle.api.internal.tasks.timeout.DefaultTimeoutHandler;
+import org.gradle.api.internal.tasks.timeout.TimeoutHandler;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
@@ -114,7 +119,8 @@ public class TaskExecutionServices {
                                     TaskExecutionGraphInternal taskExecutionGraph,
                                     BuildInvocationScopeId buildInvocationScopeId,
                                     BuildCancellationToken buildCancellationToken,
-                                    TaskExecutionListener taskExecutionListener
+                                    TaskExecutionListener taskExecutionListener,
+                                    TimeoutHandler timeoutHandler
     ) {
 
         boolean buildCacheEnabled = buildCacheController.isEnabled();
@@ -122,13 +128,13 @@ public class TaskExecutionServices {
         TaskOutputChangesListener taskOutputChangesListener = listenerManager.getBroadcaster(TaskOutputChangesListener.class);
 
         TaskExecuter executer = new ExecuteActionsTaskExecuter(
-            taskOutputChangesListener,
-            listenerManager.getBroadcaster(TaskActionListener.class),
             buildOperationExecutor,
             asyncWorkTracker,
-            buildInvocationScopeId,
             buildCancellationToken
         );
+        executer = new ActionEventFiringTaskExecuter(executer, taskOutputChangesListener, listenerManager.getBroadcaster(TaskActionListener.class));
+        executer = new TimeoutTaskExecuter(executer, timeoutHandler);
+        executer = new SnapshotAfterExecutionTaskExecuter(executer, buildInvocationScopeId);
         executer = new OutputDirectoryCreatingTaskExecuter(executer);
         if (buildCacheEnabled) {
             executer = new SkipCachedTaskExecuter(
@@ -153,6 +159,10 @@ public class TaskExecutionServices {
         executer = new CatchExceptionTaskExecuter(executer);
         executer = new EventFiringTaskExecuter(buildOperationExecutor, taskExecutionListener, executer);
         return executer;
+    }
+
+    TimeoutHandler createTaskTimeoutHandler(ExecutorFactory executorFactory) {
+        return new DefaultTimeoutHandler(executorFactory.createScheduled("task timeouts", 1));
     }
 
     TaskHistoryStore createCacheAccess(Gradle gradle, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -260,7 +260,8 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
                 try {
                     stateChanged.await();
                 } catch (InterruptedException e) {
-                    //ok, wrapping up
+                    execHandleRunner.abortProcess();
+                    throw UncheckedException.throwAsUncheckedException(e);
                 }
             }
 
@@ -299,7 +300,7 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
                 try {
                     stateChanged.await();
                 } catch (InterruptedException e) {
-                    //ok, wrapping up...
+                    execHandleRunner.abortProcess();
                     throw UncheckedException.throwAsUncheckedException(e);
                 }
             }
@@ -427,6 +428,12 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
         public void stop() {
             inputHandler.stop();
             outputHandler.stop();
+        }
+
+        @Override
+        public void disconnect() {
+            inputHandler.disconnect();
+            outputHandler.disconnect();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
@@ -51,8 +51,12 @@ public class ExecHandleRunner implements Runnable {
     public void abortProcess() {
         lock.lock();
         try {
+            if (aborted) {
+                return;
+            }
             aborted = true;
             if (process != null) {
+                streamsHandler.disconnect();
                 LOGGER.debug("Abort requested. Destroying process: {}.", execHandle.getDisplayName());
                 process.destroy();
             }
@@ -63,10 +67,7 @@ public class ExecHandleRunner implements Runnable {
 
     public void run() {
         try {
-            ProcessBuilder processBuilder = processBuilderFactory.createProcessBuilder(execHandle);
-            Process process = processLauncher.start(processBuilder);
-            streamsHandler.connectStreams(process, execHandle.getDisplayName(), executor);
-            setProcess(process);
+            startProcess();
 
             execHandle.started();
 
@@ -86,9 +87,15 @@ public class ExecHandleRunner implements Runnable {
         }
     }
 
-    private void setProcess(Process process) {
+    private void startProcess() {
         lock.lock();
         try {
+            if (aborted) {
+                throw new IllegalStateException("Process has already been aborted");
+            }
+            ProcessBuilder processBuilder = processBuilderFactory.createProcessBuilder(execHandle);
+            Process process = processLauncher.start(processBuilder);
+            streamsHandler.connectStreams(process, execHandle.getDisplayName(), executor);
             this.process = process;
         } finally {
             lock.unlock();

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/EmptyStdInStreamsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/EmptyStdInStreamsHandler.java
@@ -42,4 +42,8 @@ public class EmptyStdInStreamsHandler implements StreamsHandler {
     @Override
     public void stop() {
     }
+
+    @Override
+    public void disconnect() {
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
@@ -57,15 +57,20 @@ public class ForwardStdinStreamsHandler implements StreamsHandler {
     }
 
     public void stop() {
+        disconnect();
+        try {
+            completed.await();
+        } catch (InterruptedException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Override
+    public void disconnect() {
         try {
             standardInputWriter.closeInput();
         } catch (IOException e) {
             throw new UncheckedIOException(e);
-        }
-        try {
-            completed.await();
-        } catch (InterruptedException e) {
-            throw new UncheckedException(e);
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
@@ -67,7 +67,15 @@ public class OutputStreamsForwarder implements StreamsHandler {
         try {
             completed.await();
         } catch (InterruptedException e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+    }
+
+    @Override
+    public void disconnect() {
+        standardOutputReader.disconnect();
+        if (readErrorStream) {
+            standardErrorReader.disconnect();
         }
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.api.internal.project.taskfactory.ITaskFactory
 import org.gradle.api.internal.project.taskfactory.TaskFactory
 import org.gradle.api.internal.project.taskfactory.TaskIdentity
 import org.gradle.api.internal.project.taskfactory.TaskInstantiator
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskDependency
 import org.gradle.initialization.ProjectAccessListener
@@ -62,6 +63,7 @@ class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<T
             getIdentityPath() >> Path.path(":")
         }
         getServices() >> Mock(ServiceRegistry)
+        getObjects() >> Stub(ObjectFactory)
     }
     private taskCount = 1;
     private accessListener = Mock(ProjectAccessListener)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ActionEventFiringTaskExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ActionEventFiringTaskExecutorTest.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.tasks.execution
+
+import org.gradle.api.execution.TaskActionListener
+import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.tasks.TaskExecuter
+import org.gradle.api.internal.tasks.TaskExecutionContext
+import org.gradle.api.internal.tasks.TaskStateInternal
+import spock.lang.Specification
+
+class ActionEventFiringTaskExecutorTest extends Specification {
+    def delegate = Mock(TaskExecuter)
+    def publicListener = Mock(TaskActionListener)
+    def internalListener = Mock(TaskOutputChangesListener)
+    def executer = new ActionEventFiringTaskExecuter(delegate, internalListener, publicListener)
+
+    def task = Stub(TaskInternal)
+    def state = new TaskStateInternal()
+    def executionContext = Stub(TaskExecutionContext)
+
+
+    def "notifies listeners before and after task execution"() {
+        when:
+        executer.execute(task, state, executionContext)
+
+        then:
+        1 * publicListener.beforeActions(task)
+
+        then:
+        1 * delegate.execute(task, state, executionContext)
+
+        then:
+        1 * publicListener.afterActions(task)
+    }
+
+    def "notifies listeners even if delegate fails"() {
+        when:
+        executer.execute(task, state, executionContext)
+
+        then:
+        1 * publicListener.beforeActions(task)
+
+        then:
+        1 * delegate.execute(task, state, executionContext) >> { throw new IllegalStateException() }
+
+        then:
+        1 * publicListener.afterActions(task)
+
+        and:
+        thrown IllegalStateException
+    }
+}

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -69,6 +69,11 @@ When using `@OutputFiles` or `@OutputDirectories` with an `Iterable` type, Gradl
 This is no longer the case, and using such properties doesn't prevent the task from being cached.
 The only remaining reason to disable caching for the task is if the output contains file trees.
 
+### Task timeouts
+
+You can now specify a timeout for a task, after which it will be interrupted. 
+See the user guide section on “[Task timeouts](userguide/more_about_tasks.html#task_timeouts)” for more information.
+
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -420,6 +420,22 @@ include::{samplesPath}/userguide/tutorial/disableTask/disableTask.out[]
 ----
 ====
 
+[[sec:task_timeouts]]
+=== Task timeouts
+
+Every task has a `timeout` property which can be used to limit its execution time.
+When a task reaches its timeout, its task execution thread is interrupted.
+The task will be marked as failed. Finalizer tasks will still be run.
+If `--continue` is used, other tasks can continue running after it.
+Tasks that don't respond to interrupts can't be timed out.
+All of Gradle's built-in tasks respond to timeouts in a timely manner.
+
+.Specifying task timeouts
+====
+include::sample[dir="userguide/tasks/timeout/groovy",files="build.gradle[]"]
+include::sample[dir="userguide/tasks/timeout/kotlin",files="build.gradle.kts[]"]
+====
+
 [[sec:up_to_date_checks]]
 == Up-to-date checks (AKA Incremental Build)
 

--- a/subprojects/docs/src/samples/userguide/tasks/timeout/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/timeout/groovy/build.gradle
@@ -1,0 +1,6 @@
+task hangingTask() {
+    doLast {
+        Thread.sleep(100000)
+    }
+    timeout = Duration.ofMillis(500)
+}

--- a/subprojects/docs/src/samples/userguide/tasks/timeout/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/timeout/groovy/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = "task-timeout"

--- a/subprojects/docs/src/samples/userguide/tasks/timeout/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/tasks/timeout/kotlin/build.gradle.kts
@@ -1,0 +1,10 @@
+import java.time.Duration
+
+tasks {
+    register("hangingTask") {
+        doLast {
+            Thread.sleep(100000)
+        }
+        timeout.set(Duration.ofMillis(500))
+    }
+}

--- a/subprojects/docs/src/samples/userguide/tasks/timeout/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/tasks/timeout/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "task-timeout"

--- a/subprojects/docs/src/samples/userguide/tasks/timeout/taskTimeout.out
+++ b/subprojects/docs/src/samples/userguide/tasks/timeout/taskTimeout.out
@@ -1,0 +1,5 @@
+
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+task ':hangingTask' exceeded its timeout

--- a/subprojects/docs/src/samples/userguide/tasks/timeout/taskTimeout.sample.conf
+++ b/subprojects/docs/src/samples/userguide/tasks/timeout/taskTimeout.sample.conf
@@ -1,0 +1,21 @@
+# tag::cli[]
+# gradle --quiet hangingTask
+# end::cli[]
+
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: hangingTask
+    flags: --quiet
+    expect-failure: true
+    expected-output-file: taskTimeout.out
+    allow-additional-output: true
+}, {
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: hangingTask
+    flags: --quiet
+    expect-failure: true
+    expected-output-file: taskTimeout.out
+    allow-additional-output: true
+}]

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -257,7 +257,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
             }
             return parser;
         } catch (Exception ex) {
-            throw new UncheckedException(ex);
+            throw UncheckedException.throwAsUncheckedException(ex);
         }
     }
 
@@ -327,7 +327,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         } catch (SAXException ex) {
-            throw new UncheckedException(ex);
+            throw UncheckedException.throwAsUncheckedException(ex);
         } finally {
             IOUtils.closeQuietly(reader);
         }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonOutputConsumer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonOutputConsumer.java
@@ -73,4 +73,8 @@ public class DaemonOutputConsumer implements StreamsHandler {
 
     public void stop() {
     }
+
+    @Override
+    public void disconnect() {
+    }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/DaemonConnectionBackedEventConsumer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/DaemonConnectionBackedEventConsumer.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.daemon.server.exec;
+
+import org.gradle.initialization.BuildEventConsumer;
+import org.gradle.launcher.daemon.server.api.DaemonCommandExecution;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An event consumer that asynchronously dispatches events to the client.
+ */
+class DaemonConnectionBackedEventConsumer implements BuildEventConsumer {
+    private final DaemonCommandExecution execution;
+    private final BlockingQueue<Object> queue = new LinkedBlockingQueue<Object>();
+    private final ForwardEvents forwarder = new ForwardEvents();
+
+    public DaemonConnectionBackedEventConsumer(DaemonCommandExecution execution) {
+        this.execution = execution;
+        forwarder.start();
+    }
+
+    @Override
+    public void dispatch(Object event) {
+        queue.offer(event);
+    }
+
+    public void waitForFinish() {
+        forwarder.waitForFinish();
+    }
+
+    private class ForwardEvents extends Thread {
+        private volatile boolean stopped;
+        private boolean ableToSend = true;
+
+        @Override
+        public void run() {
+            while (moreMessagesToSend()) {
+                Object event = getNextEvent();
+                if (event != null) {
+                    dispatchEvent(event);
+                }
+            }
+        }
+
+        private boolean moreMessagesToSend() {
+            return ableToSend && !(stopped && queue.isEmpty());
+        }
+
+        private Object getNextEvent() {
+            try {
+                return queue.poll(10, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                stopped = true;
+                return null;
+            }
+        }
+
+        private void dispatchEvent(Object event) {
+            try {
+                execution.getConnection().event(event);
+            } catch (RuntimeException e) {
+                ableToSend = false;
+            }
+        }
+
+        public void waitForFinish() {
+            stopped = true;
+            try {
+                join();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/LogToClient.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/LogToClient.java
@@ -147,7 +147,7 @@ public class LogToClient extends BuildCommandOnly {
             try {
                 completionLock.await();
             } catch (InterruptedException e) {
-                // the caller has been interrupted
+                Thread.currentThread().interrupt();
             }
         }
     }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/dispatch/ExceptionTrackingFailureHandler.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/dispatch/ExceptionTrackingFailureHandler.java
@@ -28,7 +28,7 @@ public class ExceptionTrackingFailureHandler implements DispatchFailureHandler<O
     }
 
     public void dispatchFailed(Object message, Throwable failure) {
-        if (this.failure != null) {
+        if (this.failure != null && !Thread.currentThread().isInterrupted()) {
             logger.error(failure.getMessage(), failure);
         } else {
             this.failure = new DispatchException(String.format("Could not dispatch message %s.", message), failure);

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
@@ -57,7 +57,7 @@ public class MessageHubBackedObjectConnection implements ObjectConnection {
     public MessageHubBackedObjectConnection(ExecutorFactory executorFactory, ConnectCompletion completion) {
         Action<Throwable> errorHandler = new Action<Throwable>() {
             public void execute(Throwable throwable) {
-                if (!aborted) {
+                if (!aborted && !Thread.currentThread().isInterrupted()) {
                     LOGGER.error("Unexpected exception thrown.", throwable);
                 }
             }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaIDEModelPerformanceTest.groovy
@@ -32,7 +32,7 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         given:
         experiment(testProject.projectName) {
             minimumVersion = "2.11"
-            targetVersions = ["5.0-20180909235858+0000"]
+            targetVersions = ["5.0-20180912081209+0000"]
             invocationCount = iterations
             warmUpCount = iterations
             action {
@@ -92,7 +92,7 @@ class JavaIDEModelPerformanceTest extends AbstractToolingApiCrossVersionPerforma
         given:
         experiment(testProject.projectName) {
             minimumVersion = "2.11"
-            targetVersions = ["5.0-20180909235858+0000"]
+            targetVersions = ["5.0-20180912081209+0000"]
             invocationCount = iterations
             warmUpCount = iterations
             action {

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AsyncCacheAccessDecoratedCache.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/AsyncCacheAccessDecoratedCache.java
@@ -56,30 +56,40 @@ public class AsyncCacheAccessDecoratedCache<K, V> implements MultiProcessSafeAsy
 
     @Override
     public void putLater(final K key, final V value, final Runnable completion) {
-        asyncCacheAccess.enqueue(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    persistentCache.put(key, value);
-                } finally {
-                    completion.run();
+        try {
+            asyncCacheAccess.enqueue(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        persistentCache.put(key, value);
+                    } finally {
+                        completion.run();
+                    }
                 }
-            }
-        });
+            });
+        } catch (RuntimeException e) {
+            completion.run();
+            throw e;
+        }
     }
 
     @Override
     public void removeLater(final K key, final Runnable completion) {
-        asyncCacheAccess.enqueue(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    persistentCache.remove(key);
-                } finally {
-                    completion.run();
+        try {
+            asyncCacheAccess.enqueue(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        persistentCache.remove(key);
+                    } finally {
+                        completion.run();
+                    }
                 }
-            }
-        });
+            });
+        } catch (RuntimeException e) {
+            completion.run();
+            throw e;
+        }
     }
 
     @Override

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessWorker.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/CacheAccessWorker.java
@@ -213,12 +213,12 @@ class CacheAccessWorker implements Runnable, Stoppable, AsyncCacheAccess {
             try {
                 workQueue.put(new ShutdownOperationsCommand());
             } catch (InterruptedException e) {
-                // ignore
+                Thread.currentThread().interrupt();
             }
             try {
                 doneSignal.await();
             } catch (InterruptedException e) {
-                // ignore
+                Thread.currentThread().interrupt();
             }
         }
         rethrowFailure();

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultFileLockManager.java
@@ -228,15 +228,6 @@ public class DefaultFileLockManager implements FileLockManager {
             CompositeStoppable stoppable = new CompositeStoppable();
             stoppable.add(new Stoppable() {
                 public void stop() {
-                    try {
-                        fileLockContentionHandler.stop(lockId);
-                    } catch (Exception e) {
-                        throw new RuntimeException("Unable to stop listening for file lock requests for " + displayName, e);
-                    }
-                }
-            });
-            stoppable.add(new Stoppable() {
-                public void stop() {
                     if (lockFileAccess == null) {
                         return;
                     }
@@ -264,6 +255,15 @@ public class DefaultFileLockManager implements FileLockManager {
                         }
                     } catch (Exception e) {
                         throw new RuntimeException("Failed to release lock on " + displayName, e);
+                    }
+                }
+            });
+            stoppable.add(new Stoppable() {
+                public void stop() {
+                    try {
+                        fileLockContentionHandler.stop(lockId);
+                    } catch (Exception e) {
+                        throw new RuntimeException("Unable to stop listening for file lock requests for " + displayName, e);
                     }
                 }
             });

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/LockOnDemandCrossProcessCacheAccess.java
@@ -151,11 +151,14 @@ class LockOnDemandCrossProcessCacheAccess extends AbstractCrossProcessCacheAcces
         try {
             onClose.execute(fileLock);
         } finally {
-            fileLock.close();
-            fileLock = null;
-            if (lockReleaseSignal != null) {
-                lockReleaseSignal.trigger();
-                lockReleaseSignal = null;
+            try {
+                fileLock.close();
+                fileLock = null;
+            } finally {
+                if (lockReleaseSignal != null) {
+                    lockReleaseSignal.trigger();
+                    lockReleaseSignal = null;
+                }
             }
         }
     }

--- a/subprojects/process-services/src/main/java/org/gradle/process/internal/StreamsHandler.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/internal/StreamsHandler.java
@@ -32,6 +32,11 @@ public interface StreamsHandler extends Stoppable {
     void start();
 
     /**
+     * Disconnects from the process without waiting for further work.
+     */
+    void disconnect();
+
+    /**
      * Stops doing work with the process's streams. Should block until no further asynchronous work is happening on the streams.
      */
     @Override

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultHttpSettings.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultHttpSettings.java
@@ -150,7 +150,7 @@ public class DefaultHttpSettings implements HttpSettings {
                     sslcontext.init(null, allTrustingTrustManager, null);
                     return sslcontext;
                 } catch (GeneralSecurityException e) {
-                    throw new UncheckedException(e);
+                    throw UncheckedException.throwAsUncheckedException(e);
                 }
             }
         });

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/pgp/PgpSignatory.java
@@ -76,7 +76,7 @@ public class PgpSignatory extends SignatorySupport {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } catch (PGPException e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
         }
     }
 
@@ -108,7 +108,7 @@ public class PgpSignatory extends SignatorySupport {
             generator.init(PGPSignature.BINARY_DOCUMENT, privateKey);
             return generator;
         } catch (PGPException e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
         }
     }
 
@@ -117,7 +117,7 @@ public class PgpSignatory extends SignatorySupport {
             PBESecretKeyDecryptor decryptor = new BcPBESecretKeyDecryptorBuilder(new BcPGPDigestCalculatorProvider()).build(password.toCharArray());
             return secretKey.extractPrivateKey(decryptor);
         } catch (PGPException e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
         }
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -70,7 +70,7 @@ public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClass
             try {
                 completed.await();
             } catch (InterruptedException e) {
-                throw new UncheckedException(e);
+                throw UncheckedException.throwAsUncheckedException(e);
             }
         } finally {
             LOGGER.info("{} finished executing tests.", workerProcessContext.getDisplayName());

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/git/internal/DefaultGitVersionControlSpec.java
@@ -42,7 +42,7 @@ public class DefaultGitVersionControlSpec extends AbstractVersionControlSpec imp
         try {
             setUrl(new URI(url));
         } catch (URISyntaxException e) {
-            throw new UncheckedException(e);
+            throw UncheckedException.throwAsUncheckedException(e);
         }
     }
 

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/Install.java
@@ -182,6 +182,7 @@ public class Install {
         } catch (IOException e) {
             errorMessage = e.getMessage();
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             errorMessage = e.getMessage();
         }
         if (errorMessage != null) {


### PR DESCRIPTION

Users can now configure a timeout on a per-task level.
If the task exceeds this timeout while running, its thread
is interrupted and it is marked as failed. This works for any
task that handles InterruptedExceptions correctly, including
tasks using our exec() infrastructure or worker API.

A timed-out task behaves just like a failed task in all other
respects, e.g. finalizers will still be run. If --continue is
used, other tasks can continue running after it.

Tasks that don't respond to interrupts are not yet handled.
Those should result in a shutdown of the daemon, as there is no
other way to restore a working system.

Also fixes all kinds of broken interrupt handling in Gradle.

Fixes #1096