### PR TITLE
Improve Spock tests

### DIFF
--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/model/SimpleClassMetaDataRepositoryTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/model/SimpleClassMetaDataRepositoryTest.groovy
@@ -49,7 +49,7 @@ class SimpleClassMetaDataRepositoryTest extends Specification {
         repository.get('unknown')
 
         then:
-        UnknownDomainObjectException e = thrown()
+        def e = thrown UnknownDomainObjectException
         e.message == 'No meta-data is available for class \'unknown\'. Did you mean? [unkown]'
     }
 
@@ -61,7 +61,7 @@ class SimpleClassMetaDataRepositoryTest extends Specification {
         repository.get('org.gradle.jvm.JUnitTestSuiteSpec')
 
         then:
-        UnknownDomainObjectException e = thrown()
+        def e = thrown UnknownDomainObjectException
         e.message == 'No meta-data is available for class \'org.gradle.jvm.JUnitTestSuiteSpec\'. Did you mean? [org.gradle.jvm.test.JUnitTestSuiteSpec]'
     }
 

--- a/subprojects/announce/src/test/groovy/org/gradle/api/plugins/announce/internal/IgnoreUnavailableAnnouncerTest.groovy
+++ b/subprojects/announce/src/test/groovy/org/gradle/api/plugins/announce/internal/IgnoreUnavailableAnnouncerTest.groovy
@@ -43,7 +43,7 @@ class IgnoreUnavailableAnnouncerTest extends Specification {
         announcer.send("title", "message")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 }

--- a/subprojects/base-services-groovy/src/test/groovy/org/gradle/internal/metaobject/MixInClosurePropertiesAsMethodsDynamicObjectTest.groovy
+++ b/subprojects/base-services-groovy/src/test/groovy/org/gradle/internal/metaobject/MixInClosurePropertiesAsMethodsDynamicObjectTest.groovy
@@ -62,7 +62,7 @@ class MixInClosurePropertiesAsMethodsDynamicObjectTest extends Specification {
         obj.invokeMethod("m", [new Date()] as Object[])
 
         then:
-        MissingMethodException e = thrown()
+        def e = thrown MissingMethodException
         e.method == "m"
     }
 
@@ -113,7 +113,7 @@ class MixInClosurePropertiesAsMethodsDynamicObjectTest extends Specification {
         obj.invokeMethod("m", ["not-a-number"] as Object[])
 
         then:
-        MissingMethodException e = thrown()
+        def e = thrown MissingMethodException
         e.method == "doCall"
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/IoActionsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/IoActionsTest.groovy
@@ -114,7 +114,7 @@ class IoActionsTest extends Specification {
         withResource(resource, action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.is(failure)
 
         then:
@@ -134,7 +134,7 @@ class IoActionsTest extends Specification {
         withResource(resource, action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.is(failure)
 
         then:
@@ -154,7 +154,7 @@ class IoActionsTest extends Specification {
         withResource(resource, action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.is(failure)
 
         then:

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableActionSetTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/MutableActionSetTest.groovy
@@ -62,7 +62,7 @@ class MutableActionSetTest extends Specification {
         broadcast.execute('value')
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/FilteringClassLoaderTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/FilteringClassLoaderTest.groovy
@@ -56,14 +56,14 @@ class FilteringClassLoaderTest extends Specification {
         classLoader.loadClass(Test.class.name, false)
 
         then:
-        ClassNotFoundException e = thrown()
+        def e = thrown ClassNotFoundException
         e.message == "$Test.name not found."
 
         when:
         classLoader.loadClass(Test.class.name)
 
         then:
-        ClassNotFoundException e2 = thrown()
+        def e2 = thrown ClassNotFoundException
         e2.message == "$Test.name not found."
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/MultiParentClassLoaderTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/MultiParentClassLoaderTest.groovy
@@ -51,7 +51,7 @@ class MultiParentClassLoaderTest extends Specification {
         loader.loadClass('string')
 
         then:
-        ClassNotFoundException e = thrown()
+        def e = thrown ClassNotFoundException
         e.message == 'string not found.'
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/DefaultExecutorFactoryTest.groovy
@@ -118,7 +118,7 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
         executor.stop()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot stop this executor from an executor thread.'
     }
 
@@ -139,7 +139,7 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Timeout waiting for concurrent jobs to complete.'
 
         and:
@@ -322,7 +322,7 @@ class DefaultExecutorFactoryTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Timeout waiting for concurrent jobs to complete.'
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/ServiceLifecycleTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/concurrent/ServiceLifecycleTest.groovy
@@ -76,7 +76,7 @@ class ServiceLifecycleTest extends ConcurrentSpec {
         lifecycle.use { }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use [service] as it has been stopped.'
     }
 
@@ -86,7 +86,7 @@ class ServiceLifecycleTest extends ConcurrentSpec {
         lifecycle.use { }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use [service] as it has been stopped.'
     }
 
@@ -105,7 +105,7 @@ class ServiceLifecycleTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use [service] as it is currently stopping.'
     }
 
@@ -130,7 +130,7 @@ class ServiceLifecycleTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use [service] as it is currently stopping.'
     }
 
@@ -197,7 +197,7 @@ class ServiceLifecycleTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot stop [service] from a thread that is using it.'
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/hash/HashUtilTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/hash/HashUtilTest.groovy
@@ -56,7 +56,7 @@ class HashUtilTest extends Specification {
         HashUtil.createHash(file, "MD5")
 
         then:
-        UncheckedIOException e = thrown()
+        def e = thrown UncheckedIOException
         e.message.contains(filename)
         e.message.contains("MD5")
     }
@@ -77,7 +77,7 @@ class HashUtilTest extends Specification {
         HashUtil.createHash(stubInputStream, "MD5")
 
         then:
-        UncheckedIOException e = thrown()
+        def e = thrown UncheckedIOException
         e.cause == ioe
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/DirectInstantiatorTest.groovy
@@ -68,7 +68,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(TypeWithAmbiguousConstructor, "param")
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause instanceof IllegalArgumentException
         e.cause.message == "Found multiple public constructors for ${TypeWithAmbiguousConstructor} which accept parameters [java.lang.String]."
 
@@ -76,7 +76,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(TypeWithAmbiguousConstructor, true)
 
         then:
-        e = thrown()
+        e = thrown ObjectInstantiationException
         e.cause.message == "Found multiple public constructors for ${TypeWithAmbiguousConstructor} which accept parameters [java.lang.Boolean]."
     }
 
@@ -87,7 +87,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(SomeType, param)
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause instanceof IllegalArgumentException
         e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [java.lang.Object]."
 
@@ -95,14 +95,14 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(SomeType, "a", "b")
 
         then:
-        e = thrown()
+        e = thrown ObjectInstantiationException
         e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [java.lang.String, java.lang.String]."
 
         when:
         instantiator.newInstance(SomeType, false)
 
         then:
-        e = thrown()
+        e = thrown ObjectInstantiationException
         e.cause.message == "Could not find any public constructor for ${SomeType} which accepts parameters [java.lang.Boolean]."
 
         when:
@@ -110,7 +110,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(SomeTypeWithPrimitiveTypes, "a")
 
         then:
-        e = thrown()
+        e = thrown ObjectInstantiationException
         e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [java.lang.String]."
 
         when:
@@ -118,7 +118,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(SomeTypeWithPrimitiveTypes, 22)
 
         then:
-        e = thrown()
+        e = thrown ObjectInstantiationException
         e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [java.lang.Integer]."
 
         when:
@@ -126,7 +126,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(SomeTypeWithPrimitiveTypes, [null] as Object[])
 
         then:
-        e = thrown()
+        e = thrown ObjectInstantiationException
         e.cause.message == "Could not find any public constructor for ${SomeTypeWithPrimitiveTypes} which accepts parameters [null]."
     }
 
@@ -135,7 +135,7 @@ class DirectInstantiatorTest extends Specification {
         instantiator.newInstance(BrokenType, false)
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause instanceof RuntimeException
         e.cause.message == 'broken'
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTest.groovy
@@ -183,7 +183,7 @@ class JavaReflectionUtilTest extends Specification {
         readableProperty(JavaTestSubject, String, property)
 
         then:
-        NoSuchPropertyException e = thrown()
+        def e = thrown NoSuchPropertyException
         e.message == "Could not find getter method for property '${property}' on class JavaTestSubject."
 
         where:
@@ -201,7 +201,7 @@ class JavaReflectionUtilTest extends Specification {
         readableProperty(JavaTestSubject, String, property)
 
         then:
-        NoSuchPropertyException e = thrown()
+        def e = thrown NoSuchPropertyException
         e.message == "Could not find getter method for property '${property}' on class JavaTestSubject."
 
         where:
@@ -215,7 +215,7 @@ class JavaReflectionUtilTest extends Specification {
         writeableProperty(JavaTestSubject, property, Object.class)
 
         then:
-        NoSuchPropertyException e = thrown()
+        def e = thrown NoSuchPropertyException
         e.message == "Could not find setter method for property '${property}' of type Object on class JavaTestSubject."
 
         where:
@@ -231,7 +231,7 @@ class JavaReflectionUtilTest extends Specification {
         writeableProperty(JavaTestSubject, property, Object.class)
 
         then:
-        NoSuchPropertyException e = thrown()
+        def e = thrown NoSuchPropertyException
         e.message == "Could not find setter method for property '${property}' of type Object on class JavaTestSubject."
 
         where:
@@ -272,14 +272,14 @@ class JavaReflectionUtilTest extends Specification {
         method(myProperties.class, Void, "throwsException").invoke(myProperties)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e == myProperties.failure
 
         when:
         method(myProperties.class, Void, "throwsCheckedException").invoke(myProperties)
 
         then:
-        UncheckedException checkedFailure = thrown()
+        def checkedFailure = thrown UncheckedException
         checkedFailure.cause instanceof JavaTestSubject.TestCheckedException
         checkedFailure.cause.cause == myProperties.failure
     }
@@ -295,7 +295,7 @@ class JavaReflectionUtilTest extends Specification {
         method(JavaTestSubjectSubclass, String, "unknown")
 
         then:
-        NoSuchMethodException e = thrown()
+        def e = thrown NoSuchMethodException
         e.message == /Could not find method unknown() on JavaTestSubjectSubclass./
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -34,7 +34,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(StringBuilder.class)
 
         then:
-        UnknownServiceException e = thrown()
+        def e = thrown UnknownServiceException
         e.message == "No service of type StringBuilder available in TestRegistry."
     }
 
@@ -81,7 +81,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(StringBuilder)
 
         then:
-        UnknownServiceException e = thrown()
+        def e = thrown UnknownServiceException
         e.message == "No service of type StringBuilder available in TestRegistry."
     }
 
@@ -103,7 +103,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Object)
 
         then:
-        ServiceValidationException e = thrown()
+        def e = thrown ServiceValidationException
         e.message == "Locating services with type Object is not supported."
     }
 
@@ -270,14 +270,14 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Cannot create service of type String using StringProvider.createString() as required service of type Runnable is not available."
 
         when:
         registry.get(Number)
 
         then:
-        e = thrown()
+        e = thrown ServiceCreationException
         e.message == "Cannot create service of type Integer using StringProvider.createInteger() as there is a problem with parameter #1 of type String."
         e.cause.message == "Cannot create service of type String using StringProvider.createString() as required service of type Runnable is not available."
     }
@@ -290,7 +290,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Could not create service of type String using BrokenProvider.createString()."
         e.cause == BrokenProvider.failure
 
@@ -298,7 +298,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Number)
 
         then:
-        e = thrown()
+        e = thrown ServiceCreationException
         e.message == "Could not create service of type String using BrokenProvider.createString()."
         e.cause == BrokenProvider.failure
     }
@@ -367,7 +367,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Long).is(registry.get(Long))
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message.contains("Multiple services of type Long available in DefaultServiceRegistry:")
         e.message.contains("- Service Long at ConflictingDecoratorMethods.createLong()")
         e.message.contains("- Service Long at ConflictingDecoratorMethods.decorateLong()")
@@ -381,7 +381,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.addProvider(decoratorProvider)
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message == "Cannot use decorator method ${decoratorProvider.class.simpleName}.${methodName}Long() when no parent registry is provided."
 
         where:
@@ -403,7 +403,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Long)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Cannot create service of type Long using ${decoratorProvider.class.simpleName}.${methodName}Long() as required service of type Long is not available in parent registries."
 
         where:
@@ -425,7 +425,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Long)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Could not create service of type Long using ${decoratorProvider.class.simpleName}.${methodName}Long()."
         e.cause == decoratorProvider.failure
 
@@ -445,7 +445,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == 'Cannot create service of type String using ProviderWithCycle.createString() as there is a problem with parameter #1 of type Integer.'
         e.cause.message == 'Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String.'
         e.cause.cause.message == 'Cycle in dependencies of Service String at ProviderWithCycle.createString() detected'
@@ -454,7 +454,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.getAll(Number)
 
         then:
-        e = thrown()
+        e = thrown ServiceCreationException
 
         e.message == 'Cannot create service of type Integer using ProviderWithCycle.createInteger() as there is a problem with parameter #1 of type String.'
         e.cause.message == 'Cannot create service of type String using ProviderWithCycle.createString() as there is a problem with parameter #1 of type Integer.'
@@ -471,7 +471,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Could not create service of type String using NullProvider.createString() as this method returned null."
     }
 
@@ -488,7 +488,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Could not create service of type String using ${decoratorProvider.class.simpleName}.${methodName}String() as this method returned null."
 
         where:
@@ -532,7 +532,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Comparable)
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message == TextUtil.toPlatformLineSeparators("""Multiple services of type Comparable available in DefaultServiceRegistry:
    - Service Integer at TestProvider.createInt()
    - Service String at TestProvider.createString()""")
@@ -543,7 +543,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String[].class)
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message == "Locating services with array type is not supported."
     }
 
@@ -555,7 +555,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(Number)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == "Cannot create service of type Number using UnsupportedInjectionProvider.create() as there is a problem with parameter #1 of type String[]."
         e.cause.message == 'Locating services with array type is not supported.'
     }
@@ -600,7 +600,7 @@ class DefaultServiceRegistryTest extends Specification {
         decoratorCreator.call() /* .call needed in spock 0.7 */
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message.matches(/Cannot use decorator method RegistryWithDecoratorMethodsWith(Create|Decorate)\..*\(\) when no parent registry is provided./)
 
         where:
@@ -657,7 +657,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.addProvider(new NoOpConfigureProvider())
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message == 'Cannot configure services using NoOpConfigureProvider.configure() as required service of type String is not available.'
     }
 
@@ -668,7 +668,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.addProvider(new BrokenConfigureProvider())
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message == 'Could not configure services using BrokenConfigureProvider.configure().'
         e.cause == BrokenConfigureProvider.failure
     }
@@ -681,7 +681,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(ClassWithBrokenConstructor)
 
         then:
-        ServiceCreationException e = thrown()
+        def e = thrown ServiceCreationException
         e.message == 'Could not create service of type ClassWithBrokenConstructor.'
         e.cause == ClassWithBrokenConstructor.failure
     }
@@ -872,7 +872,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.getFactory(String)
 
         then:
-        UnknownServiceException e = thrown()
+        def e = thrown UnknownServiceException
         e.message == "No factory for objects of type String available in TestRegistry."
     }
 
@@ -915,7 +915,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.getFactory(Comparable)
 
         then:
-        ServiceLookupException e = thrown()
+        def e = thrown ServiceLookupException
         e.message == TextUtil.toPlatformLineSeparators("""Multiple factories for objects of type Comparable available in RegistryWithAmbiguousFactoryMethods:
    - Service Factory<Integer> at RegistryWithAmbiguousFactoryMethods.createIntegerFactory()
    - Service Factory<String> at RegistryWithAmbiguousFactoryMethods.createStringFactory()""")
@@ -1097,7 +1097,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.close()
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:
@@ -1153,14 +1153,14 @@ class DefaultServiceRegistryTest extends Specification {
         registry.get(String)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "TestRegistry has been closed."
 
         when:
         registry.getAll(String)
 
         then:
-        e = thrown()
+        e = thrown IllegalStateException
         e.message == "TestRegistry has been closed."
     }
 
@@ -1173,7 +1173,7 @@ class DefaultServiceRegistryTest extends Specification {
         registry.getFactory(BigDecimal)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "TestRegistry has been closed."
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/ServiceLocatorTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/ServiceLocatorTest.groovy
@@ -71,7 +71,7 @@ class ServiceLocatorTest extends Specification {
         serviceLocator.findFactory(String.class)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == "Could not load implementation class 'org.gradle.ImplClass' for service 'java.lang.String' specified in resource '" + serviceFile + "'."
         e.cause == failure
         1 * classLoader.getResources("META-INF/services/java.lang.String") >> Collections.enumeration([serviceFile])
@@ -114,7 +114,7 @@ org.gradle.ImplClass2""")
         serviceLocator.findFactory(String.class)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == "Could not determine implementation class for service 'java.lang.String' specified in resource '" + serviceFile + "'."
         e.cause.message == "No implementation class for service 'java.lang.String' specified."
         1 * classLoader.getResources("META-INF/services/java.lang.String") >> Collections.enumeration([serviceFile])
@@ -128,7 +128,7 @@ org.gradle.ImplClass2""")
         serviceLocator.findFactory(String)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message.startsWith("Could not load implementation class 'java.lang.Integer' for service 'java.lang.String' specified in resource '")
         e.cause.message == "Implementation class 'java.lang.Integer' is not assignable to service class 'java.lang.String'."
     }
@@ -149,7 +149,7 @@ org.gradle.ImplClass2""")
         serviceLocator.get(CharSequence)
 
         then:
-        UnknownServiceException e = thrown()
+        def e = thrown UnknownServiceException
         e.message == "Could not find meta-data resource 'META-INF/services/java.lang.CharSequence' for service 'java.lang.CharSequence'."
         1 * classLoader.getResources("META-INF/services/java.lang.CharSequence") >> Collections.enumeration([])
     }
@@ -174,7 +174,7 @@ org.gradle.ImplClass2""")
         serviceLocator.getFactory(CharSequence)
 
         then:
