### PR TITLE
Cache JavaExec task by Java version.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionErrorHandlingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedTaskExecutionErrorHandlingIntegrationTest.groovy
@@ -84,10 +84,10 @@ class CachedTaskExecutionErrorHandlingIntegrationTest extends AbstractIntegratio
     }
 
     @Unroll
-    def "cache switches off after first error for the current build (stacktraces: #showStractrace)"() {
+    def "cache switches off after first error for the current build (stacktraces: #showStacktrace)"() {
         // Need to do it like this because stacktraces are always enabled for integration tests
         settingsFile << """
-            gradle.startParameter.setShowStacktrace(org.gradle.api.logging.configuration.ShowStacktrace.$showStractrace)
+            gradle.startParameter.setShowStacktrace(org.gradle.api.logging.configuration.ShowStacktrace.$showStacktrace)
         """
 
         buildFile << """
@@ -128,7 +128,7 @@ class CachedTaskExecutionErrorHandlingIntegrationTest extends AbstractIntegratio
         skippedTasks.empty
 
         where:
-        showStractrace                     | expectStacktrace
+        showStacktrace                     | expectStacktrace
         ShowStacktrace.INTERNAL_EXCEPTIONS | false
         ShowStacktrace.ALWAYS              | true
         ShowStacktrace.ALWAYS_FULL         | true

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/JavaExecJavaVersionIntegrationSpec.groovy
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.AvailableJavaHomes
+import org.gradle.util.Requires
+import spock.lang.Issue
+
+import static org.gradle.api.JavaVersion.VERSION_1_8
+import static org.gradle.api.JavaVersion.VERSION_1_9
+
+@Requires(adhoc = { AvailableJavaHomes.getAvailableJdks(VERSION_1_8).size() > 1 && AvailableJavaHomes.getJdk(VERSION_1_9) })
+class JavaExecJavaVersionIntegrationSpec extends AbstractIntegrationSpec {
+
+    def setup() {
+        // Without this, executing the JavaExec tasks leave behind running daemons.
+        executer.requireDaemon().requireIsolatedDaemons()
+    }
+
+    def "up-to-date when executing twice in a row"() {
+        given:
+        setupRunHelloWorldTask()
+
+        when:
+        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_8).javaHome
+        succeeds "runHelloWorld"
+        then:
+        nonSkippedTasks.contains ":runHelloWorld"
+
+        when:
+        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_8).javaHome
+        succeeds "runHelloWorld"
+        then:
+        skippedTasks.contains ":runHelloWorld"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/6694")
+    def "not up-to-date when the Java version changes"() {
+        given:
+        setupRunHelloWorldTask()
+
+        when:
+        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_8).javaHome
+        succeeds "runHelloWorld"
+        then:
+        nonSkippedTasks.contains ":runHelloWorld"
+
+        when:
+        executer.withJavaHome AvailableJavaHomes.getJdk(VERSION_1_9).javaHome
+        succeeds "runHelloWorld", "--info"
+        then:
+        nonSkippedTasks.contains ":runHelloWorld"
+        output.contains "Value of input property 'javaVersion' has changed for task ':runHelloWorld'"
+    }
+
+    @Issue("https://github.com/gradle/gradle/issues/6694")
+    def "up-to-date when the Java executable changes but the version does not"() {
+        given:
+        setupRunHelloWorldTask()
+
+        when:
+        executer.withJavaHome AvailableJavaHomes.getAvailableJdks(VERSION_1_8)[0].javaHome
+        succeeds "runHelloWorld"
+        then:
+        nonSkippedTasks.contains ":runHelloWorld"
+
+        when:
+        executer.withJavaHome AvailableJavaHomes.getAvailableJdks(VERSION_1_8)[1].javaHome
+        succeeds "runHelloWorld"
+        then:
+        skippedTasks.contains ":runHelloWorld"
+    }
+
+    private void setupRunHelloWorldTask() {
+        buildScript'''
+            apply plugin: "java"
+
+            task runHelloWorld(type: JavaExec) {
+                classpath = sourceSets.main.runtimeClasspath
+                main = "Hello"
+                outputs.dir "$buildDir/runHelloWorld"
+            }
+        '''
+
+        file("src/main/java/Hello.java") << '''
+            public class Hello {
+                public static void main(String... args) {
+                    // Generate files into "$buildDir/runHelloWorld"
+                }
+            }
+        '''
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -18,9 +18,11 @@ package org.gradle.api.tasks;
 
 import org.apache.tools.ant.types.Commandline;
 import org.gradle.api.Incubating;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.tasks.options.Option;
+import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.process.CommandLineArgumentProvider;
 import org.gradle.process.JavaExecSpec;
 import org.gradle.process.JavaForkOptions;
@@ -377,9 +379,21 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
     }
 
     /**
+     * Returns the version of the Java executable specified by {@link #getExecutable()}.
+     *
+     * @since 5.1
+     */
+    @Input
+    public JavaVersion getJavaVersion() {
+        return getServices().get(JvmVersionDetector.class).getJavaVersion(getExecutable());
+    }
+
+    /**
      * {@inheritDoc}
      */
-    @Nullable @Optional @Input
+    @Internal
+    @Nullable
+    @Override
     public String getExecutable() {
         return javaExecHandleBuilder.getExecutable();
     }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-   "acceptedApiChanges": []
+   "acceptedApiChanges": [
+       {
+           "type": "org.gradle.api.tasks.JavaExec",
+           "member": "Method org.gradle.api.tasks.JavaExec.getJavaVersion()",
+           "acceptation": "Improving cacheability of an existing task",
+           "changes": []
+       }
+   ]
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestTaskJdkRelocationIntegrationTest.groovy
@@ -25,19 +25,19 @@ import org.gradle.util.TextUtil
 
 import static org.gradle.util.TextUtil.normaliseLineSeparators
 
-@Requires(adhoc = { AvailableJavaHomes.getAvailableJdks(JavaVersion.VERSION_1_7).size() > 1 })
+@Requires(adhoc = { AvailableJavaHomes.getAvailableJdks(JavaVersion.VERSION_1_8).size() > 1 })
 class TestTaskJdkRelocationIntegrationTest extends AbstractTaskRelocationIntegrationTest {
 
     private File getOriginalJavaExecutable() {
-        getAvailableJdk7s()[0].javaExecutable
+        getAvailableJdk8s()[0].javaExecutable
     }
 
     private File getDifferentJavaExecutable() {
-        getAvailableJdk7s()[1].javaExecutable
+        getAvailableJdk8s()[1].javaExecutable
     }
 
-    private List<Jvm> getAvailableJdk7s() {
-        AvailableJavaHomes.getAvailableJdks(JavaVersion.VERSION_1_7)
+    private List<Jvm> getAvailableJdk8s() {
+        AvailableJavaHomes.getAvailableJdks(JavaVersion.VERSION_1_8)
     }
 
     @Override


### PR DESCRIPTION
Instead of caching by the executable, cache by the Java version so that the task remains cacheable if the path to the executable changes.

Resolves #6694.

Signed-off-by: Theodore Ni <zyloch@gmail.com>

I attempted to write a test for this but could not figure out a way to emulate a changing Java path that returns the same Java version. I did not find a similar test for the Java compile or test tasks that could be used as a template.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
