### PR TITLE
Add experimental builds for JDK 11 on Windows

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -77,7 +77,10 @@ data class CIBuildModel (
             Stage(StageNames.EXPERIMENTAL,
                     trigger = Trigger.never,
                     runsIndependent = true,
-                    functionalTests = listOf(TestCoverage(TestType.platform, OS.linux, JvmVersion.java11)))
+                    functionalTests = listOf(
+                        TestCoverage(TestType.platform, OS.linux, JvmVersion.java11),
+                        TestCoverage(TestType.platform, OS.windows, JvmVersion.java11))
+            )
         ),
         val subProjects : List<GradleSubproject> = listOf(
             GradleSubproject("announce"),


### PR DESCRIPTION
@donat installed JDK 11 on the Windows agents to `c:\Program Files\Java\jdk-11`.

@blindpirate @wolfs Where do I have to configure that?