### PR TITLE
Restrict users on Java 9

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -59,10 +59,6 @@ private
 const val oracleJdk9 = "Oracle JDK 9"
 
 
-private
-const val oracleJdk8 = "Oracle JDK 8"
-
-
 open class AvailableJavaInstallations(private val project: Project, private val javaInstallationProbe: JavaInstallationProbe, private val jvmVersionDetector: JvmVersionDetector) {
     private
     val logger = LoggerFactory.getLogger(AvailableJavaInstallations::class.java)
@@ -109,8 +105,8 @@ open class AvailableJavaInstallations(private val project: Project, private val 
 
     private
     fun validateForRemoteCache(): Map<String, Boolean> =
-        mapOf("Remote cache is enabled, which requires Oracle JDK 8/9 to perform this build. It's currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
-            (currentJavaInstallation.vendorAndMajorVersion != oracleJdk8 && currentJavaInstallation.vendorAndMajorVersion != oracleJdk9))
+        mapOf("Remote cache is enabled, which requires Oracle JDK 9 to perform this build. It's currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
+            (currentJavaInstallation.vendorAndMajorVersion != oracleJdk9))
 
     private
     fun validate(errorMessages: Map<String, Boolean>) {
@@ -137,8 +133,8 @@ open class AvailableJavaInstallations(private val project: Project, private val 
     private
     fun validateProductionJdks(): Map<String, Boolean> =
         mapOf(
-            "Must use Oracle JDK 8/9 to perform this build. Is currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
-                (currentJavaInstallation.vendorAndMajorVersion != oracleJdk8 && currentJavaInstallation.vendorAndMajorVersion != oracleJdk9)
+            "Must use Oracle JDK 9 to perform this build. Is currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
+                (currentJavaInstallation.vendorAndMajorVersion != oracleJdk9)
         )
 
     private

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/DistributionTest.kt
@@ -60,7 +60,6 @@ open class DistributionTest : Test() {
         jvmArgumentProviders.add(gradleInstallationForTest)
         jvmArgumentProviders.add(BinaryDistributionsEnvironmentProvider(binaryDistributions))
         jvmArgumentProviders.add(libsRepository)
-        systemProperty("java9Home", project.findProperty("java9Home") ?: System.getProperty("java9Home"))
     }
 }
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/PerformanceTest.java
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/PerformanceTest.java
@@ -185,7 +185,17 @@ public class PerformanceTest extends DistributionTest {
             List<String> result = new ArrayList<>();
             addExecutionParameters(result);
             addDatabaseParameters(result);
+            addJava9HomeSystemProperty(result);
             return result;
+        }
+
+        private void addJava9HomeSystemProperty(List<String> result) {
+            Object java9Home = getProject().findProperty("java9Home");
+            if (java9Home != null) {
+                addSystemPropertyIfExist(result, "java9Home", java9Home.toString());
+            } else {
+                addSystemPropertyIfExist(result, "java9Home", System.getProperty("java9Home"));
+            }
         }
 
         private void addExecutionParameters(List<String> result) {

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/SrcDistributionIntegrationSpec.groovy
@@ -50,7 +50,7 @@ class SrcDistributionIntegrationSpec extends DistributionIntegrationSpec {
             inDirectory(contentsDir)
             usingExecutable('gradlew')
             withTasks('binZip')
-            withArguments("-Djava9Home=${System.getProperty('java9Home')}", "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")
+            withArguments("-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}")
             withWarningMode(null)
         }.run()
 


### PR DESCRIPTION
### Context

This PR forbids users to use Java 8 if they enable build cache. Also it removes `java9Home` in `SrcDistributionIntegrationSpec`.