### PR TITLE
Do not set a default value for properties created by ObjectFactory.property()

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -17,19 +17,21 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
 
-@Ignore("Leaks files")
-@Requires(TestPrecondition.JDK8_OR_LATER)
 class KotlinApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
 
     public static final String SAMPLE_APP_CLASS = "some/thing/App.kt"
     public static final String SAMPLE_APP_TEST_CLASS = "some/thing/AppTest.kt"
+
+    def setup() {
+        executer.beforeExecute {
+            // Run Kotlin compiler in-process to avoid file locking issues
+            executer.withArguments("-Dkotlin.compiler.execution.strategy=in-process")
+        }
+    }
 
     def "defaults to kotlin build scripts"() {
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -17,18 +17,21 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
-import org.gradle.test.fixtures.file.LeaksFileHandles
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
 
-@Requires(TestPrecondition.JDK8_OR_LATER)
 class KotlinLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
 
     public static final String SAMPLE_LIBRARY_CLASS = "some/thing/Library.kt"
     public static final String SAMPLE_LIBRARY_TEST_CLASS = "some/thing/LibraryTest.kt"
+
+    def setup() {
+        executer.beforeExecute {
+            // Run Kotlin compiler in-process to avoid file locking issues
+            executer.withArguments("-Dkotlin.compiler.execution.strategy=in-process")
+        }
+    }
 
     def "defaults to kotlin build scripts"() {
         when:
@@ -38,7 +41,6 @@ class KotlinLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
         dslFixtureFor(KOTLIN).assertGradleFilesGenerated()
     }
 
-    @LeaksFileHandles
     @Unroll
     def "creates sample source if no source present with #scriptDsl build scripts"() {
         when:

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -88,12 +88,15 @@ public interface ObjectFactory {
     SourceDirectorySet sourceDirectorySet(String name, String displayName);
 
     /**
-     * Creates a {@link Property} implementation to hold values of the given type.
+     * Creates a {@link Property} implementation to hold values of the given type. The property has no initial value.
      *
-     * <p>When the given type is a wrapper type for a Java primitive type, such as {@link Boolean}, the property will have a value equal to the default value of the corresponding primitive type as defined by the Java language specification (JLS). For example, a property with type {@link Boolean} will have a default value of {@code false}.
-     * Please see <a href="https://docs.oracle.com/javase/tutorial/java/nutsandbolts/datatypes.html">Oracle's Java manual</a> for more information.
-     * <p>
-     * Any other data type than the standard Java data types returns a property with no value defined.
+     * <p>For certain types, there are more specialized property factory methods available:</p>
+     * <ul>
+     * <li>For {@link List} properties, you should use {@link #listProperty(Class)}.</li>
+     * <li>For {@link Set} properties, you should use {@link #setProperty(Class)}.</li>
+     * <li>For {@link org.gradle.api.file.Directory} properties, you should use {@link #directoryProperty()}.</li>
+     * <li>For {@link org.gradle.api.file.RegularFile} properties, you should use {@link #fileProperty()}.</li>
+     * </ul>
      *
      * @param valueType The type of the property.
      * @return The property. Never returns null.
@@ -102,7 +105,7 @@ public interface ObjectFactory {
     <T> Property<T> property(Class<T> valueType);
 
     /**
-     * Creates a {@link ListProperty} implementation to hold a {@link List} of the given element type. The property will have an empty list as its initial value.
+     * Creates a {@link ListProperty} implementation to hold a {@link List} of the given element type {@code T}. The property will have an empty list as its initial value.
      *
      * <p>The implementation will return immutable {@link List} values from its query methods.</p>
      *
@@ -114,7 +117,7 @@ public interface ObjectFactory {
     <T> ListProperty<T> listProperty(Class<T> elementType);
 
     /**
-     * Creates a {@link SetProperty} implementation to hold a {@link Set} of the given element type. The property will have an empty set as its initial value.
+     * Creates a {@link SetProperty} implementation to hold a {@link Set} of the given element type {@code T}. The property will have an empty set as its initial value.
      *
      * <p>The implementation will return immutable {@link Set} values from its query methods.</p>
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -105,6 +105,23 @@ public interface ObjectFactory {
     <T> Property<T> property(Class<T> valueType);
 
     /**
+     * Creates a {@link Property} implementation to hold values of the given type and initial value.
+     *
+     * <p>For certain types, there are more specialized property factory methods available:</p>
+     * <ul>
+     * <li>For {@link List} properties, you should use {@link #listProperty(Class)}.</li>
+     * <li>For {@link Set} properties, you should use {@link #setProperty(Class)}.</li>
+     * <li>For {@link org.gradle.api.file.Directory} properties, you should use {@link #directoryProperty()}.</li>
+     * <li>For {@link org.gradle.api.file.RegularFile} properties, you should use {@link #fileProperty()}.</li>
+     * </ul>
+     *
+     * @param valueType The type of the property.
+     * @return The property. Never returns null.
+     * @since 5.0
+     */
+    <T> Property<T> property(Class<T> valueType, T initialValue);
+
+    /**
      * Creates a {@link ListProperty} implementation to hold a {@link List} of the given element type {@code T}. The property will have an empty list as its initial value.
      *
      * <p>The implementation will return immutable {@link List} values from its query methods.</p>

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -17,7 +17,9 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.Named;
+import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.DefaultSourceDirectorySet;
@@ -27,7 +29,6 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.provider.DefaultListProperty;
 import org.gradle.api.internal.provider.DefaultPropertyState;
 import org.gradle.api.internal.provider.DefaultSetProperty;
-import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
@@ -40,6 +41,8 @@ import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
 
 public class DefaultObjectFactory implements ObjectFactory {
     private final Instantiator instantiator;
@@ -97,28 +100,17 @@ public class DefaultObjectFactory implements ObjectFactory {
             // Kotlin passes these types for its own basic types
             return Cast.uncheckedCast(property(JavaReflectionUtil.getWrapperTypeForPrimitiveType(valueType)));
         }
-
-        Property<T> property = new DefaultPropertyState<T>(valueType);
-
-        if (valueType == Boolean.class) {
-            ((Property<Boolean>) property).set(Providers.FALSE);
-        } else if (valueType == Byte.class) {
-            ((Property<Byte>) property).set(Providers.BYTE_ZERO);
-        } else if (valueType == Short.class) {
-            ((Property<Short>) property).set(Providers.SHORT_ZERO);
-        } else if (valueType == Integer.class) {
-            ((Property<Integer>) property).set(Providers.INTEGER_ZERO);
-        } else if (valueType == Long.class) {
-            ((Property<Long>) property).set(Providers.LONG_ZERO);
-        } else if (valueType == Float.class) {
-            ((Property<Float>) property).set(Providers.FLOAT_ZERO);
-        } else if (valueType == Double.class) {
-            ((Property<Double>) property).set(Providers.DOUBLE_ZERO);
-        } else if (valueType == Character.class) {
-            ((Property<Character>) property).set(Providers.CHAR_ZERO);
+        if (List.class.isAssignableFrom(valueType)) {
+            DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() to create a property of type List<T>", "ObjectFactory.listProperty()");
+        } else if (Set.class.isAssignableFrom(valueType)) {
+            DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type Set<T>", "ObjectFactory.setProperty()");
+        } else if (Directory.class.isAssignableFrom(valueType)) {
+            DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type Directory", "ObjectFactory.directoryProperty()");
+        } else if (RegularFile.class.isAssignableFrom(valueType)) {
+            DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type RegularFile", "ObjectFactory.fileProperty()");
         }
 
-        return property;
+        return new DefaultPropertyState<T>(valueType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -114,6 +114,13 @@ public class DefaultObjectFactory implements ObjectFactory {
     }
 
     @Override
+    public <T> Property<T> property(Class<T> valueType, T initialValue) {
+        Property<T> property = property(valueType);
+        property.set(initialValue);
+        return property;
+    }
+
+    @Override
     public <T> ListProperty<T> listProperty(Class<T> elementType) {
         return new DefaultListProperty<T>(elementType);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -50,6 +50,13 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     }
 
     @Override
+    public <T> Property<T> property(Class<T> valueType, T initialValue) {
+        Property<T> property = property(valueType);
+        property.set(initialValue);
+        return property;
+    }
+
+    @Override
     public <T> ListProperty<T> listProperty(Class<T> elementType) {
         return broken();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -765,14 +765,14 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
     @Deprecated
     @Override
     public boolean add(Task o) {
-        DeprecationLogger.nagUserOfReplacedMethodWithCustomRemoval("add()", "create() or register()", "This method will cause an error in Gradle 6.0.");
+        DeprecationLogger.nagUserOfReplacedMethodInvocation("TaskContainer.add()", "TaskContainer.register()");
         return addInternal(o);
     }
 
     @Deprecated
     @Override
     public boolean addAll(Collection<? extends Task> c) {
-        DeprecationLogger.nagUserOfReplacedMethodWithCustomRemoval("addAll()", "create() or register()", "This method will cause an error in Gradle 6.0.");
+        DeprecationLogger.nagUserOfDiscontinuedMethodInvocation("TaskContainer.addAll()");
         return addAllInternal(c);
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -30,8 +30,14 @@ class DefaultObjectFactoryTest extends Specification {
     def "can create a property"() {
         expect:
         def property = factory.property(Boolean)
-        property.present
-        !property.get()
+        !property.present
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'No value has been specified for this provider.'
     }
 
     def "cannot create property for null value"() {
@@ -44,54 +50,24 @@ class DefaultObjectFactoryTest extends Specification {
     }
 
     @Unroll
-    def "properties with wrapper type #type provide default value"() {
+    def "can create property wih primitive type"() {
         given:
         def property = factory.property(type)
 
         expect:
-        property.get() == defaultValue
-
-        where:
-        type      | defaultValue
-        Boolean   | false
-        Byte      | 0
-        Short     | 0
-        Integer   | 0
-        Long      | 0L
-        Float     | 0.0f
-        Double    | 0.0d
-        Character | '\u0000'
-    }
-
-    @Unroll
-    def "properties wih primitive type #type provide default value"() {
-        given:
-        def property = factory.property(type)
-
-        expect:
-        property.get() == defaultValue
         property.type == boxedType
+        !property.present
 
         where:
-        type           | boxedType | defaultValue
-        Boolean.TYPE   | Boolean   | false
-        Byte.TYPE      | Byte      | 0
-        Short.TYPE     | Short     | 0
-        Integer.TYPE   | Integer   | 0
-        Long.TYPE      | Long      | 0L
-        Float.TYPE     | Float     | 0.0f
-        Double.TYPE    | Double    | 0.0d
-        Character.TYPE | Character | '\u0000'
-    }
-
-    def "creating property type for reference type throws exception upon retrieval of value"() {
-        when:
-        def property = factory.property(Runnable)
-        property.get()
-
-        then:
-        def t = thrown(IllegalStateException)
-        t.message == 'No value has been specified for this provider.'
+        type           | boxedType
+        Boolean.TYPE   | Boolean
+        Byte.TYPE      | Byte
+        Short.TYPE     | Short
+        Integer.TYPE   | Integer
+        Long.TYPE      | Long
+        Float.TYPE     | Float
+        Double.TYPE    | Double
+        Character.TYPE | Character
     }
 
     def "can create SourceDirectorySet"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -40,6 +40,13 @@ class DefaultObjectFactoryTest extends Specification {
         e.message == 'No value has been specified for this provider.'
     }
 
+    def "can create a property with initial value"() {
+        expect:
+        def property = factory.property(Boolean, true)
+        property.present
+        property.get()
+    }
+
     def "cannot create property for null value"() {
         when:
         factory.property(null)

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -138,9 +138,11 @@ In the next major release (6.0), removing dependencies from a task will become a
 Gradle will emit a deprecation warning for code such as `foo.dependsOn.remove(bar)`.  Removing dependencies in this way is error-prone and relies on the internal implementation details of how different tasks are wired together.
 At the moment, we are not planning to provide an alternative. In most cases, task dependencies should be expressed via [task inputs](userguide/more_about_tasks.html#sec:task_inputs_outputs) instead of explicit `dependsOn` relationships.
 
-### Factory methods for creating file and directory properties
+### Factory methods for creating properties
 
 TBD - The methods on `DefaultTask` and `ProjectLayout` that create file and directory `Property` instances have been deprecated and replaced by methods on `ObjectFactory`. These deprecated methods will be removed in Gradle 6.0.
+
+TBD - The `ObjectFactory.property(type)` method no longer sets a default value for the property. There is an overload `property(type, initialValue)` that can be used instead.
 
 ### The property `append` on `JacocoTaskExtension` has been deprecated
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/TaskDefinitionIntegrationTest.groovy
@@ -597,7 +597,7 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         succeeds("help")
 
         then:
-        outputContains("The add() method has been deprecated. This method will cause an error in Gradle 6.0. Please use the create() or register() method instead.")
+        outputContains("Using method TaskContainer.add() has been deprecated. This will fail with an error in Gradle 6.0. Please use the TaskContainer.register() method instead.")
     }
 
     def "cannot add a pre-created task provider to the task container"() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -104,8 +104,8 @@ public class SwiftCompile extends DefaultTask {
         this.source = getProject().files();
         this.sourceCompatibility = objectFactory.property(SwiftVersion.class);
         this.macros = objectFactory.listProperty(String.class);
-        this.debuggable = objectFactory.property(Boolean.class);
-        this.optimize = objectFactory.property(Boolean.class);
+        this.debuggable = objectFactory.property(Boolean.class, false);
+        this.optimize = objectFactory.property(Boolean.class, false);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
     }

--- a/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/util/SingleMessageLogger.java
@@ -126,12 +126,29 @@ public class SingleMessageLogger {
         }
     }
 
-    public static void nagUserOfReplacedMethodWithCustomRemoval(String methodName, String replacement, String removalDetails) {
+    /**
+     * Use for a method that is not deprecated, but some combination of parameter is deprecated.
+     */
+    public static void nagUserOfDiscontinuedMethodInvocation(String invocation) {
         if (isEnabled()) {
             nagUserWith(
-                String.format("The %s method has been deprecated.", methodName),
-                removalDetails,
-                String.format("Please use the %s method instead.", replacement),
+                String.format("Using method %s has been deprecated.", invocation),
+                thisWillBecomeAnError(),
+                null,
+                null,
+                DeprecatedFeatureUsage.Type.USER_CODE_DIRECT);
+        }
+    }
+
+    /**
+     * Use for a method that is not deprecated, but some combination of parameter is deprecated.
+     */
+    public static void nagUserOfReplacedMethodInvocation(String invocation, String replacement) {
+        if (isEnabled()) {
+            nagUserWith(
+                String.format("Using method %s has been deprecated.", invocation),
+                thisWillBecomeAnError(),
+                String.format(String.format("Please use the %s method instead.", replacement)),
                 null,
                 DeprecatedFeatureUsage.Type.USER_CODE_DIRECT);
         }
@@ -177,16 +194,6 @@ public class SingleMessageLogger {
     public static void nagUserOfDiscontinuedProperty(String propertyName, String advice) {
         if (isEnabled()) {
             nagUserWith(String.format("The %s property has been deprecated.", propertyName),
-                thisWillBeRemovedMessage(),
-                advice,
-                null,
-                DeprecatedFeatureUsage.Type.USER_CODE_DIRECT);
-        }
-    }
-
-    public static void nagUserOfDiscontinuedApi(String api, String advice) {
-        if (isEnabled()) {
-            nagUserWith(String.format("The %s has been deprecated.", api),
                 thisWillBeRemovedMessage(),
                 advice,
                 null,
@@ -330,6 +337,10 @@ public class SingleMessageLogger {
 
     private static boolean isEnabled() {
         return ENABLED.get();
+    }
+
+    private static String thisWillBecomeAnError() {
+        return String.format("This will fail with an error in Gradle %s.", GradleVersion.current().getNextMajor().getVersion());
     }
 
     private static String thisWillBeRemovedMessage() {

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -45,6 +45,8 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
         if (!hasKotlin) {
             executer.beforeExecute {
                 expectDeprecationWarning()
+                // Run Kotlin compiler in-process to avoid file locking issues
+                executer.withArguments("-Dkotlin.compiler.execution.strategy=in-process")
             }
             hasKotlin = true
         }
@@ -159,7 +161,6 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
         outputContains("message = some new value")
     }
 
-    @Requires(TestPrecondition.JDK8_OR_LATER)
     def "can define property in language plugin and set value from Java plugin"() {
         pluginDefinesTask()
 
@@ -223,6 +224,8 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
 
         def otherDir = file("buildSrc/other")
         usesKotlin(file(otherDir))
+        // This is because the Kotlin compiler is run in-process (to avoid issues with the Kotlin compiler daemon) and also keeps jars open
+        executer.requireDaemon().requireIsolatedDaemons()
         otherDir.file("build.gradle.kts") << """
             dependencies {
                 implementation(project(":plugin"))

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyJavaInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyJavaInterOpIntegrationTest.groovy
@@ -21,13 +21,9 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
 
 import javax.inject.Inject
 
-// Require Java 8+ to verify that Java lambdas work with the APIs.
-@Requires(TestPrecondition.JDK8_OR_LATER)
 class PropertyJavaInterOpIntegrationTest extends AbstractPropertyLanguageInterOpIntegrationTest {
     def setup() {
         pluginDir.file("build.gradle") << """

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -21,14 +21,12 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskAction
-import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import javax.inject.Inject
 
 @Requires(TestPrecondition.KOTLIN_SCRIPT)
-@LeaksFileHandles
 class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInterOpIntegrationTest {
     def setup() {
         usesKotlin(pluginDir)

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -84,7 +84,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
             }
         }));
         this.linkerArgs = getProject().getObjects().listProperty(String.class);
-        this.debuggable = objectFactory.property(Boolean.class);
+        this.debuggable = objectFactory.property(Boolean.class, false);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
     }

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/SimpleReport.java
@@ -52,7 +52,7 @@ public class SimpleReport implements ConfigurableReport {
         this.fileResolver = fileResolver;
         this.outputType = outputType;
         destination = project.getObjects().property(File.class);
-        enabled = project.getObjects().property(Boolean.class);
+        enabled = project.getObjects().property(Boolean.class, false);
         this.project = project;
     }
 


### PR DESCRIPTION
### Context

This PR changes `ObjectFactory.property()` so that it no longer sets a default value for the `Property` implementations that it creates. A new overload of `property()` is available as a convenience (possibly temporary) to create a property with an initial value.

This PR deprecates using this method when a more specialized factory method is available and points the user at the method to use.

This PR also attempts to fix some CI flakiness for those int tests that use the kotlin plugin to build stuff, such as the build init plugin.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
