### PR TITLE
Add missing `@CleanupTestDirectory` annotation

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleBuildPerformanceTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.performance.fixture.PerformanceTestConditions
 import org.gradle.performance.results.BaselineVersion
 import org.gradle.performance.results.CrossBuildPerformanceResults
 import org.gradle.performance.results.CrossBuildResultsStore
+import org.gradle.test.fixtures.file.CleanupTestDirectory
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
 import org.junit.experimental.categories.Category
@@ -54,11 +55,12 @@ import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
  * - be careful when rebasing/squashing/merging
  */
 @Category(PerformanceRegressionTest)
+@CleanupTestDirectory
 @Retry(condition = { PerformanceTestConditions.whenSlowerButNotAdhoc(failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 class GradleBuildPerformanceTest extends Specification {
 
     @Rule
-    TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
+    TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
     @Rule
     TestName testName = new TestName()
@@ -83,7 +85,7 @@ class GradleBuildPerformanceTest extends Specification {
             @Override
             protected void defaultSpec(BuildExperimentSpec.Builder builder) {
                 super.defaultSpec(builder)
-                builder.workingDirectory = tmpDir.testDirectory
+                builder.workingDirectory = temporaryFolder.testDirectory
                 if (builder instanceof GradleBuildExperimentSpec.GradleBuilder) {
                     builder.invocation.args("-Djava9Home=${System.getProperty('java9Home')}", "-D${PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY}=${gradlePluginRepositoryMirrorUrl()}", "-I", createMirrorInitScript().absolutePath)
                 }


### PR DESCRIPTION
Without it, the temporaryFolder is cleaned out even if the test
fails.

Fixes https://github.com/gradle/gradle-private/issues/1497.