### PR TITLE
WIP - Enable improved POM support by default

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FeaturePreviews.java
@@ -26,7 +26,7 @@ public class FeaturePreviews {
      * A feature that is no longer relevant will have the {@code active} flag set to {@code false}.
      */
     public enum Feature {
-        IMPROVED_POM_SUPPORT(true),
+        IMPROVED_POM_SUPPORT(false),
         GRADLE_METADATA(true),
         STABLE_PUBLISHING(true);
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/FeaturePreviewsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/FeaturePreviewsTest.groovy
@@ -45,7 +45,7 @@ class FeaturePreviewsTest extends Specification {
         then:
         previews.isFeatureEnabled(feature)
         where:
-        feature << [IMPROVED_POM_SUPPORT, GRADLE_METADATA]
+        feature << [GRADLE_METADATA]
     }
 
     @Unroll
@@ -57,7 +57,7 @@ class FeaturePreviewsTest extends Specification {
         then:
         previews.isFeatureEnabled(feature)
         where:
-        feature << ['IMPROVED_POM_SUPPORT', 'GRADLE_METADATA']
+        feature << ['GRADLE_METADATA']
     }
 
     def 'fails when enabling an unknown feature'() {
@@ -84,6 +84,6 @@ class FeaturePreviewsTest extends Specification {
         given:
         def previews = new FeaturePreviews()
         expect:
-        previews.getActiveFeatures() == [IMPROVED_POM_SUPPORT, GRADLE_METADATA, STABLE_PUBLISHING] as Set
+        previews.getActiveFeatures() == [GRADLE_METADATA, STABLE_PUBLISHING] as Set
     }
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -51,7 +51,6 @@ import org.gradle.testfixtures.internal.NativeServicesTestFixture
 import java.rmi.server.UID
 
 import static org.gradle.api.internal.FeaturePreviews.Feature.GRADLE_METADATA
-import static org.gradle.api.internal.FeaturePreviews.Feature.IMPROVED_POM_SUPPORT
 
 class TestUtil {
     public static final Closure TEST_CLOSURE = {}
@@ -99,11 +98,8 @@ class TestUtil {
         return NamedObjectInstantiator.INSTANCE
     }
 
-    static FeaturePreviews featurePreviews(boolean improvedPomSupportEnabled = false, boolean gradleMetadataEnabled = false) {
+    static FeaturePreviews featurePreviews(boolean gradleMetadataEnabled = false) {
         def previews = new FeaturePreviews()
-        if (improvedPomSupportEnabled) {
-            previews.enableFeature(IMPROVED_POM_SUPPORT)
-        }
         if (gradleMetadataEnabled) {
             previews.enableFeature(GRADLE_METADATA)
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ClientModuleDependenciesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ClientModuleDependenciesResolveIntegrationTest.groovy
@@ -16,17 +16,11 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
-import spock.lang.Unroll
 
 class ClientModuleDependenciesResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
-    @Unroll
-    def "uses metadata from Client Module and looks up artifact in declared repositories (improvedPomSupport = #improvedPomSupport)"() {
+    def "uses metadata from Client Module and looks up artifact in declared repositories"() {
         given:
-        if (improvedPomSupport) {
-            FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
-        }
         def repo1 = ivyHttpRepo("repo1")
         def repo2 = mavenHttpRepo("repo2")
         def projectAInRepo1 = repo1.module('group', 'projectA', '1.2')
@@ -69,16 +63,10 @@ task listJars {
         then:
         succeeds('listJars')
 
-        where:
-        improvedPomSupport << [false, true]
     }
 
-    @Unroll
-    def "can resolve nested Client Module (improvedPomSupport = #improvedPomSupport)"() {
+    def "can resolve nested Client Module"() {
         given:
-        if (improvedPomSupport) {
-            FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
-        }
         def repo = mavenHttpRepo("repo")
         def projectA = repo.module('test', 'projectA', '1.2').publish()
         def projectB = repo.module('test', 'projectB', '1.5').publish()
@@ -120,17 +108,10 @@ task listJars {
 
         then:
         succeeds('listJars')
-
-        where:
-        improvedPomSupport << [false, true]
     }
 
-    @Unroll
-    def "client module dependency ignores published artifact listing and resolves single jar file (improvedPomSupport = #improvedPomSupport)"() {
+    def "client module dependency ignores published artifact listing and resolves single jar file"() {
         given:
-        if (improvedPomSupport) {
-            FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
-        }
         def projectA = ivyHttpRepo.module('group', 'projectA', '1.2')
                 .artifact()
                 .artifact(classifier: "extra")
@@ -179,8 +160,5 @@ task listClientModuleJars {
 
         then:
         succeeds('listClientModuleJars')
-
-        where:
-        improvedPomSupport << [false, true]
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentAttributesRulesIntegrationTest.groovy
@@ -472,11 +472,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
             if (GradleMetadataResolveRunner.useIvy()) {
                 variant = 'default'
             } else {
-                if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                    variant = 'compile'
-                } else {
-                    variant = 'default'
-                }
+                variant = 'compile'
             }
         }
         variant
@@ -486,7 +482,7 @@ class ComponentAttributesRulesIntegrationTest extends AbstractModuleDependencyRe
         if (GradleMetadataResolveRunner.gradleMetadataEnabled) {
             return "variant"
         }
-        if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled && !GradleMetadataResolveRunner.useIvy()) {
+        if (!GradleMetadataResolveRunner.useIvy()) {
             return "variant"
         }
         return "configuration"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -422,12 +422,15 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         resolvedModules 'b'
 
         when:
+        executer.withStackTraceChecksDisabled()
         run 'dependencyInsight', '--configuration=conf', '--dependency=a'
 
         then:
         result.groupedOutput.task(':dependencyInsight').output.contains("""org:b:1
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : $expected

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationMutationIntegrationTest.groovy
@@ -61,8 +61,8 @@ configurations.compile.withDependencies { deps ->
 
         then:
         resolvedGraph {
-            module("org:foo:1.0")
-            module("org:bar:1.0")
+            module("org:foo:1.0:runtime")
+            module("org:bar:1.0:runtime")
         }
     }
 
@@ -84,8 +84,8 @@ configurations.conf.withDependencies { deps ->
 
         then:
         resolvedGraph {
-            module("org:foo:1.0")
-            module("org:bar:1.0")
+            module("org:foo:1.0:runtime")
+            module("org:bar:1.0:runtime")
         }
     }
 
@@ -108,8 +108,8 @@ configurations.compile.withDependencies { DependencySet deps ->
 
         then:
         resolvedGraph {
-            module("org:foo:1.0")
-            module("org:bar:1.0")
+            module("org:foo:1.0:runtime")
+            module("org:bar:1.0:runtime")
         }
     }
 
@@ -127,8 +127,8 @@ configurations.compile.defaultDependencies { DependencySet deps ->
 
         then:
         resolvedGraph {
-            module("org:foo:1.0")
-            module("org:bar:1.0")
+            module("org:foo:1.0:runtime")
+            module("org:bar:1.0:runtime")
         }
     }
 
@@ -157,8 +157,8 @@ configurations.compile.withDependencies { deps ->
 
         then:
         resolvedGraph {
-            module("org:foo:1.0")
-            module("org:bar:1.0")
+            module("org:foo:1.0:runtime")
+            module("org:bar:1.0:runtime")
         }
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -64,7 +64,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         resolve.expectGraph {
             root(":", ":test:") {
                 edgeFromConstraint("org:foo:1.1","org:foo:1.0")
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
             }
@@ -117,7 +117,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         resolve.expectGraph {
             root(":", ":test:") {
                 edgeFromConstraint("org:foo:1.1","org:foo:1.0")
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
             }
@@ -149,7 +149,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         resolve.expectGraph {
             root(":", ":test:") {
                 edgeFromConstraint("org:foo:1.1","org:foo:1.0")
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
             }
@@ -178,7 +178,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -79,8 +79,8 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo","org:foo:1.1")
-                module("org:foo:1.1")
+                edge("org:foo","org:foo:1.1:runtime")
+                module("org:foo:1.1:runtime")
             }
         }
     }
@@ -133,7 +133,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1")
                 }
                 edgeFromConstraint("org:foo:1.1", "org:foo:1.1")
@@ -228,7 +228,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:[1.0,1.2]", "org:foo:1.1").byConstraint('didn\'t match version 1.2 because tested versions')
                 }
                 edgeFromConstraint("org:foo:[1.0,1.1]", "org:foo:1.1").byConstraint('didn\'t match version 1.2 because tested versions')
@@ -257,7 +257,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:bar:1.0")
+                module("org:bar:1.0:runtime")
             }
         }
     }
@@ -294,8 +294,8 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:bar:1.1", "org:foo:1.1").selectedByRule()
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1")
+                edge("org:bar:1.1", "org:foo:1.1:runtime").selectedByRule()
+                edge("org:foo:1.0", "org:foo:1.1:runtime").byConflictResolution("between versions 1.0 and 1.1")
             }
         }
     }
@@ -325,8 +325,8 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1")
-                module("org:foo:1.1")
+                edge("org:foo:1.0", "org:foo:1.1:runtime").byConflictResolution("between versions 1.0 and 1.1")
+                module("org:foo:1.1:runtime")
             }
         }
     }
@@ -368,11 +368,11 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1").byConstraint('transitive dependency constraint')
+                edge("org:foo:1.0", "org:foo:1.1:runtime").byConflictResolution("between versions 1.0 and 1.1").byConstraint('transitive dependency constraint')
                 project(":b", "test:b:") {
                     configuration = "conf"
                     noArtifacts()
-                    module("org:foo:1.1").byConstraint('transitive dependency constraint')
+                    module("org:foo:1.1:runtime").byConstraint('transitive dependency constraint')
                 }
             }
         }
@@ -416,7 +416,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1")
+                edge("org:foo:1.0", "org:foo:1.1:runtime").byConflictResolution("between versions 1.0 and 1.1")
                 edge("org:included:1.0", "project :included", "org:included:1.0") {
                     noArtifacts()
                     module("org:foo:1.1:runtime")
@@ -449,7 +449,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:foo:1.0")
+                module("org:foo:1.0:runtime")
             }
         }
     }
@@ -474,8 +474,8 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0","org:foo:1.1")
-                module("org:foo:1.1") {
+                edge("org:foo:1.0","org:foo:1.1:runtime")
+                module("org:foo:1.1:runtime") {
                     artifact(classifier: 'shaded')
                 }
             }
@@ -503,11 +503,11 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:foo:1.1") {
+                module("org:foo:1.1:runtime") {
                     graph.constraints.add(delegate)
                     artifact(classifier: 'shaded')
                 }
-                module("org:bar:1.0") {
+                module("org:bar:1.0:runtime") {
                     edge("org:foo:1.0","org:foo:1.1")
                 }
             }
@@ -535,7 +535,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:bar:1.1") {
+                module("org:bar:1.1:runtime") {
                     edge('org:foo:1.0', 'org:foo:1.0')
                 }
                 edge('org:bar:1.0', 'org:bar:1.1')
@@ -564,7 +564,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:bar:1.1") {
+                module("org:bar:1.1:runtime") {
                     edge('org:foo:1.0', 'org:foo:1.0')
                 }
                 edge('org:bar', 'org:bar:1.1')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -71,16 +71,16 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                module("org.stuff:foo:2.0") {
+                module("org.stuff:foo:2.0:runtime") {
                     edge("org.utils:api:1.5", "org.utils:api:1.5") {
                         selectedByRule()
                     }
                 }
-                edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
+                edge("org.utils:impl:1.3", "org.utils:impl:1.5:runtime") {
                     selectedByRule()
                     module("org.utils:api:1.5")
                 }
-                module("org.utils:optional-lib:5.0")
+                module("org.utils:optional-lib:5.0:runtime")
             }
         }
     }
@@ -119,10 +119,10 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                module("org.stuff:foo:2.0") {
+                module("org.stuff:foo:2.0:runtime") {
                     edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
                         selectedByRule()
-                        module("org.utils:api:1.5").selectedByRule()
+                        module("org.utils:api:1.5:runtime").selectedByRule()
                     }
                 }
             }
@@ -170,9 +170,9 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
+                edge("org.utils:impl:1.3", "org.utils:impl:1.5:runtime") {
                     selectedByRule()
-                    module("org.utils:api:1.5").selectedByRule()
+                    module("org.utils:api:1.5:runtime").selectedByRule()
                 }
             }
         }
@@ -221,7 +221,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
+                edge("org.utils:impl:1.3", "org.utils:impl:1.5:runtime") {
                     selectedByRule()
                     module("org.utils:api:1.5").selectedByRule()
                 }
@@ -261,9 +261,9 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:impl:1.3", "org.utils:impl:1.3") {
+                edge("org.utils:impl:1.3", "org.utils:impl:1.3:runtime") {
                     selectedByRule()
-                    module("org.utils:api:1.3").selectedByRule()
+                    module("org.utils:api:1.3:runtime").selectedByRule()
                 }
             }
         }
@@ -299,9 +299,9 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:impl:1.3", "org.utils:impl:1.5") {
+                edge("org.utils:impl:1.3", "org.utils:impl:1.5:runtime") {
                     forced()
-                    edge("org.utils:api:1.5", "org.utils:api:1.6").selectedByRule()
+                    edge("org.utils:api:1.5", "org.utils:api:1.6:runtime").selectedByRule()
                 }
             }
         }
@@ -342,7 +342,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:api:1.3", "org.utils:api:1.5").selectedByRule()
+                edge("org.utils:api:1.3", "org.utils:api:1.5:runtime").selectedByRule()
             }
         }
     }
@@ -507,7 +507,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":test", "depsub:test:") {
-                module("org.utils:impl:1.5") {
+                module("org.utils:impl:1.5:runtime") {
                     edge("org.utils:api:1.5", "project :api", "depsub:api:") {
                         configuration = "conf"
                         selectedByRule()
@@ -823,8 +823,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":impl", "depsub:impl:") {
-                module("org.utils:api:2.0")
-                edge("project :api", "org.utils:api:2.0").byConflictResolution("between versions 1.6 and 2.0").selectedByRule()
+                module("org.utils:api:2.0:runtime")
+                edge("project :api", "org.utils:api:2.0:runtime").byConflictResolution("between versions 1.6 and 2.0").selectedByRule()
             }
         }
     }
@@ -872,8 +872,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":impl", "depsub:impl:") {
-                edge("org.utils:dep1:1.5", "org.utils:dep1:2.0").byConflictResolution("between versions 1.6 and 2.0")
-                edge("org.utils:dep1:2.0", "org.utils:dep1:2.0")
+                edge("org.utils:dep1:1.5", "org.utils:dep1:2.0:runtime").byConflictResolution("between versions 1.6 and 2.0")
+                edge("org.utils:dep1:2.0", "org.utils:dep1:2.0:runtime")
 
                 edge("org.utils:dep2:1.5", "project :dep2", "org.utils:dep2:3.0") {
                     selectedByRule().byConflictResolution("between versions 3.0 and 2.0")
@@ -909,10 +909,10 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                module("org.utils:b:1.3") {
-                    edge("org.utils:a:1.3", "org.utils:a:1.4").selectedByRule().byConflictResolution("between versions 1.4 and 1.3")
+                module("org.utils:b:1.3:runtime") {
+                    edge("org.utils:a:1.3", "org.utils:a:1.4:runtime").selectedByRule().byConflictResolution("between versions 1.4 and 1.3")
                 }
-                edge("org.utils:a:1.2", "org.utils:a:1.4")
+                edge("org.utils:a:1.2", "org.utils:a:1.4:runtime")
 
             }
         }
@@ -942,10 +942,10 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                module("org.utils:b:1.3") {
-                    module("org.utils:a:1.3")
+                module("org.utils:b:1.3:runtime") {
+                    module("org.utils:a:1.3:runtime")
                 }
-                edge("org.utils:a:1.2", "org.utils:a:1.3").byConflictResolution("between versions 1.2.1 and 1.3")
+                edge("org.utils:a:1.2", "org.utils:a:1.3:runtime").byConflictResolution("between versions 1.2.1 and 1.3")
             }
         }
     }
@@ -974,7 +974,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:api:default", "org.utils:api:1.3").selectedByRule()
+                edge("org.utils:api:default", "org.utils:api:1.3:runtime").selectedByRule()
             }
         }
     }
@@ -1004,8 +1004,8 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                module("org.utils:impl:1.3") {
-                    edge("org.utils:api:default", "org.utils:api:1.3").selectedByRule()
+                module("org.utils:impl:1.3:runtime") {
+                    edge("org.utils:api:default", "org.utils:api:1.3:runtime").selectedByRule()
                 }
             }
         }
@@ -1235,8 +1235,8 @@ Required by:
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org.utils:a:1.2", "org.utils:b:2.1").selectedByRule().byConflictResolution("between versions 2.1 and 2.0")
-                edge("org.utils:b:2.0", "org.utils:b:2.1")
+                edge("org.utils:a:1.2", "org.utils:b:2.1:runtime").selectedByRule().byConflictResolution("between versions 2.1 and 2.0")
+                edge("org.utils:b:2.0", "org.utils:b:2.1:runtime")
             }
         }
     }
@@ -1270,13 +1270,13 @@ Required by:
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org:a:1.0", "org:a:2.0") {
+                edge("org:a:1.0", "org:a:2.0:runtime") {
                     byConflictResolution("between versions 1.0 and 2.0")
                     module("org:c:1.0")
                 }
-                edge("foo:b:1.0", "org:b:1.0") {
+                edge("foo:b:1.0", "org:b:1.0:runtime") {
                     selectedByRule()
-                    module("org:a:2.0")
+                    module("org:a:2.0:runtime")
                 }
             }
         }
@@ -1310,13 +1310,13 @@ Required by:
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org:a:1.0", "org:a:2.0") {
+                edge("org:a:1.0", "org:a:2.0:runtime") {
                     byConflictResolution("between versions 1.0 and 2.0")
                     module("org:c:1.0")
                 }
-                edge("foo:bar:baz", "org:b:1.0") {
+                edge("foo:bar:baz", "org:b:1.0:runtime") {
                     selectedByRule()
-                    module("org:a:2.0")
+                    module("org:a:2.0:runtime")
                 }
             }
         }
@@ -1369,12 +1369,12 @@ Required by:
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org:a:1.0", "org:c:2.0") {
+                edge("org:a:1.0", "org:c:2.0:runtime") {
                     byConflictResolution("between versions 1.1 and 2.0")
                 }
-                module("org:a:2.0") {
-                    module("org:b:2.0") {
-                        module("org:c:2.0")
+                module("org:a:2.0:runtime") {
+                    module("org:b:2.0:runtime") {
+                        module("org:c:2.0:runtime")
                     }
                 }
             }
@@ -1440,13 +1440,13 @@ Required by:
         then:
         resolve.expectGraph {
             root(":", ":depsub:") {
-                edge("org:a:1.0", "org:a:2.0") {
+                edge("org:a:1.0", "org:a:2.0:runtime") {
                     byConflictResolution("between versions 1.0 and 2.0")
                     module("org:c:1.0")
                 }
-                edge("foo:bar:baz", "org:b:1.0") {
+                edge("foo:bar:baz", "org:b:1.0:runtime") {
                     selectedByRule('we need integration tests')
-                    module("org:a:2.0")
+                    module("org:a:2.0:runtime")
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Issue
 import spock.lang.Unroll
 
-public class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
+class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
 
     void "can force the version of a particular module"() {
         mavenRepo.module("org", "foo", '1.3.3').publish()
@@ -395,8 +395,8 @@ task checkDeps {
         then:
         resolve.expectGraph {
             root(':', ':test:') {
-                edge('org:foo:1.1', 'org:foo:1.0').forced()
-                module('org:foo:1.0')
+                edge('org:foo:1.1', 'org:foo:1.0:runtime').forced()
+                module('org:foo:1.0:runtime')
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -179,7 +179,7 @@ project(":b") {
                     variant('runtime')
                     module('org.other:externalA:1.2') {
                         byReason('also check dependency reasons')
-                        variant('default', ['org.gradle.status': 'release'])
+                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.component.category':'library', 'org.gradle.usage':'java-runtime'])
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -58,10 +58,11 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
         run 'checkDeps'
 
         then:
+        def expectedVariant = useMaven()?'runtime':'default'
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:first-level:1.0:default")
-                module("org:foo:1.0:default")
+                module("org:first-level:1.0:${expectedVariant}")
+                module("org:foo:1.0:${expectedVariant}")
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
@@ -461,7 +461,7 @@ task show {
       - Required flavor 'preview' and found incompatible value 'paid'.
       - Required usage 'compile' and found compatible value 'compile'.""")
 
-        failure.assertHasCause("""No variants of test:test:1.2 match the consumer attributes: test:test:1.2 configuration default:
+        failure.assertHasCause("""No variants of test:test:1.2 match the consumer attributes: test:test:1.2 configuration runtime:
   - Required artifactType 'dll' and found incompatible value 'jar'.
   - Required flavor 'preview' but no value provided.
   - Required usage 'compile' but no value provided.""")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VariantAttributesRulesIntegrationTest.groovy
@@ -203,11 +203,8 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                                 expectedTargetVariant = 'compile'
                                 // the format attribute is added by the rule
                                 expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
-                                if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-                                    // when experimental resolve is on, the "compile" configuration is mapped to the "java-api" usage
-                                    expectedAttributes['org.gradle.usage'] = 'java-api'
-                                    expectedAttributes['org.gradle.component.category'] = 'library'
-                                }
+                                expectedAttributes['org.gradle.usage'] = 'java-api'
+                                expectedAttributes['org.gradle.component.category'] = 'library'
                             }
                         }
                         variant(expectedTargetVariant, expectedAttributes)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -208,11 +208,11 @@ task resolve {
         then:
         resolve.expectGraph {
             root(":", "org:test:1.0") {
-                module("org:bar:1.0") {
-                    edge("org:foo:1.3.3", "org:foo:1.4.4").byConflictResolution("between versions 1.3.3 and 1.4.4")
+                module("org:bar:1.0:runtime") {
+                    edge("org:foo:1.3.3", "org:foo:1.4.4:runtime").byConflictResolution("between versions 1.3.3 and 1.4.4")
                 }
-                module("org:baz:1.0") {
-                    module("org:foo:1.4.4").byConflictResolution("between versions 1.3.3 and 1.4.4")
+                module("org:baz:1.0:runtime") {
+                    module("org:foo:1.4.4:runtime").byConflictResolution("between versions 1.3.3 and 1.4.4")
                 }
             }
         }
@@ -246,9 +246,9 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:external:1.2").byConflictResolution("between versions 1.2 and 1.0")
-                module("org:dep:2.2") {
-                    edge("org:external:1.0", "org:external:1.2")
+                module("org:external:1.2:runtime").byConflictResolution("between versions 1.2 and 1.0")
+                module("org:dep:2.2:runtime") {
+                    edge("org:external:1.0", "org:external:1.2:runtime")
                 }
             }
         }
@@ -684,8 +684,8 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", "org:test:1.3") {
-                module("org:other:1.7") {
-                    edge("org:test:1.2", "org:test:1.3")
+                module("org:other:1.7:runtime") {
+                    edge("org:test:1.2", "org:test:1.3:runtime")
                 }
             }
         }
@@ -722,8 +722,8 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", "org:test:1.3") {
-                module("org:other:1.7") {
-                    module("org:test:2.1").byConflictResolution("between versions 2.1 and 1.3")
+                module("org:other:1.7:runtime") {
+                    module("org:test:2.1:runtime").byConflictResolution("between versions 2.1 and 1.3")
                 }
             }
         }
@@ -1595,13 +1595,13 @@ task checkDeps(dependsOn: configurations.compile) {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module('org:bar:1.1') {
-                    module('org:baz:1.1') {
-                        module('org:foo:1.1')
+                module('org:bar:1.1:runtime') {
+                    module('org:baz:1.1:runtime') {
+                        module('org:foo:1.1:runtime')
                     }
                 }
-                edge("org:foo:[1.0,2.0)", 'org:foo:1.1')
-                edge('org:baz:[1.0,2.0)', 'org:baz:1.1')
+                edge("org:foo:[1.0,2.0)", 'org:foo:1.1:runtime')
+                edge('org:baz:[1.0,2.0)', 'org:baz:1.1:runtime')
             }
         }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionRangeResolveIntegrationTest.groovy
@@ -79,8 +79,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:bar:${dep1}", "org:bar:${lenientResult}")
-                edge("org:bar:${dep2}", "org:bar:${lenientResult}")
+                edge("org:bar:${dep1}", "org:bar:${lenientResult}:runtime")
+                edge("org:bar:${dep2}", "org:bar:${lenientResult}:runtime")
             }
         }
         when:
@@ -96,8 +96,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:bar:${dep1}", "org:bar:${lenientResult}")
-                edge("org:bar:${dep2}", "org:bar:${lenientResult}")
+                edge("org:bar:${dep1}", "org:bar:${lenientResult}:runtime")
+                edge("org:bar:${dep2}", "org:bar:${lenientResult}:runtime")
             }
         }
 
@@ -122,8 +122,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             succeeds(":checkDeps")
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org:bar:${dep1}", "org:bar:${strictResult}")
-                    edge("org:bar:${dep2}", "org:bar:${strictResult}")
+                    edge("org:bar:${dep1}", "org:bar:${strictResult}:runtime")
+                    edge("org:bar:${dep2}", "org:bar:${strictResult}:runtime")
                 }
             }
         }
@@ -145,8 +145,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             succeeds(":checkDeps")
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org:bar:${dep1}", "org:bar:${strictResult}")
-                    edge("org:bar:${dep2}", "org:bar:${strictResult}")
+                    edge("org:bar:${dep1}", "org:bar:${strictResult}:runtime")
+                    edge("org:bar:${dep2}", "org:bar:${strictResult}:runtime")
                 }
             }
         }
@@ -204,8 +204,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             run ':checkDeps'
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org:bar:${dep1}", "org:bar:${lenientResult}")
-                    edge("org:bar", "org:bar:${lenientResult}")
+                    edge("org:bar:${dep1}", "org:bar:${lenientResult}:runtime")
+                    edge("org:bar", "org:bar:${lenientResult}:runtime")
                 }
             }
         }
@@ -228,8 +228,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             run ':checkDeps'
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org:bar:${dep1}", "org:bar:${lenientResult}")
-                    edge("org:bar", "org:bar:${lenientResult}")
+                    edge("org:bar:${dep1}", "org:bar:${lenientResult}:runtime")
+                    edge("org:bar", "org:bar:${lenientResult}:runtime")
                 }
             }
         }
@@ -254,8 +254,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             run ':checkDeps'
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org:bar:${dep1}", "org:bar:${lenientResult}")
-                    edge("org:bar", "org:bar:${lenientResult}")
+                    edge("org:bar:${dep1}", "org:bar:${lenientResult}:runtime")
+                    edge("org:bar", "org:bar:${lenientResult}:runtime")
                 }
             }
         }
@@ -280,8 +280,8 @@ class VersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTes
             succeeds(":checkDeps")
             resolve.expectGraph {
                 root(":", ":test:") {
-                    edge("org:bar:${dep1}", "org:bar:${strictResult}")
-                    edge("org:bar", "org:bar:${strictResult}")
+                    edge("org:bar:${dep1}", "org:bar:${strictResult}:runtime")
+                    edge("org:bar", "org:bar:${strictResult}:runtime")
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/MetadataSourcesResolveIntegrationTest.groovy
@@ -100,7 +100,7 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
         succeeds ":checkDeps"
 
         // We are resolving with "legacy" metadata: always gives default configuration, unless we derive Java library variants for maven repositories
-        resolve.expectDefaultConfiguration(isExperimentalEnabled() && useMaven() ? "runtime" : "default")
+        resolve.expectDefaultConfiguration(useMaven() ? "runtime" : "default")
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:projectA:1.+", "org.test:projectA:1.2")
@@ -142,7 +142,7 @@ class MetadataSourcesResolveIntegrationTest extends AbstractModuleDependencyReso
         succeeds ":checkDeps"
 
         // We are resolving with `artifact()` metadata: always gives default configuration, unless we derive Java library variants for maven repositories
-        resolve.expectDefaultConfiguration(isExperimentalEnabled() && useMaven() ? "runtime" : "default")
+        resolve.expectDefaultConfiguration(useMaven() ? "runtime" : "default")
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:projectA:1.+", "org.test:projectA:1.2")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -801,7 +801,7 @@ dependencies {
         mavenModule.artifact.sha1.expectGet()
 
         then:
-        checkResolve "org.test:a:[1.0,2.0)": "org.test:a:1.1"
+        checkResolve "org.test:a:[1.0,2.0)": "org.test:a:1.1:runtime"
     }
 
     def "can resolve dynamic versions from repository with multiple ivy patterns"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -62,6 +62,7 @@ dependencies {
         succeeds 'checkDeps'
 
         then:
+        resolve.expectDefaultConfiguration('runtime')
         resolve.expectGraph {
             root(":", ":depLock:") {
                 edge("org:foo:1.+", "org:foo:1.0") {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/MixedDependencyLockingIntegrationTest.groovy
@@ -54,6 +54,7 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
+        executer.withStackTraceChecksDisabled()
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:
@@ -61,6 +62,7 @@ dependencies {
         outputContains('dependency was locked to version \'1.0\'')
 
         when:
+        executer.withStackTraceChecksDisabled()
         succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
 
         then:
@@ -96,6 +98,7 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
+        executer.withStackTraceChecksDisabled()
         succeeds 'dependencyInsight', '--configuration', 'unlockedConf', '--dependency', 'foo'
 
         then:
@@ -131,6 +134,7 @@ dependencies {
         lockfileFixture.createLockfile('lockedConf', ['org:foo:1.0'])
 
         when:
+        executer.withStackTraceChecksDisabled()
         succeeds 'dependencyInsight', '--configuration', 'lockedConf', '--dependency', 'foo'
 
         then:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.maven
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
 import spock.lang.Ignore
@@ -30,7 +29,6 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
     def setup() {
         resolve.prepare()
         settingsFile << "rootProject.name = 'testproject'"
-        FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
         buildFile << """
             repositories { maven { url "${mavenHttpRepo.uri}" } }
             configurations { compile }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenProfileResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenProfileResolveIntegrationTest.groovy
@@ -28,6 +28,7 @@ class MavenProfileResolveIntegrationTest extends AbstractHttpDependencyResolutio
         settingsFile << "rootProject.name = 'test' "
         resolve = new ResolveTestFixture(buildFile)
         resolve.prepare()
+        resolve.expectDefaultConfiguration('runtime')
     }
 
     def "uses properties from active profile to resolve dependency"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRealProjectsDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRealProjectsDependencyResolveIntegrationTest.groovy
@@ -73,6 +73,7 @@ task check {
 
         expect:
         succeeds "check", "checkDep"
+        resolve.expectDefaultConfiguration('runtime')
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module('ch.qos.logback:logback-classic:0.9.30') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -117,7 +117,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2")
+                module("test:a:1.2:runtime")
             }
         }
 
@@ -128,7 +128,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2")
+                module("test:a:1.2:runtime")
             }
         }
 
@@ -144,7 +144,7 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("test:a:1.2")
+                module("test:a:1.2:runtime")
             }
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
@@ -24,6 +24,7 @@ class MavenScopesAndProjectDependencySubstitutionIntegrationTest extends Abstrac
 
     def setup() {
         resolve.prepare()
+        resolve.expectDefaultConfiguration("runtime")
         settingsFile << """
             rootProject.name = 'testproject'
             include 'child1', 'child2'
@@ -43,13 +44,14 @@ class MavenScopesAndProjectDependencySubstitutionIntegrationTest extends Abstrac
         """
     }
 
-    def "when no target configuration is specified then a dependency on maven module includes the compile, runtime and master configurations of target project when they are present"() {
+    def "when no target configuration is specified then a dependency on maven module includes the default configuration of target project when they are present"() {
         mavenRepo.module("org.test", "m1", "1.0").publish()
         mavenRepo.module("org.test", "m2", "1.0").publish()
         mavenRepo.module("org.test", "m3", "1.0").publish()
         mavenRepo.module("org.test", "maven", "1.0")
             .dependsOn("org.test", "replaced", "1.0")
             .publish()
+        mavenRepo.module("org.test", "dont-ignore-me", "1.0").publish()
 
         buildFile << """
 project(':child1') {
@@ -73,7 +75,7 @@ project(':child2') {
         runtime 'org.test:m2:1.0'
         master 'org.test:m3:1.0'
         other 'org.test.ignore-me:1.0'
-        "default" 'org.test.ignore-me:1.0'
+        "default" 'org.test:dont-ignore-me:1.0'
     }
 }
 """
@@ -85,9 +87,7 @@ project(':child2') {
                     edge('org.test:replaced:1.0', 'project :child2', 'testproject:child2:') {
                         noArtifacts()
                         selectedByRule()
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
-                        module('org.test:m3:1.0')
+                        module('org.test:dont-ignore-me:1.0')
                     }
                 }
             }
@@ -137,12 +137,13 @@ project(':child2') {
         }
     }
 
-    def "a dependency on compile scope of maven module includes the compile and master configurations of target project when they are present"() {
+    def "a dependency on compile scope of maven module includes the default of target project when they are present"() {
         mavenRepo.module("org.test", "m1", "1.0").publish()
         mavenRepo.module("org.test", "m2", "1.0").publish()
         mavenRepo.module("org.test", "maven", "1.0")
             .dependsOn("org.test", "replaced", "1.0")
             .publish()
+        mavenRepo.module("org.test", "dont-ignore-me", "1.0").publish()
 
         buildFile << """
 project(':child1') {
@@ -166,7 +167,7 @@ project(':child2') {
         master 'org.test:m2:1.0'
         runtime 'org.test.ignore-me:1.0'
         other 'org.test.ignore-me:1.0'
-        "default" 'org.test.ignore-me:1.0'
+        "default" 'org.test:dont-ignore-me:1.0'
     }
 }
 """
@@ -179,8 +180,7 @@ project(':child2') {
                     edge('org.test:replaced:1.0', 'project :child2', 'testproject:child2:') {
                         selectedByRule()
                         noArtifacts()
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
+                        module('org.test:dont-ignore-me:1.0')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -37,7 +37,7 @@ class MavenScopesIntegrationTest extends AbstractDependencyResolutionTest {
 """
     }
 
-    def "default includes runtime dependencies of compile and runtime scoped dependencies of module"() {
+    def "prefers the runtime variant of a Maven module"() {
         def notRequired = mavenRepo.module('test', 'dont-include-me', '1.0')
         def m1 = mavenRepo.module('test', 'test1', '1.0').publish()
         def m2 = mavenRepo.module('test', 'test2', '1.0').publish()
@@ -69,6 +69,7 @@ dependencies {
 """
         expect:
         succeeds 'checkDep'
+        resolve.expectDefaultConfiguration("runtime")
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module('test:target:1.0') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -51,6 +51,7 @@ dependencies {
         run 'checkDeps'
 
         then:
+        resolve.expectDefaultConfiguration("runtime")
         resolve.expectGraph {
             root(":", ":test:") {
                 snapshot("org.gradle.integtests.resolve:unique:1.0-SNAPSHOT", uniqueVersionModule.uniqueSnapshotVersion)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -45,6 +45,7 @@ dependencies {
 
         def resolve = new ResolveTestFixture(buildFile)
         resolve.prepare()
+        resolve.expectDefaultConfiguration("runtime")
 
         when:
         succeeds 'checkDeps'
@@ -91,6 +92,7 @@ dependencies {
         succeeds 'checkDeps'
 
         then:
+        resolve.expectDefaultConfiguration("runtime")
         resolve.expectGraph {
             root(":", ":test:") {
                 edge("org.test:child:1.0", "org.test:child:1.0") {
@@ -127,6 +129,7 @@ dependencies {
 
         def resolve = new ResolveTestFixture(buildFile)
         resolve.prepare()
+        resolve.expectDefaultConfiguration("runtime")
 
         when:
         succeeds 'checkDeps'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
@@ -38,8 +38,8 @@ class MixedMavenAndIvyModulesIntegrationTest extends AbstractDependencyResolutio
 """
     }
 
-    def "when no target configuration is specified then a dependency on maven module includes the compile, runtime and master configurations of required ivy module when they are present"() {
-        def notRequired = ivyRepo.module("org.test", "ignore-me", "1.0")
+    def "when no target configuration is specified then a dependency on maven module includes the default configuration of required ivy module"() {
+        def inDefault = ivyRepo.module("org.test", "in-default", "1.0").publish()
         def m1 = ivyRepo.module("org.test", "m1", "1.0")
             .configuration("compile")
             .publish()
@@ -56,11 +56,11 @@ class MixedMavenAndIvyModulesIntegrationTest extends AbstractDependencyResolutio
             .dependsOn(m1, conf: "compile")
             .dependsOn(m2, conf: "runtime")
             .dependsOn(m3, conf: "master")
-            .dependsOn(notRequired, conf: "other,default")
+            .dependsOn(inDefault, conf: "other,default")
             .artifact(name: "compile", conf: "compile")
             .artifact(name: "runtime", conf: "runtime")
             .artifact(name: "master", conf: "master")
-            .artifact(name: 'ignore-me', conf: "other,default")
+            .artifact(name: 'in-default', conf: "other,default")
             .publish()
         mavenRepo.module("org.test", "maven", "1.0")
             .dependsOn(ivyModule)
@@ -75,22 +75,18 @@ dependencies {
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module('org.test:maven:1.0') {
+                module('org.test:maven:1.0:runtime') {
                     module('org.test:ivy:1.0') {
-                        artifact(name: 'compile')
-                        artifact(name: 'runtime')
-                        artifact(name: 'master')
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
-                        module('org.test:m3:1.0')
+                        artifact(name: 'in-default')
+                        module('org.test:in-default:1.0')
                     }
                 }
             }
         }
     }
 
-    def "a dependency on compile scope of maven module includes compile and master configurations of required ivy module when they are present"() {
-        def notRequired = ivyRepo.module("org.test", "ignore-me", "1.0")
+    def "a dependency on compile scope of maven module includes default of required ivy module when they are present"() {
+        def inDefault = ivyRepo.module("org.test", "in-default", "1.0").publish()
         def m1 = ivyRepo.module("org.test", "m1", "1.0")
             .configuration("compile")
             .publish()
@@ -105,10 +101,10 @@ dependencies {
             .configuration("default")
             .dependsOn(m1, conf: "compile")
             .dependsOn(m2, conf: "master")
-            .dependsOn(notRequired, conf: "other,default,runtime")
+            .dependsOn(inDefault, conf: "other,default,runtime")
             .artifact(name: "compile", conf: "compile")
             .artifact(name: "master", conf: "master")
-            .artifact(name: 'ignore-me', conf: "other,default,runtime")
+            .artifact(name: 'in-default', conf: "other,default,runtime")
             .publish()
         mavenRepo.module("org.test", "maven", "1.0")
             .dependsOn(ivyModule)
@@ -126,10 +122,8 @@ dependencies {
                 module('org.test:maven:1.0') {
                     configuration = 'compile'
                     module('org.test:ivy:1.0') {
-                        artifact(name: 'compile')
-                        artifact(name: 'master')
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
+                        module('org.test:in-default:1.0')
+                        artifact(name: 'in-default')
                     }
                 }
             }
@@ -137,7 +131,7 @@ dependencies {
     }
 
     def "ignores missing master configuration of ivy module when consumed by maven module"() {
-        def notRequired = ivyRepo.module("org.test", "ignore-me", "1.0")
+        def inDefault = ivyRepo.module("org.test", "in-default", "1.0").publish()
         def m1 = ivyRepo.module("org.test", "m1", "1.0").publish()
         def m2 = ivyRepo.module("org.test", "m2", "1.0").publish()
         def ivyModule = ivyRepo.module("org.test", "ivy", "1.0")
@@ -147,10 +141,10 @@ dependencies {
             .configuration("default")
             .dependsOn(m1, conf: "compile->default")
             .dependsOn(m2, conf: "runtime->default")
-            .dependsOn(notRequired, conf: "*,!compile,!runtime")
+            .dependsOn(inDefault, conf: "*,!compile,!runtime")
             .artifact(name: "compile", conf: "compile")
             .artifact(name: "runtime", conf: "runtime")
-            .artifact(name: 'ignore-me', conf: "other,default")
+            .artifact(name: 'in-default', conf: "other,default")
             .publish()
         mavenRepo.module("org.test", "maven", "1.0")
             .dependsOn(ivyModule)
@@ -165,12 +159,10 @@ dependencies {
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module('org.test:maven:1.0') {
+                module('org.test:maven:1.0:runtime') {
                     module('org.test:ivy:1.0') {
-                        artifact(name: 'compile')
-                        artifact(name: 'runtime')
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
+                        module('org.test:in-default:1.0')
+                        artifact(name: 'in-default')
                     }
                 }
             }
@@ -263,8 +255,8 @@ configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
         }
     }
 
-    def "selects correct configuration of ivy module when dynamic dependency is used from consuming maven module"() {
-        def notRequired = ivyRepo.module("org.test", "ignore-me", "1.0")
+    def "selects default configuration of ivy module when dynamic dependency is used from consuming maven module"() {
+        def inDefault = ivyRepo.module("org.test", "in-default", "1.0").publish()
         def m1 = ivyRepo.module("org.test", "m1", "1.0")
             .configuration("compile")
             .publish()
@@ -279,10 +271,10 @@ configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
             .configuration("default")
             .dependsOn(m1, conf: "compile")
             .dependsOn(m2, conf: "master")
-            .dependsOn(notRequired, conf: "*,!compile,!master->unknown")
+            .dependsOn(inDefault, conf: "*,!compile,!master")
             .artifact(name: "compile", conf: "compile")
             .artifact(name: "master", conf: "master")
-            .artifact(name: 'ignore-me', conf: "other,default,runtime")
+            .artifact(name: 'in-default', conf: "other,default,runtime")
             .publish()
         mavenRepo.module("org.test", "maven", "1.0")
             .dependsOn("org.test", "ivy", "1.+")
@@ -297,13 +289,11 @@ dependencies {
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module('org.test:maven:1.0') {
+                module('org.test:maven:1.0:runtime') {
                     configuration = 'compile'
                     edge('org.test:ivy:1.+', 'org.test:ivy:1.2') {
-                        artifact(name: 'compile')
-                        artifact(name: 'master')
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
+                        artifact(name: 'in-default')
+                        module('org.test:in-default:1.0')
                     }
                 }
             }
@@ -331,9 +321,9 @@ dependencies {
         succeeds 'checkDep'
         resolve.expectGraph {
             root(':', ':testproject:') {
-                module('org.test:m4:1.0') {
+                module('org.test:m4:1.0:runtime') {
                     module('org.test:m3:1.0') {
-                        module('org.test:m2:1.0') {
+                        module('org.test:m2:1.0:runtime') {
                             module('org.test:m1:1.0')
                         }
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -385,7 +385,7 @@ class DependencyManagementBuildScopeServices {
                                                                       BuildCommencedTimeProvider timeProvider,
                                                                       ModuleComponentResolveMetadataSerializer serializer,
                                                                       FeaturePreviews featurePreviews) {
-        return new ComponentMetadataRuleExecutor(cacheRepository, cacheDecoratorFactory, valueSnapshotter, timeProvider, serializer, featurePreviews.isFeatureEnabled(FeaturePreviews.Feature.IMPROVED_POM_SUPPORT));
+        return new ComponentMetadataRuleExecutor(cacheRepository, cacheDecoratorFactory, valueSnapshotter, timeProvider, serializer, true);
     }
 
     ComponentMetadataSupplierRuleExecutor createComponentMetadataSupplierRuleExecutor(ValueSnapshotter snapshotter,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenMutableModuleMetadataFactory.java
@@ -29,8 +29,6 @@ import org.gradle.internal.component.external.model.maven.MutableMavenModuleReso
 import java.util.Collections;
 import java.util.List;
 
-import static org.gradle.api.internal.FeaturePreviews.Feature.IMPROVED_POM_SUPPORT;
-
 public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataFactory<MutableMavenModuleResolveMetadata> {
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final ImmutableAttributesFactory attributesFactory;
@@ -49,7 +47,7 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
     @Override
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, featurePreviews.isFeatureEnabled(IMPROVED_POM_SUPPORT));
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, Collections.<MavenDependencyDescriptor>emptyList(), attributesFactory, objectInstantiator, true);
     }
 
     private ModuleVersionIdentifier asVersionIdentifier(ModuleComponentIdentifier from) {
@@ -65,6 +63,6 @@ public class MavenMutableModuleMetadataFactory implements MutableModuleMetadataF
 
     public MutableMavenModuleResolveMetadata create(ModuleComponentIdentifier from, List<MavenDependencyDescriptor> dependencies) {
         ModuleVersionIdentifier mvi = asVersionIdentifier(from);
-        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, featurePreviews.isFeatureEnabled(IMPROVED_POM_SUPPORT));
+        return new DefaultMutableMavenModuleResolveMetadata(mvi, from, dependencies, attributesFactory, objectInstantiator, true);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -59,7 +59,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
     @Shared componentIdentifier = DefaultModuleComponentIdentifier.newId(versionIdentifier)
     @Shared attributes = TestUtil.attributesFactory().of(Attribute.of("someAttribute", String), "someValue")
     @Shared schema = createSchema()
-    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews(true))
+    @Shared mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
     @Shared ivyMetadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory())
     @Shared defaultVariant
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -29,7 +29,7 @@ import org.gradle.util.TestUtil
 import static org.gradle.internal.component.external.model.DefaultModuleComponentSelector.newSelector
 
 class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRulesTest {
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews(true))
+    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     @Override
     boolean addAllDependenciesAsConstraints() {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -47,7 +47,7 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
     }
 
     boolean usesJavaLibraryVariants() {
-        GradleMetadataResolveRunner.isGradleMetadataEnabled() || (useMaven() && isExperimentalEnabled())
+        GradleMetadataResolveRunner.isGradleMetadataEnabled() || useMaven()
     }
 
     String getTestConfiguration() { 'conf' }
@@ -154,7 +154,6 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
         resolve.expectDefaultConfiguration(usesJavaLibraryVariants() ? "runtime" : "default")
         settingsFile << "rootProject.name = '$rootProjectName'"
         if (GradleMetadataResolveRunner.experimentalResolveBehaviorEnabled) {
-            FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
             FeaturePreviewsFixture.enableGradleMetadata(settingsFile)
         }
         resolve.prepare()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -144,7 +144,9 @@ No dependencies matching given input were found in configuration ':conf'
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -196,7 +198,9 @@ org:leaf2:1.0
 Task :dependencyInsight
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
@@ -250,7 +254,9 @@ org:leaf2:1.5 -> 2.5
         outputContains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -270,7 +276,9 @@ org:leaf:1.0
         outputContains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -326,7 +334,9 @@ org:leaf:1.0
 
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
@@ -399,7 +409,9 @@ org:leaf2:1.5 -> 2.5
 
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
@@ -564,7 +576,9 @@ org:foo:1.+ FAILED
         outputContains """
 org:leaf:1.0 (forced)
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -669,7 +683,9 @@ org:leaf:latest.integration -> 1.0
         outputContains """
 org:leaf:1.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -727,8 +743,10 @@ org:leaf:2.0 -> 1.0
         then:
         outputContains """
 org.test:bar:2.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : why not?
@@ -737,16 +755,20 @@ org:bar:1.0 -> org.test:bar:2.0
 \\--- conf
 
 org:baz:1.0 (selected by rule)
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:baz:1.0
 \\--- conf
 
 org:foo:2.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : because I am in control
@@ -789,8 +811,10 @@ org:foo:1.0 -> 2.0
 
         then:
         outputContains """org:bar:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : foo superceded by bar
@@ -835,7 +859,9 @@ org:foo:1.0 -> org:bar:1.0
         outputContains """
 org:new-leaf:77 (selected by rule)
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0 -> org:new-leaf:77
@@ -881,8 +907,10 @@ org:leaf:2.0 -> org:new-leaf:77
 
         then:
         outputContains """org:bar:2.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : I am not sure I want to explain
@@ -891,8 +919,10 @@ org:bar:1.0 -> 2.0
 \\--- conf
 
 org:foo:2.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : I want to
@@ -983,7 +1013,9 @@ org:leaf:latest.integration -> 1.6
         outputContains """
 org:leaf:2.0 (forced)
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:2.0
@@ -1029,7 +1061,9 @@ org:leaf:1.0 -> 2.0
         outputContains """
 org:leaf:1.5 (forced)
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0 -> 1.5
@@ -1075,8 +1109,10 @@ org:leaf:2.0 -> 1.5
         then:
         outputContains """
 org:leaf:1.0 (forced)
-   variant "default+runtime" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -1121,8 +1157,10 @@ org:leaf:2.0 -> 1.0
         then:
         outputContains """
 org:leaf:2.0
-   variant "runtime+default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Forced
@@ -1483,7 +1521,9 @@ org:leaf:[1.5,2.0] FAILED
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -1570,7 +1610,9 @@ project :
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -1666,10 +1708,10 @@ project :impl
         then:
         outputContains """
 org:leaf4:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf4:1.0
@@ -1700,10 +1742,10 @@ org:leaf4:1.0
         then:
         outputContains """
 org:leaf1:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf1:1.0
@@ -1716,10 +1758,10 @@ org:leaf1:1.0
         then:
         outputContains """
 org:leaf2:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -1816,10 +1858,10 @@ project :api
         then:
         outputContains """
 org:leaf3:1.0
-   variant "runtime" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf3:1.0
@@ -1862,16 +1904,20 @@ org:leaf3:1.0
 
         then:
         result.groupedOutput.task(":dependencyInsight").output.contains("""foo:bar:2.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 foo:bar:2.0
 \\--- compile
 
 foo:foo:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 foo:foo:1.0
@@ -1913,10 +1959,10 @@ foo:foo:1.0
         then:
         if (!rejected) {
             outputContains """org:foo:$selected (by constraint)
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
 
 org:foo -> $selected
@@ -1924,10 +1970,10 @@ org:foo -> $selected
 """
         } else {
             outputContains """org:foo:$selected
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By constraint : $rejected
@@ -1977,10 +2023,10 @@ org:foo -> $selected
 
         then:
         outputContains """org:foo:$selected
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By constraint : ${rejected}${reason}
@@ -2026,10 +2072,10 @@ org:foo -> $selected
 
         then:
         outputContains """org:foo:$selected
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : ${rejected}${reason}
@@ -2072,10 +2118,10 @@ org:foo:${displayVersion} -> $selected
 
         then:
         outputContains """org:foo:1.3
-   variant "default+runtime" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : didn't match versions 2.0, 1.5, 1.4
@@ -2124,10 +2170,10 @@ org:foo:[1.1,1.3] -> 1.3
 
         then:
         outputContains """org:bar:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2136,10 +2182,10 @@ org:bar:[1.0,) -> 1.0
 \\--- compileClasspath
 
 org:foo:1.1
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2192,10 +2238,10 @@ org:foo:[1.0,) -> 1.1
         then:
         outputContains """Task :dependencyInsight
 org:bar:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Rejection : 1.2 by rule because version 1.2 is bad
@@ -2205,10 +2251,10 @@ org:bar:[1.0,) -> 1.0
 \\--- compileClasspath
 
 org:foo:1.1
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2226,8 +2272,6 @@ org:foo:[1.0,) -> 1.1
         bom.packaging = 'pom'
         bom.dependencyConstraint(leaf)
         bom.publish()
-
-        FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
 
         file("build.gradle") << """
             apply plugin: 'java-library'
@@ -2293,10 +2337,10 @@ org:leaf -> 1.0
         then:
         outputContains """
 org.test:leaf:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2339,7 +2383,9 @@ org.test:leaf:1.0
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -2469,10 +2515,10 @@ org:foo:[1.0,) FAILED
 
         then:
         outputContains """org.test:leaf:1.0
-   variant "default" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2530,12 +2576,11 @@ org.test:leaf:1.0
         then:
         outputContains """Task :dependencyInsight
 org:foo:1.0
-   variant "default" [
-      color             = blue
-      org.gradle.status = release (not requested)
-
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      color                         = blue
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - Rejection : version 1.2:
@@ -2596,10 +2641,10 @@ org:foo:[1.0,) -> 1.0
         then:
         outputContains """> Task :dependencyInsight
 planet:mercury:1.0.2
-   variant "runtime" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.0.2 and 1.0.1
@@ -2623,10 +2668,10 @@ planet:mercury:1.0.1 -> 1.0.2
         then:
         outputContains """> Task :dependencyInsight
 planet:venus:2.0.1
-   variant "runtime" [
-      org.gradle.status = release (not requested)
-      Requested attributes not found in the selected variant:
-         org.gradle.usage  = java-api
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.0.0, 2.0.1 and 1.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -171,7 +171,9 @@ org:middle:1.0 FAILED
         output.contains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -209,9 +211,11 @@ org:leaf:1.0
         then:
         output.contains """org:leaf:1.0
    variant "runtime" [
-      org.gradle.status = release (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
       Requested attributes not found in the selected variant:
-         usage             = dummy
+         usage                         = dummy
    ]
 
 org:leaf:1.0
@@ -268,18 +272,22 @@ org:leaf:1.0
         then:
         outputContains """
 org:testA:1.0
-   variant "default" [
-      custom            = dep_value
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      custom                        = dep_value
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:testA:1.0
 \\--- conf
 
 org:testB:1.0
-   variant "default" [
-      custom            = dep_value
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      custom                        = dep_value
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
 
 org:testB:+ -> 1.0

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out
@@ -1,6 +1,8 @@
 commons-codec:commons-codec:1.7
-   variant "default+runtime" [
-      org.gradle.status = release (not requested)
+   variant "runtime" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime (not requested)
+      org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.7 and 1.6

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FeaturePreviewsFixture.groovy
@@ -24,12 +24,6 @@ enableFeaturePreview("GRADLE_METADATA")
 """
     }
 
-    static void enableImprovedPomSupport(File settings) {
-        settings << """
-enableFeaturePreview("IMPROVED_POM_SUPPORT")
-"""
-    }
-
     static void enableStablePublishing(File settings) {
         settings << """
 enableFeaturePreview("STABLE_PUBLISHING")

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleMetadataResolveRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleMetadataResolveRunner.groovy
@@ -34,7 +34,7 @@ class GradleMetadataResolveRunner extends BehindFlagFeatureRunner {
     }
 
     def isInvalidCombination(Map<String, String> values) {
-        values[(GRADLE_METADATA)] == 'true' && values[(EXPERIMENTAL_RESOLVE_BEHAVIOR)] == 'false'
+        (values[(GRADLE_METADATA)] == 'true' && values[(EXPERIMENTAL_RESOLVE_BEHAVIOR)] == 'false')
     }
 
     static boolean isGradleMetadataEnabled() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1149,8 +1149,14 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
                     throw new UncheckedIOException(e);
                 }
                 int i = 0;
+                boolean insideVariantDescriptionBlock = false;
                 while (i < lines.size()) {
                     String line = lines.get(i);
+                    if (insideVariantDescriptionBlock && line.contains("]")) {
+                        insideVariantDescriptionBlock = false;
+                    } else if (!insideVariantDescriptionBlock && line.contains("variant \"")) {
+                        insideVariantDescriptionBlock = true;
+                    }
                     if (line.matches(".*use(s)? or override(s)? a deprecated API\\.")) {
                         // A javac warning, ignore
                         i++;
@@ -1166,7 +1172,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
                         while (i < lines.size() && STACK_TRACE_ELEMENT.matcher(lines.get(i)).matches()) {
                             i++;
                         }
-                    } else if (!expectStackTraces && STACK_TRACE_ELEMENT.matcher(line).matches() && i < lines.size() - 1 && STACK_TRACE_ELEMENT.matcher(lines.get(i + 1)).matches()) {
+                    } else if (!expectStackTraces && !insideVariantDescriptionBlock && STACK_TRACE_ELEMENT.matcher(line).matches() && i < lines.size() - 1 && STACK_TRACE_ELEMENT.matcher(lines.get(i + 1)).matches()) {
                         // 2 or more lines that look like stack trace elements
                         throw new AssertionError(String.format("%s line %d contains an unexpected stack trace: %s%n=====%n%s%n=====%n", displayName, i + 1, line, output));
                     } else {

--- a/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/testFixtures/groovy/org/gradle/api/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -55,7 +55,6 @@ abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec imple
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
         FeaturePreviewsFixture.enableGradleMetadata(settingsFile)
-        FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
         FeaturePreviewsFixture.enableStablePublishing(settingsFile)
         String attributes = params.variant == null ?
             "" :

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -70,7 +70,6 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
         // Replace the existing buildfile with one for resolving the published module
         settingsFile.text = "rootProject.name = 'resolve'"
         FeaturePreviewsFixture.enableGradleMetadata(settingsFile)
-        FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
         def attributes = params.variant == null ?
             "" :
             """ 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -105,6 +105,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
 
@@ -148,6 +149,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
         when:
@@ -207,6 +209,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
 
@@ -244,6 +247,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryConsumptionIntegrationTest.groovy
@@ -17,13 +17,11 @@
 package org.gradle.java
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 
 class JavaLibraryConsumptionIntegrationTest extends AbstractIntegrationSpec {
 
     def "runtime dependencies from maven modules do not leak into compile classpath"() {
         given:
-        FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
         buildFile << """
             apply plugin: 'java-library'
             ${jcenterRepository()}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -107,6 +107,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
         when:
@@ -149,6 +150,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
         when:
@@ -208,6 +210,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
 
@@ -245,6 +248,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -105,6 +105,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
         when:
@@ -147,6 +148,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
         when:
@@ -206,6 +208,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
         when:
@@ -242,6 +245,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
             }
 """
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -468,6 +468,15 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
             } else if (details.getConsumerValue().getName().equals(Usage.JAVA_RUNTIME_RESOURCES) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME_JARS)) {
                 // Can use the Java runtime jars if present, but prefer Java runtime resources
                 details.compatible();
+            } else if (details.getConsumerValue().getName().equals(Usage.JAVA_RUNTIME_CLASSES) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME)) {
+                // Can use the Java runtime if present, but prefer Java runtime classes
+                details.compatible();
+            } else if (details.getConsumerValue().getName().equals(Usage.JAVA_RUNTIME_RESOURCES) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME)) {
+                // Can use the Java runtime if present, but prefer Java runtime resources
+                details.compatible();
+            } else if (details.getConsumerValue().getName().equals(Usage.JAVA_RUNTIME_JARS) && details.getProducerValue().getName().equals(Usage.JAVA_RUNTIME)) {
+                // Can use the Java runtime if present, but prefer Java runtime jar
+                details.compatible();
             }
         }
     }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -16,11 +16,9 @@
 
 package org.gradle.smoketests
 
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.file.TestFile
 import spock.lang.Unroll
-
 /**
  * https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies
  */
@@ -40,7 +38,6 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
         settingsFile << """
             rootProject.name = 'springbootproject'
         """
-        FeaturePreviewsFixture.enableImprovedPomSupport(settingsFile)
         def buildScript = """
             plugins {
                 id "java"


### PR DESCRIPTION
### Context

This commit makes the experimental flag `IMPROVED_POM_SUPPORT` the default.
The flag is still there for backwards compatibility but has effectively no
impact. As a consequence, the behavior of improved POM support is now the
default, which implies that:

- Maven dependencies packaged as `pom` or `jar` now have derived variants
(`compile` and `runtime`) and we properly choose between the variants based
on the consumer attributes
- platform dependencies using the `platform` and `enforcedPlatform` keywords
are enabled

Enabling improved POM support by default is a **breaking change**: there's
a risk that resolved dependencies is different, in particular because we
will now only include the `compile` dependencies of a POM file whenever the
consumer asks for the API variant. There are also some changes in the
dependency insight reports due to the use of attribute based matching instead
of configuration selection.

Last but not least, this commit is likely to introduce a small performance
regression due to attribute based selection.
