### PR TITLE
Fix flaky task timeout test

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecution.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/ConditionalExecution.java
@@ -33,7 +33,8 @@ public interface ConditionalExecution<T> {
     Runnable getExecution();
 
     /**
-     * Blocks waiting for this execution to complete.  Returns a result provided by the execution.
+     * Blocks waiting for this execution to complete. Returns a result provided by the execution.
+     * When this method returns, the resource lock of this execution has been unlocked.
      */
     T await();
 
@@ -48,7 +49,7 @@ public interface ConditionalExecution<T> {
     boolean isComplete();
 
     /**
-     * If a failure occurs during execution, this method will be called with the exception.
+     * Cancels this execution.
      */
-    void registerFailure(Throwable t);
+    void cancel();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -213,8 +213,6 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
         private void runExecution(ConditionalExecution execution) {
             try {
                 execution.getExecution().run();
-            } catch (Throwable t) {
-                execution.registerFailure(t);
             } finally {
                 coordinationService.withStateLock(unlock(execution.getResourceLock()));
                 execution.complete();

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultConditionalExecutionQueue.java
@@ -125,11 +125,14 @@ public class DefaultConditionalExecutionQueue<T> implements ConditionalExecution
     private class ExecutionRunner implements Runnable {
         @Override
         public void run() {
-            ConditionalExecution operation;
-            while ((operation = waitForNextOperation()) != null) {
-                runBatch(operation);
+            try {
+                ConditionalExecution operation;
+                while ((operation = waitForNextOperation()) != null) {
+                    runBatch(operation);
+                }
+            } finally {
+                shutDown();
             }
-            shutDown();
         }
 
         private ConditionalExecution waitForNextOperation() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/DefaultTimeoutHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/timeout/DefaultTimeoutHandler.java
@@ -32,11 +32,9 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
 
     @Override
     public Timeout start(Thread taskExecutionThread, Duration timeout) {
-        long timeoutMillis = timeout.toMillis();
-        long limit = System.currentTimeMillis() + timeoutMillis;
-        InterruptOnTimeout interrupter = new InterruptOnTimeout(taskExecutionThread, limit);
-        ScheduledFuture<?> periodicCheck = executor.scheduleAtFixedRate(interrupter, timeoutMillis, 50, TimeUnit.MILLISECONDS);
-        return new DefaultTimeout(interrupter, periodicCheck);
+        InterruptOnTimeout interrupter = new InterruptOnTimeout(taskExecutionThread);
+        ScheduledFuture<?> timeoutTask = executor.schedule(interrupter, timeout.toMillis(), TimeUnit.MILLISECONDS);
+        return new DefaultTimeout(timeoutTask);
     }
 
     @Override
@@ -45,46 +43,33 @@ public class DefaultTimeoutHandler implements TimeoutHandler, Stoppable {
     }
 
     private static final class DefaultTimeout implements Timeout {
+        private final ScheduledFuture<?> timeoutTask;
 
-        private final InterruptOnTimeout interrupter;
-        private final ScheduledFuture<?> periodicCheck;
-
-        private DefaultTimeout(InterruptOnTimeout interrupter, ScheduledFuture<?> periodicCheck) {
-            this.interrupter = interrupter;
-            this.periodicCheck = periodicCheck;
+        private DefaultTimeout(ScheduledFuture<?> timeoutTask) {
+            this.timeoutTask = timeoutTask;
         }
 
         @Override
         public void stop() {
-            periodicCheck.cancel(true);
+            timeoutTask.cancel(true);
         }
 
         @Override
         public boolean timedOut() {
-            return interrupter.timedOut;
+            return timeoutTask.isDone() && !timeoutTask.isCancelled();
         }
     }
 
     private static class InterruptOnTimeout implements Runnable {
         private final Thread thread;
-        private final long limit;
 
-        private volatile boolean timedOut;
-
-        private InterruptOnTimeout(Thread thread, long limit) {
+        private InterruptOnTimeout(Thread thread) {
             this.thread = thread;
-            this.limit = limit;
         }
 
         @Override
         public void run() {
-            if (timedOut) {
-                return;
-            }
-            if (System.currentTimeMillis() > limit) {
-                timedOut = true;
-                thread.interrupt();
-            }
+            thread.interrupt();
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkCompletion.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkCompletion.java
@@ -29,4 +29,9 @@ public interface AsyncWorkCompletion {
      * Returns true if the work item is completed.
      */
     boolean isComplete();
+
+    /**
+     * Cancels this work item.
+     */
+    void cancel();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/DefaultAsyncWorkTracker.java
@@ -114,12 +114,21 @@ public class DefaultAsyncWorkTracker implements AsyncWorkTracker {
             try {
                 item.waitForCompletion();
             } catch (Throwable t) {
+                if (Thread.currentThread().isInterrupted()) {
+                    cancel(workItems);
+                }
                 failures.add(t);
             }
         }
 
         if (failures.size() > 0) {
             throw new DefaultMultiCauseException("There were failures while executing asynchronous work:", failures);
+        }
+    }
+
+    private void cancel(Iterable<AsyncWorkCompletion> workItems) {
+        for (AsyncWorkCompletion workItem : workItems) {
+            workItem.cancel();
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
@@ -77,6 +77,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
                     boolean isComplete() {
                         return false
                     }
+
+                    @Override
+                    void cancel() {
+
+                    }
                 })
                 instant.worker2Started
             }
@@ -138,6 +143,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
                     boolean isComplete() {
                         return false
                     }
+
+                    @Override
+                    void cancel() {
+
+                    }
                 })
                 instant.worker1Started
             }
@@ -183,6 +193,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
             boolean isComplete() {
                 return true
             }
+
+            @Override
+            void cancel() {
+
+            }
         })
         asyncWorkTracker.registerWork(operation1, completedWorkCompletion())
 
@@ -214,6 +229,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
                     boolean isComplete() {
                         return false
                     }
+
+                    @Override
+                    void cancel() {
+
+                    }
                 })
                 instant.registered
             }
@@ -232,6 +252,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
                         @Override
                         boolean isComplete() {
                             return false
+                        }
+
+                        @Override
+                        void cancel() {
+
                         }
                     })
                 } finally {
@@ -264,6 +289,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
             boolean isComplete() {
                 return false
             }
+
+            @Override
+            void cancel() {
+
+            }
         })
         asyncWorkTracker.waitForCompletion(operation1, true)
 
