### PR TITLE
Move the implementation of various plugin convention objects into internal packages

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPlugin.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPlugin.java
@@ -19,12 +19,11 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.plugins.DslObject;
+import org.gradle.api.plugins.internal.DefaultProjectReportsPluginConvention;
 import org.gradle.api.reporting.dependencies.HtmlDependencyReportTask;
 import org.gradle.api.tasks.diagnostics.DependencyReportTask;
 import org.gradle.api.tasks.diagnostics.PropertyReportTask;
 import org.gradle.api.tasks.diagnostics.TaskReportTask;
-import org.gradle.internal.Factory;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -42,12 +41,7 @@ public class ProjectReportsPlugin implements Plugin<Project> {
     @Override
     public void apply(final Project project) {
         project.getPluginManager().apply(ReportingBasePlugin.class);
-        final ProjectReportsPluginConvention convention = DeprecationLogger.whileDisabled(new Factory<ProjectReportsPluginConvention>() {
-            @Override
-            public ProjectReportsPluginConvention create() {
-                return new ProjectReportsPluginConvention(project);
-            }
-        });
+        final ProjectReportsPluginConvention convention = new DefaultProjectReportsPluginConvention(project);
         project.getConvention().getPlugins().put("projectReports", convention);
 
         TaskReportTask taskReportTask = project.getTasks().create(TASK_REPORT, TaskReportTask.class);

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPluginConvention.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/ProjectReportsPluginConvention.java
@@ -17,9 +17,6 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Project;
-import org.gradle.api.reporting.ReportingExtension;
-import org.gradle.util.DeprecationLogger;
-import org.gradle.util.WrapUtil;
 
 import java.io.File;
 import java.util.Set;
@@ -27,40 +24,18 @@ import java.util.Set;
 /**
  * The conventional configuration for the `ProjectReportsPlugin`.
  */
-public class ProjectReportsPluginConvention {
-    private String projectReportDirName = "project";
-    private final Project project;
-
-    /**
-     * Creates a {@link ProjectReportsPluginConvention} instance.
-     *
-     * @deprecated Creating instances of this class is deprecated. These should be created by the reporting base plugin only.
-     */
-    @Deprecated
-    public ProjectReportsPluginConvention(Project project) {
-        DeprecationLogger.nagUserOfDeprecated("Creating instances of ProjectReportsPluginConvention");
-        this.project = project;
-    }
-
+public abstract class ProjectReportsPluginConvention {
     /**
      * The name of the directory to generate the project reports into, relative to the project's reports dir.
      */
-    public String getProjectReportDirName() {
-        return projectReportDirName;
-    }
+    public abstract String getProjectReportDirName();
 
-    public void setProjectReportDirName(String projectReportDirName) {
-        this.projectReportDirName = projectReportDirName;
-    }
+    public abstract void setProjectReportDirName(String projectReportDirName);
 
     /**
      * Returns the directory to generate the project reports into.
      */
-    public File getProjectReportDir() {
-        return project.getExtensions().getByType(ReportingExtension.class).file(projectReportDirName);
-    }
+    public abstract File getProjectReportDir();
 
-    public Set<Project> getProjects() {
-        return WrapUtil.toSet(project);
-    }
+    public abstract Set<Project> getProjects();
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/internal/DefaultProjectReportsPluginConvention.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/internal/DefaultProjectReportsPluginConvention.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.ProjectReportsPluginConvention;
+import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.util.WrapUtil;
+
+import java.io.File;
+import java.util.Set;
+
+public class DefaultProjectReportsPluginConvention extends ProjectReportsPluginConvention {
+    private String projectReportDirName = "project";
+    private final Project project;
+
+    public DefaultProjectReportsPluginConvention(Project project) {
+        this.project = project;
+    }
+
+    @Override
+    public String getProjectReportDirName() {
+        return projectReportDirName;
+    }
+
+    @Override
+    public void setProjectReportDirName(String projectReportDirName) {
+        this.projectReportDirName = projectReportDirName;
+    }
+
+    @Override
+    public File getProjectReportDir() {
+        return project.getExtensions().getByType(ReportingExtension.class).file(projectReportDirName);
+    }
+
+    @Override
+    public Set<Project> getProjects() {
+        return WrapUtil.toSet(project);
+    }
+}

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -23,6 +23,548 @@
             ]
         },
         {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Class org.gradle.api.plugins.ApplicationPluginConvention",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Class is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Constructor org.gradle.api.plugins.ApplicationPluginConvention()",
+            "acceptation": "Implementation has moved to internal package"
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.getApplicationDefaultJvmArgs()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.getApplicationDistribution()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.getApplicationName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.getMainClassName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.getProject()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.setApplicationDefaultJvmArgs(java.lang.Iterable)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.setApplicationDistribution(org.gradle.api.file.CopySpec)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.setApplicationName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ApplicationPluginConvention",
+            "member": "Method org.gradle.api.plugins.ApplicationPluginConvention.setMainClassName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Class org.gradle.api.plugins.BasePluginConvention",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Class is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getArchivesBaseName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getDistsDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getDistsDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getLibsDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getLibsDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.getProject()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.setArchivesBaseName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.setDistsDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.setLibsDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Method org.gradle.api.plugins.BasePluginConvention.setProject(org.gradle.api.internal.project.ProjectInternal)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.BasePluginConvention",
+            "member": "Constructor org.gradle.api.plugins.BasePluginConvention()",
+            "acceptation": "Implementation has moved to internal package"
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Class org.gradle.api.plugins.JavaPluginConvention",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Class is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getDocsDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getDocsDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getProject()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getSourceCompatibility()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getSourceSets()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getTargetCompatibility()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getTestReportDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getTestReportDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getTestResultsDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.getTestResultsDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.manifest()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.manifest(groovy.lang.Closure)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.manifest(org.gradle.api.Action)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setDocsDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setSourceCompatibility(java.lang.Object)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setSourceCompatibility(org.gradle.api.JavaVersion)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setTargetCompatibility(java.lang.Object)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setTargetCompatibility(org.gradle.api.JavaVersion)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setTestReportDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.setTestResultsDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Method org.gradle.api.plugins.JavaPluginConvention.sourceSets(groovy.lang.Closure)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.JavaPluginConvention",
+            "member": "Constructor org.gradle.api.plugins.JavaPluginConvention()",
+            "acceptation": "Implementation has moved to internal package"
+        },
+        {
+            "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "member": "Class org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Class is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "member": "Method org.gradle.api.plugins.ProjectReportsPluginConvention.getProjectReportDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "member": "Method org.gradle.api.plugins.ProjectReportsPluginConvention.getProjectReportDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "member": "Method org.gradle.api.plugins.ProjectReportsPluginConvention.getProjects()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "member": "Method org.gradle.api.plugins.ProjectReportsPluginConvention.setProjectReportDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.ProjectReportsPluginConvention",
+            "member": "Constructor org.gradle.api.plugins.ProjectReportsPluginConvention()",
+            "acceptation": "Implementation has moved to internal package"
+        },
+        {
+            "type": "org.gradle.api.plugins.WarPluginConvention",
+            "member": "Class org.gradle.api.plugins.WarPluginConvention",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Class is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.WarPluginConvention",
+            "member": "Method org.gradle.api.plugins.WarPluginConvention.getProject()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.WarPluginConvention",
+            "member": "Method org.gradle.api.plugins.WarPluginConvention.getWebAppDir()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.WarPluginConvention",
+            "member": "Method org.gradle.api.plugins.WarPluginConvention.getWebAppDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.WarPluginConvention",
+            "member": "Method org.gradle.api.plugins.WarPluginConvention.setWebAppDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.WarPluginConvention",
+            "member": "Constructor org.gradle.api.plugins.WarPluginConvention()",
+            "acceptation": "Implementation has moved to internal package"
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Class org.gradle.plugins.ear.EarPluginConvention",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Class is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.appDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.deploymentDescriptor(groovy.lang.Closure)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.deploymentDescriptor(org.gradle.api.Action)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.getAppDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.getDeploymentDescriptor()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.getLibDirName()",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.libDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.setAppDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.setDeploymentDescriptor(org.gradle.plugins.ear.descriptor.DeploymentDescriptor)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Method org.gradle.plugins.ear.EarPluginConvention.setLibDirName(java.lang.String)",
+            "acceptation": "Implementation has moved to internal package",
+            "changes": [
+                "Method is now abstract"
+            ]
+        },
+        {
+            "type": "org.gradle.plugins.ear.EarPluginConvention",
+            "member": "Constructor org.gradle.plugins.ear.EarPluginConvention()",
+            "acceptation": "Implementation has moved to internal package"
+        },
+        {
             "type": "org.gradle.api.plugins.quality.CheckstyleReports",
             "member": "Method org.gradle.api.plugins.quality.CheckstyleReports.getHtml()",
             "acceptation": "Support type-safe configuration for Checkstyle HTML report stylesheet when using Kotlin DSL",

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -6,10 +6,6 @@ Here are the new features introduced in this Gradle release.
 IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
 Add-->
 
-<!--
-### Example new and noteworthy
--->
-
 ### Build init plugin improvements
 
 This release includes a number of improvements to The [Build Init plugin](userguide/build_init_plugin.html).
@@ -97,10 +93,6 @@ The following are the newly deprecated items in this Gradle release. If you have
 
 The `interactive` flag is deprecated and will be removed in Gradle 6.0.
 
-<!--
-### Example deprecation
--->
-
 ### Removing tasks from TaskContainer
 
 Removing tasks from the `TaskContainer` using the following methods has been deprecated and will be an error in Gradle 6.0.
@@ -138,7 +130,7 @@ In the next major release (6.0), removing dependencies from a task will become a
 Gradle will emit a deprecation warning for code such as `foo.dependsOn.remove(bar)`.  Removing dependencies in this way is error-prone and relies on the internal implementation details of how different tasks are wired together.
 At the moment, we are not planning to provide an alternative. In most cases, task dependencies should be expressed via [task inputs](userguide/more_about_tasks.html#sec:task_inputs_outputs) instead of explicit `dependsOn` relationships.
 
-### Factory methods for creating properties
+### Incubating factory methods for creating properties
 
 TBD - The methods on `DefaultTask` and `ProjectLayout` that create file and directory `Property` instances have been deprecated and replaced by methods on `ObjectFactory`. These deprecated methods will be removed in Gradle 6.0.
 
@@ -268,6 +260,12 @@ The `IdeaModule` Tooling API model element contains methods to retrieve resource
 - Chaining calls to the methods `file`, `files`, and `dir` on `TaskInputs` is now impossible.
 - Chaining calls to the methods `file`, `files`, and `dir` on `TaskOutputs` is now impossible.
 - Chaining calls to the method `property` and `properties` on `TaskInputs` is now an error.
+- `JavaPluginConvention` is now abstract. 
+- `ApplicationPluginConvention` is now abstract. 
+- `WarPluginConvention` is now abstract. 
+- `EarPluginConvention` is now abstract. 
+- `BasePluginConvention` is now abstract. 
+- `ProjectReportsPluginConvention` is now abstract. 
 
 ### Changes to internal APIs
 

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPlugin.java
@@ -33,9 +33,8 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.internal.Factory;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
-import org.gradle.util.DeprecationLogger;
+import org.gradle.plugins.ear.internal.DefaultEarPluginConvention;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -71,12 +70,7 @@ public class EarPlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(BasePlugin.class);
 
-        EarPluginConvention earPluginConvention = DeprecationLogger.whileDisabled(new Factory<EarPluginConvention>() {
-            @Override
-            public EarPluginConvention create() {
-                return objectFactory.newInstance(EarPluginConvention.class, fileResolver, objectFactory);
-            }
-        });
+        EarPluginConvention earPluginConvention = objectFactory.newInstance(DefaultEarPluginConvention.class, fileResolver, objectFactory);
         project.getConvention().getPlugins().put("ear", earPluginConvention);
         earPluginConvention.setLibDirName(DEFAULT_LIB_DIR_NAME);
         earPluginConvention.setAppDirName("src/main/application");
@@ -124,7 +118,7 @@ public class EarPlugin implements Plugin<Project> {
                         task.dependsOn(new Callable<FileCollection>() {
                             public FileCollection call() throws Exception {
                                 return javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME)
-                                        .getRuntimeClasspath();
+                                    .getRuntimeClasspath();
                             }
                         });
                         task.from(new Callable<FileCollection>() {
@@ -199,11 +193,11 @@ public class EarPlugin implements Plugin<Project> {
 
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration moduleConfiguration = configurations.create(DEPLOY_CONFIGURATION_NAME).setVisible(false)
-                .setTransitive(false).setDescription("Classpath for deployable modules, not transitive.");
+            .setTransitive(false).setDescription("Classpath for deployable modules, not transitive.");
         Configuration earlibConfiguration = configurations.create(EARLIB_CONFIGURATION_NAME).setVisible(false)
-                .setDescription("Classpath for module dependencies.");
+            .setDescription("Classpath for module dependencies.");
 
         configurations.getByName(Dependency.DEFAULT_CONFIGURATION)
-                .extendsFrom(moduleConfiguration, earlibConfiguration);
+            .extendsFrom(moduleConfiguration, earlibConfiguration);
     }
 }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/EarPluginConvention.java
@@ -17,110 +17,46 @@ package org.gradle.plugins.ear;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.internal.reflect.Instantiator;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
-import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
-import org.gradle.util.ConfigureUtil;
-import org.gradle.util.DeprecationLogger;
-
-import javax.inject.Inject;
-import java.io.File;
 
 /**
  * Ear Plugin Convention.
  */
-public class EarPluginConvention {
-
-    private FileResolver fileResolver;
-    private ObjectFactory objectFactory;
-
-    private DeploymentDescriptor deploymentDescriptor;
-    private String appDirName;
-    private String libDirName;
-
-    /**
-     * Construct an {@link EarPluginConvention} using internal {@link Instantiator}.
-     *
-     * @deprecated Creating instances of this class is deprecated. These should be created by the EAR plugin only.
-     */
-    @Deprecated
-    public EarPluginConvention(FileResolver fileResolver, Instantiator instantiator) {
-        this(fileResolver, new InstantiatorBackedObjectFactory(instantiator));
-    }
-
-    /**
-     * Construct an {@link EarPluginConvention} using public {@link ObjectFactory}.
-     *
-     * @since 4.2
-     * @deprecated Creating instances of this class is deprecated. These should be created by the EAR plugin only.
-     */
-    @Inject
-    @Deprecated
-    public EarPluginConvention(FileResolver fileResolver, ObjectFactory objectFactory) {
-        DeprecationLogger.nagUserOfDeprecated("Creating instances of EarPluginConvention");
-        this.fileResolver = fileResolver;
-        this.objectFactory = objectFactory;
-        deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class, fileResolver, objectFactory);
-        deploymentDescriptor.readFrom("META-INF/application.xml");
-        deploymentDescriptor.readFrom(appDirName + "/META-INF/" + deploymentDescriptor.getFileName());
-    }
-
+public abstract class EarPluginConvention {
     /**
      * The name of the application directory, relative to the project directory.
      * Default is "src/main/application".
      */
-    public String getAppDirName() {
-        return appDirName;
-    }
+    public abstract String getAppDirName();
 
-    public void setAppDirName(String appDirName) {
-        this.appDirName = appDirName;
-        if (deploymentDescriptor != null) {
-            deploymentDescriptor.readFrom(new File(appDirName, "META-INF/" + deploymentDescriptor.getFileName()));
-        }
-    }
+    public abstract void setAppDirName(String appDirName);
 
     /**
      * Allows changing the application directory.
      * Default is "src/main/application".
      */
-    public void appDirName(String appDirName) {
-        this.setAppDirName(appDirName);
-    }
+    public abstract void appDirName(String appDirName);
 
     /**
      * The name of the library directory in the EAR file.
      * Default is "lib".
      */
-    public String getLibDirName() {
-        return libDirName;
-    }
+    public abstract String getLibDirName();
 
-    public void setLibDirName(String libDirName) {
-        this.libDirName = libDirName;
-    }
+    public abstract void setLibDirName(String libDirName);
 
     /**
      * Allows changing the library directory in the EAR file. Default is "lib".
      */
-    public void libDirName(String libDirName) {
-        this.libDirName = libDirName;
-    }
+    public abstract void libDirName(String libDirName);
 
     /**
      * A custom deployment descriptor configuration.
      * Default is an "application.xml" with sensible defaults.
      */
-    public DeploymentDescriptor getDeploymentDescriptor() {
-        return deploymentDescriptor;
-    }
+    public abstract DeploymentDescriptor getDeploymentDescriptor();
 
-    public void setDeploymentDescriptor(DeploymentDescriptor deploymentDescriptor) {
-        this.deploymentDescriptor = deploymentDescriptor;
-    }
+    public abstract void setDeploymentDescriptor(DeploymentDescriptor deploymentDescriptor);
 
     /**
      * Configures the deployment descriptor for this EAR archive.
@@ -131,10 +67,7 @@ public class EarPluginConvention {
      * @param configureClosure The closure.
      * @return This.
      */
-    public EarPluginConvention deploymentDescriptor(Closure configureClosure) {
-        ConfigureUtil.configure(configureClosure, forceDeploymentDescriptor());
-        return this;
-    }
+    public abstract EarPluginConvention deploymentDescriptor(Closure configureClosure);
 
     /**
      * Configures the deployment descriptor for this EAR archive.
@@ -145,16 +78,5 @@ public class EarPluginConvention {
      * @return This.
      * @since 3.5
      */
-    public EarPluginConvention deploymentDescriptor(Action<? super DeploymentDescriptor> configureAction) {
-        configureAction.execute(forceDeploymentDescriptor());
-        return this;
-    }
-
-    private DeploymentDescriptor forceDeploymentDescriptor() {
-        if (deploymentDescriptor == null) {
-            deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class, fileResolver, objectFactory);
-            assert deploymentDescriptor != null;
-        }
-        return deploymentDescriptor;
-    }
+    public abstract EarPluginConvention deploymentDescriptor(Action<? super DeploymentDescriptor> configureAction);
 }

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ear.internal;
+
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.internal.file.FileResolver;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.plugins.ear.EarPluginConvention;
+import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
+import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
+import org.gradle.util.ConfigureUtil;
+
+import javax.inject.Inject;
+import java.io.File;
+
+public class DefaultEarPluginConvention extends EarPluginConvention {
+
+    private FileResolver fileResolver;
+    private ObjectFactory objectFactory;
+
+    private DeploymentDescriptor deploymentDescriptor;
+    private String appDirName;
+    private String libDirName;
+
+    @Inject
+    public DefaultEarPluginConvention(FileResolver fileResolver, ObjectFactory objectFactory) {
+        this.fileResolver = fileResolver;
+        this.objectFactory = objectFactory;
+        deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class, fileResolver, objectFactory);
+        deploymentDescriptor.readFrom("META-INF/application.xml");
+        deploymentDescriptor.readFrom(appDirName + "/META-INF/" + deploymentDescriptor.getFileName());
+    }
+
+    @Override
+    public String getAppDirName() {
+        return appDirName;
+    }
+
+    @Override
+    public void setAppDirName(String appDirName) {
+        this.appDirName = appDirName;
+        if (deploymentDescriptor != null) {
+            deploymentDescriptor.readFrom(new File(appDirName, "META-INF/" + deploymentDescriptor.getFileName()));
+        }
+    }
+
+    @Override
+    public void appDirName(String appDirName) {
+        this.setAppDirName(appDirName);
+    }
+
+    @Override
+    public String getLibDirName() {
+        return libDirName;
+    }
+
+    @Override
+    public void setLibDirName(String libDirName) {
+        this.libDirName = libDirName;
+    }
+
+    @Override
+    public void libDirName(String libDirName) {
+        this.libDirName = libDirName;
+    }
+
+    @Override
+    public DeploymentDescriptor getDeploymentDescriptor() {
+        return deploymentDescriptor;
+    }
+
+    @Override
+    public void setDeploymentDescriptor(DeploymentDescriptor deploymentDescriptor) {
+        this.deploymentDescriptor = deploymentDescriptor;
+    }
+
+    @Override
+    public DefaultEarPluginConvention deploymentDescriptor(Closure configureClosure) {
+        ConfigureUtil.configure(configureClosure, forceDeploymentDescriptor());
+        return this;
+    }
+
+    @Override
+    public DefaultEarPluginConvention deploymentDescriptor(Action<? super DeploymentDescriptor> configureAction) {
+        configureAction.execute(forceDeploymentDescriptor());
+        return this;
+    }
+
+    private DeploymentDescriptor forceDeploymentDescriptor() {
+        if (deploymentDescriptor == null) {
+            deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class, fileResolver, objectFactory);
+            assert deploymentDescriptor != null;
+        }
+        return deploymentDescriptor;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -27,13 +27,12 @@ import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.plugins.DistributionPlugin;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.internal.IConventionAware;
+import org.gradle.api.plugins.internal.DefaultApplicationPluginConvention;
 import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
 import org.gradle.api.tasks.application.CreateStartScripts;
-import org.gradle.internal.Factory;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.concurrent.Callable;
@@ -106,12 +105,7 @@ public class ApplicationPlugin implements Plugin<Project> {
     }
 
     private void addExtensions() {
-        pluginConvention = DeprecationLogger.whileDisabled(new Factory<ApplicationPluginConvention>() {
-            @Override
-            public ApplicationPluginConvention create() {
-                return new ApplicationPluginConvention(project);
-            }
-        });
+        pluginConvention = new DefaultApplicationPluginConvention(project);
         pluginConvention.setApplicationName(project.getName());
         project.getConvention().getPlugins().put("application", pluginConvention);
         project.getExtensions().create(JavaApplication.class, "application", DefaultJavaApplication.class, pluginConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPluginConvention.java
@@ -19,75 +19,40 @@ package org.gradle.api.plugins;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
-import org.gradle.util.DeprecationLogger;
-
-import java.util.ArrayList;
 
 /**
  * <p>The {@link Convention} used for configuring the {@link ApplicationPlugin}.</p>
  */
-public class ApplicationPluginConvention {
-    private String applicationName;
-    private String mainClassName;
-    private Iterable<String> applicationDefaultJvmArgs = new ArrayList<String>();
-    private String executableDir = "bin";
-    private CopySpec applicationDistribution;
-
-    private final Project project;
-
+public abstract class ApplicationPluginConvention {
     /**
-     * Constructs an {@link ApplicationPluginConvention}.
-     *
-     * @deprecated Creating instances of this class is deprecated. These should be created by the application plugin only.
+     * The name of the application.
      */
-    @Deprecated
-    public ApplicationPluginConvention(Project project) {
-        DeprecationLogger.nagUserOfDeprecated("Creating instances of ApplicationPluginConvention");
-        this.project = project;
-        applicationDistribution = project.copySpec();
-    }
+    public abstract String getApplicationName();
 
     /**
      * The name of the application.
      */
-    public String getApplicationName() {
-        return applicationName;
-    }
-
-    /**
-     * The name of the application.
-     */
-    public void setApplicationName(String applicationName) {
-        this.applicationName = applicationName;
-    }
+    public abstract void setApplicationName(String applicationName);
 
     /**
      * The fully qualified name of the application's main class.
      */
-    public String getMainClassName() {
-        return mainClassName;
-    }
+    public abstract String getMainClassName();
 
     /**
      * The fully qualified name of the application's main class.
      */
-    public void setMainClassName(String mainClassName) {
-        this.mainClassName = mainClassName;
-    }
+    public abstract void setMainClassName(String mainClassName);
 
     /**
      * Array of string arguments to pass to the JVM when running the application
      */
-    public Iterable<String> getApplicationDefaultJvmArgs() {
-        return applicationDefaultJvmArgs;
-    }
+    public abstract Iterable<String> getApplicationDefaultJvmArgs();
 
     /**
      * Array of string arguments to pass to the JVM when running the application
      */
-    public void setApplicationDefaultJvmArgs(Iterable<String> applicationDefaultJvmArgs) {
-        this.applicationDefaultJvmArgs = applicationDefaultJvmArgs;
-    }
+    public abstract void setApplicationDefaultJvmArgs(Iterable<String> applicationDefaultJvmArgs);
 
     /**
      * Directory to place executables in
@@ -95,9 +60,7 @@ public class ApplicationPluginConvention {
      * @since 4.5
      */
     @Incubating
-    public String getExecutableDir() {
-        return executableDir;
-    }
+    public abstract String getExecutableDir();
 
     /**
      * Directory to place executables in
@@ -105,9 +68,7 @@ public class ApplicationPluginConvention {
      * @since 4.5
      */
     @Incubating
-    public void setExecutableDir(String executableDir) {
-        this.executableDir = executableDir;
-    }
+    public abstract void setExecutableDir(String executableDir);
 
     /**
      * <p>The specification of the contents of the distribution.</p>
@@ -125,15 +86,9 @@ public class ApplicationPluginConvention {
      * copy the application start scripts into the "{@code bin}" directory, and copy the built jar and its dependencies
      * into the "{@code lib}" directory.
      */
-    public CopySpec getApplicationDistribution() {
-        return applicationDistribution;
-    }
+    public abstract CopySpec getApplicationDistribution();
 
-    public void setApplicationDistribution(CopySpec applicationDistribution) {
-        this.applicationDistribution = applicationDistribution;
-    }
+    public abstract void setApplicationDistribution(CopySpec applicationDistribution);
 
-    public final Project getProject() {
-        return project;
-    }
+    public abstract Project getProject();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -36,14 +36,13 @@ import org.gradle.api.internal.plugins.BuildConfigurationRule;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.internal.plugins.UploadRule;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.internal.DefaultBasePluginConvention;
 import org.gradle.api.tasks.Upload;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.configuration.project.ProjectConfigurationActionContainer;
 import org.gradle.internal.Describables;
-import org.gradle.internal.Factory;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
-import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -74,12 +73,7 @@ public class BasePlugin implements Plugin<Project> {
     public void apply(final Project project) {
         project.getPluginManager().apply(LifecycleBasePlugin.class);
 
-        BasePluginConvention convention = DeprecationLogger.whileDisabled(new Factory<BasePluginConvention>() {
-            @Override
-            public BasePluginConvention create() {
-                return new BasePluginConvention(project);
-            }
-        });
+        BasePluginConvention convention = new DefaultBasePluginConvention(project);
         project.getConvention().getPlugins().put("base", convention);
 
         configureBuildConfigurationRule(project);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePluginConvention.java
@@ -16,116 +16,50 @@
 
 package org.gradle.api.plugins;
 
-import org.gradle.api.Project;
-import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
 /**
  * <p>A {@link Convention} used for the BasePlugin.</p>
  */
-public class BasePluginConvention {
-    private ProjectInternal project;
-
-    private String distsDirName;
-
-    private String libsDirName;
-
-    // cached resolved values
-    private File buildDir;
-    private File libsDir;
-    private File distsDir;
-
-    private String archivesBaseName;
-
-    /**
-     * Creates a {@link BasePluginConvention} instance.
-     *
-     * @deprecated Creating instances of this class is deprecated. These should be created by the base plugin only.
-     */
-    @Deprecated
-    public BasePluginConvention(Project project) {
-        DeprecationLogger.nagUserOfDeprecated("Creating instances of BasePluginConvention");
-        this.project = (ProjectInternal) project;
-        archivesBaseName = project.getName();
-        distsDirName = "distributions";
-        libsDirName = "libs";
-    }
-
+public abstract class BasePluginConvention {
     /**
      * Returns the directory to generate TAR and ZIP archives into.
      *
      * @return The directory. Never returns null.
      */
-    public File getDistsDir() {
-        File curProjectBuildDir = project.getBuildDir();
-        if (distsDir != null && curProjectBuildDir.equals(buildDir)) {
-            return distsDir;
-        }
-        buildDir = curProjectBuildDir;
-        File dir = project.getServices().get(FileLookup.class).getFileResolver(curProjectBuildDir).resolve(distsDirName);
-        distsDir = dir;
-        return dir;
-    }
+    public abstract File getDistsDir();
 
     /**
      * Returns the directory to generate JAR and WAR archives into.
      *
      * @return The directory. Never returns null.
      */
-    public File getLibsDir() {
-        File curProjectBuildDir = project.getBuildDir();
-        if (libsDir != null && curProjectBuildDir.equals(buildDir)) {
-            return libsDir;
-        }
-        buildDir = curProjectBuildDir;
-        File dir = project.getServices().get(FileLookup.class).getFileResolver(curProjectBuildDir).resolve(libsDirName);
-        libsDir = dir;
-        return dir;
-    }
+    public abstract File getLibsDir();
 
-    public ProjectInternal getProject() {
-        return project;
-    }
+    public abstract ProjectInternal getProject();
 
-    public void setProject(ProjectInternal project) {
-        this.project = project;
-    }
+    public abstract void setProject(ProjectInternal project);
 
     /**
      * The name for the distributions directory. This in interpreted relative to the project' build directory.
      */
-    public String getDistsDirName() {
-        return distsDirName;
-    }
+    public abstract String getDistsDirName();
 
-    public void setDistsDirName(String distsDirName) {
-        this.distsDirName = distsDirName;
-        this.distsDir = null;
-    }
+    public abstract void setDistsDirName(String distsDirName);
 
     /**
      * The name for the libs directory. This in interpreted relative to the project' build directory.
      */
-    public String getLibsDirName() {
-        return libsDirName;
-    }
+    public abstract String getLibsDirName();
 
-    public void setLibsDirName(String libsDirName) {
-        this.libsDirName = libsDirName;
-        this.libsDir = null;
-    }
+    public abstract void setLibsDirName(String libsDirName);
 
     /**
      * The base name to use for archive files.
      */
-    public String getArchivesBaseName() {
-        return archivesBaseName;
-    }
+    public abstract String getArchivesBaseName();
 
-    public void setArchivesBaseName(String archivesBaseName) {
-        this.archivesBaseName = archivesBaseName;
-    }
+    public abstract void setArchivesBaseName(String archivesBaseName);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -39,6 +39,7 @@ import org.gradle.api.internal.ReusableAction;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.DefaultJavaPluginConvention;
 import org.gradle.api.plugins.internal.DefaultJavaPluginExtension;
 import org.gradle.api.plugins.internal.SourceSetUtil;
 import org.gradle.api.provider.Provider;
@@ -49,12 +50,10 @@ import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
-import org.gradle.internal.Factory;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.language.jvm.tasks.ProcessResources;
-import org.gradle.util.DeprecationLogger;
 import org.gradle.util.SingleMessageLogger;
 
 import javax.inject.Inject;
@@ -102,12 +101,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private JavaPluginConvention addExtensions(final ProjectInternal project) {
-        JavaPluginConvention javaConvention = DeprecationLogger.whileDisabled(new Factory<JavaPluginConvention>() {
-            @Override
-            public JavaPluginConvention create() {
-                return new JavaPluginConvention(project, instantiator);
-            }
-        });
+        JavaPluginConvention javaConvention = new DefaultJavaPluginConvention(project, instantiator);
         project.getConvention().getPlugins().put("java", javaConvention);
         project.getExtensions().add(SourceSetContainer.class, "sourceSets", javaConvention.getSourceSets());
         project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
@@ -19,56 +19,17 @@ package org.gradle.api.plugins;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.DefaultSourceSetContainer;
 import org.gradle.api.java.archives.Manifest;
-import org.gradle.api.java.archives.internal.DefaultManifest;
-import org.gradle.api.model.ObjectFactory;
-import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.gradle.internal.Actions;
-import org.gradle.internal.reflect.Instantiator;
-import org.gradle.testing.base.plugins.TestingBasePlugin;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
-
-import static org.gradle.util.ConfigureUtil.configure;
 
 /**
  * Is mixed into the project when applying the {@link org.gradle.api.plugins.JavaBasePlugin} or the
  * {@link org.gradle.api.plugins.JavaPlugin}.
  */
-public class JavaPluginConvention {
-    private ProjectInternal project;
-
-    private String docsDirName;
-
-    private String testResultsDirName;
-
-    private String testReportDirName;
-
-    private final SourceSetContainer sourceSets;
-
-    private JavaVersion srcCompat;
-    private JavaVersion targetCompat;
-
-    /**
-     * Constructs a {@link JavaPluginConvention}.
-     *
-     * @deprecated Creating instances of this class is deprecated. These should be created by the Java base plugin only.
-     */
-    @Deprecated
-    public JavaPluginConvention(ProjectInternal project, Instantiator instantiator) {
-        DeprecationLogger.nagUserOfDeprecated("Creating instances of JavaPluginConvention");
-        this.project = project;
-        sourceSets = instantiator.newInstance(DefaultSourceSetContainer.class, project.getFileResolver(), project.getTasks(), instantiator, project.getServices().get(ObjectFactory.class));
-        docsDirName = "docs";
-        testResultsDirName = TestingBasePlugin.TEST_RESULTS_DIR_NAME;
-        testReportDirName = TestingBasePlugin.TESTS_DIR_NAME;
-    }
-
+public abstract class JavaPluginConvention {
     /**
      * Configures the source sets of this project.
      *
@@ -93,91 +54,65 @@ public class JavaPluginConvention {
      * @param closure The closure to execute.
      * @return NamedDomainObjectContainer&lt;org.gradle.api.tasks.SourceSet&gt;
      */
-    public Object sourceSets(Closure closure) {
-        return sourceSets.configure(closure);
-    }
+    public abstract Object sourceSets(Closure closure);
 
     /**
      * Returns a file pointing to the root directory supposed to be used for all docs.
      */
-    public File getDocsDir() {
-        return project.getServices().get(FileLookup.class).getFileResolver(project.getBuildDir()).resolve(docsDirName);
-    }
+    public abstract File getDocsDir();
 
     /**
      * Returns a file pointing to the root directory of the test results.
      */
-    public File getTestResultsDir() {
-        return project.getServices().get(FileLookup.class).getFileResolver(project.getBuildDir()).resolve(testResultsDirName);
-    }
+    public abstract File getTestResultsDir();
 
     /**
      * Returns a file pointing to the root directory to be used for reports.
      */
-    public File getTestReportDir() {
-        return project.getServices().get(FileLookup.class).getFileResolver(getReportsDir()).resolve(testReportDirName);
-    }
-
-    private File getReportsDir() {
-        return project.getExtensions().getByType(ReportingExtension.class).getBaseDir();
-    }
+    public abstract File getTestReportDir();
 
     /**
      * Returns the source compatibility used for compiling Java sources.
      */
-    public JavaVersion getSourceCompatibility() {
-        return srcCompat != null ? srcCompat : JavaVersion.current();
-    }
+    public abstract JavaVersion getSourceCompatibility();
 
     /**
      * Sets the source compatibility used for compiling Java sources.
      *
      * @param value The value for the source compatibility as defined by {@link JavaVersion#toVersion(Object)}
      */
-    public void setSourceCompatibility(Object value) {
-        setSourceCompatibility(JavaVersion.toVersion(value));
-    }
+    public abstract void setSourceCompatibility(Object value);
 
     /**
      * Sets the source compatibility used for compiling Java sources.
      *
      * @param value The value for the source compatibility
      */
-    public void setSourceCompatibility(JavaVersion value) {
-        srcCompat = value;
-    }
+    public abstract void setSourceCompatibility(JavaVersion value);
 
     /**
      * Returns the target compatibility used for compiling Java sources.
      */
-    public JavaVersion getTargetCompatibility() {
-        return targetCompat != null ? targetCompat : getSourceCompatibility();
-    }
+    public abstract JavaVersion getTargetCompatibility();
 
     /**
      * Sets the target compatibility used for compiling Java sources.
      *
      * @param value The value for the target compatibility as defined by {@link JavaVersion#toVersion(Object)}
      */
-    public void setTargetCompatibility(Object value) {
-        setTargetCompatibility(JavaVersion.toVersion(value));
-    }
+    public abstract void setTargetCompatibility(Object value);
 
     /**
      * Sets the target compatibility used for compiling Java sources.
      *
      * @param value The value for the target compatibility
      */
-    public void setTargetCompatibility(JavaVersion value) {
-        targetCompat = value;
-    }
+    public abstract void setTargetCompatibility(JavaVersion value);
 
     /**
      * Creates a new instance of a {@link Manifest}.
      */
-    public Manifest manifest() {
-        return manifest(Actions.<Manifest>doNothing());
-    }
+    public abstract Manifest manifest();
 
     /**
      * Creates and configures a new instance of a {@link Manifest}. The given closure configures
@@ -185,9 +120,7 @@ public class JavaPluginConvention {
      *
      * @param closure The closure to use to configure the manifest.
      */
-    public Manifest manifest(Closure closure) {
-        return configure(closure, createManifest());
-    }
+    public abstract Manifest manifest(Closure closure);
 
     /**
      * Creates and configures a new instance of a {@link Manifest}.
@@ -195,57 +128,33 @@ public class JavaPluginConvention {
      * @param action The action to use to configure the manifest.
      * @since 3.5
      */
-    public Manifest manifest(Action<? super Manifest> action) {
-        Manifest manifest = createManifest();
-        action.execute(manifest);
-        return manifest;
-    }
-
-    private Manifest createManifest() {
-        return new DefaultManifest(project.getFileResolver());
-    }
+    public abstract Manifest manifest(Action<? super Manifest> action);
 
     /**
      * The name of the docs directory. Can be a name or a path relative to the build dir.
      */
-    public String getDocsDirName() {
-        return docsDirName;
-    }
+    public abstract String getDocsDirName();
 
-    public void setDocsDirName(String docsDirName) {
-        this.docsDirName = docsDirName;
-    }
+    public abstract void setDocsDirName(String docsDirName);
 
     /**
      * The name of the test results directory. Can be a name or a path relative to the build dir.
      */
-    public String getTestResultsDirName() {
-        return testResultsDirName;
-    }
+    public abstract String getTestResultsDirName();
 
-    public void setTestResultsDirName(String testResultsDirName) {
-        this.testResultsDirName = testResultsDirName;
-    }
+    public abstract void setTestResultsDirName(String testResultsDirName);
 
     /**
      * The name of the test reports directory. Can be a name or a path relative to {@link org.gradle.api.reporting.ReportingExtension#getBaseDir}.
      */
-    public String getTestReportDirName() {
-        return testReportDirName;
-    }
+    public abstract String getTestReportDirName();
 
-    public void setTestReportDirName(String testReportDirName) {
-        this.testReportDirName = testReportDirName;
-    }
+    public abstract void setTestReportDirName(String testReportDirName);
 
     /**
      * The source sets container.
      */
-    public SourceSetContainer getSourceSets() {
-        return sourceSets;
-    }
+    public abstract SourceSetContainer getSourceSets();
 
-    public ProjectInternal getProject() {
-        return project;
-    }
+    public abstract ProjectInternal getProject();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -28,11 +28,10 @@ import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.java.WebApplication;
 import org.gradle.api.internal.plugins.DefaultArtifactPublicationSet;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.internal.DefaultWarPluginConvention;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
-import org.gradle.internal.Factory;
-import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -56,12 +55,7 @@ public class WarPlugin implements Plugin<Project> {
 
     public void apply(final Project project) {
         project.getPluginManager().apply(JavaPlugin.class);
-        final WarPluginConvention pluginConvention = DeprecationLogger.whileDisabled(new Factory<WarPluginConvention>() {
-            @Override
-            public WarPluginConvention create() {
-                return new WarPluginConvention(project);
-            }
-        });
+        final WarPluginConvention pluginConvention = new DefaultWarPluginConvention(project);
         project.getConvention().getPlugins().put("war", pluginConvention);
 
         project.getTasks().withType(War.class).configureEach(new Action<War>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPluginConvention.java
@@ -17,48 +17,24 @@
 package org.gradle.api.plugins;
 
 import org.gradle.api.Project;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
 /**
  * <p>A {@link Convention} used for the WarPlugin.</p>
  */
-public class WarPluginConvention {
-    private String webAppDirName;
-    private final Project project;
-
-    /**
-     * Creates a {@link WarPluginConvention}.
-     *
-     * @deprecated Creating instances of this class is deprecated. These should be created by the WAR plugin only.
-     */
-    @Deprecated
-    public WarPluginConvention(Project project) {
-        DeprecationLogger.nagUserOfDeprecated("Creating instances of WarPluginConvention");
-        this.project = project;
-        webAppDirName = "src/main/webapp";
-    }
-
+public abstract class WarPluginConvention {
     /**
      * Returns the web application directory.
      */
-    public File getWebAppDir() {
-        return project.file(webAppDirName);
-    }
+    public abstract File getWebAppDir();
 
     /**
      * The name of the web application directory, relative to the project directory.
      */
-    public String getWebAppDirName() {
-        return webAppDirName;
-    }
+    public abstract String getWebAppDirName();
 
-    public void setWebAppDirName(String webAppDirName) {
-        this.webAppDirName = webAppDirName;
-    }
+    public abstract void setWebAppDirName(String webAppDirName);
 
-    public final Project getProject() {
-        return project;
-    }
+    public abstract Project getProject();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultApplicationPluginConvention.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.CopySpec;
+import org.gradle.api.plugins.ApplicationPluginConvention;
+
+import java.util.ArrayList;
+
+public class DefaultApplicationPluginConvention extends ApplicationPluginConvention {
+    private String applicationName;
+    private String mainClassName;
+    private Iterable<String> applicationDefaultJvmArgs = new ArrayList<String>();
+    private String executableDir = "bin";
+    private CopySpec applicationDistribution;
+
+    private final Project project;
+
+    public DefaultApplicationPluginConvention(Project project) {
+        this.project = project;
+        applicationDistribution = project.copySpec();
+    }
+
+    @Override
+    public String getApplicationName() {
+        return applicationName;
+    }
+
+    @Override
+    public void setApplicationName(String applicationName) {
+        this.applicationName = applicationName;
+    }
+
+    @Override
+    public String getMainClassName() {
+        return mainClassName;
+    }
+
+    @Override
+    public void setMainClassName(String mainClassName) {
+        this.mainClassName = mainClassName;
+    }
+
+    @Override
+    public Iterable<String> getApplicationDefaultJvmArgs() {
+        return applicationDefaultJvmArgs;
+    }
+
+    @Override
+    public void setApplicationDefaultJvmArgs(Iterable<String> applicationDefaultJvmArgs) {
+        this.applicationDefaultJvmArgs = applicationDefaultJvmArgs;
+    }
+
+    @Override
+    public String getExecutableDir() {
+        return executableDir;
+    }
+
+    @Override
+    public void setExecutableDir(String executableDir) {
+        this.executableDir = executableDir;
+    }
+
+    @Override
+    public CopySpec getApplicationDistribution() {
+        return applicationDistribution;
+    }
+
+    @Override
+    public void setApplicationDistribution(CopySpec applicationDistribution) {
+        this.applicationDistribution = applicationDistribution;
+    }
+
+    @Override
+    public Project getProject() {
+        return project;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.file.FileLookup;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.plugins.BasePluginConvention;
+
+import java.io.File;
+
+public class DefaultBasePluginConvention extends BasePluginConvention {
+    private ProjectInternal project;
+
+    private String distsDirName;
+
+    private String libsDirName;
+
+    // cached resolved values
+    private File buildDir;
+    private File libsDir;
+    private File distsDir;
+
+    private String archivesBaseName;
+
+    public DefaultBasePluginConvention(Project project) {
+        this.project = (ProjectInternal) project;
+        archivesBaseName = project.getName();
+        distsDirName = "distributions";
+        libsDirName = "libs";
+    }
+
+    @Override
+    public File getDistsDir() {
+        File curProjectBuildDir = project.getBuildDir();
+        if (distsDir != null && curProjectBuildDir.equals(buildDir)) {
+            return distsDir;
+        }
+        buildDir = curProjectBuildDir;
+        File dir = project.getServices().get(FileLookup.class).getFileResolver(curProjectBuildDir).resolve(distsDirName);
+        distsDir = dir;
+        return dir;
+    }
+
+    @Override
+    public File getLibsDir() {
+        File curProjectBuildDir = project.getBuildDir();
+        if (libsDir != null && curProjectBuildDir.equals(buildDir)) {
+            return libsDir;
+        }
+        buildDir = curProjectBuildDir;
+        File dir = project.getServices().get(FileLookup.class).getFileResolver(curProjectBuildDir).resolve(libsDirName);
+        libsDir = dir;
+        return dir;
+    }
+
+    @Override
+    public ProjectInternal getProject() {
+        return project;
+    }
+
+    @Override
+    public void setProject(ProjectInternal project) {
+        this.project = project;
+    }
+
+    @Override
+    public String getDistsDirName() {
+        return distsDirName;
+    }
+
+    @Override
+    public void setDistsDirName(String distsDirName) {
+        this.distsDirName = distsDirName;
+        this.distsDir = null;
+    }
+
+    @Override
+    public String getLibsDirName() {
+        return libsDirName;
+    }
+
+    @Override
+    public void setLibsDirName(String libsDirName) {
+        this.libsDirName = libsDirName;
+        this.libsDir = null;
+    }
+
+    @Override
+    public String getArchivesBaseName() {
+        return archivesBaseName;
+    }
+
+    @Override
+    public void setArchivesBaseName(String archivesBaseName) {
+        this.archivesBaseName = archivesBaseName;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import groovy.lang.Closure;
+import org.gradle.api.Action;
+import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.file.FileLookup;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.DefaultSourceSetContainer;
+import org.gradle.api.java.archives.Manifest;
+import org.gradle.api.java.archives.internal.DefaultManifest;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.reporting.ReportingExtension;
+import org.gradle.api.tasks.SourceSetContainer;
+import org.gradle.internal.Actions;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.testing.base.plugins.TestingBasePlugin;
+
+import java.io.File;
+
+import static org.gradle.util.ConfigureUtil.configure;
+
+public class DefaultJavaPluginConvention extends JavaPluginConvention {
+    private ProjectInternal project;
+
+    private String docsDirName;
+
+    private String testResultsDirName;
+
+    private String testReportDirName;
+
+    private final SourceSetContainer sourceSets;
+
+    private JavaVersion srcCompat;
+    private JavaVersion targetCompat;
+
+    public DefaultJavaPluginConvention(ProjectInternal project, Instantiator instantiator) {
+        this.project = project;
+        sourceSets = instantiator.newInstance(DefaultSourceSetContainer.class, project.getFileResolver(), project.getTasks(), instantiator, project.getServices().get(ObjectFactory.class));
+        docsDirName = "docs";
+        testResultsDirName = TestingBasePlugin.TEST_RESULTS_DIR_NAME;
+        testReportDirName = TestingBasePlugin.TESTS_DIR_NAME;
+    }
+
+    @Override
+    public Object sourceSets(Closure closure) {
+        return sourceSets.configure(closure);
+    }
+
+    @Override
+    public File getDocsDir() {
+        return project.getServices().get(FileLookup.class).getFileResolver(project.getBuildDir()).resolve(docsDirName);
+    }
+
+    @Override
+    public File getTestResultsDir() {
+        return project.getServices().get(FileLookup.class).getFileResolver(project.getBuildDir()).resolve(testResultsDirName);
+    }
+
+    @Override
+    public File getTestReportDir() {
+        return project.getServices().get(FileLookup.class).getFileResolver(getReportsDir()).resolve(testReportDirName);
+    }
+
+    private File getReportsDir() {
+        return project.getExtensions().getByType(ReportingExtension.class).getBaseDir();
+    }
+
+    @Override
+    public JavaVersion getSourceCompatibility() {
+        return srcCompat != null ? srcCompat : JavaVersion.current();
+    }
+
+    @Override
+    public void setSourceCompatibility(Object value) {
+        setSourceCompatibility(JavaVersion.toVersion(value));
+    }
+
+    @Override
+    public void setSourceCompatibility(JavaVersion value) {
+        srcCompat = value;
+    }
+
+    @Override
+    public JavaVersion getTargetCompatibility() {
+        return targetCompat != null ? targetCompat : getSourceCompatibility();
+    }
+
+    @Override
+    public void setTargetCompatibility(Object value) {
+        setTargetCompatibility(JavaVersion.toVersion(value));
+    }
+
+    @Override
+    public void setTargetCompatibility(JavaVersion value) {
+        targetCompat = value;
+    }
+
+    @Override
+    public Manifest manifest() {
+        return manifest(Actions.<Manifest>doNothing());
+    }
+
+    @Override
+    public Manifest manifest(Closure closure) {
+        return configure(closure, createManifest());
+    }
+
+    @Override
+    public Manifest manifest(Action<? super Manifest> action) {
+        Manifest manifest = createManifest();
+        action.execute(manifest);
+        return manifest;
+    }
+
+    private Manifest createManifest() {
+        return new DefaultManifest(project.getFileResolver());
+    }
+
+    @Override
+    public String getDocsDirName() {
+        return docsDirName;
+    }
+
+    @Override
+    public void setDocsDirName(String docsDirName) {
+        this.docsDirName = docsDirName;
+    }
+
+    @Override
+    public String getTestResultsDirName() {
+        return testResultsDirName;
+    }
+
+    @Override
+    public void setTestResultsDirName(String testResultsDirName) {
+        this.testResultsDirName = testResultsDirName;
+    }
+
+    @Override
+    public String getTestReportDirName() {
+        return testReportDirName;
+    }
+
+    @Override
+    public void setTestReportDirName(String testReportDirName) {
+        this.testReportDirName = testReportDirName;
+    }
+
+    @Override
+    public SourceSetContainer getSourceSets() {
+        return sourceSets;
+    }
+
+    @Override
+    public ProjectInternal getProject() {
+        return project;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultWarPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultWarPluginConvention.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.Project;
+import org.gradle.api.plugins.WarPluginConvention;
+
+import java.io.File;
+
+public class DefaultWarPluginConvention extends WarPluginConvention {
+    private String webAppDirName;
+    private final Project project;
+
+    public DefaultWarPluginConvention(Project project) {
+        this.project = project;
+        webAppDirName = "src/main/webapp";
+    }
+
+    @Override
+    public File getWebAppDir() {
+        return project.file(webAppDirName);
+    }
+
+    @Override
+    public String getWebAppDirName() {
+        return webAppDirName;
+    }
+
+    @Override
+    public void setWebAppDirName(String webAppDirName) {
+        this.webAppDirName = webAppDirName;
+    }
+
+    @Override
+    public Project getProject() {
+        return project;
+    }
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultBasePluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultBasePluginConventionTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins
 
 import org.gradle.api.internal.project.ProjectInternal
+import org.gradle.api.plugins.internal.DefaultBasePluginConvention
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
 import org.junit.Before
@@ -25,7 +26,7 @@ import org.junit.Test
 
 import static org.junit.Assert.assertEquals
 
-class BasePluginConventionTest {
+class DefaultBasePluginConventionTest {
     @Rule
     public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
 
@@ -34,7 +35,7 @@ class BasePluginConventionTest {
     private BasePluginConvention convention
 
     @Before public void setUp() {
-        convention = new BasePluginConvention(project)
+        convention = new DefaultBasePluginConvention(project)
     }
 
     @Test public void defaultValues() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
@@ -18,11 +18,12 @@ package org.gradle.api.plugins
 
 import org.gradle.api.Action
 import org.gradle.api.JavaVersion
-import org.gradle.api.Project
 import org.gradle.api.internal.file.FileResolver
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
 import org.gradle.api.java.archives.Manifest
 import org.gradle.api.java.archives.internal.DefaultManifest
+import org.gradle.api.plugins.internal.DefaultJavaPluginConvention
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -37,17 +38,17 @@ import static org.hamcrest.Matchers.instanceOf
 import static org.junit.Assert.assertEquals
 import static org.junit.Assert.assertThat
 
-class JavaPluginConventionTest {
+class DefaultJavaPluginConventionTest {
     private final JUnit4GroovyMockery context = new JUnit4GroovyMockery()
     @Rule
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
-    private final Project project = TestUtil.create(tmpDir).rootProject()
+    private final ProjectInternal project = TestUtil.create(tmpDir).rootProject()
     private Instantiator instantiator = project.services.get(Instantiator)
     private JavaPluginConvention convention
 
     @Before public void setUp() {
         project.pluginManager.apply(ReportingBasePlugin)
-        convention = new JavaPluginConvention(project, instantiator)
+        convention = new DefaultJavaPluginConvention(project, instantiator)
     }
 
     @Test public void defaultValues() {


### PR DESCRIPTION
### Context

This PR moves the implementation of some plugin convention object types into internal packages. The constructor for each of these types was previously deprecated.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
