### PR TITLE
Mark empty selectors failed in case resolution fails

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1492,4 +1492,32 @@ configurations.all {
             }
         }
     }
+
+    def "should fail not crash if empty selector skipped"() {
+        given:
+        buildFile << """
+            configurations {
+                conf {
+                    resolutionStrategy.dependencySubstitution {
+                        all { DependencySubstitution dependency ->
+                            throw new RuntimeException('Substitution exception')
+                        }
+                    }
+                }
+            }
+            dependencies {
+                conf 'org:foo:1.0'
+                constraints {
+                    conf 'org:foo'
+                }
+            }                       
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause("Substitution exception")
+
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -157,6 +157,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     /**
      * Does the work of actually resolving a component selector to a component identifier.
      */
+    @Override
     public ComponentIdResolveResult resolve(VersionSelector allRejects) {
         if (!requiresResolve(allRejects)) {
             return idResolveResult;
@@ -177,6 +178,15 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         this.idResolveResult = idResolveResult;
         this.resolved = true;
         return idResolveResult;
+    }
+
+    @Override
+    public void failed(ModuleVersionResolveException failure) {
+        this.failure = failure;
+        BuildableComponentIdResolveResult idResolveResult = new DefaultBuildableComponentIdResolveResult();
+        idResolveResult.failed(failure);
+        this.idResolveResult = idResolveResult;
+
     }
 
     private boolean requiresResolve(VersionSelector allRejects) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/ResolvableSelectorState.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selecto
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
+import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
 
 public interface ResolvableSelectorState {
@@ -36,6 +37,13 @@ public interface ResolvableSelectorState {
      * Resolve the selector to a component identifier.
      */
     ComponentIdResolveResult resolve(VersionSelector allRejects);
+
+    /**
+     * Marks the selector as resolved with the passed in failure.
+     *
+     * @param failure the failure to record
+     */
+    void failed(ModuleVersionResolveException failure);
 
     /**
      * Mark the selector as resolved.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -98,12 +98,17 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
      */
     private List<T> buildResolveResults(List<? extends ResolvableSelectorState> selectors, VersionSelector allRejects) {
         SelectorStateResolverResults results = new SelectorStateResolverResults(selectors.size());
+        List<ResolvableSelectorState> emptySelectors = null;
         List<ResolvableSelectorState> preferSelectors = null;
         for (ResolvableSelectorState selector : selectors) {
             // If this selector doesn't specify a prefer/require version, then ignore it here.
             // This will avoid resolving 'reject' selectors, too.
             if (isEmpty(selector)) {
                 selector.markResolved();
+                if (emptySelectors == null) {
+                    emptySelectors = Lists.newArrayList();
+                }
+                emptySelectors.add(selector);
                 continue;
             }
             // Defer prefer selectors until all other selectors are processed
@@ -120,7 +125,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
 
         processPreferSelectors(results, preferSelectors, allRejects);
 
-        return results.getResolved(componentFactory);
+        return results.getResolved(componentFactory, emptySelectors);
     }
 
     private boolean isEmpty(ResolvableSelectorState selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -106,7 +106,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
             if (isEmpty(selector)) {
                 selector.markResolved();
                 if (emptySelectors == null) {
-                    emptySelectors = Lists.newArrayList();
+                    emptySelectors = Lists.newArrayListWithCapacity(selectors.size());
                 }
                 emptySelectors.add(selector);
                 continue;
@@ -114,7 +114,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
             // Defer prefer selectors until all other selectors are processed
             if (isPrefer(selector)) {
                 if (preferSelectors == null) {
-                    preferSelectors = Lists.newArrayList();
+                    preferSelectors = Lists.newArrayListWithCapacity(selectors.size());
                 }
                 preferSelectors.add(selector);
                 continue;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestModuleSelectorState.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.resolver.DependencyToComponentIdResolver;
 import org.gradle.internal.resolve.result.BuildableComponentIdResolveResult;
 import org.gradle.internal.resolve.result.ComponentIdResolveResult;
@@ -76,6 +77,11 @@ public class TestModuleSelectorState implements ResolvableSelectorState {
         ResolvedVersionConstraint mergedConstraint = resolvedVersionConstraint.withRejectSelector(allRejects);
         resolved = resolveVersion(mergedConstraint);
         return resolved;
+    }
+
+    @Override
+    public void failed(ModuleVersionResolveException failure) {
+        throw new UnsupportedOperationException("To be implemented");
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestProjectSelectorState.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
+import org.gradle.internal.resolve.ModuleVersionResolveException
 import org.gradle.internal.resolve.result.ComponentIdResolveResult
 import org.gradle.internal.resolve.result.DefaultBuildableComponentIdResolveResult
 
@@ -48,6 +49,11 @@ class TestProjectSelectorState implements ResolvableSelectorState {
         def result = new DefaultBuildableComponentIdResolveResult()
         result.resolved(projectId, DefaultModuleVersionIdentifier.newId("org", projectId.projectName, VERSION))
         return result
+    }
+
+    @Override
+    void failed(ModuleVersionResolveException failure) {
+        throw new UnsupportedOperationException("To be implemented");
     }
 
     @Override


### PR DESCRIPTION
Changes that skipped empty selectors caused them to end in a resolved
state without a failure nor a selected target component. This commit
fixes the failure case as it was causing a NPE during failure
collection.