-        UnknownServiceException e = thrown()
+        def e = thrown UnknownServiceException
         e.message == "Could not find meta-data resource 'META-INF/services/java.lang.CharSequence' for service 'java.lang.CharSequence'."
         1 * classLoader.getResources("META-INF/services/java.lang.CharSequence") >> Collections.enumeration([])
     }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceWorkerLeaseTest.groovy
@@ -250,7 +250,7 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Some child operations have not yet completed.'
 
         cleanup:
@@ -278,7 +278,7 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
         registry.currentWorkerLease
 
         then:
-        NoAvailableWorkerLeaseException e = thrown()
+        def e = thrown NoAvailableWorkerLeaseException
         e.message == 'No worker lease associated with the current thread'
 
         when:
@@ -286,7 +286,7 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
         registry.currentWorkerLease
 
         then:
-        e = thrown()
+        e = thrown NoAvailableWorkerLeaseException
         e.message == 'No worker lease associated with the current thread'
 
         cleanup:
@@ -319,7 +319,7 @@ class DefaultWorkerLeaseServiceWorkerLeaseTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Some child operations have not yet completed.'
 
         cleanup:

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -27,7 +27,7 @@ class GradleVersionTest extends Specification {
         GradleVersion.version(versionString)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "'$versionString' is not a valid Gradle version string (examples: '1.0', '1.0-rc-1')"
 
         where:

--- a/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
+++ b/subprojects/build-cache-http/src/integTest/groovy/org/gradle/caching/http/internal/HttpBuildCacheServiceTest.groovy
@@ -100,7 +100,7 @@ class HttpBuildCacheServiceTest extends Specification {
         when:
         cache.store(key, writer(content))
         then:
-        BuildCacheException exception = thrown()
+        def exception = thrown BuildCacheException
 
         exception.message == "Received unexpected redirect (HTTP 302) to ${server.uri}/redirect/cache/${key.hashCode} when storing entry at '${server.uri}/cache/${key.hashCode}'. Ensure the configured URL for the remote build cache is correct."
     }
@@ -146,7 +146,7 @@ class HttpBuildCacheServiceTest extends Specification {
         }
 
         then:
-        BuildCacheException exception = thrown()
+        def exception = thrown BuildCacheException
 
         exception.message == "Received unexpected redirect (HTTP 302) to ${server.uri}/redirect/cache/${key.hashCode} when loading entry from '${server.uri}/cache/${key.hashCode}'. Ensure the configured URL for the remote build cache is correct."
     }
@@ -172,7 +172,7 @@ class HttpBuildCacheServiceTest extends Specification {
         }
 
         then:
-        BuildCacheException exception = thrown()
+        def exception = thrown BuildCacheException
 
         exception.message == "Loading entry from '${server.uri}/cache/${key.hashCode}' response status ${httpCode}: broken"
 
@@ -189,7 +189,7 @@ class HttpBuildCacheServiceTest extends Specification {
         }
 
         then:
-        UncheckedIOException exception = thrown()
+        def exception = thrown UncheckedIOException
 
         exception.message == "Loading entry from '${server.uri}/cache/${key.hashCode}' response status ${httpCode}: broken"
 
@@ -204,7 +204,7 @@ class HttpBuildCacheServiceTest extends Specification {
         cache.store(key, writer("".bytes))
 
         then:
-        UncheckedIOException exception = thrown()
+        def exception = thrown UncheckedIOException
 
         exception.message == "Storing entry at '${server.uri}/cache/${key.hashCode}' response status ${httpCode}: broken"
 
@@ -219,7 +219,7 @@ class HttpBuildCacheServiceTest extends Specification {
         cache.store(key, writer("".bytes))
 
         then:
-        BuildCacheException exception = thrown()
+        def exception = thrown BuildCacheException
 
         exception.message == "Storing entry at '${server.uri}/cache/${key.hashCode}' response status ${httpCode}: broken"
 

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/modifiers/BuildInitBuildScriptDslTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/plugins/internal/modifiers/BuildInitBuildScriptDslTest.groovy
@@ -42,7 +42,7 @@ class BuildInitBuildScriptDslTest extends Specification {
         BuildInitDsl.fromName("unknown")
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == TextUtil.toPlatformLineSeparators("""The requested build script DSL 'unknown' is not supported. Supported DSLs:
   - 'groovy'
   - 'kotlin'""")

--- a/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/buildinit/tasks/InitBuildSpec.groovy
@@ -117,7 +117,7 @@ class InitBuildSpec extends Specification {
         init.setupProjectLayout()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "The requested DSL 'kotlin' is not supported for 'some-type' setup type"
     }
 
@@ -134,7 +134,7 @@ class InitBuildSpec extends Specification {
         init.setupProjectLayout()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "Project name is not supported for 'some-type' setup type."
     }
 
@@ -151,7 +151,7 @@ class InitBuildSpec extends Specification {
         init.setupProjectLayout()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "Package name is not supported for 'some-type' setup type."
     }
 

--- a/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
+++ b/subprojects/composite-builds/src/test/groovy/org/gradle/composite/internal/DefaultRootBuildStateTest.groovy
@@ -141,7 +141,7 @@ class DefaultRootBuildStateTest extends Specification {
         build.run(action)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use launcher after build has completed.'
 
         and:
@@ -155,7 +155,7 @@ class DefaultRootBuildStateTest extends Specification {
         build.run(action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:
@@ -170,7 +170,7 @@ class DefaultRootBuildStateTest extends Specification {
         build.run(action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:
@@ -188,7 +188,7 @@ class DefaultRootBuildStateTest extends Specification {
         build.run(action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:
@@ -204,7 +204,7 @@ class DefaultRootBuildStateTest extends Specification {
         build.run(action)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use launcher after build has completed.'
 
         and:

--- a/subprojects/core-api/src/test/groovy/org/gradle/internal/typeconversion/ErrorHandlingNotationParserTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/internal/typeconversion/ErrorHandlingNotationParserTest.groovy
@@ -29,7 +29,7 @@ class ErrorHandlingNotationParserTest extends Specification {
         parser.parseNotation(null)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators('''Cannot convert a null value to a thing.
 The following types/formats are supported:
   - format 1
@@ -50,7 +50,7 @@ The following types/formats are supported:
         parser.parseNotation("bad")
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators('''Cannot convert the provided notation to a thing: broken-part.
 The following types/formats are supported:
   - format 1

--- a/subprojects/core-api/src/test/groovy/org/gradle/internal/typeconversion/NotationConverterToNotationParserAdapterTest.groovy
+++ b/subprojects/core-api/src/test/groovy/org/gradle/internal/typeconversion/NotationConverterToNotationParserAdapterTest.groovy
@@ -46,6 +46,6 @@ class NotationConverterToNotationParserAdapterTest extends Specification {
         parser.parseNotation(12)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerTest.groovy
@@ -85,7 +85,7 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         container.create('obj')
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == 'Cannot add a TestObject with name \'obj\' as a TestObject with that name already exists.'
     }
 
@@ -138,7 +138,7 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         }
 
         then:
-        groovy.lang.MissingMethodException e = thrown()
+        def e = thrown MissingMethodException
         e.method == 'unknown'
         e.type == TestObject
     }
@@ -152,7 +152,7 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         }
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.is(failure)
     }
 
@@ -175,7 +175,7 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         }
 
         then:
-        MissingPropertyException missingProp = thrown()
+        def missingProp = thrown MissingPropertyException
         missingProp.property == 'obj1'
     }
 
@@ -184,14 +184,14 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         container.obj1
 
         then:
-        MissingPropertyException missingProp = thrown()
+        def missingProp = thrown MissingPropertyException
         missingProp.property == 'obj1'
 
         when:
         container.obj2 { }
 
         then:
-        MissingMethodException missingMethod = thrown()
+        def missingMethod = thrown MissingMethodException
         missingMethod.method == 'obj2'
 
         when:
@@ -202,7 +202,7 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         }
 
         then:
-        missingProp = thrown()
+        missingProp = thrown MissingPropertyException
         missingProp.property == 'nested'
 
         when:
@@ -213,7 +213,7 @@ class AbstractNamedDomainObjectContainerTest extends Specification {
         }
 
         then:
-        missingProp = thrown()
+        missingProp = thrown MissingPropertyException
         missingProp.property == 'nested'
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultClassPathRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultClassPathRegistryTest.groovy
@@ -33,7 +33,7 @@ class DefaultClassPathRegistryTest extends Specification {
         registry.getClassPath("name")
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == 'unknown classpath \'name\' requested.'
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
@@ -71,7 +71,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
         list.add(1, 'a')
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot add a CharSequence with name 'a' as a CharSequence with that name already exists."
         list == ['a']
     }
@@ -147,7 +147,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
         list.set(1, 'a')
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot add a CharSequence with name 'a' as a CharSequence with that name already exists."
         list == ['a', 'b']
     }
@@ -305,7 +305,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
         iterator.set('b')
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot add a CharSequence with name 'b' as a CharSequence with that name already exists."
         list == ['a', 'b']
     }
@@ -350,7 +350,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
         iterator.add('b')
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot add a CharSequence with name 'b' as a CharSequence with that name already exists."
         list == ['a', 'b']
     }
@@ -405,7 +405,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
         list.matching { it != "b" }.get(43)
 
         then:
-        IndexOutOfBoundsException e = thrown()
+        def e = thrown IndexOutOfBoundsException
     }
 
     def "can get index of filtered element"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -140,7 +140,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObj
         container.create("fred")
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot create a Person named 'fred' because this container does not support creating " +
                 "elements by name alone. Please specify which subtype of Person to create. Known subtypes are: (None)"
     }
@@ -223,7 +223,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObj
         container.maybeCreate("fred", AgeAwarePerson)
 
         then:
-        ClassCastException e = thrown()
+        def e = thrown ClassCastException
         e.message == "Failed to cast object fred of type ${DefaultPerson.class.name} to target type ${AgeAwarePerson.class.name}"
     }
 
@@ -234,7 +234,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObj
         container.create("fred", Person)
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot create a Person because this type is not known to this container. Known types are: (None)"
     }
 
@@ -243,7 +243,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObj
         container.registerFactory(String, {} as NamedDomainObjectFactory)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot register a factory for type String because it is not a subtype of " +
                 "container element type Person."
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicNamedEntityInstantiatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicNamedEntityInstantiatorTest.groovy
@@ -43,7 +43,7 @@ class DefaultPolymorphicNamedEntityInstantiatorTest extends Specification {
         instantiator.create("foo", Integer)
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot create a Integer because this type is not known to this container. Known types are: TestType"
         e.cause instanceof NoFactoryRegisteredForTypeException
     }
@@ -77,7 +77,7 @@ class DefaultPolymorphicNamedEntityInstantiatorTest extends Specification {
         instantiator.registerFactory(String, {})
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot register a factory for type String because it is not a subtype of container element type Base."
     }
 
@@ -89,7 +89,7 @@ class DefaultPolymorphicNamedEntityInstantiatorTest extends Specification {
         instantiator.registerFactory(TestType, {})
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "Cannot register a factory for type TestType because a factory for this type is already registered."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -394,7 +394,7 @@ class DefaultTaskTest extends AbstractTaskTest {
         execute(defaultTask)
 
         then:
-        RuntimeException actual = thrown()
+        def actual = thrown RuntimeException
         actual.cause.is(failure)
         defaultTask.state.failure instanceof TaskExecutionException
         defaultTask.state.failure.cause.is(failure)
@@ -453,7 +453,7 @@ class DefaultTaskTest extends AbstractTaskTest {
         new DefaultTask()
 
         then:
-        TaskInstantiationException e = thrown()
+        def e = thrown TaskInstantiationException
         e.message.contains("has been instantiated directly which is not supported")
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DependencyInjectingInstantiatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DependencyInjectingInstantiatorTest.groovy
@@ -134,7 +134,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasBrokenConstructor)
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause == HasBrokenConstructor.failure
     }
 
@@ -146,7 +146,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasBrokenConstructor)
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.message == "Could not create an instance of type $HasBrokenConstructor.name."
         e.cause == HasBrokenConstructor.failure
     }
@@ -159,7 +159,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasOneInjectConstructor, 12, "param2")
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "Too many parameters provided for constructor for class $HasOneInjectConstructor.name. Expected 1, received 2."
     }
 
@@ -172,7 +172,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasOneInjectConstructor, new StringBuilder("string"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "Unexpected parameter provided for constructor for class $HasOneInjectConstructor.name."
     }
 
@@ -185,7 +185,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasInjectConstructor, 12)
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause instanceof IllegalArgumentException
         e.cause.message == "Unable to determine $HasInjectConstructor.name argument #1: value 12 not assignable to type class java.lang.String, or no service of type class java.lang.String"
     }
@@ -198,7 +198,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasNoInjectConstructor, new StringBuilder("param"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "Class $HasNoInjectConstructor.name has no constructor that is annotated with @Inject."
     }
 
@@ -210,7 +210,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasMixedConstructors, new StringBuilder("param"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "Class $HasMixedConstructors.name has no constructor that is annotated with @Inject."
     }
 
@@ -222,7 +222,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasMultipleInjectConstructors, new StringBuilder("param"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "Class $HasMultipleInjectConstructors.name has multiple constructors that are annotated with @Inject."
     }
 
@@ -234,7 +234,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasMixedInjectConstructors, new StringBuilder("param"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "Class $HasMixedInjectConstructors.name has multiple constructors that are annotated with @Inject."
     }
 
@@ -246,7 +246,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasNonPublicNoArgsConstructor, new StringBuilder("param"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "The constructor for class $HasNonPublicNoArgsConstructor.name should be public or package protected or annotated with @Inject."
     }
 
@@ -258,7 +258,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasSingleConstructorWithArgsAndNoAnnotation, "param")
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "The constructor for class $HasSingleConstructorWithArgsAndNoAnnotation.name should be annotated with @Inject."
     }
 
@@ -270,7 +270,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasPrivateArgsConstructor, new StringBuilder("param"))
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause.message == "The constructor for class $HasPrivateArgsConstructor.name should be annotated with @Inject."
     }
 
