### PR TITLE
Don't cache patchExternalModules for slow internet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -279,6 +279,7 @@ tasks.register<PatchExternalModules>("patchExternalModules") {
     coreModules = coreRuntime
     modulesToPatch = this@Build_gradle.externalModules
     destination = patchedExternalModulesDir
+    outputs.doNotCacheIfSlowInternetConnection()
 }
 
 evaluationDependsOn(":distributions")

--- a/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/build-extensions.kt
@@ -17,6 +17,8 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.HasConfigurableAttributes
+import org.gradle.api.tasks.TaskOutputs
+import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.kotlin.dsl.extra
 import org.gradle.util.GradleVersion
 
@@ -87,3 +89,10 @@ val Project.useAllDistribution: Boolean
 private
 fun <T> Project.ifProperty(name: String, then: T): T? =
     then.takeIf { rootProject.findProperty(name) == true }
+
+
+fun TaskOutputs.doNotCacheIfSlowInternetConnection() {
+    doNotCacheIf("Slow internet connection") {
+        BuildEnvironment.isSlowInternetConnection
+    }
+}

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
@@ -10,6 +10,8 @@ object BuildEnvironment {
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()
     val isWindows = OperatingSystem.current().isWindows
+    val isSlowInternetConnection
+        get() = System.getProperty("slow.internet.connection", "false").toBoolean()
     val agentNum: Int
         get() {
             if (System.getenv().containsKey("USERNAME")) {


### PR DESCRIPTION
Running with `-Dslow.internet.connection=true` or setting
`systemProp.slow.internet.connection=true` disables now caching
of `patchExternalModules` since the artifact to download is really big
and it may be faster to build it locally.
