### PR TITLE
Disconnect streams in the inverse order they are connected

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -426,14 +426,14 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
 
         @Override
         public void stop() {
-            inputHandler.stop();
             outputHandler.stop();
+            inputHandler.stop();
         }
 
         @Override
         public void disconnect() {
-            inputHandler.disconnect();
             outputHandler.disconnect();
+            inputHandler.disconnect();
         }
     }
 }


### PR DESCRIPTION
Otherwise there is a time window where the worker process
can no longer read its input, but can still complain about
that on its output stream. This leads to unwanted user-facing
error logging for something that is completely normal.

Fixes this flakiness: https://builds.gradle.org/viewLog.html?buildId=15792829&tab=buildResultsDiv&buildTypeId=Gradle_Check_Quick_Java8_Oracle_Windows_core