### PR TITLE
Prevent plugin resolution to try download jars for plugin markers

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.integtests.composite
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.plugin.PluginBuilder
 import spock.lang.Unroll
 
 class CompositeBuildConfigurationAttributesResolveIntegrationTest extends AbstractIntegrationSpec {
 
-    def setup(){
+    def setup() {
         using m2
     }
 
@@ -716,7 +717,7 @@ All of them match the consumer attributes:
                     'default' file('b-transitive.jar')
                 }
                 dependencies {
-                    'default'('com.acme.external:external:1.0')
+                    'default'('org.gradle.test.external:external:1.0')
                 }
             }
         """
@@ -724,7 +725,7 @@ All of them match the consumer attributes:
         file('includedBuild/build.gradle') << """
             ${usesTypedAttributesPlugin(v2, usePluginsDSL)}
 
-            group = 'com.acme.external'
+            group = 'org.gradle.test.external'
             version = '2.0-SNAPSHOT'
 
             dependencies {
@@ -785,96 +786,48 @@ All of them match the consumer attributes:
     private String usesTypedAttributesPlugin(String version, boolean usePluginsDSL) {
         String pluginsBlock = usePluginsDSL ? """
             plugins {
-                id 'com.acme.typed-attributes' version '$version'
+                id 'org.gradle.test.typed-attributes' version '$version'
             } """ : """
             buildscript {
                 repositories {
                     maven { url "${mavenRepo.uri}" }
                 }
                 dependencies {
-                    classpath 'com.acme.typed-attributes:com.acme.typed-attributes.gradle.plugin:$version'
+                    classpath 'org.gradle.test:typed-attributes:$version'
                 }
             }
 
-            apply plugin: 'com.acme.typed-attributes'
+            apply plugin: 'org.gradle.test.typed-attributes'
             """
 
         """
             $pluginsBlock
 
-            import static com.acme.Flavor.*
-            import static com.acme.BuildType.*
+            import static org.gradle.test.Flavor.*
+            import static org.gradle.test.BuildType.*
 
-            def flavor = Attribute.of(com.acme.Flavor)
-            def buildType = Attribute.of(com.acme.BuildType)
+            def flavor = Attribute.of(org.gradle.test.Flavor)
+            def buildType = Attribute.of(org.gradle.test.BuildType)
         """
     }
 
     private void buildTypedAttributesPlugin(String version = "1.0") {
-        def pluginDir = new File(testDirectory, "typed-attributes-plugin-$version")
+        def pluginDir = testDirectory.file("typed-attributes-plugin-$version")
         pluginDir.deleteDir()
         pluginDir.mkdirs()
-        def builder = new FileTreeBuilder(pluginDir)
-        builder.call {
-            'settings.gradle'('rootProject.name="com.acme.typed-attributes.gradle.plugin"')
-            'build.gradle'("""
-                apply plugin: 'groovy'
-                apply plugin: 'maven'
-
-                group = 'com.acme.typed-attributes'
-                version = '$version'
-
-                dependencies {
-                    compile localGroovy()
-                    compile gradleApi()
-                }
-
-                uploadArchives {
-                    repositories {
-                        mavenDeployer {
-                            repository(url: "${mavenRepo.uri}")
-                        }
+        new PluginBuilder(pluginDir).with {
+            groovy('Flavor.groovy') << 'package org.gradle.test; enum Flavor { free, paid }'
+            groovy('BuildType.groovy') << 'package org.gradle.test; enum BuildType { debug, release }'
+            addPlugin(
+                """
+                    project.dependencies.attributesSchema {
+                        attribute(org.gradle.api.attributes.Attribute.of(Flavor))
+                        attribute(org.gradle.api.attributes.Attribute.of(BuildType))
                     }
-                }
-            """)
-            src {
-                main {
-                    groovy {
-                        com {
-                            acme {
-                                'Flavor.groovy'('package com.acme; enum Flavor { free, paid }')
-                                'BuildType.groovy'('package com.acme; enum BuildType { debug, release }')
-                                'TypedAttributesPlugin.groovy'('''package com.acme
-
-                                    import org.gradle.api.Plugin
-                                    import org.gradle.api.Project
-                                    import org.gradle.api.attributes.Attribute
-
-                                    class TypedAttributesPlugin implements Plugin<Project> {
-                                        void apply(Project p) {
-                                            p.dependencies.attributesSchema {
-                                                attribute(Attribute.of(Flavor))
-                                                attribute(Attribute.of(BuildType))
-                                            }
-                                        }
-                                    }
-                                    ''')
-                            }
-                        }
-                    }
-                    resources {
-                        'META-INF' {
-                            'gradle-plugins' {
-                                'com.acme.typed-attributes.properties'('implementation-class: com.acme.TypedAttributesPlugin')
-                            }
-                        }
-                    }
-                }
-            }
+                """.stripIndent(),
+                'org.gradle.test.typed-attributes',
+                'TypedAttributesPlugin')
+            publishAs("org.gradle.test:typed-attributes:$version", mavenRepo, executer)
         }
-        executer.usingBuildScript(new File(pluginDir, "build.gradle"))
-            .withTasks("uploadArchives")
-            .run()
-
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -98,7 +98,7 @@ plugins {
 }
 """
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
+        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0'])
 
         when:
         succeeds 'buildEnvironment'
@@ -149,7 +149,7 @@ plugins {
 
         then:
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.verifyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
+        lockFile.verifyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1', 'org.bar:bar-plugin:1.0'])
     }
 
     def 'fails to resolve if lock state present but no dependencies remain'() {

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/AuthenticatedPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/AuthenticatedPluginRepositorySpec.groovy
@@ -92,7 +92,6 @@ class AuthenticatedPluginRepositorySpec extends AbstractHttpDependencyResolution
 
         expect:
         markerModule.ivy.expectGet(USERNAME, PASSWORD)
-        markerModule.jar.expectGet(USERNAME, PASSWORD)
         pluginModule.ivy.expectGet(USERNAME, PASSWORD)
         pluginModule.jar.expectGet(USERNAME, PASSWORD)
         succeeds("pluginTask")
@@ -128,7 +127,6 @@ class AuthenticatedPluginRepositorySpec extends AbstractHttpDependencyResolution
 
         expect:
         markerModule.pom.expectGet(USERNAME, PASSWORD)
-        markerModule.artifact.expectGet(USERNAME, PASSWORD)
         pluginModule.pom.expectGet(USERNAME, PASSWORD)
         pluginModule.artifact.expectGet(USERNAME, PASSWORD)
         succeeds("pluginTask")

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
@@ -172,7 +172,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
             Plugin [id: 'org.example.foo', version: '1.1'] was not found in any of the following sources:
             
             - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            - Plugin Repositories (could not resolve plugin artifact 'org.example.foo:org.example.foo.gradle.plugin:1.1')
+            - Plugin Repositories (could not resolve plugin marker 'org.example.foo:org.example.foo.gradle.plugin:1.1')
               Searched in the following repositories:
                 ${repoType}(${repoA.uri})
                 ${repoType}2(${repoB.uri})
@@ -198,7 +198,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
 
         then:
         failure.assertThatDescription(containsNormalizedString("""
-            - Plugin Repositories (could not resolve plugin artifact 'org.gradle.hello-world:org.gradle.hello-world.gradle.plugin:0.2')
+            - Plugin Repositories (could not resolve plugin marker 'org.gradle.hello-world:org.gradle.hello-world.gradle.plugin:0.2')
               Searched in the following repositories:
                 ${repoType}(${repoA.uri})
                 ${repoType}2(${repoB.uri})

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
@@ -189,7 +189,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
             Plugin [id: 'org.example.foo', version: '1.1'] was not found in any of the following sources:
             
             - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            - Plugin Repositories (could not resolve plugin artifact 'org.example.foo:org.example.foo.gradle.plugin:1.1')
+            - Plugin Repositories (could not resolve plugin marker 'org.example.foo:org.example.foo.gradle.plugin:1.1')
               Searched in the following repositories:
                 ${repoType}($repoUrl)
         """.stripIndent().trim())

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -328,7 +328,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("helloWorld")
 
         then:
-        failureDescriptionContains("could not resolve plugin artifact 'foo:bar:1.0'")
+        failureDescriptionContains("could not resolve plugin module 'foo:bar:1.0'")
     }
 
     def "succeeds build for resolvable custom artifact"() {

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -107,7 +107,7 @@ class DeployedPortalIntegrationSpec extends AbstractPluginIntegrationTest {
         and:
         failureDescriptionStartsWith("Plugin [id: 'org.gradle.non-existing', version: '1.0'] was not found in any of the following sources:")
         failureDescriptionContains("""
-            - Plugin Repositories (could not resolve plugin artifact 'org.gradle.non-existing:org.gradle.non-existing.gradle.plugin:1.0')
+            - Plugin Repositories (could not resolve plugin marker 'org.gradle.non-existing:org.gradle.non-existing.gradle.plugin:1.0')
               Searched in the following repositories:
                 Gradle Central Plugin Repository
         """.stripIndent().trim())

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
@@ -238,7 +238,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         and:
         failure.assertThatDescription(startsWith("Plugin [id: 'org.myplugin', version: '1.0'] was not found in any of the following sources"))
         failure.assertThatDescription(containsString("""
-            - Plugin Repositories (could not resolve plugin artifact 'org.myplugin:org.myplugin.gradle.plugin:1.0')
+            - Plugin Repositories (could not resolve plugin marker 'org.myplugin:org.myplugin.gradle.plugin:1.0')
               Searched in the following repositories:
                 Gradle Central Plugin Repository(${pluginRepo.uri})
         """.stripIndent().trim()))

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -16,74 +16,38 @@
 
 package org.gradle.plugin.use.resolve.internal
 
-import org.gradle.api.artifacts.Configuration
-import org.gradle.api.artifacts.ConfigurationContainer
-import org.gradle.api.artifacts.ResolvedConfiguration
-import org.gradle.api.artifacts.dsl.RepositoryHandler
-import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
-import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal
-import org.gradle.groovy.scripts.StringScriptSource
-import org.gradle.plugin.management.internal.DefaultPluginRequest
-import org.gradle.plugin.management.internal.PluginRequestInternal
-import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 import static org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver.SOURCE_NAME
 
 class ArtifactRepositoriesPluginResolverTest extends Specification {
-    def versionSelectorScheme = new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser()))
-    def repository = Mock(ArtifactRepositoryInternal) {
-        getDisplayName() >> "maven(url)"
-    }
-    def repositories = Mock(RepositoryHandler) {
-        iterator() >> [repository].iterator()
-    }
-    def resolvedConfiguration = Mock(ResolvedConfiguration) {
-        hasError() >> false
-    }
-    def configuration = Mock(Configuration) {
-        getResolvedConfiguration() >> resolvedConfiguration
-        setTransitive(false) >> {}
-    }
-    def configurations = Mock(ConfigurationContainer) {
-        detachedConfiguration(_) >> configuration
-    }
 
-    def resolution = Mock(DependencyResolutionServices) {
-        getResolveRepositoryHandler() >> repositories
-        getConfigurationContainer() >> configurations
-    }
+    def versionSelectorScheme = new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser()))
     def result = Mock(PluginResolutionResult)
 
-    def resolver = new ArtifactRepositoriesPluginResolver(resolution, versionSelectorScheme)
-
-    PluginRequestInternal request(String id, String version = null) {
-        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
-    }
-
-    def "fail pluginRequests without versions"() {
+    def "validation of pluginRequests without version fails"() {
         when:
-        resolver.resolve(request("plugin"), result)
+        ArtifactRepositoriesPluginResolver.validateVersion(versionSelectorScheme, null, result)
 
         then:
         1 * result.notFound(SOURCE_NAME, "plugin dependency must include a version number for this source")
     }
 
-    def "succeed pluginRequests with SNAPSHOT versions"() {
+    def "validation of pluginRequests with SNAPSHOT versions succeeds"() {
         when:
-        resolver.resolve(request("plugin", "1.1-SNAPSHOT"), result)
+        ArtifactRepositoriesPluginResolver.validateVersion(versionSelectorScheme, "1.1-SNAPSHOT", result)
 
         then:
-        1 * result.found(SOURCE_NAME, _)
+        0 * result.notFound(SOURCE_NAME, _)
     }
 
-    def "fail pluginRequests with dynamic versions"() {
+    def "validation of pluginRequests with dynamic versions fails"() {
         when:
-        resolver.resolve(request("plugin", "latest.revision"), result)
+        ArtifactRepositoriesPluginResolver.validateVersion(versionSelectorScheme, "latest.revision", result)
 
         then:
         1 * result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported")


### PR DESCRIPTION
This PR prevents plugin resolution to try download jars for plugin markers, see #6155.

The jar download was triggered when the build script classpath is resolved (in `PluginRequestApplicator`).

The `ArtifactRepositoriesPluginResolver` now resolves the plugin module dependency from the marker requiring metadata only and feed it into `PluginRequestApplicator` which remains unchanged.

One thing this PR changes is that plugin resolution client code is now more tied to the markers: it requires them to have a _single_ dependency.