### PR TITLE
Remove testFixtures from archives

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -178,6 +178,6 @@ open class TestFixturesPlugin : Plugin<Project> {
     // https://builds.gradle.org/viewLog.html?buildId=15853642&buildTypeId=bt39
     private
     fun Project.removeTestFixturesFromArchivesConfiguration() = afterEvaluate {
-        configurations.findByName("archives")?.artifacts?.removeIf({ it.name == "testFixtures" })
+        configurations["archives"]?.artifacts?.removeIf({ it.name == "testFixtures" })
     }
 }

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -52,11 +52,11 @@ open class TestFixturesPlugin : Plugin<Project> {
 
         if (file("src/testFixtures").isDirectory) {
             configureAsProducer()
+            removeTestFixturesFromArchivesConfiguration()
         }
 
         configureAsConsumer()
     }
-
 
     /**
      * This mimics what the java-library plugin does, but creating a library of test fixtures instead.
@@ -120,6 +120,8 @@ open class TestFixturesPlugin : Plugin<Project> {
             }
         }
 
+        removeTestFixturesFromArchivesConfiguration()
+
         dependencies {
             val testFixturesApi by configurations
 
@@ -170,5 +172,12 @@ open class TestFixturesPlugin : Plugin<Project> {
                 runtimeConfig(project(path = projectPath, configuration = "testFixturesRuntimeElements"))
             }
         }
+    }
+
+    // This is a hack to get rid of `Cannot publish artifact 'testFixtures' as it does not exist.`
+    // https://builds.gradle.org/viewLog.html?buildId=15853642&buildTypeId=bt39
+    private
+    fun Project.removeTestFixturesFromArchivesConfiguration() = afterEvaluate {
+        configurations.findByName("archives")?.artifacts?.removeIf({ it.name == "testFixtures" })
     }
 }


### PR DESCRIPTION
### Context

This is a hack to get rid of https://builds.gradle.org/viewLog.html?buildId=15853642&buildTypeId=bt39 error.

