### PR TITLE
fix #6653: avoid double deprecation message when using the publishing plugin

### DIFF
--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -90,7 +90,7 @@ public class PublishingPlugin implements Plugin<Project> {
             return DefaultPublishingExtension.class;
         } else {
             DeprecationLogger.nagUserWithDeprecatedBuildInvocationFeature(
-                "As part of making the publishing plugins stable, the 'deferred configurable' behavior of the 'publishing {}' block is now deprecated.",
+                "As part of making the publishing plugins stable, the 'deferred configurable' behavior of the 'publishing {}' block",
                 "In Gradle 5.0 the 'enableFeaturePreview('STABLE_PUBLISHING')' flag will be removed and the new behavior will become the default.",
                     "Please add 'enableFeaturePreview('STABLE_PUBLISHING')' to your settings file and do a test run by publishing to a local repository. " +
                     "If all artifacts are published as expected, there is nothing else to do. " +


### PR DESCRIPTION
### Context
fix #6653 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
