### PR TITLE
Move logic that updates build init versions resource into gradle/gradle build

### DIFF
--- a/subprojects/build-init/build-init.gradle
+++ b/subprojects/build-init/build-init.gradle
@@ -41,3 +41,50 @@ gradlebuildJava {
 testFixtures {
     from(':core')
 }
+
+task updateInitPluginTemplateVersionFile() {
+    doLast {
+        def libraryVersionFile = file("src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties")
+
+        Properties versionProperties = new Properties()
+
+        findLatest('scala-library', 'org.scala-lang:scala-library:2.11.+', versionProperties)
+        def scalaVersion = VersionNumber.parse(versionProperties['scala-library'])
+        versionProperties.put('scala', "${scalaVersion.major}.${scalaVersion.minor}" as String)
+        findLatest('scalatest', "org.scalatest:scalatest_${versionProperties.scala}:(3.0,)", versionProperties)
+        findLatest('scala-xml', "org.scala-lang.modules:scala-xml_${versionProperties.scala}:latest.release", versionProperties)
+        findLatest('groovy', 'org.codehaus.groovy:groovy:(2.4,2.5]', versionProperties)
+        findLatest('junit', 'junit:junit:(4.0,)', versionProperties)
+        findLatest('testng', 'org.testng:testng:(6.0,)', versionProperties)
+        findLatest('slf4j', 'org.slf4j:slf4j-api:(1.7,)', versionProperties)
+        def groovyVersion = VersionNumber.parse(versionProperties['groovy'])
+        versionProperties.put('spock', "1.0-groovy-${groovyVersion.major}.${groovyVersion.minor}" as String)
+        findLatest('guava', 'com.google.guava:guava:(20,)', versionProperties)
+        findLatest('commons-math', 'org.apache.commons:commons-math3:latest.release', versionProperties)
+        findLatest('kotlin', 'org.jetbrains.kotlin:kotlin-gradle-plugin:(1.2,)', versionProperties)
+
+        org.gradle.build.ReproduciblePropertiesWriter.store(versionProperties, libraryVersionFile,
+                                                            "Version values used in build-init templates\nGenerated file, please to not edit")
+    }
+}
+
+private void findLatest(String name, String notation, Properties dest) {
+    def libDependencies = [ project.dependencies.create(notation) ]
+    def templateVersionConfiguration = project.configurations.detachedConfiguration(libDependencies as Dependency[])
+    templateVersionConfiguration.resolutionStrategy.componentSelection.all { selection ->
+        def devSuffixes = ["-SNAP\\d+", "-SNAPSHOT", "-alpha-?\\d+", "-beta-?\\d+", "-dev-?\\d+", "-rc-?\\d+", "-M\\d+", "-eap-?\\d+"]
+        devSuffixes.each {
+            if (selection.candidate.version.matches(".+$it\$")) {
+                selection.reject("don't use snapshots")
+                return
+            }
+        }
+    }
+    templateVersionConfiguration.transitive = false
+    ResolutionResult resolutionResult = templateVersionConfiguration.incoming.resolutionResult
+    def matches = resolutionResult.allComponents.findAll { it != resolutionResult.root }
+    if (matches.empty) {
+        throw new GradleException("Could not locate any matches for $notation")
+    }
+    matches.each { dep -> dest.put(name, dep.id.version) }
+}

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -1,14 +1,14 @@
 # Version values used in build-init templates
-# Generated file, please to not edit
+Generated file, please to not edit
 scalatest=3.0.5
+kotlin=1.2.70
 scala-xml=1.1.0
 scala-library=2.11.12
-testng=6.10
+testng=6.14.3
 slf4j=1.7.25
-guava=23.0
+guava=26.0-jre
 commons-math=3.6.1
 scala=2.11
 groovy=2.4.15
 junit=4.12
 spock=1.0-groovy-2.4
-kotlin=1.2.60


### PR DESCRIPTION
### Context

This PR moves the logic that updates the build init versions out of the promotion project and into the gradle/gradle build. This way, the build init project can present an interface that the promotion builds can use that isn't version specific (i.e. it can just call a specific entry point task whose implementation can do whatever it sees fit), rather than understanding what files need to be updated, what their format is, how to figure out the values, and so on.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
