### PR TITLE
Disallow mutation during `NamedDomainObjectProvider#configure`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
@@ -28,19 +28,21 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
 
     Map<String, Object> getQueryCodeUnderTest() {
         [
-            "getByName(String)":    "${containerUnderTest}.getByName('b')",
-            "named(String)":        "${containerUnderTest}.named('b')",
-            "findAll(Closure)":     "${containerUnderTest}.findAll { it.name == 'b' }",
-            "findByName(String)":   "${containerUnderTest}.findByName('b')",
-            "TaskProvider.get()":   "b.get()",
+            "getByName(String)":    "${containerUnderTest}.getByName('unrealized')",
+            "named(String)":        "${containerUnderTest}.named('unrealized')",
+            "findAll(Closure)":     "${containerUnderTest}.findAll { it.name == 'unrealized' }",
+            "findByName(String)":   "${containerUnderTest}.findByName('unrealized')",
+            "TaskProvider.get()":   "unrealized.get()",
             "iterator()":           "for ($baseElementType element : ${containerUnderTest}) { println element.name }",
         ]
     }
 
     List<Object> getConfigurationHookUnderTest() {
         [
-            "configureEach",
-            "withType($baseElementType).configureEach",
+            "${containerUnderTest}.configureEach",
+            "${containerUnderTest}.withType($baseElementType).configureEach",
+            "toBeRealized.configure",
+            "realized.configure",
         ]
     }
 
@@ -66,12 +68,13 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
     @Unroll
     def "can execute query method #description from #configurationHookUnderTest(Closure) configuration action"() {
         buildFile << """
-            def a = ${containerUnderTest}.register('a')
-            def b = ${containerUnderTest}.register('b')
-            ${containerUnderTest}.${configurationHookUnderTest} {
+            def toBeRealized = ${containerUnderTest}.register('toBeRealized')
+            def unrealized = ${containerUnderTest}.register('unrealized')
+            def realized = ${containerUnderTest}.register('realized'); realized.get()
+            ${configurationHookUnderTest} {
                 ${codeUnderTest}
             }
-            a.get()
+            toBeRealized.get()
         """
 
         expect:
@@ -84,12 +87,13 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
     @Unroll
     def "cannot execute mutation method #description from #configurationHookUnderTest(Closure) configuration action"() {
         buildFile << """
-            def a = ${containerUnderTest}.register('a')
-            def b = ${containerUnderTest}.register('b')
-            ${containerUnderTest}.${configurationHookUnderTest} {
+            def toBeRealized = ${containerUnderTest}.register('toBeRealized')
+            def unrealized = ${containerUnderTest}.register('unrealized')
+            def realized = ${containerUnderTest}.register('realized'); realized.get()
+            ${configurationHookUnderTest} {
                 ${codeUnderTest}
             }
-            a.get()
+            toBeRealized.get()
         """
 
         expect:

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -868,7 +868,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         }
 
         public void configure(Action<? super I> action) {
-            action.execute(get());
+            withMutationDisabled(action).execute(get());
         }
 
         @Override
@@ -888,6 +888,10 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         public I getOrNull() {
             return Cast.uncheckedCast(findByNameWithoutRules(getName()));
         }
+
+        protected Action<? super I> withMutationDisabled(Action<? super I> action) {
+            return getMutationGuard().withMutationDisabled(action);
+        }
     }
 
     public abstract class AbstractDomainObjectCreatingProvider<I extends T> extends AbstractNamedDomainObjectProvider<I> {
@@ -901,7 +905,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             this.onCreate = ImmutableActionSet.<I>empty().mergeFrom(getEventRegister().getAddActions());
 
             if (configureAction != null) {
-                configure(configureAction);
+                configure(getMutationGuard().withMutationEnabled(configureAction));
             }
         }
 
