### PR TITLE
Improve modeling of test fixtures

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -17,21 +17,17 @@ package org.gradle.gradlebuild.test.fixtures
 
 import accessors.groovy
 import accessors.java
-
 import library
-
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.tasks.SourceSet
 import org.gradle.kotlin.dsl.*
-
-import org.gradle.plugins.ide.eclipse.EclipsePlugin
-import org.gradle.plugins.ide.eclipse.model.EclipseModel
 import org.gradle.plugins.ide.idea.IdeaPlugin
 import org.gradle.plugins.ide.idea.model.IdeaModel
-
 import testLibraries
 import testLibrary
+import java.util.Locale
 
 
 /**
@@ -44,6 +40,7 @@ import testLibrary
  *
  * Configures the Project as a test fixtures consumer according to the `testFixtures` extension configuration.
  */
+//TODO convert this to use variant aware dependency management
 @Suppress("unused")
 open class TestFixturesPlugin : Plugin<Project> {
 
@@ -60,46 +57,76 @@ open class TestFixturesPlugin : Plugin<Project> {
         configureAsConsumer()
     }
 
+
+    /**
+     * This mimics what the java-library plugin does, but creating a library of test fixtures instead.
+     */
     private
     fun Project.configureAsProducer() {
-
-        configurations {
-            create("outputDirs")
-
-            create("testFixturesCompile") { extendsFrom(configurations["compile"]) }
-            create("testFixturesImplementation") { extendsFrom(configurations["implementation"]) }
-            create("testFixturesRuntime") { extendsFrom(configurations["runtime"]) }
-
-            // Expose configurations that include the test fixture classes for clients to use
-            create("testFixturesUsageCompile") {
-                extendsFrom(configurations["testFixturesCompile"], configurations["outputDirs"])
-            }
-            create("testFixturesUsageRuntime") {
-                extendsFrom(configurations["testFixturesRuntime"], configurations["testFixturesUsageCompile"])
-            }
-
-            // Assume that the project wants to use the fixtures for its tests
-            "testCompile" { extendsFrom(configurations["testFixturesUsageCompile"]) }
-            "testRuntime" { extendsFrom(configurations["testFixturesUsageRuntime"]) }
-        }
-
-        val outputDirs by configurations
-        val testFixturesCompile by configurations
-        val testFixturesRuntime by configurations
-        val testFixturesUsageCompile by configurations
-
         val main by java.sourceSets
         val testFixtures by java.sourceSets.creating {
-            compileClasspath = main.output + configurations["testFixturesCompileClasspath"]
-            runtimeClasspath = output + compileClasspath + configurations["testFixturesRuntimeClasspath"]
+            extendsFrom(main, configurations)
+        }
+        java.sourceSets.named("test", SourceSet::class) {
+            extendsFrom(testFixtures, configurations)
+        }
+
+        java.sourceSets.matching { it.name.toLowerCase(Locale.ROOT).endsWith("test") }.all {
+            compileClasspath += testFixtures.output
+            runtimeClasspath += testFixtures.output
+        }
+
+        configurations {
+            val testFixturesApi by creating {
+                extendsFrom(configurations[testFixtures.compileConfigurationName])
+            }
+
+            val testFixturesImplementation by getting {
+                extendsFrom(testFixturesApi)
+            }
+
+            val testFixturesRuntime by getting
+            val testFixturesRuntimeOnly by getting
+
+            create(testFixtures.apiElementsConfigurationName) {
+                extendsFrom(testFixturesApi, testFixturesRuntime)
+                /*
+                 * FIXME only the classes would be more appropriate here, but the Groovy compiler
+                 * needs resources too because we make use of extension methods registred through
+                 * a META-INF file.
+                 */
+                afterEvaluate {
+                    testFixtures.output.forEach {
+                        outgoing.artifact(it) {
+                            builtBy(testFixtures.output)
+                        }
+                    }
+                }
+            }
+
+            create(testFixtures.runtimeElementsConfigurationName) {
+                extendsFrom(testFixturesImplementation, testFixturesRuntime, testFixturesRuntimeOnly)
+                /*
+                 * FIXME a JAR would be more appropriate here, but the PlayApp fixture assumes that
+                 * its class is loaded from a directory.
+                 */
+                afterEvaluate {
+                    testFixtures.output.forEach {
+                        outgoing.artifact(it) {
+                            builtBy(testFixtures.output)
+                        }
+                    }
+                }
+            }
         }
 
         dependencies {
-            outputDirs(testFixtures.output)
-            testFixturesUsageCompile(project(path))
-            testFixturesCompile(library("junit"))
-            testFixturesCompile(testLibrary("spock"))
-            testLibraries("jmock").forEach { testFixturesCompile(it) }
+            val testFixturesApi by configurations
+
+            testFixturesApi(project(path))
+            testFixturesApi(library("junit"))
+            testFixturesApi(testLibrary("spock"))
+            testLibraries("jmock").forEach { testFixturesApi(it) }
         }
 
         plugins.withType<IdeaPlugin> {
@@ -110,32 +137,37 @@ open class TestFixturesPlugin : Plugin<Project> {
                 }
             }
         }
+    }
 
