### PR TITLE
Run platform instead of parallel tests on IBM JDK

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -44,8 +44,7 @@ data class CIBuildModel (
                     functionalTests = listOf(
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.linux, JvmVersion.java8),
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java8),
-                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java10),
-                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java8, JvmVendor.ibm))
+                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java10))
             ),
             Stage("Release Accept", "Once a day: Rerun tests in more environments",
                     trigger = Trigger.daily,

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -44,8 +44,8 @@ data class CIBuildModel (
                     functionalTests = listOf(
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.linux, JvmVersion.java8),
                             TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java8),
-                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java10),
-                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java8, JvmVendor.ibm))
+                            TestCoverage(TestType.parallel, OS.linux, JvmVersion.java10),
+                            TestCoverage(TestType.platform, OS.linux, JvmVersion.java8, JvmVendor.ibm))
             ),
             Stage("Release Accept", "Once a day: Rerun tests in more environments",
                     trigger = Trigger.daily,


### PR DESCRIPTION
## Context

We observed frequent internal errors and timeouts on IBM JDK recently:

- https://github.com/gradle/gradle-private/issues/1493
- https://github.com/gradle/gradle-private/issues/1491

They might be related - some unexpected error in test worker may cause worker process hangs. According to the error message, it's very similar to http://www-01.ibm.com/support/docview.wss?uid=swg1IJ00181. However, the bug report alleges this issue has been fixed by `8.0.5.0` but we still see this error on `8.0.5.20`:

```
root@dev91 /opt/files/jdk-linux/ibm-java-sdk-8.0-5.20-x86_64-archive.bin # bin/java -version
java version "1.8.0_181"
Java(TM) SE Runtime Environment (build 8.0.5.20 - pxa6480sr5fp20-20180802_01(SR5 FP20))
IBM J9 VM (build 2.9, JRE 1.8.0 Linux amd64-64-Bit Compressed References 20180731_393394 (JIT enabled, AOT enabled)
OpenJ9   - bd23af8
OMR      - ca1411c
IBM      - 98805ca)
JCL - 20180719_01 based on Oracle jdk8u181-b12
```

Let's first make IBM JDK tests non-parallel and see if everything goes well. If not, we probably need to drop the test coverage for IBM JDK.

To test parallel Gradle execution, this PR changes another configuration to parallel, otherwise there will be no parallel tests at all.
