### PR TITLE
Let conventions implementations expose their public type

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/internal/DefaultProjectReportsPluginConvention.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/plugins/internal/DefaultProjectReportsPluginConvention.java
@@ -18,18 +18,25 @@ package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Project;
 import org.gradle.api.plugins.ProjectReportsPluginConvention;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.util.WrapUtil;
 
 import java.io.File;
 import java.util.Set;
 
-public class DefaultProjectReportsPluginConvention extends ProjectReportsPluginConvention {
+public class DefaultProjectReportsPluginConvention extends ProjectReportsPluginConvention implements HasPublicType {
     private String projectReportDirName = "project";
     private final Project project;
 
     public DefaultProjectReportsPluginConvention(Project project) {
         this.project = project;
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(ProjectReportsPluginConvention.class);
     }
 
     @Override

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/internal/DefaultEarPluginConvention.java
@@ -19,6 +19,8 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 import org.gradle.plugins.ear.EarPluginConvention;
 import org.gradle.plugins.ear.descriptor.DeploymentDescriptor;
 import org.gradle.plugins.ear.descriptor.internal.DefaultDeploymentDescriptor;
@@ -27,7 +29,7 @@ import org.gradle.util.ConfigureUtil;
 import javax.inject.Inject;
 import java.io.File;
 
-public class DefaultEarPluginConvention extends EarPluginConvention {
+public class DefaultEarPluginConvention extends EarPluginConvention implements HasPublicType {
 
     private FileResolver fileResolver;
     private ObjectFactory objectFactory;
@@ -43,6 +45,11 @@ public class DefaultEarPluginConvention extends EarPluginConvention {
         deploymentDescriptor = objectFactory.newInstance(DefaultDeploymentDescriptor.class, fileResolver, objectFactory);
         deploymentDescriptor.readFrom("META-INF/application.xml");
         deploymentDescriptor.readFrom(appDirName + "/META-INF/" + deploymentDescriptor.getFileName());
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(EarPluginConvention.class);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultApplicationPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultApplicationPluginConvention.java
@@ -19,10 +19,12 @@ package org.gradle.api.plugins.internal;
 import org.gradle.api.Project;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.plugins.ApplicationPluginConvention;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 
 import java.util.ArrayList;
 
-public class DefaultApplicationPluginConvention extends ApplicationPluginConvention {
+public class DefaultApplicationPluginConvention extends ApplicationPluginConvention implements HasPublicType {
     private String applicationName;
     private String mainClassName;
     private Iterable<String> applicationDefaultJvmArgs = new ArrayList<String>();
@@ -34,6 +36,11 @@ public class DefaultApplicationPluginConvention extends ApplicationPluginConvent
     public DefaultApplicationPluginConvention(Project project) {
         this.project = project;
         applicationDistribution = project.copySpec();
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(ApplicationPluginConvention.class);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultBasePluginConvention.java
@@ -20,10 +20,12 @@ import org.gradle.api.Project;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.plugins.BasePluginConvention;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 
 import java.io.File;
 
-public class DefaultBasePluginConvention extends BasePluginConvention {
+public class DefaultBasePluginConvention extends BasePluginConvention implements HasPublicType {
     private ProjectInternal project;
 
     private String distsDirName;
@@ -42,6 +44,11 @@ public class DefaultBasePluginConvention extends BasePluginConvention {
         archivesBaseName = project.getName();
         distsDirName = "distributions";
         libsDirName = "libs";
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(BasePluginConvention.class);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -26,6 +26,8 @@ import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.java.archives.internal.DefaultManifest;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.internal.Actions;
@@ -36,7 +38,7 @@ import java.io.File;
 
 import static org.gradle.util.ConfigureUtil.configure;
 
-public class DefaultJavaPluginConvention extends JavaPluginConvention {
+public class DefaultJavaPluginConvention extends JavaPluginConvention implements HasPublicType {
     private ProjectInternal project;
 
     private String docsDirName;
@@ -56,6 +58,11 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention {
         docsDirName = "docs";
         testResultsDirName = TestingBasePlugin.TEST_RESULTS_DIR_NAME;
         testReportDirName = TestingBasePlugin.TESTS_DIR_NAME;
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(JavaPluginConvention.class);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultWarPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultWarPluginConvention.java
@@ -18,16 +18,23 @@ package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Project;
 import org.gradle.api.plugins.WarPluginConvention;
+import org.gradle.api.reflect.HasPublicType;
+import org.gradle.api.reflect.TypeOf;
 
 import java.io.File;
 
-public class DefaultWarPluginConvention extends WarPluginConvention {
+public class DefaultWarPluginConvention extends WarPluginConvention implements HasPublicType {
     private String webAppDirName;
     private final Project project;
 
     public DefaultWarPluginConvention(Project project) {
         this.project = project;
         webAppDirName = "src/main/webapp";
+    }
+
+    @Override
+    public TypeOf<?> getPublicType() {
+        return TypeOf.typeOf(WarPluginConvention.class);
     }
 
     @Override


### PR DESCRIPTION
to prevent exposing internal types in kotlin-dsl generated accessors.

As a follow up to #6708 
cc @adammurdoch 