### PR TITLE
Set source level to Java 7 in IDEA

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Gradle" />
+    <inspection_tool class="Convert2Diamond" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="EqualsReplaceableByObjectsCall" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+    <inspection_tool class="SafeVarargsDetector" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="TryWithIdenticalCatches" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Gradle" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -217,7 +217,9 @@ open class IdePlugin : Plugin<Project> {
                     configureCompilerSettings(rootProject)
                     configureCopyright()
                     configureCodeStyle()
-                    configureInspections()
+                    // TODO The idea-ext plugin does not yet support customizing inspections.
+                    // TODO Delete .idea/inspectionProfiles and uncomment the code below when it does
+                    // configureInspections()
                     configureRunConfigurations(rootProject)
                     doNotDetectFrameworks("android", "web")
                 }


### PR DESCRIPTION
In order to use Java 7 features (e.g. try-with-resources) in subprojects
that don't need to run as entrypoints or in workers, all projects now
use source level 7. However, since not all of them can indeed use Java 7
all Java 7 related IDEA inspections are disabled.