### PR TITLE
Rebaseline `help on the gradle build comparing gradle`

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -38,7 +38,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
         given:
         runner.testProject = "gradleBuildCurrent"
         runner.tasksToRun = tasks.split(' ')
-        runner.targetVersions = ["5.0-20180909235858+0000"]
+        runner.targetVersions = ["5.0-20180912002106+0000"]
         runner.args = ["-Djava9Home=${System.getProperty('java9Home')}"]
 
         when:


### PR DESCRIPTION
Accepting a performance regression in the latest Kotlin DSL release caused by the additional hashing of the compilation classpath required by the generated project accessors.