### PR TITLE
Remove Maven optional dependencies support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ import org.gradle.gradlebuild.ProjectGroups.implementationPluginProjects
 import org.gradle.gradlebuild.ProjectGroups.javaProjects
 import org.gradle.gradlebuild.ProjectGroups.pluginProjects
 import org.gradle.gradlebuild.ProjectGroups.publishedProjects
+import org.gradle.util.GradleVersion
 
 plugins {
     `java-base`

--- a/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
@@ -55,16 +55,14 @@ fun Project.testLibrary(name: String): String =
 val gradle5CategoryAttribute = Attribute.of("org.gradle.component.category", String::class.java)
 
 
-fun DependencyHandler.gradle5Platform(name: Any) = if (GradleVersion.current().baseVersion >= GradleVersion.version("5.0")) {
-    val dep = create(name)
-    if (dep is HasConfigurableAttributes<*>) {
-        dep.attributes {
-            attribute(gradle5CategoryAttribute, "platform")
+fun DependencyHandler.gradle5Platform(name: Any) = create(name).apply {
+    if (GradleVersion.current().baseVersion >= GradleVersion.version("5.0")) {
+        if (this is HasConfigurableAttributes<*>) {
+            attributes {
+                attribute(gradle5CategoryAttribute, "platform")
+            }
         }
     }
-    dep
-} else {
-    create(name)
 }
 
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -384,7 +384,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     def "can set version on dependency constraint"() {
         given:
@@ -757,7 +757,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 }
             }
         """
-        if (defineAsConstraint && !gradleMetadataEnabled && useIvy()) {
+        if (defineAsConstraint && !gradleMetadataEnabled) {
             //in plain ivy, we do not have the constraint published. But we can add still add it.
             buildFile.text = buildFile.text.replace("d ->", "d -> d.add('org.test:moduleB:1.0')")
         }
@@ -824,7 +824,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 }
             }
         """
-        if (defineAsConstraint && !gradleMetadataEnabled && useIvy()) {
+        if (defineAsConstraint && !gradleMetadataEnabled) {
             //in plain ivy, we do not have the constraint published. But we can add still add it.
             buildFile.text = buildFile.text.replace("d ->", "d -> d.add('org.test:moduleB') { version { prefer '1.0'; reject '1.1', '1.2' }}")
         }
@@ -943,7 +943,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 }
             }
         """
-        boolean constraintsUnsupported = !gradleMetadataEnabled && useIvy()
+        boolean constraintsUnsupported = !gradleMetadataEnabled
 
         repositoryInteractions {
             'org.test:moduleA:1.0' {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -51,7 +51,7 @@ public enum CacheLayout {
         .changedTo(56, "4.7-rc-1")
         .changedTo(58, "4.8-rc-1")
         .changedTo(63, "4.10-rc-1")
-        .changedTo(66, "5.0-rc-1")),
+        .changedTo(67, "5.0-rc-1")),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -55,7 +55,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         this.dependencyDescriptor = dependencyDescriptor;
         this.reason = reason;
         this.isTransitive = dependencyDescriptor.isTransitive();
-        this.isConstraint = dependencyDescriptor.isConstraint() || dependencyDescriptor.isOptional();
+        this.isConstraint = dependencyDescriptor.isConstraint();
     }
 
     public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -200,14 +200,10 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     }
 
     private boolean include(MavenDependencyDescriptor dependency, Collection<String> hierarchy) {
-        if (dependency.isOptional() && ignoreOptionalDependencies()) {
+        if (dependency.isOptional()) {
             return false;
         }
         return hierarchy.contains(dependency.getScope().getLowerName());
-    }
-
-    private boolean ignoreOptionalDependencies() {
-        return !improvedPomSupportEnabled;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -133,7 +133,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         for (MavenDependencyDescriptor dependency : dependencies) {
             if (isOptionalConfiguration && includeInOptionalConfiguration(dependency)) {
                 filteredDependencies.add(new DefaultMavenModuleResolveMetadata.OptionalConfigurationDependencyMetadata(config, componentId, dependency));
-            } else if (include(dependency, config.getHierarchy(), improvedPomSupport)) {
+            } else if (include(dependency, config.getHierarchy())) {
                 filteredDependencies.add(contextualize(config, componentId, dependency, improvedPomSupport));
             }
         }
@@ -156,9 +156,9 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
             && dependencyScope != MavenScope.System;
     }
 
-    private static boolean include(MavenDependencyDescriptor dependency, Collection<String> hierarchy, boolean improvedPomSupport) {
+    private static boolean include(MavenDependencyDescriptor dependency, Collection<String> hierarchy) {
         MavenScope dependencyScope = dependency.getScope();
-        if (dependency.isOptional() && !improvedPomSupport) {
+        if (dependency.isOptional()) {
             return false;
         }
         return hierarchy.contains(dependencyScope.getLowerName());

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,10 +54,10 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.66'
-        cacheLayout.version == CacheVersion.parse("2.66")
-        cacheLayout.version.toString() == '2.66'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.66')
+        cacheLayout.key == 'metadata-2.67'
+        cacheLayout.version == CacheVersion.parse("2.67")
+        cacheLayout.version.toString() == '2.67'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.67')
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserBomTest.groovy
@@ -241,7 +241,7 @@ class GradlePomModuleDescriptorParserBomTest extends AbstractGradlePomModuleDesc
         !dep.transitive
     }
 
-    def "a bom can declare an optional dependency with excludes"() {
+    def "a bom can declare a constraint with excludes"() {
         given:
         pomFile << """
 <project>

--- a/subprojects/docs/src/docs/userguide/managing_transitive_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/managing_transitive_dependencies.adoc
@@ -38,12 +38,7 @@ Dependency constraints are not yet published, but that will be added in a future
 This means that their use currently only targets builds that do not publish artifacts to maven or ivy repositories.
 ====
 
-Dependency constraints themselves can also be added transitively. If a modules's metadata is defined in a `.pom` file that contains dependency entries with `<optional>true</optional>`, Gradle will create a dependency constraint for each of these so-called _optional dependencies_. This leads to a similar resolution behavior as provided by Maven: if the corresponding module is brought in by another, non-optional dependency declaration, then the constraint will apply when choosing the version for that module (e.g., if the optional dependency defines a higher version, that one is chosen).
-
-[NOTE]
-====
-Support for _optional dependencies_ from pom files is active by default with Gradle 5.0+. For using it in Gradle 4.6+, you need to activate it by adding `enableFeaturePreview('IMPROVED_POM_SUPPORT')` in _settings.gradle_.
-====
+Dependency constraints themselves can also be added transitively.
 
 [[sec:excluding_transitive_module_dependencies]]
 == Excluding transitive module dependencies

--- a/subprojects/docs/src/docs/userguide/upgrade_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrade_version_4.adoc
@@ -129,6 +129,11 @@ For now, by-convention config files in subprojects will override any in the root
  * `getEnabledDirectoryReportDestinations()`, `getEnabledFileReportDestinations()` and `getEnabledReportNames()` have all been removed from `org.gradle.api.reporting.ReportContainer`.
  * link:{javadocPath}/org/gradle/StartParameter.html#getProjectProperties--[StartParameter.projectProperties] and link:{javadocPath}/org/gradle/StartParameter.html#getSystemPropertiesArgs--[StartParameter.systemPropertiesArgs] now return immutable maps.
 
+[[changes_5.0]]
+== Changes in 5.0
+
+* <<#rel5.0:pom_optional_dependencies,Maven optional dependencies are no longer interpreted as dependency constraints>>
+
 [[changes_4.6]]
 == Changes in 4.6
 
@@ -288,6 +293,11 @@ To override this behavior, you can explicitly declare the configuration to use i
 
 
 == Changes in detail
+
+[[rel5.0:pom_optional_dependencies]]
+=== [5.0] Support for optional dependencies when consuming POMs
+
+Support for importing optional dependencies as dependency constraints, introduced using the experimental POM support flag in 4.6, has been removed.
 
 [[rel4.10:aws_s3_permissions]]
 === [4.10] Publishing to AWS S3 requires new permissions


### PR DESCRIPTION
### Context

Whenever we used the "improved POM support" experimental flag, Gradle was
interpreting optional dependencies as constraints. It meant that if a
hard dependency was found in the graph, and that another module had an
optional dependency on it, then we would conflict resolve between the two
versions.

It appears that this behavior causes some troubles, for example mentioned
in #5434. In Maven, optional dependencies are really never used. They are
pure documentation.

We also want to provide a better alternative to optional dependencies,
which will include a better model of optional features. Support for optional
dependencies coming from a Maven POM may be included as part of this work.