@@ -912,7 +916,7 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
 
         @Override
         public void configure(final Action<? super I> action) {
-            Action<? super I> wrappedAction = wrap(action);
+            Action<? super I> wrappedAction = withMutationDisabled(action);
             if (object != null) {
                 // Already realized, just run the action now
                 wrappedAction.execute(object);
@@ -922,9 +926,8 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             onCreate = onCreate.mergeFrom(getEventRegister().getAddActions()).add(wrappedAction);
         }
 
-        protected Action<? super I> wrap(Action<? super I> action) {
-            // Do nothing.
-            return action;
+        protected Action<? super I> withMutationDisabled(Action<? super I> action) {
+            return getMutationGuard().withMutationDisabled(action);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -709,8 +709,8 @@ public class DefaultTaskContainer extends DefaultTaskCollection<Task> implements
         }
 
         @Override
-        protected Action<? super I> wrap(Action action) {
-            return MutationGuards.of(crossProjectConfigurator).withMutationDisabled(action);
+        protected Action<? super I> withMutationDisabled(Action action) {
+            return MutationGuards.of(crossProjectConfigurator).withMutationDisabled(super.withMutationDisabled(action));
         }
 
         @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerSpec.groovy
@@ -16,8 +16,52 @@
 
 package org.gradle.api.internal
 
-import org.gradle.api.NamedDomainObjectContainer
+import org.gradle.api.NamedDomainObjectCollection
+import spock.lang.Unroll
 
 abstract class AbstractNamedDomainObjectContainerSpec<T> extends AbstractNamedDomainObjectCollectionSpec<T> {
-    abstract NamedDomainObjectContainer<T> getContainer()
+    abstract NamedDomainObjectCollection<T> getContainer()
+
+    abstract void behaveLikeNamedContainer()
+
+    @Unroll
+    def "disallow mutating when creating NamedDomainObjectProvider.configure(#factoryClass.configurationType.simpleName) calls #description"() {
+        behaveLikeNamedContainer()
+        def factory = factoryClass.newInstance()
+        if (factory.isUseExternalProviders()) {
+            containerAllowsExternalProviders()
+        }
+
+        when:
+        def a = container.register("a")
+        a.configure(factory.create(container, b))
+        a.get()
+
+        then:
+        def ex = thrown(RuntimeException)
+        ex.cause.message == "${containerPublicType.simpleName}#${description} on ${container.toString()} cannot be executed in the current context."
+
+        where:
+        [description, factoryClass] << getInvalidCallFromLazyConfiguration()
+    }
+
+    @Unroll
+    def "allow querying when creating NamedDomainObjectProvider.configure(#factoryClass.configurationType.simpleName) calls #description"() {
+        behaveLikeNamedContainer()
+        def factory = factoryClass.newInstance()
+        if (factory.isUseExternalProviders()) {
+            containerAllowsExternalProviders()
+        }
+
+        when:
+        def a = container.register("a")
+        a.configure(factory.create(container, b))
+        a.get()
+
+        then:
+        noExceptionThrown()
+
+        where:
+        [description, factoryClass] << getValidCallFromLazyConfiguration()
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainerSpec.groovy
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal
+
+import org.gradle.api.NamedDomainObjectCollection
+
+abstract class AbstractPolymorphicDomainObjectContainerSpec<T> extends AbstractNamedDomainObjectContainerSpec<T> {
+    abstract NamedDomainObjectCollection<T> getContainer()
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.internal.reflect.DirectInstantiator
 
-class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObjectContainerSpec<Person> {
+class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDomainObjectContainerSpec<Person> {
     def fred = new DefaultPerson(name: "fred")
     def barney = new DefaultPerson(name: "barney")
     def agedFred = new DefaultAgeAwarePerson(name: "fred", age: 42)
@@ -42,6 +42,11 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractNamedDomainObj
     Person c = new DefaultPerson(name: "c")
     Person d = new DefaultCtorNamedPerson("d")
     boolean externalProviderAllowed = true
+
+    @Override
+    void behaveLikeNamedContainer() {
+        container.registerDefaultFactory({ new DefaultPerson(name: it) } as NamedDomainObjectFactory )
+    }
 
     @Override
     List<Person> iterationOrder(Person... elements) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskContainerTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.NamedDomainObjectCollection
 import org.gradle.api.Rule
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
-import org.gradle.api.internal.AbstractNamedDomainObjectCollectionSpec
+import org.gradle.api.internal.AbstractPolymorphicDomainObjectContainerSpec
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.TaskInternal
@@ -48,7 +48,7 @@ import org.gradle.util.Path
 import static java.util.Collections.singletonMap
 import static org.gradle.util.WrapUtil.toList
 
-class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<Task> {
+class DefaultTaskContainerTest extends AbstractPolymorphicDomainObjectContainerSpec<Task> {
 
     private taskFactory = Mock(ITaskFactory)
     def modelRegistry = Mock(ModelRegistry)
@@ -1552,6 +1552,14 @@ class DefaultTaskContainerTest extends AbstractNamedDomainObjectCollectionSpec<T
 
     final Class<SomeTask> type = SomeTask
     final Class<SomeOtherTask> otherType = SomeOtherTask
+
+    @Override
+    void behaveLikeNamedContainer() {
+        taskFactory.create(_ as TaskIdentity) >> { args ->
+            def taskIdentity = args[0]
+            task(taskIdentity.name, taskIdentity.type)
+        }
+    }
 
     @Override
     List<Task> iterationOrder(Task... elements) {


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/709

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fdisallow-task-provider-configure)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
