### PR TITLE
Fix header of generated build init versions resource

### DIFF
--- a/subprojects/build-init/build-init.gradle
+++ b/subprojects/build-init/build-init.gradle
@@ -48,7 +48,7 @@ task updateInitPluginTemplateVersionFile() {
 
         Properties versionProperties = new Properties()
 
-        findLatest('scala-library', 'org.scala-lang:scala-library:2.11.+', versionProperties)
+        findLatest('scala-library', 'org.scala-lang:scala-library:2.12.+', versionProperties)
         def scalaVersion = VersionNumber.parse(versionProperties['scala-library'])
         versionProperties.put('scala', "${scalaVersion.major}.${scalaVersion.minor}" as String)
         findLatest('scalatest', "org.scalatest:scalatest_${versionProperties.scala}:(3.0,)", versionProperties)
@@ -64,7 +64,7 @@ task updateInitPluginTemplateVersionFile() {
         findLatest('kotlin', 'org.jetbrains.kotlin:kotlin-gradle-plugin:(1.2,)', versionProperties)
 
         org.gradle.build.ReproduciblePropertiesWriter.store(versionProperties, libraryVersionFile,
-                                                            "Version values used in build-init templates\nGenerated file, please to not edit")
+                                                            "Generated file, please to not edit - Version values used in build-init templates")
     }
 }
 

--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -1,14 +1,13 @@
-# Version values used in build-init templates
-Generated file, please to not edit
+# Generated file, please to not edit - Version values used in build-init templates
 scalatest=3.0.5
 kotlin=1.2.70
 scala-xml=1.1.0
-scala-library=2.11.12
+scala-library=2.12.6
 testng=6.14.3
 slf4j=1.7.25
 guava=26.0-jre
 commons-math=3.6.1
-scala=2.11
+scala=2.12
 groovy=2.4.15
 junit=4.12
 spock=1.0-groovy-2.4


### PR DESCRIPTION
… Scala 2.12.

### Context

Fix the build init version resource generation added in https://github.com/gradle/gradle/pull/6751

Update the versions so that Scala 2.12 is used for the Scala library template.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