@@ -285,6 +315,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
             @Override
             boolean isComplete() {
                 return false
+            }
+
+            @Override
+            void cancel() {
+
             }
         })
         asyncWorkTracker.waitForCompletion(operation1, false)
@@ -331,6 +366,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
             boolean isComplete() {
                 return false
             }
+
+            @Override
+            void cancel() {
+
+            }
         }
     }
 
@@ -343,6 +383,11 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
             @Override
             boolean isComplete() {
                 return true
+            }
+
+            @Override
+            void cancel() {
+
             }
         }
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -95,7 +95,6 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
     private DefaultWorkResult executeInWorkerClassLoader(ActionExecutionSpec spec, DaemonForkOptions forkOptions) {
         ClassLoader actionClasspathLoader = createActionClasspathLoader(forkOptions);
         GroovySystemLoader actionClasspathGroovy = groovySystemLoaderFactory.forClassLoader(actionClasspathLoader);
-
         ClassLoader workerClassLoader = createWorkerClassLoader(actionClasspathLoader, forkOptions.getSharedPackages(), spec.getClass());
 
         ClassLoader previousContextLoader = Thread.currentThread().getContextClassLoader();
@@ -107,7 +106,6 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         } finally {
-            // Eventually shutdown any leaky groovy runtime loaded from action classpath loader
             actionClasspathGroovy.shutdown();
             Thread.currentThread().setContextClassLoader(previousContextLoader);
         }


### PR DESCRIPTION
Classpath isolation workers are currently very inefficient, they create a new classloader for every item. Classloading is also not interruptible, so it takes a long time until such a worker hits a point where it can be interrupted.

The flaky test was creating 100 such items. The problem was that we were interrupting them one by one, but only after they had started. As a result we were waiting 100 times longer than necessary.

The fix was to eagerly cancel any further items when we encounter the first interrupt. 