### PR TITLE
Remove usage of deprecated API

### DIFF
--- a/subprojects/distributions/binary-compatibility.gradle
+++ b/subprojects/distributions/binary-compatibility.gradle
@@ -31,7 +31,7 @@ repositories {
         ivy {
             name 'Gradle distributions'
             url 'https://services.gradle.org'
-            layout 'pattern', {
+            patternLayout {
                 // Dummy 'ivy' pattern: Ivy files do not exist on services.gradle.org
                 ivy '[module]-[revision]-ivy.xml'
                 artifact "/${distUrl}/[module]-[revision]-bin(.[ext])"


### PR DESCRIPTION
layout("pattern", Action) is now replaced by patternLayout(Action)