-        plugins.withType<EclipsePlugin> {
-            configure<EclipseModel> {
-                classpath {
-                    plusConfigurations.add(testFixturesCompile)
-                    plusConfigurations.add(testFixturesRuntime)
-
-                    //avoiding the certain output directories from the classpath in Eclipse
-                    minusConfigurations.add(outputDirs)
-                }
+    private
+    fun SourceSet.extendsFrom(other: SourceSet, configurations: ConfigurationContainer) {
+        configurations {
+            compileConfigurationName {
+                extendsFrom(configurations[other.compileConfigurationName])
+            }
+            implementationConfigurationName {
+                extendsFrom(configurations[other.implementationConfigurationName])
+            }
+            runtimeConfigurationName {
+                extendsFrom(configurations[other.runtimeConfigurationName])
+            }
+            runtimeOnlyConfigurationName {
+                extendsFrom(configurations[other.runtimeOnlyConfigurationName])
             }
         }
     }
 
     private
     fun Project.configureAsConsumer() = afterEvaluate {
-
         the<TestFixturesExtension>().origins.forEach { (projectPath, sourceSetName) ->
-
-            val compileConfig = if (sourceSetName == "main") "compile" else "${sourceSetName}Compile"
-            val runtimeConfig = if (sourceSetName == "main") "runtime" else "${sourceSetName}Runtime"
+            val sourceSet = java.sourceSets[sourceSetName]
+            val compileConfig = sourceSet.compileConfigurationName
+            val runtimeConfig = sourceSet.runtimeConfigurationName
 
             dependencies {
-                compileConfig(project(path = projectPath, configuration = "testFixturesUsageCompile"))
+                compileConfig(project(path = projectPath, configuration = "testFixturesApiElements"))
                 compileConfig(project(":internalTesting"))
-                runtimeConfig(project(path = projectPath, configuration = "testFixturesUsageRuntime"))
+                runtimeConfig(project(path = projectPath, configuration = "testFixturesRuntimeElements"))
             }
         }
     }

--- a/subprojects/build-scan-performance/build-scan-performance.gradle
+++ b/subprojects/build-scan-performance/build-scan-performance.gradle
@@ -25,7 +25,7 @@ dependencies {
     // so that all Gradle features are available
     performanceTestRuntime allTestRuntimeDependencies
 
-    testFixturesCompile project(':internalPerformanceTesting')
+    testFixturesApi project(':internalPerformanceTesting')
 }
 
 gradlebuildJava {

--- a/subprojects/core/core.gradle
+++ b/subprojects/core/core.gradle
@@ -75,9 +75,9 @@ dependencies {
     testFixturesImplementation project(":internalTesting")
     testFixturesImplementation libraries.ivy.coordinates
 
-    testFixturesRuntime project(':runtimeApiInfo')
-    testFixturesRuntime rootProject.ext.allCoreRuntimeExtensions
-    testFixturesRuntime project(':testingJunitPlatform')
+    testFixturesRuntimeOnly project(':runtimeApiInfo')
+    testFixturesRuntimeOnly rootProject.ext.allCoreRuntimeExtensions
+    testFixturesRuntimeOnly project(':testingJunitPlatform')
 
     integTestImplementation project(":internalIntegTesting")
     integTestImplementation project(":plugins")
@@ -91,7 +91,6 @@ gradlebuildJava {
 }
 
 testFixtures {
-    from(':core')
     from(':coreApi')
     from(':messaging')
     from(':modelCore')

--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     integTestRuntimeOnly(project(":resourcesSftp"))
     integTestRuntimeOnly(project(":testKit"))
 
-    testFixturesCompile(project(":resourcesHttp", "testFixturesUsageCompile"))
+    testFixturesApi(project(":resourcesHttp", "testFixturesApiElements"))
     testFixturesImplementation(project(":internalIntegTesting"))
 }
 

--- a/subprojects/ide-native/ide-native.gradle
+++ b/subprojects/ide-native/ide-native.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile project(':testingNative')
     compile libraries.plist.coordinates
 
-    testFixturesCompile project(':internalTesting')
+    testFixturesApi project(':internalTesting')
 }
 
 gradlebuildJava {

--- a/subprojects/ide/ide.gradle
+++ b/subprojects/ide/ide.gradle
@@ -34,8 +34,8 @@ dependencies {
     testCompile 'nl.jqno.equalsverifier:equalsverifier:2.1.6'
     testCompile project(':dependencyManagement')
 
-    testFixturesCompile project(':internalTesting')
-    testFixturesCompile project(':internalIntegTesting')
+    testFixturesApi project(':internalTesting')
+    testFixturesApi project(':internalIntegTesting')
 }
 
 gradlebuildJava {

--- a/subprojects/language-jvm/language-jvm.gradle
+++ b/subprojects/language-jvm/language-jvm.gradle
@@ -12,7 +12,7 @@ dependencies {
 
     testRuntime project(":languageJava")
 
-    testFixturesCompile project(":internalIntegTesting")
+    testFixturesApi project(":internalIntegTesting")
 }
 
 gradlebuildJava {

--- a/subprojects/launcher/launcher.gradle
+++ b/subprojects/launcher/launcher.gradle
@@ -29,7 +29,7 @@ dependencies {
     integTestRuntime project(':plugins')
     integTestRuntime project(':languageNative')
 
-    testFixturesCompile project(':internalIntegTesting')
+    testFixturesApi project(':internalIntegTesting')
 }
 // Needed for testing debug command line option (JDWPUtil)
 if (!rootProject.availableJavaInstallations.javaInstallationForTest.javaVersion.java9Compatible) {

--- a/subprojects/platform-native/platform-native.gradle
+++ b/subprojects/platform-native/platform-native.gradle
@@ -34,7 +34,7 @@ dependencies {
     // Required to test visual studio project file generation for generated sources
     integTestRuntime project(':ideNative')
 
-    testFixturesCompile project(':internalIntegTesting')
+    testFixturesApi project(':internalIntegTesting')
 }
 
 gradlebuildJava {

--- a/subprojects/platform-play/platform-play.gradle
+++ b/subprojects/platform-play/platform-play.gradle
@@ -16,8 +16,8 @@ dependencies {
 
     integTestRuntime project(":compositeBuilds")
     integTestRuntime project(":idePlay")
-    testFixturesCompile project(":internalIntegTesting")
-    testFixturesCompile libraries.commons_httpclient.coordinates
+    testFixturesApi project(":internalIntegTesting")
+    testFixturesApi libraries.commons_httpclient.coordinates
 }
 
 gradlebuildJava {

--- a/subprojects/plugins/plugins.gradle
+++ b/subprojects/plugins/plugins.gradle
@@ -42,7 +42,7 @@ dependencies {
     // Making this better would likely involve a separate `:gradleRuntime` module that brings in `:core`, `:dependencyManagement` and other key subprojects
     runtime project(":compositeBuilds")
 
-    testFixturesCompile project(":internalIntegTesting")
+    testFixturesApi project(":internalIntegTesting")
 
     testCompile testLibraries.jsoup
 

--- a/subprojects/soak/soak.gradle
+++ b/subprojects/soak/soak.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-    testFixturesCompile project(':internalIntegTesting')
+    testFixturesApi project(':internalIntegTesting')
 }
 
 gradlebuildJava {

--- a/subprojects/testing-base/testing-base.gradle
+++ b/subprojects/testing-base/testing-base.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation libraries.commons_io.coordinates
     implementation libraries.kryo.coordinates
 
-    testFixturesCompile project(':internalIntegTesting')
+    testFixturesApi project(':internalIntegTesting')
 }
 
 gradlebuildJava {

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -48,8 +48,8 @@ dependencies {
     publishCompile(library("slf4j_api")) { version { prefer(libraryVersion("slf4j_api")) } }
     compile(library("jcip"))
 
-    testFixturesCompile(project(":baseServicesGroovy"))
-    testFixturesCompile(project(":internalIntegTesting"))
+    testFixturesApi(project(":baseServicesGroovy"))
+    testFixturesApi(project(":internalIntegTesting"))
 
     integTestRuntime(project(":toolingApiBuilders"))
     integTestRuntime(project(":ivy"))

--- a/subprojects/version-control/version-control.gradle
+++ b/subprojects/version-control/version-control.gradle
@@ -30,7 +30,7 @@ dependencies {
 
     testFixturesImplementation project(":internalTesting")
     testFixturesImplementation project(":internalIntegTesting")
-    testFixturesCompile libraries.jgit.coordinates, libraries.commons_httpclient.coordinates, libraries.jsch.coordinates
+    testFixturesApi libraries.jgit.coordinates, libraries.commons_httpclient.coordinates, libraries.jsch.coordinates
 }
 
 gradlebuildJava {


### PR DESCRIPTION
Previously they were modeled as just a file collection,
which confused the IDEA importer. They now use the more
canonical way of defining an additional artifact.

In a next step they should be reimplemented using variant
aware dependency resolution, so that we don't need a special
DSL to declare these dependencies.

cc @wolfs as promised yesterday
cc @eskatos because I'm still a Kotlin noob.