### PR TITLE
Refine `integTest.gradleGeneratedApiJarCacheDir` behaviour

### DIFF
--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -376,7 +376,7 @@ open class IdePlugin : Plugin<Project> {
             "-Dorg.gradle.docs.releasenotes.rendered=${releaseNotes.destinationDir.resolve(releaseNotes.property("fileName") as String)}",
             "-DintegTest.gradleHomeDir=\$MODULE_DIR\$/build/integ test",
             "-DintegTest.gradleUserHomeDir=${rootProject.file("intTestHomeDir").absolutePath}",
-            "-DintegTest.gradleGeneratedApiJarCacheDir=\$MODULE_DIR\$/build/generatedApiJars/${rootProject.version}",
+            "-DintegTest.gradleGeneratedApiJarCacheDir=\$MODULE_DIR\$/build/generatedApiJars",
             "-DintegTest.libsRepo=${rootProject.file("build/repo").absolutePath}",
             "-Dorg.gradle.integtest.daemon.registry=${rootProject.file("build/daemon").absolutePath}",
             "-DintegTest.distsDir=${rootProject.base.distsDir.absolutePath}",

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -958,7 +958,10 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
             properties.put(REUSE_USER_HOME_SERVICES, "false");
         }
         if (!useCustomGradleUserHomeDir) {
-            properties.put(DefaultGeneratedGradleJarCache.BASE_DIR_OVERRIDE_PROPERTY, buildContext.getGradleGeneratedApiJarCacheDir().getAbsolutePath());
+            TestFile generatedApiJarCacheDir = buildContext.getGradleGeneratedApiJarCacheDir();
+            if (generatedApiJarCacheDir != null) {
+                properties.put(DefaultGeneratedGradleJarCache.BASE_DIR_OVERRIDE_PROPERTY, generatedApiJarCacheDir.getAbsolutePath());
+            }
         }
         if (!noExplicitTmpDir) {
             if (tmpDir == null) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
@@ -19,6 +19,7 @@ package org.gradle.integtests.fixtures.executer;
 import org.gradle.test.fixtures.file.TestFile;
 import org.gradle.util.GradleVersion;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -53,8 +54,9 @@ public class IntegrationTestBuildContext {
         return file("integTest.gradleUserHomeDir", "intTestHomeDir").file("worker-1");
     }
 
+    @Nullable
     public TestFile getGradleGeneratedApiJarCacheDir() {
-        return file("integTest.gradleGeneratedApiJarCacheDir", null);
+        return optionalFile("integTest.gradleGeneratedApiJarCacheDir");
     }
 
     public TestFile getTmpDir() {
@@ -102,14 +104,20 @@ public class IntegrationTestBuildContext {
     }
 
     protected static TestFile file(String propertyName, String defaultPath) {
-        String path = System.getProperty(propertyName);
-        if (path != null) {
-            return new TestFile(new File(path));
+        TestFile testFile = optionalFile(propertyName);
+        if (testFile != null) {
+            return testFile;
         }
         if (defaultPath == null) {
             throw new RuntimeException("You must set the '" + propertyName + "' property to run the integration tests.");
         }
         return testFile(defaultPath);
+    }
+
+    @Nullable
+    private static TestFile optionalFile(String propertyName) {
+        String path = System.getProperty(propertyName);
+        return path != null ? new TestFile(new File(path)) : null;
     }
 
     private static TestFile testFile(String path) {


### PR DESCRIPTION
So it's possible to run saved test `Run` configurations and execute tests when the Gradle project is imported.