### PR TITLE
Ensure that ide destroy tasks always run before generate tasks

### DIFF
--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeLifecycleIntegrationTest.groovy
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide
+
+abstract class AbstractIdeLifecycleIntegrationTest extends AbstractIdeProjectIntegrationTest {
+    abstract String[] getGenerationTaskNames(String projectPath)
+
+    def setup() {
+        project("root") {
+            project("foo") {
+                project("bar") {}
+            }
+        }
+    }
+
+    def "lifecycle task is added and generates metadata"() {
+        when:
+        run lifeCycleTaskName
+
+        then:
+        executed ":${lifeCycleTaskName}"
+        executed getGenerationTaskNames(":")
+        executed getGenerationTaskNames(":foo")
+        executed getGenerationTaskNames(":foo:bar")
+
+        and:
+        projectName(".") == "root"
+        projectName("foo") == "foo"
+        projectName("foo/bar") == "bar"
+    }
+
+    def "clean tasks always run before generation tasks when specified on the command line"() {
+        when:
+        run cleanTaskName, lifeCycleTaskName
+
+        then:
+        assertCleanTasksRunBeforeGenerationTasks()
+
+        when:
+        run lifeCycleTaskName, cleanTaskName
+
+        then:
+        assertCleanTasksRunBeforeGenerationTasks()
+
+        and:
+        projectName(".") == "root"
+        projectName("foo") == "foo"
+        projectName("foo/bar") == "bar"
+    }
+
+    def "clean tasks always run before generation tasks when modeled as a dependency"() {
+        given:
+        buildFile << """
+            allprojects {
+                tasks.${lifeCycleTaskName}.dependsOn tasks.${cleanTaskName}
+            }    
+        """
+
+        when:
+        run lifeCycleTaskName
+
+        then:
+        assertCleanTasksRunBeforeGenerationTasks()
+
+        and:
+        projectName(".") == "root"
+        projectName("foo") == "foo"
+        projectName("foo/bar") == "bar"
+    }
+
+    def assertCleanTasksRunBeforeGenerationTasks() {
+        [":", ":foo", ":foo:bar"].each { projectPath ->
+            getGenerationTaskNames(projectPath).each { taskName ->
+                result.assertTaskOrder(getCleanTaskName(taskName), taskName)
+            }
+        }
+    }
+
+    String getCleanTaskName(String generationTaskName) {
+        int lastSeparator = generationTaskName.lastIndexOf(":")
+        String taskName = generationTaskName.substring(lastSeparator + 1)
+        String cleanTaskName = "clean${taskName.capitalize()}"
+        return generationTaskName.substring(0, lastSeparator + 1) + cleanTaskName
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeProjectIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/AbstractIdeProjectIntegrationTest.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.ConfigureUtil
+
+abstract class AbstractIdeProjectIntegrationTest extends AbstractIntegrationSpec {
+    protected abstract String projectName(String path)
+
+    protected abstract String getIdeName()
+
+    protected abstract String getConfiguredModule()
+
+    String getLifeCycleTaskName() {
+        return ideName
+    }
+
+    String getCleanTaskName() {
+        return "clean${lifeCycleTaskName.capitalize()}"
+    }
+
+    Project project(String projectName, boolean allProjects = true, Closure configClosure) {
+        String applyTo = allProjects ? "allprojects" : "subprojects"
+        buildFile.createFile().text = """
+$applyTo {
+    apply plugin:'java'
+    apply plugin:'$ideName'
+}
+"""
+        settingsFile.createFile().text = "rootProject.name='$projectName'\n"
+        def proj = new Project(name: projectName, path: "", projectDir: getTestDirectory())
+        ConfigureUtil.configure(configClosure, proj);
+
+        def includeSubProject
+        includeSubProject = { Project p ->
+            for (Project subProj : p.subProjects) {
+                settingsFile << "include '${subProj.path}'\n"
+                includeSubProject.trampoline().call(subProj)
+            }
+        }
+
+        includeSubProject.trampoline().call(proj);
+    }
+
+    public static class Project {
+        String name
+        String path
+        def subProjects = []
+        TestFile projectDir
+
+        def project(String projectName, Closure configClosure) {
+            def p = new Project(name: projectName, path: "$path:$projectName", projectDir: projectDir.createDir(projectName));
+            subProjects << p;
+            ConfigureUtil.configure(configClosure, p);
+        }
+
+        File getBuildFile() {
+            def buildFile = projectDir.file("build.gradle")
+            if (!buildFile.exists()) {
+                buildFile.createFile()
+            }
+            return buildFile
+        }
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseLifecycleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseLifecycleIntegrationTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.eclipse
+
+import org.gradle.plugins.ide.AbstractIdeLifecycleIntegrationTest
+
+class EclipseLifecycleIntegrationTest extends AbstractIdeLifecycleIntegrationTest {
+    @Override
+    protected String projectName(String project) {
+        EclipseProjectFixture.create(testDirectory.file(project)).getProjectName()
+    }
+
+    @Override
+    protected String getIdeName() {
+        return "eclipse"
+    }
+
+    @Override
+    protected String getConfiguredModule() {
+        return "eclipse.project"
+    }
+
+    @Override
+    String[] getGenerationTaskNames(String projectPath) {
+        if (projectPath == ":") {
+            projectPath = ""
+        }
+        return ["${projectPath}:eclipseProject", "${projectPath}:eclipseJdt", "${projectPath}:eclipseClasspath"]
+    }
+}

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaLifecycleIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaLifecycleIntegrationTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.idea
+
+import org.gradle.plugins.ide.AbstractIdeLifecycleIntegrationTest
+
+class IdeaLifecycleIntegrationTest extends AbstractIdeLifecycleIntegrationTest {
+
+    @Override
+    protected String getIdeName() {
+        return "idea"
+    }
+
+    @Override
+    protected String getConfiguredModule() {
+        return "idea.module"
+    }
+
+    @Override
+    protected String projectName(String path) {
+        File iml = file(path).listFiles().find { it.name.endsWith("iml") }
+        assert iml != null
+        return iml.name - ".iml"
+    }
+
+    @Override
+    String[] getGenerationTaskNames(String projectPath) {
+        def taskNames = []
+        if (projectPath == ":") {
+            projectPath = ""
+            taskNames << ":ideaProject"
+        }
+        taskNames << "${projectPath}:ideaModule"
+        return taskNames
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/IdePlugin.java
@@ -75,16 +75,17 @@ public abstract class IdePlugin implements Plugin<Project> {
         project = target;
         String lifecycleTaskName = getLifecycleTaskName();
         lifecycleTask = target.getTasks().register(lifecycleTaskName);
-        lifecycleTask.configure(new Action<Task>() {
-            @Override
-            public void execute(Task task) {
-                task.setGroup("IDE");
-            }
-        });
         cleanTask = target.getTasks().register(cleanName(lifecycleTaskName), Delete.class, new Action<Delete>() {
             @Override
             public void execute(Delete task) {
                 task.setGroup("IDE");
+            }
+        });
+        lifecycleTask.configure(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                task.setGroup("IDE");
+                task.shouldRunAfter(cleanTask);
             }
         });
         onApply(target);
@@ -126,6 +127,14 @@ public abstract class IdePlugin implements Plugin<Project> {
         if (includeInClean) {
             cleanTask.configure(dependsOn(cleanWorker));
         }
+
+        // Always schedule the generation task after the clean task
+        worker.configure(new Action<Task>() {
+            @Override
+            public void execute(Task task) {
+                task.shouldRunAfter(cleanWorker);
+            }
+        });
     }
 
     protected static Action<? super Task> dependsOn(final Task taskDependency) {


### PR DESCRIPTION
This is a "fix" for https://github.com/gradle/gradle/issues/6582.