@@ -283,7 +283,7 @@ class DependencyInjectingInstantiatorTest extends Specification {
         instantiator.newInstance(HasInjectConstructor, null, null)
 
         then:
-        ObjectInstantiationException e = thrown()
+        def e = thrown ObjectInstantiationException
         e.cause instanceof IllegalArgumentException
         e.cause.message == "Unable to determine $HasInjectConstructor.name argument #1: value null not assignable to type class java.lang.String, or no service of type class java.lang.String"
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/FeaturePreviewsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/FeaturePreviewsTest.groovy
@@ -66,7 +66,7 @@ class FeaturePreviewsTest extends Specification {
         when:
         previews.enableFeature('UNKNOWN_FEATURE')
         then:
-        IllegalArgumentException exception = thrown()
+        def exception = thrown IllegalArgumentException
         exception.getMessage() == 'There is no feature named UNKNOWN_FEATURE'
     }
 
@@ -76,7 +76,7 @@ class FeaturePreviewsTest extends Specification {
         when:
         previews.isFeatureEnabled('UNKNOWN_FEATURE')
         then:
-        IllegalArgumentException exception = thrown()
+        def exception = thrown IllegalArgumentException
         exception.getMessage() == 'There is no feature named UNKNOWN_FEATURE'
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/attributes/DefaultImmutableAttributesFactoryTest.groovy
@@ -210,7 +210,7 @@ class DefaultImmutableAttributesFactoryTest extends Specification {
         attributes.attribute(FOO, "foo")
 
         then:
-        UnsupportedOperationException t = thrown()
+        def t = thrown UnsupportedOperationException
         t.message == "Mutation of attributes is not allowed"
     }
 
@@ -251,7 +251,7 @@ class DefaultImmutableAttributesFactoryTest extends Specification {
         factory.safeConcat(set1, set2)
 
         then:
-        AttributeMergingException e = thrown()
+        def e = thrown AttributeMergingException
         e.attribute == BAR
         e.leftValue == "bar1"
         e.rightValue == "bar2"
@@ -266,7 +266,7 @@ class DefaultImmutableAttributesFactoryTest extends Specification {
         factory.safeConcat(set1, set2)
 
         then:
-        AttributeMergingException e = thrown()
+        def e = thrown AttributeMergingException
         e.attribute == OTHER_BAR
         e.leftValue == "bar1"
         e.rightValue == "bar2"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
@@ -222,7 +222,7 @@ class DefaultModuleRegistryTest extends Specification {
         registry.getModule("gradle-some-module")
 
         then:
-        UnknownModuleException e = thrown()
+        def e = thrown UnknownModuleException
         e.message ==~ /Cannot locate manifest for module 'gradle-some-module' in classpath: \[.*]\./
     }
 
@@ -234,7 +234,7 @@ class DefaultModuleRegistryTest extends Specification {
         registry.getModule("gradle-other-module")
 
         then:
-        UnknownModuleException e = thrown()
+        def e = thrown UnknownModuleException
         e.message == "Cannot locate JAR for module 'gradle-other-module' in distribution directory '$distDir'."
     }
 
@@ -267,7 +267,7 @@ class DefaultModuleRegistryTest extends Specification {
         registry.getExternalModule("unknown")
 
         then:
-        UnknownModuleException e = thrown()
+        def e = thrown UnknownModuleException
         e.message == "Cannot locate JAR for module 'unknown' in distribution directory '$distDir'."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BaseDirFileResolverSpec.groovy
@@ -156,7 +156,7 @@ class BaseDirFileResolverSpec extends Specification {
         resolver().resolve(12)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators("""Cannot convert the provided notation to a File or URI: 12.
 The following types/formats are supported:
   - A String or CharSequence path, for example 'src/main/java' or '/usr/include'.
@@ -185,7 +185,7 @@ The following types/formats are supported:
             }
         }, baseDir)
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot convert path to File. path='null returning Callable'"
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BasicFileResolverTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/BasicFileResolverTest.groovy
@@ -52,7 +52,7 @@ class BasicFileResolverTest extends Specification {
         resolver.transform("http://127.0.0.1")
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot convert URL 'http://127.0.0.1' to a file."
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultSourceDirectorySetTest.groovy
@@ -277,7 +277,7 @@ class DefaultSourceDirectorySetTest extends Specification {
         set.addToAntBuilder("node", "fileset")
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Source directory '$srcDir' is not a directory."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/FileOrUriNotationConverterTest.groovy
@@ -154,7 +154,7 @@ class FileOrUriNotationConverterTest extends Specification {
         parse(12)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators("""Cannot convert the provided notation to a File or URI: 12.
 The following types/formats are supported:
   - A String or CharSequence path, for example 'src/main/java' or '/usr/include'.

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/TarCopyActionSpec.groovy
@@ -44,19 +44,19 @@ public class TarCopyActionSpec extends Specification {
 
     def "creates tar file"() {
         expect:
-        final TestFile tarFile = initializeTarFile(temporaryFolder.testDirectory.file("test.tar"), new SimpleCompressor())
+        TestFile tarFile = initializeTarFile(temporaryFolder.testDirectory.file("test.tar"), new SimpleCompressor())
         tarAndUntarAndCheckFileContents(tarFile)
     }
 
     def "creates gzip compressed tar file"() {
         expect:
-        final TestFile tarFile = initializeTarFile(temporaryFolder.testDirectory.file("test.tgz"), GzipArchiver.getCompressor())
+        TestFile tarFile = initializeTarFile(temporaryFolder.testDirectory.file("test.tgz"), GzipArchiver.getCompressor())
         tarAndUntarAndCheckFileContents(tarFile)
     }
 
     def "creates bzip compressed tar file"() {
         expect:
-        final TestFile tarFile = initializeTarFile(temporaryFolder.testDirectory.file("test.tbz2"), Bzip2Archiver.getCompressor());
+        TestFile tarFile = initializeTarFile(temporaryFolder.testDirectory.file("test.tbz2"), Bzip2Archiver.getCompressor());
         tarAndUntarAndCheckFileContents(tarFile);
     }
 
@@ -71,7 +71,7 @@ public class TarCopyActionSpec extends Specification {
 
     def "tar file contains expected permissions"() {
         when:
-        final TestFile tarFile = initializeTarFile(temporaryFolder.getTestDirectory().file("test.tar"), new SimpleCompressor());
+        TestFile tarFile = initializeTarFile(temporaryFolder.getTestDirectory().file("test.tar"), new SimpleCompressor());
 
         tar(dir("dir"), file("file"));
 
@@ -83,7 +83,7 @@ public class TarCopyActionSpec extends Specification {
 
     def "wraps failure to open output file"() {
         when:
-        final TestFile tarFile = initializeTarFile(temporaryFolder.createDir("test.tar"), new SimpleCompressor());
+        TestFile tarFile = initializeTarFile(temporaryFolder.createDir("test.tar"), new SimpleCompressor());
 
         action.execute(new CopyActionProcessingStream() {
             public void process(CopyActionProcessingStreamAction action) {
@@ -98,7 +98,7 @@ public class TarCopyActionSpec extends Specification {
 
     def "wraps failure to add element"() {
         when:
-        final TestFile tarFile = initializeTarFile(temporaryFolder.getTestDirectory().file("test.tar"), new SimpleCompressor());
+        TestFile tarFile = initializeTarFile(temporaryFolder.getTestDirectory().file("test.tar"), new SimpleCompressor());
 
         Throwable failure = new RuntimeException("broken");
         visit(action, brokenFile("dir/file1", failure));

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -270,7 +270,7 @@ class DefaultPluginContainerTest extends Specification {
         container.withType(TestRuleSource)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "'$TestRuleSource.name' does not implement the Plugin interface."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginRegistryTest.groovy
@@ -233,14 +233,14 @@ class DefaultPluginRegistryTest extends Specification {
         pluginRegistry.lookup(DefaultPluginId.of("noImpl"))
 
         then:
-        InvalidPluginException e = thrown()
+        def e = thrown InvalidPluginException
         e.message == "No implementation class specified for plugin 'noImpl' in $url."
 
         when:
         pluginRegistry.lookup(DefaultPluginId.of("noImpl"))
 
         then:
-        e = thrown()
+        e = thrown InvalidPluginException
         e.message == "No implementation class specified for plugin 'noImpl' in $url."
     }
 
@@ -266,7 +266,7 @@ class DefaultPluginRegistryTest extends Specification {
         pluginRegistry.lookup(DefaultPluginId.of("somePlugin"))
 
         then:
-        InvalidPluginException e = thrown()
+        def e = thrown InvalidPluginException
         e.message == "Could not find implementation class '$TestPlugin1.name' for plugin 'somePlugin' specified in $url."
         e.cause instanceof ClassNotFoundException
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/ExtensionContainerTest.groovy
@@ -71,7 +71,7 @@ class ExtensionContainerTest extends Specification {
         container.extensionsAsDynamicObject.foo = new FooExtension()
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "There's an extension registered with name 'foo'. You should not reassign it via a property setter."
     }
 
@@ -99,21 +99,21 @@ class ExtensionContainerTest extends Specification {
         container.add('foo', 'other')
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot add extension with name 'foo', as there is an extension already registered with that name."
 
         when:
         container.foo = 'other'
 
         then:
-        IllegalArgumentException e2 = thrown()
+        def e2 = thrown IllegalArgumentException
         e2.message == "There's an extension registered with name 'foo'. You should not reassign it via a property setter."
 
         when:
         container.create('foo', Thing, 'bar')
 
         then:
-        IllegalArgumentException e3 = thrown()
+        def e3 = thrown IllegalArgumentException
         e3.message == "Cannot add extension with name 'foo', as there is an extension already registered with that name."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/RuleSourceApplicationTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/RuleSourceApplicationTest.groovy
@@ -57,7 +57,7 @@ class RuleSourceApplicationTest extends Specification {
         project.apply type: String
 
         then:
-        PluginApplicationException e = thrown()
+        def e = thrown PluginApplicationException
         e.cause instanceof InvalidPluginException
         e.cause.message == "'${String.name}' is neither a plugin or a rule source and cannot be applied."
     }
@@ -68,7 +68,7 @@ class RuleSourceApplicationTest extends Specification {
         project.gradle.apply plugin: "custom-rule-source"
 
         then:
-        PluginApplicationException e = thrown()
+        def e = thrown PluginApplicationException
         e.cause instanceof UnsupportedOperationException
         e.cause.message == "Cannot apply model rules of plugin '${CustomRuleSource.name}' as the target 'build 'test'' is not model rule aware"
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -312,7 +312,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "No value has been specified for property '$property'.")
 
         where:
@@ -336,7 +336,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Cannot write to file '$task.outputFile' specified for property 'outputFile' as it is a directory.")
     }
 
@@ -348,7 +348,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Cannot write to file '${task.outputFiles[0]}' specified for property 'outputFiles' as it is a directory.")
     }
 
@@ -361,7 +361,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Cannot write to file '$task.outputFile' specified for property 'outputFile', as ancestor '$task.outputFile.parentFile' is not a directory.")
     }
 
@@ -374,7 +374,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Cannot write to file '${task.outputFiles[0]}' specified for property 'outputFiles', as ancestor '${task.outputFiles[0].parentFile}' is not a directory.")
     }
 
@@ -386,7 +386,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Directory '$task.outputDir' specified for property 'outputDir' is not a directory.")
     }
 
@@ -398,7 +398,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Directory '${task.outputDirs[0]}' specified for property 'outputDirs' is not a directory.")
     }
 
@@ -411,7 +411,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Cannot write to directory '$task.outputDir' specified for property 'outputDir', as ancestor '$task.outputDir.parentFile' is not a directory.")
     }
 
@@ -424,7 +424,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Cannot write to directory '${task.outputDirs[0]}' specified for property 'outputDirs', as ancestor '${task.outputDirs[0].parentFile}' is not a directory.")
     }
 
@@ -436,7 +436,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Directory '$task.inputDir' specified for property 'inputDir' does not exist.")
     }
 
@@ -449,7 +449,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "Directory '$task.inputDir' specified for property 'inputDir' is not a directory.")
     }
 
@@ -461,7 +461,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "No value has been specified for property 'bean.inputFile'.")
     }
 
@@ -474,7 +474,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "No value has been specified for property 'bean'.")
     }
 
@@ -487,7 +487,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "No value has been specified for property 'bean'.")
     }
 
@@ -499,7 +499,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e, "No value has been specified for property 'srcFile'.")
     }
 
@@ -511,7 +511,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e,
             "No value has been specified for property 'outputFile'.",
             "No value has been specified for property 'bean.inputFile'.")
@@ -525,7 +525,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e,
             "No value has been specified for property 'cCompiler'.",
             "No value has been specified for property 'CFlags'.",
@@ -541,7 +541,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         execute(task)
 
         then:
-        TaskValidationException e = thrown()
+        def e = thrown TaskValidationException
         validateException(task, e,
             "No value has been specified for property 'a'.",
             "No value has been specified for property 'b'.")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/TaskFactoryTest.groovy
@@ -85,7 +85,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
         taskFactory.create(new TaskIdentity(NotATask, 'task', null, null, null, 12))
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Cannot create task of type 'NotATask' as it does not implement the Task interface."
     }
 
@@ -96,7 +96,7 @@ class TaskFactoryTest extends AbstractProjectBuilderSpec {
         taskFactory.create(new TaskIdentity(TestDefaultTask, 'task', null, null, null, 12))
 
         then:
-        TaskInstantiationException e = thrown()
+        def e = thrown TaskInstantiationException
         e.message == "Could not create task of type 'TestDefaultTask'."
         e.cause == failure
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -89,7 +89,7 @@ class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<T
         container.create([:])
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "The task name must be provided."
     }
 
@@ -110,14 +110,14 @@ class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<T
         container.create([name: 'task', dependson: 'anotherTask'])
 
         then:
-        InvalidUserDataException exception = thrown()
+        def exception = thrown InvalidUserDataException
         exception.message == "Could not create task 'task': Unknown argument(s) in task definition: [dependson]"
 
         when:
         container.create([name: 'task', Type: NotATask])
 
         then:
-        exception = thrown()
+        exception = thrown InvalidUserDataException
         exception.message == "Could not create task 'task': Unknown argument(s) in task definition: [Type]"
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -246,7 +246,7 @@ class DefaultTaskOutputsTest extends Specification {
         outputs.getCachingState(taskPropertiesWithCacheableOutput, validBuildCacheKey)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.contains("Could not evaluate spec for 'Exception is thrown'.")
     }
 
@@ -258,7 +258,7 @@ class DefaultTaskOutputsTest extends Specification {
         outputs.getCachingState(taskPropertiesWithCacheableOutput, validBuildCacheKey)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.contains("Could not evaluate spec for 'Exception is thrown'.")
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskMutatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/TaskMutatorTest.groovy
@@ -50,7 +50,7 @@ class TaskMutatorTest extends Specification {
         nagger.mutate("Task.thing()", action)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot call Task.thing() on <task> after task has started execution.'
     }
 
@@ -71,7 +71,7 @@ class TaskMutatorTest extends Specification {
         wrappedAction.execute(task)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot call Task.thing() on <task> after task has started execution. Check the configuration of <task> as you may have misused \'<<\' at task declaration.'
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuterTest.groovy
@@ -226,7 +226,7 @@ class SkipEmptySourceFilesTaskExecuterTest extends Specification {
         1 * previousFile.toString() >> "output"
 
         then:
-        UncheckedIOException exception = thrown()
+        def exception = thrown UncheckedIOException
         exception.message.contains("Unable to delete file: output")
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/deployment/internal/DefaultDeploymentRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/deployment/internal/DefaultDeploymentRegistryTest.groovy
@@ -86,7 +86,7 @@ class DefaultDeploymentRegistryTest extends Specification {
         when:
         registry.start("id", DeploymentRegistry.ChangeBehavior.NONE, TestDeploymentHandle)
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "A deployment with id 'id' is already registered."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/execution/TaskPathProjectEvaluatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/TaskPathProjectEvaluatorTest.groovy
@@ -53,7 +53,7 @@ class TaskPathProjectEvaluatorTest extends Specification {
         evaluator.configureHierarchy(project)
 
         then:
-        BuildCancelledException e = thrown()
+        def e = thrown BuildCancelledException
 
         and:
         1 * project.evaluate()

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanParallelTest.groovy
@@ -638,7 +638,7 @@ class DefaultTaskExecutionPlanParallelTest extends AbstractProjectBuilderSpec {
         selectNextTask()
 
         then:
-        Exception e = thrown()
+        def e = thrown Exception
         e.message.contains("Execution failed for task ':finalizer'")
 
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionPlanTest.groovy
@@ -586,7 +586,7 @@ class DefaultTaskExecutionPlanTest extends AbstractProjectBuilderSpec {
         addToGraphAndPopulate([d])
 
         then:
-        CircularReferenceException e = thrown()
+        def e = thrown CircularReferenceException
         e.message == toPlatformLineSeparators("""Circular dependency between the following tasks:
 :c
 \\--- :d

--- a/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/groovy/scripts/internal/DefaultScriptCompilationHandlerTest.groovy
@@ -139,7 +139,7 @@ println 'hi'
         scriptCompilationHandler.compileToDir(scriptSource, classLoader, scriptCacheDir, metadataCacheDir, null, expectedScriptClass, verifier)
 
         then:
-        UnsupportedOperationException e = thrown()
+        def e = thrown UnsupportedOperationException
         e.message == "Script-display-name should not contain a package statement."
     }
 
@@ -247,7 +247,7 @@ println 'hi'
         scriptCompilationHandler.loadFromDir(scriptSource, sourceHashCode, classLoader, scriptCacheDir, metadataCacheDir, null, expectedScriptClass, classLoaderId).loadClass()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.contains("Could not load compiled classes for script-display-name from cache.")
         e.cause instanceof ClassCastException
     }
@@ -259,7 +259,7 @@ println 'hi'
         scriptCompilationHandler.compileToDir(source, classLoader, scriptCacheDir, metadataCacheDir, null, expectedScriptClass, verifier)
 
         then:
-        ScriptCompilationException e = thrown()
+        def e = thrown ScriptCompilationException
         e.lineNumber == 3
         e.cause.message.contains("script.gradle: 3: unexpected token: jsj")
 
@@ -406,7 +406,7 @@ println 'hi'
         scriptCompilationHandler.compileToDir(source, classLoader, scriptCacheDir, metadataCacheDir, null, expectedScriptClass, verifier)
 
         then:
-        ScriptCompilationException e = thrown()
+        def e = thrown ScriptCompilationException
         e.lineNumber == 1
         e.cause.message.contains("script.gradle: 1: unable to resolve class ${unknownClass}")
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/BuildFileProjectSpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/BuildFileProjectSpecTest.groovy
@@ -62,7 +62,7 @@ class BuildFileProjectSpecTest extends Specification {
         spec.selectProject(registry())
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "No projects in this build have build file '$file'.".toString()
     }
 
@@ -71,7 +71,7 @@ class BuildFileProjectSpecTest extends Specification {
         spec.selectProject(registry(project(file), project(file)))
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message.startsWith("Multiple projects in this build have build file '$file':")
     }
 
@@ -81,7 +81,7 @@ class BuildFileProjectSpecTest extends Specification {
         spec.containsProject(registry())
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Build file '$file' does not exist.".toString()
 
         when:
@@ -89,7 +89,7 @@ class BuildFileProjectSpecTest extends Specification {
         spec.containsProject(registry())
 
         then:
-        e = thrown()
+        e = thrown InvalidUserDataException
         e.message == "Build file '$file' is not a file.".toString()
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultBuildCancellationTokenSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultBuildCancellationTokenSpec.groovy
@@ -93,7 +93,7 @@ class DefaultBuildCancellationTokenSpec extends Specification {
         token.cancel()
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.cause == ex
         token.cancellationRequested
 
@@ -118,7 +118,7 @@ class DefaultBuildCancellationTokenSpec extends Specification {
         token.cancel()
 
         then:
-        DefaultMultiCauseException e = thrown()
+        def e = thrown DefaultMultiCauseException
         e.causes == [ex1, ex2]
         token.cancellationRequested
 

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/MixInLegacyTypesClassLoaderTest.groovy
@@ -207,7 +207,7 @@ class MixInLegacyTypesClassLoaderTest extends Specification {
         loader.loadClass("org.gradle.Unknown")
 
         then:
-        ClassNotFoundException e = thrown()
+        def e = thrown ClassNotFoundException
     }
 
     ClassLoader getGroovyClassLoader() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/progress/DefaultBuildOperationExecutorTest.groovy
@@ -416,7 +416,7 @@ class DefaultBuildOperationExecutorTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "No operation is currently running."
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/MapNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/MapNotationConverterTest.groovy
@@ -63,7 +63,7 @@ class MapNotationConverterTest extends Specification {
         parser.parseNotation([name: 'name'])
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == 'Required keys [version] are missing from map {name=name}.'
     }
 
@@ -72,7 +72,7 @@ class MapNotationConverterTest extends Specification {
         parser.parseNotation([name: null, version: ''])
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message.startsWith 'Required keys [name, version] are missing from map '
     }
 
@@ -81,7 +81,7 @@ class MapNotationConverterTest extends Specification {
         parser.parseNotation([name: 'name', version: 1.2, unknown: 'unknown'])
 
         then:
-        MissingPropertyException e = thrown()
+        def e = thrown MissingPropertyException
         e.property == 'unknown'
         e.type == TargetObject
     }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/NotationParserBuilderSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/NotationParserBuilderSpec.groovy
@@ -105,7 +105,7 @@ class NotationParserBuilderSpec extends Specification {
         parser.parseNotation(false)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators("""Cannot convert the provided notation to an object of type Number: false.
 The following types/formats are supported:
   - Instances of Number.
@@ -123,7 +123,7 @@ The following types/formats are supported:
         parser.parseNotation("broken")
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators("""Cannot convert the provided notation to an object of type Number: broken.
 The following types/formats are supported:
   - a string containing a greeting, for example 'hello world'.""")
@@ -137,7 +137,7 @@ The following types/formats are supported:
         parser.parseNotation(12)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators("""Cannot convert the provided notation to a thing: 12.
 The following types/formats are supported:
   - Instances of String.""")
@@ -151,7 +151,7 @@ The following types/formats are supported:
         parser.parseNotation(12)
 
         then:
-        UnsupportedNotationException e = thrown()
+        def e = thrown UnsupportedNotationException
         e.message == toPlatformLineSeparators("""Cannot convert the provided notation to a String: 12.
 The following types/formats are supported:
   - Instances of String.""")

--- a/subprojects/core/src/test/groovy/org/gradle/internal/xml/SimpleXmlWriterSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/xml/SimpleXmlWriterSpec.groovy
@@ -199,7 +199,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.endElement()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot end element, as there are no started elements.'
     }
 
@@ -208,7 +208,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.characters("text")
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot write text, as there are no started elements.'
 
         given:
@@ -219,7 +219,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.characters("text")
 
         then:
-        e = thrown()
+        e = thrown IllegalStateException
         e.message == 'Cannot write text, as there are no started elements.'
     }
 
@@ -231,7 +231,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.endElement()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot end element, as current CDATA node has not been closed.'
     }
 
@@ -243,7 +243,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.startElement("nested")
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot start element, as current CDATA node has not been closed.'
     }
 
@@ -255,7 +255,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.startCDATA()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot start CDATA node, as current CDATA node has not been closed.'
     }
 
@@ -266,7 +266,7 @@ class SimpleXmlWriterSpec extends Specification {
         writer.endCDATA()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot end CDATA node, as not currently in a CDATA node.'
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/tooling/provider/model/internal/DefaultToolingModelBuilderRegistryTest.groovy
@@ -51,7 +51,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         registy.getBuilder("model")
 
         then:
-        UnknownModelException e = thrown()
+        def e = thrown UnknownModelException
         e.message == "No builders are available to build a model of type 'model'."
     }
 
@@ -71,7 +71,7 @@ class DefaultToolingModelBuilderRegistryTest extends Specification {
         registy.getBuilder("model")
 
         then:
-        UnsupportedOperationException e = thrown()
+        def e = thrown UnsupportedOperationException
         e.message == "Multiple builders are available to build a model of type 'model'."
     }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/AbstractTaskTest.groovy
@@ -121,7 +121,7 @@ abstract class AbstractTaskTest extends AbstractProjectBuilderSpec {
         getTask().doLast((Closure) null)
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message.equals("Action must not be null!")
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1511,7 +1511,7 @@ class DefaultConfigurationSpec extends Specification {
         conf.getAttributes().attribute(a1, "a1")
 
         then:
-        IllegalArgumentException t = thrown()
+        def t = thrown IllegalArgumentException
         t.message == "Cannot change attributes of configuration ':conf' after it has been resolved"
     }
 
@@ -1549,7 +1549,7 @@ class DefaultConfigurationSpec extends Specification {
         }
 
         then:
-        IllegalStateException t = thrown()
+        def t = thrown IllegalStateException
         t.message == "The component filter can only be set once before the view was computed"
     }
 
@@ -1581,7 +1581,7 @@ class DefaultConfigurationSpec extends Specification {
         artifactView.attributes.attribute(a1, "A")
 
         then:
-        UnsupportedOperationException t = thrown()
+        def t = thrown UnsupportedOperationException
         t.message == "Mutation of attributes is not allowed"
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultMutableVersionConstraintTest.groovy
@@ -172,7 +172,7 @@ class DefaultMutableVersionConstraintTest extends Specification {
         version.reject()
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "The 'reject' clause requires at least one rejected version"
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraintTest.groovy
@@ -53,7 +53,7 @@ class DefaultResolvedVersionConstraintTest extends Specification {
         new DefaultResolvedVersionConstraint('', '', version, [], versionSelectorScheme)
 
         then:
-        IllegalArgumentException ex = thrown()
+        def ex = thrown IllegalArgumentException
         ex.message == "Version '$version' cannot be converted to a strict version constraint."
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactoryTest.groovy
@@ -43,7 +43,7 @@ class CapabilityNotationParserFactoryTest extends Specification {
         parser.parseNotation(notation)
 
         then:
-        InvalidUserDataException ex = thrown()
+        def ex = thrown InvalidUserDataException
         ex.message == "Invalid format for capability: '$notation'. The correct notation is a 3-part group:name:version notation, e.g: 'org.group:capability:1.0'"
 
         where:
@@ -71,7 +71,7 @@ class CapabilityNotationParserFactoryTest extends Specification {
         parser.parseNotation(notation)
 
         then:
-        InvalidUserDataException ex = thrown()
+        def ex = thrown InvalidUserDataException
         ex.message == error
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandlerTest.groovy
@@ -276,7 +276,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.createComponentMetadataProcessor(context).processMetadata(metadata.asImmutable())
 
         then:
-        InvalidUserCodeException e = thrown()
+        def e = thrown InvalidUserCodeException
         e.message == "There was an error while evaluating a component metadata rule for group:module:version."
         e.cause == failure
     }
@@ -393,7 +393,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all { String s -> }
 
         then:
-        InvalidUserCodeException e = thrown()
+        def e = thrown InvalidUserCodeException
         e.message == "The closure provided is not valid as a rule for 'ComponentMetadataHandler'."
         e.cause instanceof RuleActionValidationException
         e.cause.message == "First parameter of rule action closure must be of type 'ComponentMetadataDetails'."
@@ -404,7 +404,7 @@ class DefaultComponentMetadataHandlerTest extends Specification {
         handler.all { ComponentMetadataDetails details, String str -> }
 
         then:
-        InvalidUserCodeException e = thrown()
+        def e = thrown InvalidUserCodeException
         e.message == "The closure provided is not valid as a rule for 'ComponentMetadataHandler'."
         e.cause instanceof RuleActionValidationException
         e.cause.message == "Rule may not have an input parameter of type: java.lang.String. Second parameter must be of type: org.gradle.api.artifacts.ivy.IvyModuleDescriptor."

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessorTest.groovy
@@ -114,7 +114,7 @@ class DefaultComponentMetadataProcessorTest extends Specification {
         processor.processMetadata(metadata.asImmutable())
 
         then:
-        ModuleVersionResolveException e = thrown()
+        def e = thrown ModuleVersionResolveException
         e.message == /Unexpected status 'green' specified for group:module:version. Expected one of: [alpha, beta]/
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -242,7 +242,7 @@ class DefaultDependencyHandlerTest extends Specification {
         dependencyHandler.add(TEST_CONF_NAME, other)
 
         then:
-        UnsupportedOperationException e = thrown()
+        def e = thrown UnsupportedOperationException
         e.message == 'Currently you can only declare dependencies on configurations from the same project.'
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultIvyContextManagerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/DefaultIvyContextManagerTest.groovy
@@ -109,7 +109,7 @@ class DefaultIvyContextManagerTest extends ConcurrentSpec {
         manager.withIvy(action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DefaultMetadataProviderTest.groovy
@@ -255,7 +255,7 @@ class DefaultMetadataProviderTest extends Specification {
         metadataProvider.componentMetadata
 
         then:
-        InvalidUserDataException ex = thrown()
+        def ex = thrown InvalidUserDataException
         ex.message == toPlatformLineSeparators("""Invalid attributes types have been provider by component metadata supplier. Attributes must either be strings or booleans:
   - Attribute 'integer' has type class java.lang.Integer
   - Attribute 'long' has type class java.lang.Long""")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/LatestVersionSelectorTest.groovy
@@ -38,7 +38,7 @@ class LatestVersionSelectorTest extends AbstractStringVersionSelectorTest {
         accept("latest.integration", "1.0")
 
         then:
-        UnsupportedOperationException e = thrown()
+        def e = thrown UnsupportedOperationException
         e.message.contains("accept")
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -743,7 +743,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionResolveException
         e.cause.message.contains "project :root > group:a:1.0"
         e.cause.message.contains "project :root > group:b:1.0"
@@ -770,7 +770,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionResolveException
         e.cause.message.contains "project :root > group:a:1.0"
         e.cause.message.contains "project :root > group:b:1.0"
@@ -796,7 +796,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionResolveException
         e.cause.message.contains "project :root > group:a:1.0"
         e.cause.message.contains "project :root > group:b:1.0"
@@ -823,7 +823,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionNotFoundException
         e.cause.message.contains "project :root > group:a:1.0"
         e.cause.message.contains "project :root > group:b:1.0"
@@ -850,7 +850,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionNotFoundException
         e.cause.message.contains "project :root > group:a:1.0"
         e.cause.message.contains "project :root > group:b:1.0"
@@ -876,7 +876,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionNotFoundException
         e.cause.message.contains "project :root > group:a:1.0 > group:b:1.0"
     }
@@ -911,7 +911,7 @@ class DependencyGraphBuilderTest extends Specification {
         result.rethrowFailure()
 
         then:
-        ResolveException ex = thrown()
+        def ex = thrown ResolveException
         ex.cause instanceof ModuleVersionNotFoundException
         !ex.cause.message.contains("group:a:1.1")
         ex.cause.message.contains "project :root > group:a:1.2"
@@ -941,7 +941,7 @@ class DependencyGraphBuilderTest extends Specification {
         }
 
         and:
-        ResolveException e = thrown()
+        def e = thrown ResolveException
         e.cause instanceof ModuleVersionNotFoundException
         e.cause.message.contains("project :root")
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepositoryChangingNameAfterContainerInclusion.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractArtifactRepositoryChangingNameAfterContainerInclusion.groovy
@@ -30,7 +30,7 @@ class AbstractArtifactRepositoryChangingNameAfterContainerInclusion extends Abst
         repo.name = "changed"
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'The name of an ArtifactRepository cannot be changed after it has been added to a repository container. You should set the name when creating the repository.'
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultFlatDirArtifactRepositoryTest.groovy
@@ -81,7 +81,7 @@ class DefaultFlatDirArtifactRepositoryTest extends Specification {
         repository.createResolver()
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == 'You must specify at least one directory for a flat directory repository.'
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -286,7 +286,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
         repository.createResolver()
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == 'You must specify a base url or at least one artifact pattern for an Ivy repository.'
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -144,7 +144,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
         repository.createRealResolver()
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == 'You must specify a URL for a Maven repository.'
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResourcePatternTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/IvyResourcePatternTest.groovy
@@ -104,7 +104,7 @@ class IvyResourcePatternTest extends Specification {
         ivyPattern.toModuleVersionPath(moduleId).path
 
         then:
-        UnsupportedOperationException e = thrown()
+        def e = thrown UnsupportedOperationException
         e.message == 'Cannot locate module version for non standard Ivy layout.'
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionListerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/MavenVersionListerTest.groovy
@@ -162,7 +162,7 @@ class MavenVersionListerTest extends Specification {
         lister.listVersions(module, [pattern], result)
 
         then:
-        ResourceException e = thrown()
+        def e = thrown ResourceException
         e.message == "Unable to load Maven meta-data from $metaDataResource."
         e.cause instanceof UncheckedException
         e.cause.cause instanceof SAXParseException
@@ -183,7 +183,7 @@ class MavenVersionListerTest extends Specification {
         lister.listVersions(module, [pattern], result)
 
         then:
-        ResourceException e = thrown()
+        def e = thrown ResourceException
         e.message == "Unable to load Maven meta-data from $metaDataResource."
         e.cause == failure
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionListerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ResourceVersionListerTest.groovy
@@ -53,7 +53,7 @@ class ResourceVersionListerTest extends Specification {
         lister.listVersions(module, artifact, [testPattern], result)
 
         then:
-        ResourceException e = thrown()
+        def e = thrown ResourceException
         e.message == "Could not list versions using Ivy pattern '/a/pattern/with/[revision]/'."
         e.cause == failure
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactoryTest.groovy
@@ -52,7 +52,7 @@ class RepositoryTransportFactoryTest extends Specification {
         repositoryTransportFactory.createTransport(['unsupported'] as Set, null, [])
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "Not a supported repository protocol 'unsupported': valid protocols are [protocol1, protocol2a, protocol2b]"
     }
 
@@ -61,7 +61,7 @@ class RepositoryTransportFactoryTest extends Specification {
         repositoryTransportFactory.createTransport(['protocol1', 'protocol2b'] as Set, null, [])
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message == "You cannot mix different URL schemes for a single repository. Please declare separate repositories."
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ComponentIdentifierParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ComponentIdentifierParserTest.groovy
@@ -56,7 +56,7 @@ class ComponentIdentifierParserTest extends Specification {
         parser.parseNotation(notation)
 
         then:
-        InvalidUserDataException ex = thrown()
+        def ex = thrown InvalidUserDataException
         ex.message == "Invalid module component notation: $notation : must be a valid 3 part identifier, eg.: org.gradle:gradle:1.0"
 
         where:
@@ -69,7 +69,7 @@ class ComponentIdentifierParserTest extends Specification {
         parser.parseNotation(notation)
 
         then:
-        Exception ex = thrown()
+        def ex = thrown Exception
         ex.message.startsWith(error)
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/IvyDependencyDescriptorTest.groovy
@@ -432,7 +432,7 @@ class IvyDependencyDescriptorTest extends ExternalDependencyDescriptorTest {
         metadata.selectLegacyConfigurations(fromComponent, fromConfig, toComponent)
 
         then:
-        ConfigurationNotFoundException e = thrown()
+        def e = thrown ConfigurationNotFoundException
         e.message == "Thing a declares a dependency from configuration 'from' to configuration 'to' which is not declared in the descriptor for thing b."
 
         where:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableArtifactResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableArtifactResolveResultTest.groovy
@@ -71,7 +71,7 @@ class DefaultBuildableArtifactResolveResultTest extends Specification {
         result.result
 
         then:
-        ArtifactResolveException e = thrown()
+        def e = thrown ArtifactResolveException
         e == failure
     }
 
@@ -80,7 +80,7 @@ class DefaultBuildableArtifactResolveResultTest extends Specification {
         result.result
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -89,7 +89,7 @@ class DefaultBuildableArtifactResolveResultTest extends Specification {
         result.failure
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -101,7 +101,7 @@ class DefaultBuildableArtifactResolveResultTest extends Specification {
         result.result
 
         then:
-        ArtifactResolveException e = thrown()
+        def e = thrown ArtifactResolveException
         e == failure
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableArtifactSetResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableArtifactSetResolveResultTest.groovy
@@ -28,7 +28,7 @@ class DefaultBuildableArtifactSetResolveResultTest extends Specification {
         result.result
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -37,7 +37,7 @@ class DefaultBuildableArtifactSetResolveResultTest extends Specification {
         result.failure
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -49,7 +49,7 @@ class DefaultBuildableArtifactSetResolveResultTest extends Specification {
         result.result
 
         then:
-        ArtifactResolveException e = thrown()
+        def e = thrown ArtifactResolveException
         e == failure
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResultTest.groovy
@@ -74,7 +74,7 @@ class DefaultBuildableComponentIdResolveResultTest extends Specification {
         result.id
 
         then:
-        ModuleVersionResolveException e = thrown()
+        def e = thrown ModuleVersionResolveException
         e == failure
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
@@ -50,7 +50,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
         result.moduleVersionId
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -59,7 +59,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
         result.metadata
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -68,7 +68,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
         result.failure
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'No result has been specified.'
     }
 
@@ -80,7 +80,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
         result.moduleVersionId
 
         then:
-        ModuleVersionResolveException e = thrown()
+        def e = thrown ModuleVersionResolveException
         e == failure
     }
 
@@ -92,7 +92,7 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
         result.metadata
 
         then:
-        ModuleVersionResolveException e = thrown()
+        def e = thrown ModuleVersionResolveException
         e == failure
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
@@ -120,7 +120,7 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
         descriptor.metaData
 
         then:
-        ModuleVersionResolveException e = thrown()
+        def e = thrown ModuleVersionResolveException
         e == failure
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/DefaultRuleActionValidatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/rules/DefaultRuleActionValidatorTest.groovy
@@ -22,7 +22,7 @@ class DefaultRuleActionValidatorTest extends Specification {
 
     def "rejects invalid types" () {
         when:
-        def ruleValidator = new DefaultRuleActionValidator<Object>([String, Integer])
+        def ruleValidator = new DefaultRuleActionValidator([String, Integer])
         ruleValidator.validate(Stub(RuleAction) {
             getInputTypes() >> { [ String, Long ] }
         })
@@ -34,7 +34,7 @@ class DefaultRuleActionValidatorTest extends Specification {
 
     def "rejects invalid type" () {
         when:
-        def ruleValidator = new DefaultRuleActionValidator<Object>([Integer])
+        def ruleValidator = new DefaultRuleActionValidator([Integer])
         ruleValidator.validate(Stub(RuleAction) {
             getInputTypes() >> { [ Long ] }
         })
@@ -45,7 +45,7 @@ class DefaultRuleActionValidatorTest extends Specification {
     }
 
     def "accepts valid types" () {
-        def ruleValidator = new DefaultRuleActionValidator<Object>([String, Integer])
+        def ruleValidator = new DefaultRuleActionValidator([String, Integer])
         def ruleAction = Stub(RuleAction) {
             getInputTypes() >> { [ String, Integer ] }
         }

--- a/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/jdk7/Jdk7DirectoryWalkerTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/jdk7/Jdk7DirectoryWalkerTest.groovy
@@ -244,7 +244,7 @@ class Jdk7DirectoryWalkerTest extends Specification {
         fileTree.visit(fileVisitor)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.contains("Could not list contents of '${link.absolutePath}'.")
 
         cleanup:

--- a/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/jdk7/Jdk7UnauthorizedDirectoryWalkerTest.groovy
+++ b/subprojects/files/src/test/groovy/org/gradle/api/internal/file/collections/jdk7/Jdk7UnauthorizedDirectoryWalkerTest.groovy
@@ -72,7 +72,7 @@ class Jdk7UnauthorizedDirectoryWalkerTest extends Specification {
         fileTree.visit(fileVisitor)
 
         then:
-        Exception exception = thrown()
+        def exception = thrown Exception
         Throwables.getRootCause(exception).class == AccessDeniedException
     }
 }

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r34/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r34/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -82,7 +82,7 @@ class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
         ideaProject.modules.find { it.name == 'root' }.jdkName
 
         then:
-        UnsupportedMethodException e = thrown()
+        def e = thrown UnsupportedMethodException
         e.message.startsWith("Unsupported method: IdeaModule.getJdkName()")
     }
 

--- a/subprojects/internal-testing/src/test/groovy/org/gradle/test/fixtures/concurrent/ConcurrentSpecTest.groovy
+++ b/subprojects/internal-testing/src/test/groovy/org/gradle/test/fixtures/concurrent/ConcurrentSpecTest.groovy
@@ -195,7 +195,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         instant.unknown
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Instant 'unknown' has not been defined by any test thread."
     }
 
@@ -204,7 +204,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         operation.unknown
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Operation 'unknown' has not been defined by any test thread."
     }
 
@@ -215,7 +215,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Operation 'doStuff' has not completed yet."
     }
 
@@ -226,7 +226,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         }
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Operation 'doStuff' has not completed yet."
     }
 
@@ -266,7 +266,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         thread.blockUntil.unknown
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Timeout waiting for instant 'unknown' to be defined by another thread."
 
         when:
@@ -275,7 +275,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         }
 
         then:
-        e = thrown()
+        e = thrown IllegalStateException
         e.message == "Timeout waiting for instant 'unknown' to be defined by another thread."
 
         when:
@@ -285,7 +285,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         async { }
 
         then:
-        e = thrown()
+        e = thrown IllegalStateException
         e.message == "Timeout waiting for instant 'unknown' to be defined by another thread."
     }
 
@@ -299,7 +299,7 @@ class ConcurrentSpecTest extends ConcurrentSpec {
         }
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 

--- a/subprojects/internal-testing/src/test/groovy/org/gradle/testing/internal/util/RetryRuleTest.groovy
+++ b/subprojects/internal-testing/src/test/groovy/org/gradle/testing/internal/util/RetryRuleTest.groovy
@@ -63,7 +63,7 @@ class RetryRuleTest extends Specification {
         throwWhen(new RuntimeException("test"), iteration == 2)
 
         then:
-        RuntimeException ex = thrown()
+        def ex = thrown RuntimeException
         ex.message.contains("test")
     }
 

--- a/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
+++ b/subprojects/jvm-services/src/test/groovy/org/gradle/internal/jvm/inspection/DefaultJvmVersionDetectorTest.groovy
@@ -79,7 +79,7 @@ Java HotSpot(TM) 64-Bit Server VM (build 25.91-b14, mixed mode)
         detector.parseJavaVersionCommandOutput("/usr/bin/java", new BufferedReader(new StringReader(output)))
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == "Could not determine Java version using executable /usr/bin/java."
 
         where:

--- a/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
+++ b/subprojects/language-groovy/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompilerTest.groovy
@@ -69,7 +69,7 @@ class NormalizingGroovyCompilerTest extends Specification {
         compiler.execute(spec)
 
         then:
-        CompilationFailedException e = thrown()
+        def e = thrown CompilationFailedException
         e == failure
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/NormalizingJavaCompilerTest.groovy
@@ -85,7 +85,7 @@ class NormalizingJavaCompilerTest extends Specification {
         compiler.execute(spec)
 
         then:
-        CompilationFailedException e = thrown()
+        def e = thrown CompilationFailedException
         e == failure
     }
 
@@ -110,7 +110,7 @@ class NormalizingJavaCompilerTest extends Specification {
         compiler.execute(spec)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 

--- a/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/NormalizingScalaCompilerTest.groovy
+++ b/subprojects/language-scala/src/test/groovy/org/gradle/api/internal/tasks/scala/NormalizingScalaCompilerTest.groovy
@@ -65,7 +65,7 @@ class NormalizingScalaCompilerTest extends Specification {
         compiler.execute(spec)
 
         then:
-        CompilationFailedException e = thrown()
+        def e = thrown CompilationFailedException
         e == failure
     }
 
@@ -95,7 +95,7 @@ class NormalizingScalaCompilerTest extends Specification {
         compiler.execute(spec)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/client/DaemonClientTest.groovy
@@ -70,7 +70,7 @@ class DaemonClientTest extends ConcurrentSpecification {
         client.execute(Stub(BuildAction), Stub(BuildRequestContext), Stub(BuildActionParameters), Stub(ServiceRegistry))
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * processEnvironment.maybeGetPid()
         1 * connector.connect(compatibilitySpec) >> connection
@@ -93,7 +93,7 @@ class DaemonClientTest extends ConcurrentSpecification {
         client.execute(Stub(BuildAction), buildRequestContext, Stub(BuildActionParameters), Stub(ServiceRegistry))
 
         then:
-        BuildCancelledException gce = thrown()
+        def gce = thrown BuildCancelledException
         1 * processEnvironment.maybeGetPid()
         1 * connector.connect(compatibilitySpec) >> connection
         _ * connection.daemon >> Stub(DaemonConnectDetails)
@@ -124,7 +124,7 @@ class DaemonClientTest extends ConcurrentSpecification {
         client.execute(Stub(BuildAction), buildRequestContext, Stub(BuildActionParameters), Stub(ServiceRegistry))
 
         then:
-        BuildCancelledException gce = thrown()
+        def gce = thrown BuildCancelledException
         gce == cancelledException
         1 * processEnvironment.maybeGetPid()
         1 * connector.connect(compatibilitySpec) >> connection

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonStateCoordinatorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/DaemonStateCoordinatorTest.groovy
@@ -106,7 +106,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * onStartCommand.run()
         1 * command.run() >> { throw failure }
@@ -124,7 +124,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        DaemonUnavailableException e = thrown()
+        def e = thrown DaemonUnavailableException
         e.message == 'This daemon is currently executing: command'
     }
 
@@ -138,7 +138,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        DaemonUnavailableException e = thrown()
+        def e = thrown DaemonUnavailableException
         e.message == 'This daemon has stopped.'
     }
 
@@ -152,7 +152,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        DaemonUnavailableException e = thrown()
+        def e = thrown DaemonUnavailableException
         e.message == 'This daemon has stopped.'
     }
 
@@ -166,7 +166,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        DaemonUnavailableException e = thrown()
+        def e = thrown DaemonUnavailableException
         e.message == 'This daemon has stopped.'
     }
 
@@ -178,7 +178,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         1 * onStartCommand.run() >> { throw failure }
@@ -188,7 +188,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        DaemonUnavailableException unavailableException = thrown()
+        def unavailableException = thrown DaemonUnavailableException
         unavailableException.message == 'This daemon is in a broken state and will stop.'
     }
 
@@ -200,7 +200,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:
@@ -213,7 +213,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        DaemonUnavailableException unavailableException = thrown()
+        def unavailableException = thrown DaemonUnavailableException
         unavailableException.message == 'This daemon is in a broken state and will stop.'
     }
 
@@ -225,7 +225,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * onStartCommand.run() >> { throw failure }
         0 * _._
@@ -234,7 +234,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.awaitStop()
 
         then:
-        IllegalStateException illegalStateException = thrown()
+        def illegalStateException = thrown IllegalStateException
         illegalStateException.message == 'This daemon is in a broken state.'
     }
 
@@ -246,7 +246,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * onStartCommand.run() >> { throw failure }
         0 * _._
@@ -266,7 +266,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * onStartCommand.run()
         1 * command.run()
@@ -288,7 +288,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.runCommand(command, "command")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * onStartCommand.run()
         1 * command.run()
@@ -299,7 +299,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         coordinator.awaitStop()
 
         then:
-        IllegalStateException illegalStateException = thrown()
+        def illegalStateException = thrown IllegalStateException
         illegalStateException.message == 'This daemon is in a broken state.'
     }
 
@@ -378,7 +378,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         }
 
         and:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:
@@ -442,7 +442,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         }
 
         then:
-        DaemonStoppedException e = thrown()
+        def e = thrown DaemonStoppedException
         e.message == "Gradle build daemon has been stopped: stop from test"
 
         and:
@@ -570,7 +570,7 @@ class DaemonStateCoordinatorTest extends ConcurrentSpec {
         }
 
         then:
-        DaemonStoppedException e = thrown()
+        def e = thrown DaemonStoppedException
 
         and:
         canceled

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FailsafePhasedActionResultListenerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/FailsafePhasedActionResultListenerTest.groovy
@@ -49,7 +49,7 @@ class FailsafePhasedActionResultListenerTest extends Specification {
         failsafeListener.rethrowErrors()
 
         then:
-        ListenerNotificationException e = thrown()
+        def e = thrown ListenerNotificationException
         e.message == 'One or more build phasedAction listeners failed with an exception.'
         e.causes.size() == 1
         e.cause == failure

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/LoggingBridgingBuildActionExecuterTest.groovy
@@ -53,7 +53,7 @@ class LoggingBridgingBuildActionExecuterTest extends Specification {
         executer.execute(action, buildRequestContext, parameters, contextServices)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * loggingManager.start()
         1 * target.execute(action, buildRequestContext, parameters, contextServices) >> {throw failure}

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/LoggingCommandLineConverterTest.groovy
@@ -83,7 +83,7 @@ class LoggingCommandLineConverterTest extends Specification {
         converter.convert(["--console", "unknown"], new DefaultLoggingConfiguration())
 
         then:
-        CommandLineArgumentException e = thrown()
+        def e = thrown CommandLineArgumentException
         e.message == /Argument value 'unknown' given for --console option is invalid/
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/progress/DefaultProgressLoggerFactoryTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/progress/DefaultProgressLoggerFactoryTest.groovy
@@ -230,7 +230,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.started()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'A description must be specified before this operation is started.'
     }
 
@@ -243,7 +243,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.description = 'new'
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot configure this operation (logger - old) once it has started.'
     }
 
@@ -256,7 +256,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.shortDescription = 'new'
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot configure this operation (logger - old) once it has started.'
     }
 
@@ -269,7 +269,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.loggingHeader = 'new'
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot configure this operation (logger - old) once it has started.'
     }
 
@@ -281,7 +281,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.progress('new')
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This operation (logger - op) has not been started.'
     }
 
@@ -295,7 +295,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.progress('new')
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This operation (logger - op) has already been completed.'
     }
 
@@ -307,7 +307,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.completed('finished', false)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This operation (logger - op) has not been started.'
     }
 
@@ -320,7 +320,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.started()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This operation (logger - op) has already been started.'
     }
 
@@ -334,7 +334,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.started()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This operation (logger - op) has already completed.'
     }
 
@@ -348,7 +348,7 @@ class DefaultProgressLoggerFactoryTest extends ConcurrentSpec {
         logger.completed()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This operation (logger - op) has already been completed.'
     }
 

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContextTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLoggerContextTest.groovy
@@ -57,7 +57,7 @@ class OutputEventListenerBackedLoggerContextTest extends Specification {
         context.level = null
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Global log level cannot be set to null"
     }
 }

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/actor/internal/DefaultActorFactorySpec.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/actor/internal/DefaultActorFactorySpec.groovy
@@ -196,7 +196,7 @@ class DefaultActorFactorySpec extends ConcurrentSpec {
         actor.stop()
 
         then:
-        DispatchException e = thrown()
+        def e = thrown DispatchException
         e.message.startsWith("Could not dispatch message")
         e.cause == failure
     }
@@ -281,7 +281,7 @@ class DefaultActorFactorySpec extends ConcurrentSpec {
         proxy.doStuff('param')
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'This actor has been stopped.'
     }
 
@@ -296,7 +296,7 @@ class DefaultActorFactorySpec extends ConcurrentSpec {
         proxy.doStuff('param')
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message.startsWith('Cannot dispatch message, as this message dispatch has been stopped.')
     }
 }

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/dispatch/AsyncDispatchTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/dispatch/AsyncDispatchTest.groovy
@@ -179,7 +179,7 @@ public class AsyncDispatchTest extends Specification {
         dispatch.stop()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot wait for messages to be dispatched, as there are no dispatch threads running.'
     }
 
@@ -197,7 +197,7 @@ public class AsyncDispatchTest extends Specification {
             throw failure
         }
         0 * _._
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot wait for messages to be dispatched, as there are no dispatch threads running.'
     }
 
@@ -209,7 +209,7 @@ public class AsyncDispatchTest extends Specification {
         dispatch.dispatch('message')
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot dispatch message, as this message dispatch has been stopped. Message: message'
     }
 

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/dispatch/ContextClassLoaderDispatchTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/dispatch/ContextClassLoaderDispatchTest.groovy
@@ -59,7 +59,7 @@ class ContextClassLoaderDispatchTest extends Specification {
             throw failure
         }
         0 * _._
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.is(failure)
         assertContextClassloaderIs(original)
     }

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/dispatch/FailureHandlingDispatchTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/dispatch/FailureHandlingDispatchTest.groovy
@@ -49,7 +49,7 @@ class FailureHandlingDispatchTest extends Specification {
         dispatch.dispatch("message")
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == adaptedFailure
         1 * target.dispatch("message") >> { throw failure }
         1 * handler.dispatchFailed("message", failure) >> { throw adaptedFailure }

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/event/DefaultListenerManagerTest.groovy
@@ -367,7 +367,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         0 * _
 
         and:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 
@@ -390,7 +390,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         0 * _
 
         and:
-        ListenerNotificationException e = thrown()
+        def e = thrown ListenerNotificationException
         e.causes == [failure1, failure2]
     }
 
@@ -415,7 +415,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         0 * _
 
         and:
-        ListenerNotificationException e = thrown()
+        def e = thrown ListenerNotificationException
         e.causes == [failure1, failure2, failure3]
     }
 
@@ -465,7 +465,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         0 * _
 
         and:
-        ListenerNotificationException e = thrown()
+        def e = thrown ListenerNotificationException
         e.causes == [failure1, failure2, failure3]
     }
 
@@ -618,7 +618,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         manager.getBroadcaster(TestFooListener.class).foo("param")
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cannot notify listeners of type TestFooListener as these listeners are already being notified."
 
         and:
@@ -631,7 +631,7 @@ class DefaultListenerManagerTest extends ConcurrentSpec {
         manager.getBroadcaster(TestFooListener.class).foo("param")
 
         then:
-        IllegalStateException e2 = thrown()
+        def e2 = thrown IllegalStateException
         e2.message == "Cannot notify listeners of type TestFooListener as these listeners are already being notified."
 
         and:

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/event/ListenerBroadcastTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/event/ListenerBroadcastTest.groovy
@@ -207,7 +207,7 @@ class ListenerBroadcastTest extends Specification {
         then:
         1 * listener.event3() >> { throw failure }
         0 * _._
-        ListenerNotificationException exception = thrown()
+        def exception = thrown ListenerNotificationException
         exception.message == 'Failed to notify test listener.'
         exception.cause.is(failure)
     }
@@ -227,7 +227,7 @@ class ListenerBroadcastTest extends Specification {
         1 * listener1.event1("param") >> { throw failure }
         1 * listener2.event1("param")
         0 * _._
-        RuntimeException exception = thrown()
+        def exception = thrown RuntimeException
         exception.is(failure)
 
     }
@@ -251,7 +251,7 @@ class ListenerBroadcastTest extends Specification {
         1 * listener3.event1("param")
         0 * _._
 
-        ListenerNotificationException exception = thrown()
+        def exception = thrown ListenerNotificationException
         exception.causes == [failure1, failure2]
     }
 

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/hub/MessageHubTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/hub/MessageHubTest.groovy
@@ -647,7 +647,7 @@ class MessageHubTest extends ConcurrentSpec {
         dispatcher.dispatch("message 1")
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot dispatch message, as <hub> has been stopped.'
     }
 
@@ -660,7 +660,7 @@ class MessageHubTest extends ConcurrentSpec {
         hub.getOutgoing("channel", String)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot create outgoing dispatch, as <hub> has been stopped.'
     }
 
@@ -670,7 +670,7 @@ class MessageHubTest extends ConcurrentSpec {
         hub.addHandler("channel", new Object())
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot add handler, as <hub> has been stopped.'
     }
 
@@ -680,7 +680,7 @@ class MessageHubTest extends ConcurrentSpec {
         hub.addConnection(Mock(RemoteConnection))
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot add connection, as <hub> has been stopped.'
     }
 

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/TcpConnectorTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/TcpConnectorTest.groovy
@@ -98,7 +98,7 @@ class TcpConnectorTest extends ConcurrentSpec {
         outgoingConnector.connect(address)
 
         then:
-        ConnectException e = thrown()
+        def e = thrown ConnectException
         e.message.startsWith "Could not connect to server ${address}."
         e.cause instanceof java.net.ConnectException
     }
@@ -110,7 +110,7 @@ class TcpConnectorTest extends ConcurrentSpec {
         outgoingConnector.connect(address)
 
         then:
-        ConnectException e = thrown()
+        def e = thrown ConnectException
         e.message.startsWith "Could not connect to server ${address}."
         e.cause instanceof java.net.ConnectException
     }
@@ -122,7 +122,7 @@ class TcpConnectorTest extends ConcurrentSpec {
         outgoingConnector.connect(acceptor.address)
 
         then:
-        ConnectException e = thrown()
+        def e = thrown ConnectException
         e.message.startsWith "Could not connect to server ${acceptor.address}."
         e.cause instanceof java.net.ConnectException
     }
@@ -165,7 +165,7 @@ class TcpConnectorTest extends ConcurrentSpec {
         outgoingConnector.connect(acceptor.address)
 
         then:
-        ConnectException e = thrown()
+        def e = thrown ConnectException
         e.message.startsWith "Could not connect to server ${acceptor.address}."
         e.cause instanceof java.net.ConnectException
 
@@ -271,7 +271,7 @@ class TcpConnectorTest extends ConcurrentSpec {
         connection.receive()
 
         then:
-        MessageIOException e = thrown()
+        def e = thrown MessageIOException
         e.message == "Could not read message from '${connection.remoteAddress}'."
         e.cause == failure
 

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/DefaultSerializerRegistryTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/DefaultSerializerRegistryTest.groovy
@@ -108,7 +108,7 @@ class DefaultSerializerRegistryTest extends SerializerSpec {
         toBytes(123.4, serializer)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Don't know how to serialize an object of type java.math.BigDecimal."
     }
 
@@ -121,7 +121,7 @@ class DefaultSerializerRegistryTest extends SerializerSpec {
         registry.build(String)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Don't know how to serialize objects of type java.lang.String."
     }
 

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/serialize/MessageTest.groovy
@@ -248,14 +248,14 @@ class MessageTest extends Specification {
         transported.message
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == 'broken getMessage()'
 
         when:
         transported.toString()
 
         then:
-        RuntimeException e2 = thrown()
+        def e2 = thrown RuntimeException
         e2.message == 'broken toString()'
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
@@ -92,7 +92,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
         property.set(12)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot set the value of a property of type java.lang.Boolean using an instance of type java.lang.Integer."
 
         and:
@@ -107,7 +107,7 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
         property.set(other)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot set the value of a property of type java.lang.Boolean using a provider of type java.lang.Number."
 
         and:

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -175,7 +175,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         property.setFromAnyValue(new Thing())
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot set the value of a property of type ${type().name} using an instance of type ${Thing.name}."
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/NodeBackedModelMapSpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/NodeBackedModelMapSpec.groovy
@@ -589,7 +589,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         realize()
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         e.cause.message.startsWith("Model reference to element '${path.child('foo')}' with type java.lang.String is invalid due to incompatible types.")
     }
@@ -945,7 +945,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         registry.realize("values", ModelType.UNTYPED)
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause.class == InvalidModelRuleDeclarationException
         e.cause.message.startsWith('''Type java.lang.Object is not a valid rule source:
 - Rule source classes must directly extend org.gradle.model.RuleSource''')
@@ -1064,7 +1064,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         registry.bindAllReferences()
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         normaliseLineSeparators(e.message).contains("""
   testrule > named(missingElement, $ElementRules.name)
     subject:
@@ -1153,7 +1153,7 @@ This element was created by testrule > create(item) and can be mutated as the fo
         registry.bindAllReferences()
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         e.rules.size() == 1
         e.rules.first().mutableInputs.first().path == "beans.sb1.foo"
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/core/NamedEntityInstantiatorsTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/core/NamedEntityInstantiatorsTest.groovy
@@ -33,7 +33,7 @@ class NamedEntityInstantiatorsTest extends Specification {
         instantiator.create("foo", NonSubtypeChild)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot create an item of type ${NonSubtypeChild.name} as this is not a subtype of ${Base.name}."
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleExtractorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/inspect/ModelRuleExtractorTest.groovy
@@ -500,7 +500,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
         extract(RuleSourceCreatingARawModelMap)
 
         then:
-        InvalidModelRuleDeclarationException e = thrown()
+        def e = thrown InvalidModelRuleDeclarationException
         e.message == """Type ${fullyQualifiedNameOf(RuleSourceCreatingARawModelMap)} is not a valid rule source:
 - Method bar(org.gradle.model.ModelMap) is not a valid rule method: Raw type org.gradle.model.ModelMap used for parameter 1 (all type parameters must be specified of parameterized type)"""
     }
@@ -516,7 +516,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
         extract(RuleSourceWithAVoidReturningNoArgumentMethod)
 
         then:
-        InvalidModelRuleDeclarationException e = thrown()
+        def e = thrown InvalidModelRuleDeclarationException
         e.message == """Type ${fullyQualifiedNameOf(RuleSourceWithAVoidReturningNoArgumentMethod)} is not a valid rule source:
 - Method bar() is not a valid rule method: A method annotated with @Model must either take at least one parameter or have a non-void return type"""
     }
@@ -539,7 +539,7 @@ class ModelRuleExtractorTest extends ProjectRegistrySpec {
         extract(inspected)
 
         then:
-        InvalidModelRuleDeclarationException e = thrown()
+        def e = thrown InvalidModelRuleDeclarationException
         e.message == "Declaration of model rule ModelRuleExtractorTest.$inspected.simpleName#bar($managedType.simpleName) is invalid."
         e.cause instanceof InvalidManagedModelElementTypeException
         e.cause.message == """Type $ModelMap.name<?> is not a valid model element type:
@@ -567,7 +567,7 @@ ${fullyQualifiedNameOf(managedType)}
         extract(RuleSourceCreatingManagedWithNonManageableParent)
 
         then:
-        InvalidModelRuleDeclarationException e = thrown()
+        def e = thrown InvalidModelRuleDeclarationException
         e.message == "Declaration of model rule ModelRuleExtractorTest.RuleSourceCreatingManagedWithNonManageableParent#bar(ManagedWithNonManageableParents) is invalid."
         e.cause instanceof InvalidManagedModelElementTypeException
         e.cause.message == """Type $ModelMap.name<?> is not a valid model element type:
@@ -593,7 +593,7 @@ ${fullyQualifiedNameOf(ManagedWithNonManageableParents)}
         extract(HasRuleWithUncheckedModelMap)
 
         then:
-        InvalidModelRuleDeclarationException e = thrown()
+        def e = thrown InvalidModelRuleDeclarationException
         e.message == """Type ${fullyQualifiedNameOf(HasRuleWithUncheckedModelMap)} is not a valid rule source:
 - Method modelPath(org.gradle.model.ModelMap) is not a valid rule method: Raw type org.gradle.model.ModelMap used for parameter 1 (all type parameters must be specified of parameterized type)"""
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/projection/AbstractCollectionModelProjectionTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/projection/AbstractCollectionModelProjectionTest.groovy
@@ -151,7 +151,7 @@ abstract class AbstractCollectionModelProjectionTest<T, C extends Collection<T>>
         registry.realize(collectionPath, collectionType)
 
         then:
-        ModelRuleExecutionException ex = thrown()
+        def ex = thrown ModelRuleExecutionException
         ex.cause.message == 'Cannot add an element of type java.lang.Integer to a collection of java.lang.String'
     }
 
@@ -178,7 +178,7 @@ abstract class AbstractCollectionModelProjectionTest<T, C extends Collection<T>>
         registry.realize(collectionPath, collectionType)
 
         then:
-        ModelRuleExecutionException ex = thrown()
+        def ex = thrown ModelRuleExecutionException
         ex.cause.message == 'Cannot add an element of type java.lang.Integer to a collection of java.lang.String'
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/DefaultModelSchemaExtractorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/DefaultModelSchemaExtractorTest.groovy
@@ -443,7 +443,7 @@ class DefaultModelSchemaExtractorTest extends Specification {
         extract(type)
 
         then:
-        InvalidManagedModelElementTypeException e = thrown()
+        def e = thrown InvalidManagedModelElementTypeException
         e.message == """Type $ModelMap.name is not a valid model element type:
 - type parameter of $ModelMap.name has to be specified.
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGeneratorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/ManagedProxyClassGeneratorTest.groovy
@@ -568,14 +568,14 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.unknown
 
         then:
-        MissingPropertyException e = thrown()
+        def e = thrown MissingPropertyException
         e.message == "No such property: unknown for class: ${SomeType.name}"
 
         when:
         impl.unknown = '12'
 
         then:
-        e = thrown()
+        e = thrown MissingPropertyException
         e.message == "No such property: unknown for class: ${SomeType.name}"
     }
 
@@ -587,7 +587,7 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.readOnly = '12'
 
         then:
-        ReadOnlyPropertyException e = thrown()
+        def e = thrown ReadOnlyPropertyException
         e.message == "Cannot set readonly property: readOnly for class: ${SomeTypeWithReadOnly.name}"
     }
 
@@ -599,7 +599,7 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.unknown('12')
 
         then:
-        MissingMethodException e = thrown()
+        def e = thrown MissingMethodException
         e.message.startsWith("No signature of method: ${SomeType.name}.unknown() is applicable")
     }
 
@@ -611,7 +611,7 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.value { broken }
 
         then:
-        MissingMethodException e = thrown()
+        def e = thrown MissingMethodException
         e.message.startsWith("No signature of method: ${SomeType.name}.value() is applicable")
     }
 
@@ -624,7 +624,7 @@ class ManagedProxyClassGeneratorTest extends ProjectRegistrySpec {
         impl.readOnly Boolean.FALSE
 
         then:
-        MissingMethodException e = thrown()
+        def e = thrown MissingMethodException
         e.message.startsWith("No signature of method: ${SomeTypeWithReadOnlyProperty.name}.readOnly() is applicable")
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/DefaultModelRegistryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/DefaultModelRegistryTest.groovy
@@ -79,7 +79,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("foo")
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         normaliseLineSeparators(e.message).contains '''
   foo creator
     inputs:
@@ -95,7 +95,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("foo")
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         normaliseLineSeparators(e.message).contains '''
   foo creator
     inputs:
@@ -113,7 +113,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.bindAllReferences()
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         normaliseLineSeparators(e.cause.message) == """Type-only model reference of type java.lang.Number is ambiguous as multiple model elements are available for this type:
   - other-1 (created by: other-1 creator)
@@ -128,7 +128,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.register("foo") { it.descriptor("create foo as Integer").unmanaged(12.toInteger()) }
 
         then:
-        DuplicateModelException e = thrown()
+        def e = thrown DuplicateModelException
         e.message == /Cannot create 'foo' using creation rule 'create foo as Integer' as the rule 'create foo as String' is already registered to create this model element./
     }
 
@@ -142,7 +142,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.register("foo") { it.descriptor("create foo as Integer").unmanaged(12.toInteger()) }
 
         then:
-        DuplicateModelException e = thrown()
+        def e = thrown DuplicateModelException
         e.message == /Cannot create 'foo' using creation rule 'create foo as Integer' as the rule 'create foo as String' has already been used to create this model element./
     }
 
@@ -156,7 +156,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.bindAllReferences()
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         normaliseLineSeparators(e.cause.message) == """Type-only model reference of type java.lang.Number is ambiguous as multiple model elements are available for this type:
   - other-1 (created by: other-1 creator)
@@ -178,7 +178,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("foo")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.message == /Exception thrown while executing model rule: mutate foo as Integer/
         e.cause instanceof DuplicateModelException
         e.cause.message == /Cannot create 'foo.bar' using creation rule 'create foo.bar as Integer' as the rule 'create foo.bar as String' is already registered to create this model element./
@@ -324,7 +324,7 @@ class DefaultModelRegistryTest extends Specification {
         ref.setTarget(newTarget)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cannot set target for model element 'ref' as this element is not mutable."
 
         where:
@@ -602,7 +602,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("thing")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause instanceof IllegalStateException
         e.cause.message == "Cannot create 'thing.child' using creation rule 'create thing.child as String' as model element 'thing' is no longer mutable."
     }
@@ -619,7 +619,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("thing")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause instanceof IllegalStateException
         e.cause.message == "Cannot set value for model element 'thing' as this element is not mutable."
     }
@@ -746,7 +746,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("thing")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause instanceof IllegalStateException
         e.cause.message == "Cannot add rule X for model element 'thing' at state ${targetRole.targetState.previous()} as this element is already at state ${fromRole.targetState.previous()}."
 
@@ -777,7 +777,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.realize("another")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause instanceof IllegalStateException
         e.cause.message == "Cannot add rule X for model element 'thing' at state ${targetRole.targetState.previous()} as this element is already at state ${fromState}."
 
@@ -945,7 +945,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.atState(ModelPath.path("thing"), state)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "No model node at 'thing'"
 
         where:
@@ -1088,7 +1088,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.bindAllReferences()
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         normaliseLineSeparators(e.message).contains '''
   by-path
     subject:
@@ -1114,7 +1114,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.bindAllReferences()
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         normaliseLineSeparators(e.message).contains '''
   by-path
     subject:
@@ -1188,7 +1188,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.bindAllReferences()
 
         then:
-        UnboundModelRulesException e = thrown()
+        def e = thrown UnboundModelRulesException
         normaliseLineSeparators(e.message).contains '''
   non-bindable
     subject:
@@ -1225,7 +1225,7 @@ class DefaultModelRegistryTest extends Specification {
         registry.get("foo")
 
         then:
-        ConfigurationCycleException e = thrown()
+        def e = thrown ConfigurationCycleException
         e.message == TextUtil.toPlatformLineSeparators("""A cycle has been detected in model rule dependencies. References forming the cycle:
 foo
 \\- foo mutator
@@ -1246,7 +1246,7 @@ foo
         registry.get("foo")
 
         then:
-        ConfigurationCycleException e = thrown()
+        def e = thrown ConfigurationCycleException
         e.message == TextUtil.toPlatformLineSeparators("""A cycle has been detected in model rule dependencies. References forming the cycle:
 foo
 \\- foo creator
@@ -1268,7 +1268,7 @@ foo
         registry.get("foo")
 
         then:
-        ConfigurationCycleException e = thrown()
+        def e = thrown ConfigurationCycleException
         e.message == TextUtil.toPlatformLineSeparators("""A cycle has been detected in model rule dependencies. References forming the cycle:
 foo
 \\- foo mutator
@@ -1288,7 +1288,7 @@ foo
         registry.get("foo")
 
         then:
-        ConfigurationCycleException e = thrown()
+        def e = thrown ConfigurationCycleException
         e.message == TextUtil.toPlatformLineSeparators("""A cycle has been detected in model rule dependencies. References forming the cycle:
 bar
 \\- bar creator
@@ -1307,7 +1307,7 @@ bar
         registry.get("foo")
 
         then:
-        ConfigurationCycleException e = thrown()
+        def e = thrown ConfigurationCycleException
         e.message == TextUtil.toPlatformLineSeparators("""A cycle has been detected in model rule dependencies. References forming the cycle:
 foo
 \\- foo.bar
@@ -1326,7 +1326,7 @@ foo
         registry.get("foo")
 
         then:
-        ConfigurationCycleException e = thrown()
+        def e = thrown ConfigurationCycleException
         e.message == TextUtil.toPlatformLineSeparators("""A cycle has been detected in model rule dependencies. References forming the cycle:
 foo
 \\- foo.bar

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/RuleBindingsTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/RuleBindingsTest.groovy
@@ -591,7 +591,7 @@ class RuleBindingsTest extends RegistrySpec {
         addNode(node("b", Long))
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         TextUtil.normaliseLineSeparators(e.cause.message) == '''Type-only model reference of type java.lang.Long is ambiguous as multiple model elements are available for this type:
   - a (created by: test)
@@ -607,7 +607,7 @@ class RuleBindingsTest extends RegistrySpec {
         addNode(node("b", Long))
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         TextUtil.normaliseLineSeparators(e.cause.message) == '''Type-only model reference of type java.lang.Long is ambiguous as multiple model elements are available for this type:
   - a (created by: test)
@@ -623,7 +623,7 @@ class RuleBindingsTest extends RegistrySpec {
         addNode(node("a.2", Long))
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         TextUtil.normaliseLineSeparators(e.cause.message) == '''Type-only model reference of type java.lang.Long is ambiguous as multiple model elements are available for this type:
   - a (created by: test)
@@ -639,7 +639,7 @@ class RuleBindingsTest extends RegistrySpec {
         bindings.add(rule(Long))
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         TextUtil.normaliseLineSeparators(e.cause.message) == '''Type-only model reference of type java.lang.Long is ambiguous as multiple model elements are available for this type:
   - a (created by: test)
@@ -655,7 +655,7 @@ class RuleBindingsTest extends RegistrySpec {
         bindings.add(rule("other") { it.inputReference(Long) })
 
         then:
-        InvalidModelRuleException e = thrown()
+        def e = thrown InvalidModelRuleException
         e.cause instanceof ModelRuleBindingException
         TextUtil.normaliseLineSeparators(e.cause.message) == '''Type-only model reference of type java.lang.Long is ambiguous as multiple model elements are available for this type:
   - a (created by: test)
@@ -673,7 +673,7 @@ class RuleBindingsTest extends RegistrySpec {
         bindings.add(rule)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cannot add rule <rule> for model element 'a' at state ${requiredState.previous()} as this element is already at state $currentState."
 
         where:
@@ -697,7 +697,7 @@ class RuleBindingsTest extends RegistrySpec {
         bindings.add(rule)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cannot add rule <rule> with input model element 'a' at state $requiredState as this element is already at state $currentState."
 
         where:

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/ScopedRuleTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/registry/ScopedRuleTest.groovy
@@ -68,7 +68,7 @@ class ScopedRuleTest extends ProjectRegistrySpec {
         registry.get("values")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause.class == UnsupportedOperationException
         e.cause.message == "ScopedRuleTest.RuleSourceUsingRuleWithDependencies#rule() has dependencies on plugins: [$ImperativePlugin]. Plugin dependencies are not supported in this context."
     }
@@ -89,7 +89,7 @@ class ScopedRuleTest extends ProjectRegistrySpec {
         registry.get("values")
 
         then:
-        ModelRuleExecutionException e = thrown()
+        def e = thrown ModelRuleExecutionException
         e.cause.class == InvalidModelRuleDeclarationException
         e.cause.message == "Rule ScopedRuleTest.CreatorRule#string() cannot be applied at the scope of model element values as creation rules cannot be used when applying rule sources to particular elements"
     }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/typeregistration/BaseInstanceFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/typeregistration/BaseInstanceFactoryTest.groovy
@@ -154,7 +154,7 @@ class BaseInstanceFactoryTest extends Specification {
             .withImplementation(ModelType.of(DefaultThingSpec))
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "No factory registered to create an instance of implementation class '${fullyQualifiedNameOf(DefaultThingSpec)}'."
     }
 

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/CommonFileSystemTest.groovy
@@ -39,7 +39,7 @@ class CommonFileSystemTest extends Specification {
         fs.getUnixMode(file)
 
         then:
-        FileException e = thrown()
+        def e = thrown FileException
         e.message == "Could not get file mode for '$file'."
     }
 
@@ -50,7 +50,7 @@ class CommonFileSystemTest extends Specification {
         fs.chmod(file, 0644)
 
         then:
-        FileException e = thrown()
+        def e = thrown FileException
         e.message == "Could not set file mode 644 on '$file'."
     }
 

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystemTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystemTest.groovy
@@ -40,7 +40,7 @@ class GenericFileSystemTest extends Specification {
         fileSystem.chmod(file, 0640)
 
         then:
-        FileException e = thrown()
+        def e = thrown FileException
         e.message == "Could not set file mode 640 on '$file'."
     }
 
@@ -55,7 +55,7 @@ class GenericFileSystemTest extends Specification {
         fileSystem.getUnixMode(file)
 
         then:
-        FileException e = thrown()
+        def e = thrown FileException
         e.message == "Could not get file mode for '$file'."
     }
 
@@ -71,7 +71,7 @@ class GenericFileSystemTest extends Specification {
         fileSystem.createSymbolicLink(file, target)
 
         then:
-        FileException e = thrown()
+        def e = thrown FileException
         e.message == "Could not create symlink from '$file' to '$target'."
     }
 }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/AbstractFileLockManagerTest.groovy
@@ -243,7 +243,7 @@ abstract class AbstractFileLockManagerTest extends Specification {
         lock.updateFile({ throw failure } as Runnable)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         !lock.unlockedCleanly
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheAccessTest.groovy
@@ -174,7 +174,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         0 * _._
 
         and:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 
@@ -200,7 +200,7 @@ class DefaultCacheAccessTest extends ConcurrentSpec {
         0 * _._
 
         and:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheFactoryTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheFactoryTest.groovy
@@ -171,7 +171,7 @@ class DefaultCacheFactoryTest extends Specification {
         factory.open(tmpDir.testDirectory, null, null, [prop: 'other'], CacheBuilder.LockTarget.DefaultTarget, mode(Exclusive), null, null)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cache '${tmpDir.testDirectory}' is already open with different properties."
 
         cleanup:
@@ -186,7 +186,7 @@ class DefaultCacheFactoryTest extends Specification {
         factory.open(tmpDir.testDirectory, null, null, [prop: 'other'], CacheBuilder.LockTarget.DefaultTarget, mode(Exclusive), null, null)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cache '${tmpDir.testDirectory}' is already open with different lock options."
 
         cleanup:
@@ -201,7 +201,7 @@ class DefaultCacheFactoryTest extends Specification {
         factory.open(tmpDir.testDirectory, null, null, [prop: 'other'], CacheBuilder.LockTarget.DefaultTarget, mode(Shared), null, null)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == "Cache '${tmpDir.testDirectory}' is already open with different lock target."
 
         cleanup:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultPersistentDirectoryCacheTest.groovy
@@ -161,7 +161,7 @@ class DefaultPersistentDirectoryCacheTest extends AbstractProjectBuilderSpec {
         }
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.cause.is(failure)
 
         when:

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/ByteInputTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/btree/ByteInputTest.groovy
@@ -63,6 +63,6 @@ class ByteInputTest extends Specification {
         input.start(123).readInt()
 
         then:
-        EOFException e = thrown()
+        def e = thrown EOFException
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistryTest.groovy
@@ -94,7 +94,7 @@ class DefaultNativeToolChainRegistryTest extends Specification {
         result.newCompiler(CCompileSpec.class)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == toPlatformLineSeparators("""No tool chain is available to build for platform 'platform':
   - Tool chain 'test': nope
   - Tool chain 'test2': not me
@@ -120,7 +120,7 @@ class DefaultNativeToolChainRegistryTest extends Specification {
         result.newCompiler(CCompileSpec.class)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == toPlatformLineSeparators("""No tool chain is available to build C++ for platform 'platform':
   - Tool chain 'test': nope
   - Tool chain 'test2': not me

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/UnavailableNativePlatformToolProviderTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/UnavailableNativePlatformToolProviderTest.groovy
@@ -43,7 +43,7 @@ class UnavailableNativePlatformToolProviderTest extends Specification {
         toolChain.newCompiler(NativeCompileSpec.class)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "broken"
     }
 
@@ -52,7 +52,7 @@ class UnavailableNativePlatformToolProviderTest extends Specification {
         toolChain.getCompilerMetadata()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "broken"
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/tools/ToolSearchPathTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/tools/ToolSearchPathTest.groovy
@@ -194,7 +194,7 @@ class ToolSearchPathTest extends Specification {
         result.getTool()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "Could not find C compiler 'cc' in system path."
     }
 }

--- a/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
+++ b/subprojects/plugin-development/src/test/groovy/org/gradle/plugin/devel/plugins/JavaGradlePluginPluginTest.groovy
@@ -78,7 +78,7 @@ class JavaGradlePluginPluginTest extends AbstractProjectBuilderSpec {
         classList.contains('com/xxx/TestPlugin.class')
     }
 
-    def "PluginValidationAction finds fully qualified class"(List classList, String fqClass, boolean expectedValue) {
+    def "PluginValidationAction finds fully qualified class"() {
         setup:
         Action<Task> pluginValidationAction = new JavaGradlePluginPlugin.PluginValidationAction([], [], classList as Set<String>)
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/compile/GroovyCompileTest.groovy
@@ -73,7 +73,7 @@ public class GroovyCompileTest extends AbstractCompileTest {
         testObj.compile()
 
         then:
-        InvalidUserDataException e = thrown()
+        def e = thrown InvalidUserDataException
         e.message.contains("'testTask.groovyClasspath' must not be empty.")
     }
 

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/tasks/testing/TestTaskSpec.groovy
@@ -126,7 +126,7 @@ class TestTaskSpec extends AbstractProjectBuilderSpec {
         task.executeTests()
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.startsWith("There were failing tests. See the report at")
     }
 

--- a/subprojects/resources-gcs/src/test/groovy/org/gradle/internal/resource/transport/gcp/gcs/RetryHttpInitializerWrapperTest.groovy
+++ b/subprojects/resources-gcs/src/test/groovy/org/gradle/internal/resource/transport/gcp/gcs/RetryHttpInitializerWrapperTest.groovy
@@ -67,7 +67,7 @@ class RetryHttpInitializerWrapperTest extends Specification {
             retryCount++
             return retryCount < 2
         }
-        GoogleJsonResponseException e = thrown()
+        def e = thrown GoogleJsonResponseException
         e.statusCode == 401
     }
 

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTest.groovy
@@ -39,7 +39,7 @@ class HttpClientHelperTest extends AbstractHttpClientTest {
         client.performRequest(new HttpGet("http://gradle.org"), false)
 
         then:
-        HttpRequestException e = thrown()
+        def e = thrown HttpRequestException
         e.cause.message == "ouch"
     }
 

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceUploaderTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceUploaderTest.groovy
@@ -34,7 +34,7 @@ class HttpResourceUploaderTest extends AbstractHttpClientTest {
             1 * client.performHttpRequest(_) >> mockedHttpResponse.response
             assertIsClosedCorrectly(mockedHttpResponse)
         }
-        IOException exception = thrown()
+        def exception = thrown IOException
         exception.message.contains('Could not PUT')
     }
 }

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/ScalaRuntimeTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/ScalaRuntimeTest.groovy
@@ -56,7 +56,7 @@ class ScalaRuntimeTest extends AbstractProjectBuilderSpec {
         scalaClasspath.files
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message == "Cannot infer Scala class path because no repository is declared in $project"
     }
 
@@ -70,7 +70,7 @@ class ScalaRuntimeTest extends AbstractProjectBuilderSpec {
         scalaClasspath.files
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.startsWith("Cannot infer Scala class path because no Scala library Jar was found. Does root project 'test' declare dependency to scala-library? Searched classpath:")
     }
 

--- a/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
+++ b/subprojects/scala/src/test/groovy/org/gradle/api/tasks/scala/ScalaCompileTest.groovy
@@ -75,7 +75,7 @@ class ScalaCompileTest extends AbstractCompileTest {
         execute(scalaCompile)
 
         then:
-        TaskExecutionException e = thrown()
+        def e = thrown TaskExecutionException
         e.cause instanceof InvalidUserDataException
         e.cause.message.contains("'testTask.scalaClasspath' must not be empty")
     }

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerSupportedBuildJvmIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerSupportedBuildJvmIntegrationTest.groovy
@@ -35,7 +35,7 @@ class GradleRunnerSupportedBuildJvmIntegrationTest extends BaseGradleRunnerInteg
         runner().buildAndFail()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message.startsWith("An error occurred executing build with no args in directory ")
         e.cause instanceof GradleConnectionException
         e.cause.cause.message == "Gradle ${GradleVersion.current().version} requires Java 7 or later to run. Your build is currently configured to use Java ${jdk.javaVersion.majorVersion}."

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/junit/JUnitTestClassProcessorTest.groovy
@@ -457,6 +457,6 @@ class JUnitTestClassProcessorTest extends Specification {
         when: classProcessor.stopNow()
 
         then:
-        UnsupportedOperationException uoe = thrown()
+        def uoe = thrown UnsupportedOperationException
     }
 }

--- a/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
+++ b/subprojects/testing-jvm/src/test/groovy/org/gradle/api/internal/tasks/testing/testng/TestNGTestClassProcessorTest.groovy
@@ -341,7 +341,7 @@ class TestNGTestClassProcessorTest extends Specification {
         when: classProcessor.stopNow()
 
         then:
-        UnsupportedOperationException uoe = thrown()
+        def uoe = thrown UnsupportedOperationException
     }
 }
 

--- a/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
+++ b/subprojects/tooling-api-builders/src/test/groovy/org/gradle/tooling/internal/provider/runner/DefaultBuildControllerTest.groovy
@@ -61,7 +61,7 @@ class DefaultBuildControllerTest extends Specification {
         controller.getModel(null, modelId)
 
         then:
-        InternalUnsupportedModelException e = thrown()
+        def e = thrown InternalUnsupportedModelException
         e.cause == failure
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/CrossVersionToolingApiSpecificationRetryRuleTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/fixture/CrossVersionToolingApiSpecificationRetryRuleTest.groovy
@@ -54,7 +54,7 @@ class CrossVersionToolingApiSpecificationRetryRuleTest extends ToolingApiSpecifi
         throwWhen(new GradleConnectionException("Test Exception", new NullPointerException()), iteration == 1)
 
         then:
-        GradleConnectionException gce = thrown()
+        def gce = thrown GradleConnectionException
         gce.cause instanceof NullPointerException
     }
 
@@ -79,7 +79,7 @@ class CrossVersionToolingApiSpecificationRetryRuleTest extends ToolingApiSpecifi
         throwWhen(new IOException("Some action failed", new GradleException("Timeout waiting to connect to the Gradle daemon.\n more infos")), iteration == 1)
 
         then:
-        IOException ioe = thrown()
+        def ioe = thrown IOException
         ioe.cause?.message == "Timeout waiting to connect to the Gradle daemon.\n more infos"
     }
 
@@ -108,7 +108,7 @@ class CrossVersionToolingApiSpecificationRetryRuleTest extends ToolingApiSpecifi
         throwWhen(new IOException("Could not dispatch a message to the daemon.", new IOException("An existing connection was forcibly closed by the remote host")), iteration == 1)
 
         then:
-        IOException ioe = thrown()
+        def ioe = thrown IOException
         ioe.cause?.message == "An existing connection was forcibly closed by the remote host"
     }
 
@@ -122,7 +122,7 @@ class CrossVersionToolingApiSpecificationRetryRuleTest extends ToolingApiSpecifi
         throwWhen(new IOException("Could not dispatch a message to the daemon.", new IOException("A different cause")), iteration == 1)
 
         then:
-        IOException ioe = thrown()
+        def ioe = thrown IOException
         ioe.cause?.message == "A different cause"
     }
 
@@ -136,7 +136,7 @@ class CrossVersionToolingApiSpecificationRetryRuleTest extends ToolingApiSpecifi
         throwWhen(new IOException("Could not dispatch a message to the daemon.", new IOException("An existing connection was forcibly closed by the remote host")), iteration == 1)
 
         then:
-        IOException ioe = thrown()
+        def ioe = thrown IOException
         ioe.message == "Could not dispatch a message to the daemon."
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiBuildExecutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiBuildExecutionCrossVersionSpec.groovy
@@ -94,7 +94,7 @@ System.err.println 'this is stderr'
         }
 
         then:
-        BuildException e = thrown()
+        def e = thrown BuildException
         e.message.startsWith('Could not execute build using Gradle')
         e.cause.message.contains('A problem occurred evaluating root project')
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m5/ToolingApiModelCrossVersionSpec.groovy
@@ -44,7 +44,7 @@ System.err.println 'this is stderr'
         }
 
         then:
-        BuildException e = thrown()
+        def e = thrown BuildException
         e.message.startsWith('Could not fetch model of type \'GradleProject\' using Gradle')
         e.cause.message.contains('A problem occurred evaluating root project')
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r10rc1/PassingCommandLineArgumentsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r10rc1/PassingCommandLineArgumentsCrossVersionSpec.groovy
@@ -107,7 +107,7 @@ class PassingCommandLineArgumentsCrossVersionSpec extends ToolingApiSpecificatio
         }
 
         then:
-        UnsupportedBuildArgumentException ex = thrown()
+        def ex = thrown UnsupportedBuildArgumentException
         ex.message.contains('--foreground')
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/BuildInvocationsCrossVersionSpec.groovy
@@ -289,7 +289,7 @@ project(':b:c') {
             it.forLaunchables(selectorBT1, selectorBT3, selectorT1)
         }
         then:
-        UnsupportedBuildArgumentException e = thrown()
+        def e = thrown UnsupportedBuildArgumentException
         e.message.contains 'Only selector from the same Gradle project can be built.'
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/PublicationsCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r112/PublicationsCrossVersionSpec.groovy
@@ -205,7 +205,7 @@ publishing {
         publications.publications
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message.contains('does not support building a model of type \'ProjectPublications\'.') ||
         e.message.contains('No model of type \'ProjectPublications\' is available in this build.')
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r16/UnknownCustomModelFeedbackCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r16/UnknownCustomModelFeedbackCrossVersionSpec.groovy
@@ -29,7 +29,7 @@ class UnknownCustomModelFeedbackCrossVersionSpec extends ToolingApiSpecification
         withConnection { it.getModel(CustomModel.class) }
 
         then:
-        UnknownModelException e = thrown()
+        def e = thrown UnknownModelException
         e.message == "No model of type 'CustomModel' is available in this build."
     }
 
@@ -40,7 +40,7 @@ class UnknownCustomModelFeedbackCrossVersionSpec extends ToolingApiSpecification
         withConnection { it.getModel(CustomModel.class) }
 
         then:
-        UnknownModelException e = thrown()
+        def e = thrown UnknownModelException
         e.message == "The version of Gradle you are using (${targetDist.version.version}) does not support building a model of type 'CustomModel'. Support for building custom tooling models was added in Gradle 1.6 and is available in all later versions."
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r18/BuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r18/BuildActionCrossVersionSpec.groovy
@@ -89,7 +89,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
         withConnection { it.action(new BrokenAction()).run() }
 
         then:
-        BuildActionFailureException e = thrown()
+        def e = thrown BuildActionFailureException
         e.message == /The supplied build action failed with an exception./
         e.cause instanceof BrokenAction.CustomException
     }
@@ -112,7 +112,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         then:
         // TODO:ADAM - clean this up
-        BuildException e = thrown()
+        def e = thrown BuildException
         e.message.startsWith('Could not run build action using')
     }
 
@@ -123,7 +123,7 @@ class BuildActionCrossVersionSpec extends ToolingApiSpecification {
         withConnection { it.action(new FetchCustomModel()).run() }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (${targetDist.version.version}) does not support the BuildActionExecuter API. Support for this is available in Gradle 1.8 and all later versions."
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r18/BuildScriptModelCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r18/BuildScriptModelCrossVersionSpec.groovy
@@ -49,7 +49,7 @@ class BuildScriptModelCrossVersionSpec extends ToolingApiSpecification {
         project.buildScript
 
         then:
-        UnsupportedMethodException e = thrown()
+        def e = thrown UnsupportedMethodException
         e.message.startsWith('Unsupported method: GradleProject.getBuildScript().')
 
         when:

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/BuildProgressCrossVersionSpec.groovy
@@ -104,7 +104,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then: "listener exception is wrapped"
-        ListenerFailedException ex = thrown()
+        def ex = thrown ListenerFailedException
         ex.message.startsWith("Could not execute build using")
         ex.causes == [failure]
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TaskProgressCrossVersionSpec.groovy
@@ -113,7 +113,7 @@ class TaskProgressCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then: "listener exception is wrapped"
-        ListenerFailedException ex = thrown()
+        def ex = thrown ListenerFailedException
         ex.message.startsWith("Could not execute build using")
         ex.causes == [failure]
 
@@ -197,7 +197,7 @@ class TaskProgressCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then:
-        BuildException ex = thrown()
+        def ex = thrown BuildException
         ex.cause.cause.message =~ /Execution failed for task ':test'/
 
         def test = events.operation("Task :test")

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r25/TestProgressCrossVersionSpec.groovy
@@ -123,7 +123,7 @@ class TestProgressCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then: "listener exception is wrapped"
-        ListenerFailedException ex = thrown()
+        def ex = thrown ListenerFailedException
         ex.message.startsWith("Could not execute build using")
         ex.causes == [failure]
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildEnvironmentCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildEnvironmentCrossVersionSpec.groovy
@@ -85,7 +85,7 @@ class BuildEnvironmentCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (${targetDist.version.version}) does not support the environment variables customization feature. Support for this is available in Gradle 3.5 and all later versions."
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/RunTasksBeforeRunActionCrossVersion.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/RunTasksBeforeRunActionCrossVersion.groovy
@@ -78,7 +78,7 @@ class RunTasksBeforeRunActionCrossVersion extends ToolingApiSpecification {
         }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         assert e.message == "The version of Gradle you are using (${targetDist.version.version}) does not support the forTasks() method on BuildActionExecuter. Support for this is available in Gradle 3.5 and all later versions."
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedBuildJvmCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r42/ToolingApiDeprecatedBuildJvmCrossVersionSpec.groovy
@@ -108,7 +108,7 @@ class ToolingApiDeprecatedBuildJvmCrossVersionSpec extends ToolingApiSpecificati
         }
 
         then:
-        TestExecutionException e = thrown()
+        def e = thrown TestExecutionException
         e.cause.message.startsWith("No matching tests found in any candidate test task.")
         output.toString().count(EXPECTED_JAVA7_DEPRECATION_MESSAGE) == 1
     }
@@ -175,7 +175,7 @@ class ToolingApiDeprecatedBuildJvmCrossVersionSpec extends ToolingApiSpecificati
         }
 
         then:
-        TestExecutionException e = thrown()
+        def e = thrown TestExecutionException
         e.cause.message.startsWith("No matching tests found in any candidate test task.")
         output.toString().count(EXPECTED_JAVA7_DEPRECATION_MESSAGE) == 0
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -148,7 +148,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then:
-        BuildActionFailureException e = thrown()
+        def e = thrown BuildActionFailureException
         e.message == "The supplied phased action failed with an exception."
         e.cause instanceof RuntimeException
         e.cause.message == "actionFailure"
@@ -253,7 +253,7 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
         }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (${version}) does not support the PhasedBuildActionExecuter API. Support for this is available in Gradle 4.8 and all later versions."
     }
 }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiRemoteIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiRemoteIntegrationTest.groovy
@@ -143,7 +143,7 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
         }
 
         then:
-        GradleConnectionException e = thrown()
+        def e = thrown GradleConnectionException
         e.message == "Could not install Gradle distribution from '$distUri'."
 
         and:
@@ -186,7 +186,7 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
         }
 
         then:
-        BuildCancelledException e = thrown()
+        def e = thrown BuildCancelledException
         e.message.contains('Distribution download cancelled.')
 
         and:

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiUnsupportedVersionIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiUnsupportedVersionIntegrationTest.groovy
@@ -38,7 +38,7 @@ class ToolingApiUnsupportedVersionIntegrationTest extends AbstractIntegrationSpe
         toolingApi.withConnection { ProjectConnection connection -> connection.getModel(GradleProject.class) }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (Gradle distribution '${distroZip}') does not support the ModelBuilder API. Support for this is available in Gradle 1.2 and all later versions."
     }
 
@@ -47,7 +47,7 @@ class ToolingApiUnsupportedVersionIntegrationTest extends AbstractIntegrationSpe
         toolingApi.withConnection { ProjectConnection connection -> connection.newBuild().run() }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (Gradle distribution '${distroZip}') does not support the BuildLauncher API. Support for this is available in Gradle 1.2 and all later versions."
     }
 
@@ -56,7 +56,7 @@ class ToolingApiUnsupportedVersionIntegrationTest extends AbstractIntegrationSpe
         toolingApi.withConnection { ProjectConnection connection -> connection.action(new NullAction()).run() }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (Gradle distribution '${distroZip}') does not support the BuildActionExecuter API. Support for this is available in Gradle 1.8 and all later versions."
     }
 
@@ -65,7 +65,7 @@ class ToolingApiUnsupportedVersionIntegrationTest extends AbstractIntegrationSpe
         toolingApi.withConnection { ProjectConnection connection -> connection.newTestLauncher().withJvmTestClasses("class").run() }
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "The version of Gradle you are using (Gradle distribution '${distroZip}') does not support the TestLauncher API. Support for this is available in Gradle 2.6 and all later versions."
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/adapter/ProtocolToModelAdapterTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/adapter/ProtocolToModelAdapterTest.groovy
@@ -350,7 +350,7 @@ class ProtocolToModelAdapterTest extends Specification {
         model.project
 
         then:
-        UnsupportedMethodException e = thrown()
+        def e = thrown UnsupportedMethodException
         e.message.contains "TestModel.getProject()"
     }
 
@@ -364,7 +364,7 @@ class ProtocolToModelAdapterTest extends Specification {
 
         then:
         protocolModel.name >> { throw failure }
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/ConnectorServicesTest.groovy
@@ -42,6 +42,6 @@ public class ConnectorServicesTest extends Specification {
         ConnectorServices.createConnector()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuterTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultBuildActionExecuterTest.groovy
@@ -157,7 +157,7 @@ class DefaultBuildActionExecuterTest extends ConcurrentSpec {
         }
 
         then:
-        GradleConnectionException e = thrown()
+        def e = thrown GradleConnectionException
         e.cause.is(failure)
 
         and:

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultBuildLauncherTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultBuildLauncherTest.groovy
@@ -306,7 +306,7 @@ class DefaultBuildLauncherTest extends ConcurrentSpec {
         }
 
         then:
-        GradleConnectionException e = thrown()
+        def e = thrown GradleConnectionException
         e.cause.is(failure)
 
         and:

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultGradleConnectorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultGradleConnectorTest.groovy
@@ -122,7 +122,7 @@ class DefaultGradleConnectorTest extends Specification {
         connector.connect()
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'A project directory must be specified before creating a connection.'
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultModelBuilderTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultModelBuilderTest.groovy
@@ -224,7 +224,7 @@ class DefaultModelBuilderTest extends ConcurrentSpec {
         }
 
         then:
-        GradleConnectionException e = thrown()
+        def e = thrown GradleConnectionException
         e.cause.is(failure)
 
         and:

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuterBuilderTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuterBuilderTest.groovy
@@ -52,7 +52,7 @@ class DefaultPhasedBuildActionExecuterBuilderTest extends Specification {
         builder.projectsLoaded(Stub(BuildAction), Stub(IntermediateResultHandler))
 
         then:
-        IllegalArgumentException e1 = thrown()
+        def e1 = thrown IllegalArgumentException
         e1.message == 'ProjectsLoadedAction has already been added. Only one action per phase is allowed.'
 
         when:
@@ -60,7 +60,7 @@ class DefaultPhasedBuildActionExecuterBuilderTest extends Specification {
         builder.buildFinished(Stub(BuildAction), Stub(IntermediateResultHandler))
 
         then:
-        IllegalArgumentException e2 = thrown()
+        def e2 = thrown IllegalArgumentException
         e2.message == 'BuildFinishedAction has already been added. Only one action per phase is allowed.'
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuterTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuterTest.groovy
@@ -144,7 +144,7 @@ class DefaultPhasedBuildActionExecuterTest extends ConcurrentSpec {
         }
 
         then:
-        GradleConnectionException e = thrown()
+        def e = thrown GradleConnectionException
         e.message == 'Could not run phased build action using testConnection.'
         e.cause == failure
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultProjectConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultProjectConnectionTest.groovy
@@ -36,7 +36,7 @@ class DefaultProjectConnectionTest extends Specification {
         connection.model(String.class)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "Cannot fetch a model of type 'java.lang.String' as this type is not an interface."
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DistributionFactoryTest.groovy
@@ -87,7 +87,7 @@ class DistributionFactoryTest extends Specification {
         dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "The specified Gradle installation directory '$distDir' does not exist."
     }
 
@@ -99,7 +99,7 @@ class DistributionFactoryTest extends Specification {
         dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "The specified Gradle installation directory '$distDir' is not a directory."
     }
 
@@ -111,7 +111,7 @@ class DistributionFactoryTest extends Specification {
         dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "The specified Gradle installation directory '$distDir' does not appear to contain a Gradle distribution."
     }
 
@@ -209,7 +209,7 @@ class DistributionFactoryTest extends Specification {
         dist.getToolingImplementationClasspath(progressLoggerFactory, buildProgressListener, null, cancellationToken)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "The specified Gradle distribution '${zipFile}' does not exist."
     }
 
@@ -222,7 +222,7 @@ class DistributionFactoryTest extends Specification {
 
         then:
         1 * cancellationToken.addCallback(_)
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "The specified Gradle distribution '${zipFile.toURI()}' does not appear to contain a Gradle distribution."
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/async/DefaultAsyncConsumerActionExecutorTest.groovy
@@ -75,7 +75,7 @@ class DefaultAsyncConsumerActionExecutorTest extends ConcurrentSpec {
         connection.run(action, handler)
 
         then:
-        IllegalStateException e = thrown()
+        def e = thrown IllegalStateException
         e.message == 'Cannot use [executer] as it has been stopped.'
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ActionAwareConsumerConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ActionAwareConsumerConnectionTest.groovy
@@ -132,7 +132,7 @@ class ActionAwareConsumerConnectionTest extends Specification {
         connection.run(action, parameters)
 
         then:
-        BuildActionFailureException e = thrown()
+        def e = thrown BuildActionFailureException
         e.message == /The supplied build action failed with an exception./
         e.cause == failure
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildActionRunnerBackedConsumerConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildActionRunnerBackedConsumerConnectionTest.groovy
@@ -132,7 +132,7 @@ class BuildActionRunnerBackedConsumerConnectionTest extends Specification {
         connection.run(CustomModel.class, parameters)
 
         then:
-        UnknownModelException e = thrown()
+        def e = thrown UnknownModelException
         e.message == /The version of Gradle you are using (1.2) does not support building a model of type 'CustomModel'. Support for building custom tooling models was added in Gradle 1.6 and is available in all later versions./
     }
 
@@ -145,7 +145,7 @@ class BuildActionRunnerBackedConsumerConnectionTest extends Specification {
         connection.run(Stub(BuildAction), parameters)
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == /The version of Gradle you are using (1.2) does not support the <api>. Support for this is available in Gradle 1.8 and all later versions./
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapterTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerAdapterTest.groovy
@@ -55,7 +55,7 @@ class BuildControllerAdapterTest extends Specification {
         controller.getModel(String)
 
         then:
-        UnknownModelException e = thrown()
+        def e = thrown UnknownModelException
         e.message == /No model of type 'String' is available in this build./
         e.cause == failure
     }
@@ -178,14 +178,14 @@ class BuildControllerAdapterTest extends Specification {
         })
 
         then:
-        NullPointerException e1 = thrown()
+        def e1 = thrown NullPointerException
         e1.message == "parameterType and parameterInitializer both need to be set for a parametrized model request."
 
         when:
         controller.getModel(GradleBuild, ValidParameter, null)
 
         then:
-        NullPointerException e2 = thrown()
+        def e2 = thrown NullPointerException
         e2.message == "parameterType and parameterInitializer both need to be set for a parametrized model request."
     }
 
@@ -197,7 +197,7 @@ class BuildControllerAdapterTest extends Specification {
         })
 
         then:
-        IllegalArgumentException e1 = thrown()
+        def e1 = thrown IllegalArgumentException
         e1.message == "org.gradle.tooling.internal.consumer.connection.BuildControllerAdapterTest\$InvalidParameter is not a valid parameter type. It must be an interface."
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerWithoutParameterSupportTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/BuildControllerWithoutParameterSupportTest.groovy
@@ -53,7 +53,7 @@ class BuildControllerWithoutParameterSupportTest extends Specification {
         controller.getModel(null, modelType, parameterType, parameterInitializer)
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == "Gradle version 4.1 does not support parameterized tooling models."
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/CancellableConsumerActionExecutorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/CancellableConsumerActionExecutorTest.groovy
@@ -51,6 +51,6 @@ class CancellableConsumerActionExecutorTest extends Specification {
         0 * _._
 
         and:
-        BuildCancelledException e = thrown()
+        def e = thrown BuildCancelledException
     }
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/CancellableConsumerConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/CancellableConsumerConnectionTest.groovy
@@ -98,7 +98,7 @@ class CancellableConsumerConnectionTest extends Specification {
         connection.run(action, parameters)
 
         then:
-        BuildActionFailureException e = thrown()
+        def e = thrown BuildActionFailureException
         e.message == /The supplied build action failed with an exception./
         e.cause == failure
 
@@ -115,7 +115,7 @@ class CancellableConsumerConnectionTest extends Specification {
         connection.run(action, parameters)
 
         then:
-        InternalBuildCancelledException e = thrown()
+        def e = thrown InternalBuildCancelledException
         e.cause == failure
 
         and:
@@ -152,7 +152,7 @@ class CancellableConsumerConnectionTest extends Specification {
         connection.run(Void.class, parameters)
 
         then:
-        InternalBuildCancelledException e = thrown()
+        def e = thrown InternalBuildCancelledException
         e.cause == failure
 
         and:

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutorTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/LazyConsumerActionExecutorTest.groovy
@@ -92,7 +92,7 @@ class LazyConsumerActionExecutorTest extends Specification {
         connection.run(action)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
         1 * loggingProvider.getProgressLoggerFactory() >> progressLoggerFactory
         1 * implementationLoader.create(distribution, progressLoggerFactory, _ as InternalBuildProgressListener, connectionParams, cancellationToken) >> { throw failure }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ModelBuilderBackedConsumerConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ModelBuilderBackedConsumerConnectionTest.groovy
@@ -93,7 +93,7 @@ class ModelBuilderBackedConsumerConnectionTest extends Specification {
         connection.run(GradleProject, parameters)
 
         then:
-        UnknownModelException e = thrown()
+        def e = thrown UnknownModelException
         e.message == /No model of type 'GradleProject' is available in this build./
     }
 
@@ -131,7 +131,7 @@ class ModelBuilderBackedConsumerConnectionTest extends Specification {
         connection.run(Stub(BuildAction), parameters)
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == /The version of Gradle you are using (1.6) does not support the <api>. Support for this is available in Gradle 1.8 and all later versions./
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ParameterAcceptingConsumerConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ParameterAcceptingConsumerConnectionTest.groovy
@@ -116,7 +116,7 @@ class ParameterAcceptingConsumerConnectionTest extends Specification {
         connection.run(action, parameters)
 
         then:
-        BuildActionFailureException e = thrown()
+        def e = thrown BuildActionFailureException
         e.message == /The supplied build action failed with an exception./
         e.cause == failure
 
@@ -133,7 +133,7 @@ class ParameterAcceptingConsumerConnectionTest extends Specification {
         connection.run(action, parameters)
 
         then:
-        InternalBuildCancelledException e = thrown()
+        def e = thrown InternalBuildCancelledException
         e.cause == failure
 
         and:
@@ -150,7 +150,7 @@ class ParameterAcceptingConsumerConnectionTest extends Specification {
         connection.run(phasedAction, parameters)
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e.message == 'The version of Gradle you are using (4.4) does not support the PhasedBuildActionExecuter API. Support for this is available in Gradle 4.8 and all later versions.'
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/PhasedActionAwareConsumerConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/PhasedActionAwareConsumerConnectionTest.groovy
@@ -155,7 +155,7 @@ class PhasedActionAwareConsumerConnectionTest extends Specification {
         connection.run(phasedAction, parameters)
 
         then:
-        BuildActionFailureException e = thrown()
+        def e = thrown BuildActionFailureException
         e.message == 'The supplied phased action failed with an exception.'
         e.cause == failure
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxyTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/ToolingParameterProxyTest.groovy
@@ -35,7 +35,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter1)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter1 is not a valid parameter type. Method notASetterOrGetter is neither a setter nor a getter."
     }
 
@@ -44,7 +44,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter2)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter2 is not a valid parameter type. Method setValue is neither a setter nor a getter."
     }
 
@@ -53,7 +53,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter3)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter3 is not a valid parameter type. Setter and getter for property value have non corresponding types."
     }
 
@@ -62,7 +62,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter4)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter4 is not a valid parameter type. It contains a different number of getters and setters."
     }
 
@@ -71,7 +71,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter5)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter5 is not a valid parameter type. It contains a different number of getters and setters."
     }
 
@@ -80,7 +80,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter6)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter6 is not a valid parameter type. It must be an interface."
     }
 
@@ -89,7 +89,7 @@ class ToolingParameterProxyTest extends Specification {
         ToolingParameterProxy.validateParameter(InvalidParameter7)
 
         then:
-        IllegalArgumentException e = thrown()
+        def e = thrown IllegalArgumentException
         e.message == "org.gradle.tooling.internal.consumer.connection.ToolingParameterProxyTest\$InvalidParameter7 is not a valid parameter type. More than one getter for property value was found."
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/UnsupportedOlderVersionConnectionTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/connection/UnsupportedOlderVersionConnectionTest.groovy
@@ -44,7 +44,7 @@ class UnsupportedOlderVersionConnectionTest extends Specification {
         connection.run(GradleProject.class, parameters)
 
         then:
-        UnsupportedVersionException e = thrown()
+        def e = thrown UnsupportedVersionException
         e != null
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/model/internal/ImmutableDomainObjectSetTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/model/internal/ImmutableDomainObjectSetTest.groovy
@@ -50,13 +50,13 @@ class ImmutableDomainObjectSetTest extends Specification {
         set[4]
 
         then:
-        IndexOutOfBoundsException e = thrown()
+        thrown IndexOutOfBoundsException
 
         when:
         set[-1]
 
         then:
-        e = thrown()
+        thrown IndexOutOfBoundsException
     }
 
     def iteratorOfEmptySetHasNoElements() {
@@ -96,6 +96,6 @@ class ImmutableDomainObjectSetTest extends Specification {
         set.add('a')
 
         then:
-        UnsupportedOperationException e = thrown()
+        def e = thrown UnsupportedOperationException
     }
 }

--- a/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
+++ b/subprojects/version-control/src/test/groovy/org/gradle/vcs/git/internal/GitVersionControlSystemSpec.groovy
@@ -209,7 +209,7 @@ class GitVersionControlSystemSpec extends Specification {
         gitVcs.populate(target, repoHead, repoSpec)
 
         then:
-        GradleException e = thrown()
+        def e = thrown GradleException
         e.message.contains('Could not clone from https://notarepo.invalid in')
         e.cause != null
         e.cause.message.contains('Exception caught during execution of fetch command')

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/ExclusiveFileAccessManagerTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/ExclusiveFileAccessManagerTest.groovy
@@ -33,7 +33,7 @@ class ExclusiveFileAccessManagerTest extends Specification {
         }
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == "Could not create parent directory for lock file ${fileWithSameNameAsDirectory.file('someFile.zip.lck').absolutePath}"
     }
 }

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/InstallTest.groovy
@@ -103,7 +103,7 @@ class InstallTest extends Specification {
         install.createDist(configuration)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e == failure
 
         and:

--- a/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
+++ b/subprojects/wrapper/src/test/groovy/org/gradle/wrapper/WrapperExecutorTest.groovy
@@ -120,7 +120,7 @@ class WrapperExecutorTest extends Specification {
         WrapperExecutor.forWrapperPropertiesFile(propertiesFile)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == "Could not load wrapper properties from '$propertiesFile'."
         e.cause.message == "No value with key 'distributionUrl' specified in wrapper properties file '$propertiesFile'."
     }
@@ -132,7 +132,7 @@ class WrapperExecutorTest extends Specification {
         WrapperExecutor.forWrapperPropertiesFile(propertiesFile)
 
         then:
-        RuntimeException e = thrown()
+        def e = thrown RuntimeException
         e.message == "Wrapper properties file '$propertiesFile' does not exist."
     }
 
@@ -151,7 +151,7 @@ class WrapperExecutorTest extends Specification {
         WrapperExecutor.forWrapperPropertiesFile(propertiesFile)
 
         then:
-        Exception e = thrown()
+        def e = thrown Exception
         e.cause.message == "No value with key 'distributionUrl' specified in wrapper properties file '$propertiesFile'."
     }
 


### PR DESCRIPTION
This is in preparation to upgrade to Groovy 2.5 (#6324) that is a bit more strict in some places. It also doesn't like the notion `IllegalStateException e = thrown()`.