### PR TITLE
Rework lifecycle of included builds that run tasks during both configuration and execution of main build

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/AbstractCompositeBuildIntegrationTest.groovy
@@ -19,12 +19,12 @@ package org.gradle.integtests.composite
 import com.google.common.collect.Lists
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.BuildOperationsFixture
-import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.build.BuildTestFile
 import org.gradle.internal.execution.ExecuteTaskBuildOperationType
 import org.gradle.internal.operations.BuildOperationType
 import org.gradle.launcher.exec.RunBuildBuildOperationType
 import org.gradle.test.fixtures.file.TestFile
+
 /**
  * Tests for composite build.
  */
@@ -147,10 +147,8 @@ abstract class AbstractCompositeBuildIntegrationTest extends AbstractIntegration
     def pluginProjectBuild(String name) {
         def className = name.capitalize()
         singleProjectBuild(name) {
-            FeaturePreviewsFixture.enableStablePublishing(settingsFile)
             buildFile << """
 apply plugin: 'java-gradle-plugin'
-apply plugin: 'maven-publish'
 
 gradlePlugin {
     plugins {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcBuildOperationsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.initialization.buildsrc.BuildBuildSrcBuildOperationType
@@ -108,6 +109,18 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         runTasksOps[2].displayName == "Run tasks (:buildB)"
         runTasksOps[2].parentId == root.id
 
+        def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
+        graphNotifyOps.size() == 3
+        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildB:buildSrc)'
+        graphNotifyOps[0].details.buildPath == ':buildB:buildSrc'
+        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners"
+        graphNotifyOps[1].details.buildPath == ":"
+        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[2].displayName == "Notify task graph whenReady listeners (:buildB)"
+        graphNotifyOps[2].details.buildPath == ":buildB"
+        graphNotifyOps[2].parentId == runTasksOps[2].id
+
         where:
         settings                     | display
         ""                           | "default root project name"
@@ -195,6 +208,21 @@ class CompositeBuildBuildSrcBuildOperationsIntegrationTest extends AbstractCompo
         runTasksOps[2].parentId == root.id
         runTasksOps[3].displayName == "Run tasks (:buildB)"
         runTasksOps[3].parentId == root.id
+
+        def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
+        graphNotifyOps.size() == 4
+        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildSrc)'
+        graphNotifyOps[0].details.buildPath == ':buildSrc'
+        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:buildB:buildSrc)"
+        graphNotifyOps[1].details.buildPath == ":buildB:buildSrc"
+        graphNotifyOps[1].parentId == runTasksOps[1].id
+        graphNotifyOps[2].displayName == "Notify task graph whenReady listeners"
+        graphNotifyOps[2].details.buildPath == ":"
+        graphNotifyOps[2].parentId == runTasksOps[2].id
+        graphNotifyOps[3].displayName == "Notify task graph whenReady listeners (:buildB)"
+        graphNotifyOps[3].details.buildPath == ":buildB"
+        graphNotifyOps[3].parentId == runTasksOps[3].id
 
         where:
         settings                     | display

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -120,14 +120,12 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         loggedOncePerBuild('buildListener.projectsLoaded', [':', ':buildB', ':buildC', ':pluginD'])
         loggedOncePerBuild('buildListener.projectsEvaluated', [':', ':buildB', ':buildC', ':pluginD'])
         loggedOncePerBuild('gradle.taskGraphReady', [':', ':pluginD'])
-        loggedOncePerBuild('buildListener.buildFinished', [':', ':buildC', ':pluginD'])
-        loggedOncePerBuild('gradle.buildFinished', [':', ':buildC', ':pluginD'])
+        loggedOncePerBuild('buildListener.buildFinished', [':', ':buildB', ':buildC', ':pluginD'])
+        loggedOncePerBuild('gradle.buildFinished', [':', ':buildB', ':buildC', ':pluginD'])
 
         // Tasks for buildB are run twice
         // TODO - fire these events once only
-        loggedAtLeast('gradle.taskGraphReady [:buildB]', 2)
-        loggedAtLeast('buildListener.buildFinished [:buildB]', 2)
-        loggedAtLeast('gradle.buildFinished [:buildB]', 2)
+        logged('gradle.taskGraphReady [:buildB]', 2)
     }
 
     def "fires build listener events for included builds with additional discovered (compileOnly) dependencies"() {
@@ -231,11 +229,6 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
     void logged(String message, int count = 1) {
         outputContains(message)
         assert result.output.count(message) == count
-    }
-
-    void loggedAtLeast(String message, int count = 1) {
-        outputContains(message)
-        assert result.output.count(message) >= count
     }
 
     protected void execute() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -116,17 +116,18 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         execute()
 
         then:
-        loggedOncePerBuild('buildListener.settingsEvaluated', [':', ':buildC', ':pluginD'])
-        loggedOncePerBuild('buildListener.projectsLoaded', [':', ':buildC', ':pluginD'])
-        loggedOncePerBuild('buildListener.projectsEvaluated', [':', ':buildC', ':pluginD'])
+        loggedOncePerBuild('buildListener.settingsEvaluated', [':', ':buildB', ':buildC', ':pluginD'])
+        loggedOncePerBuild('buildListener.projectsLoaded', [':', ':buildB', ':buildC', ':pluginD'])
+        loggedOncePerBuild('buildListener.projectsEvaluated', [':', ':buildB', ':buildC', ':pluginD'])
         loggedOncePerBuild('gradle.taskGraphReady', [':', ':pluginD'])
         loggedOncePerBuild('buildListener.buildFinished', [':', ':buildC', ':pluginD'])
         loggedOncePerBuild('gradle.buildFinished', [':', ':buildC', ':pluginD'])
 
-        // `:buildB` is executed twice
-        loggedAtLeast('buildListener.settingsEvaluated [:buildB]', 2)
-        loggedAtLeast('buildListener.projectsEvaluated [:buildB]', 2)
+        // Tasks for buildB are run twice
+        // TODO - fire these events once only
+        loggedAtLeast('gradle.taskGraphReady [:buildB]', 2)
         loggedAtLeast('buildListener.buildFinished [:buildB]', 2)
+        loggedAtLeast('gradle.buildFinished [:buildB]', 2)
     }
 
     def "fires build listener events for included builds with additional discovered (compileOnly) dependencies"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildEventsIntegrationTest.groovy
@@ -119,13 +119,11 @@ class CompositeBuildEventsIntegrationTest extends AbstractCompositeBuildIntegrat
         loggedOncePerBuild('buildListener.settingsEvaluated', [':', ':buildB', ':buildC', ':pluginD'])
         loggedOncePerBuild('buildListener.projectsLoaded', [':', ':buildB', ':buildC', ':pluginD'])
         loggedOncePerBuild('buildListener.projectsEvaluated', [':', ':buildB', ':buildC', ':pluginD'])
-        loggedOncePerBuild('gradle.taskGraphReady', [':', ':pluginD'])
+        loggedOncePerBuild('gradle.taskGraphReady', [':', ':buildB', ':pluginD'])
         loggedOncePerBuild('buildListener.buildFinished', [':', ':buildB', ':buildC', ':pluginD'])
         loggedOncePerBuild('gradle.buildFinished', [':', ':buildB', ':buildC', ':pluginD'])
 
-        // Tasks for buildB are run twice
-        // TODO - fire these events once only
-        logged('gradle.taskGraphReady [:buildB]', 2)
+        logged("Ignoring listeners of task graph ready event, as this build (:buildB) has already run tasks.")
     }
 
     def "fires build listener events for included builds with additional discovered (compileOnly) dependencies"() {

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildOperationsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.composite
 
+import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.build.BuildTestFile
@@ -63,7 +64,7 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
     }
 
     @Unroll
-    def "generates configure, task graph and run tasks operations for included builds with #display"() {
+    def "generates build lifecycle operations for included builds with #display"() {
         given:
         dependency "org.test:${buildName}:1.0"
 
@@ -112,10 +113,91 @@ class CompositeBuildOperationsIntegrationTest extends AbstractCompositeBuildInte
         runTasksOps[1].displayName == "Run tasks (:${buildName})"
         runTasksOps[1].parentId == root.id
 
+        def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
+        graphNotifyOps.size() == 2
+        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners'
+        graphNotifyOps[0].details.buildPath == ':'
+        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:${buildName})"
+        graphNotifyOps[1].details.buildPath == ":${buildName}"
+        graphNotifyOps[1].parentId == runTasksOps[1].id
+
         where:
         settings                     | buildName | display
         ""                           | "buildB"  | "default root project name"
         "rootProject.name='someLib'" | "someLib" | "configured root project name"
+    }
+
+    def "generates build lifecycle operations for included build used as buildscript and production dependency"() {
+        given:
+        buildA.buildFile.text = """
+            buildscript {
+                dependencies {
+                    classpath 'org.test:b1:1.0'
+                }
+            }
+        """ + buildA.buildFile.text
+        dependency "org.test:b2:1.0"
+
+        when:
+        execute(buildA, ":jar", [])
+
+        then:
+        executed ":buildB:b1:jar", ":buildB:b2:jar"
+
+        and:
+        def root = operations.root(RunBuildBuildOperationType)
+
+        def loadOps = operations.all(LoadBuildBuildOperationType)
+        loadOps.size() == 2
+        loadOps[0].displayName == "Load build"
+        loadOps[0].details.buildPath == ":"
+        loadOps[0].parentId == root.id
+        loadOps[1].displayName == "Load build (buildB)"
+        loadOps[1].details.buildPath == ":buildB"
+        loadOps[1].parentId == loadOps[0].id
+
+        def configureOps = operations.all(ConfigureBuildBuildOperationType)
+        configureOps.size() == 2
+        configureOps[0].displayName == "Configure build"
+        configureOps[0].details.buildPath == ":"
+        configureOps[0].parentId == root.id
+        configureOps[1].displayName == "Configure build (:buildB)"
+        configureOps[1].details.buildPath == ":buildB"
+        configureOps[1].parentId == configureOps[0].id
+
+        // The task graph for buildB is calculated multiple times, once for buildscript dependency and again for production dependency
+        def taskGraphOps = operations.all(CalculateTaskGraphBuildOperationType)
+        taskGraphOps.size() == 3
+        taskGraphOps[0].displayName == "Calculate task graph (:buildB)"
+        taskGraphOps[0].details.buildPath == ":buildB"
+        // parent is 'apply build script to project'
+        taskGraphOps[1].displayName == "Calculate task graph"
+        taskGraphOps[1].details.buildPath == ":"
+        taskGraphOps[1].parentId == root.id
+        taskGraphOps[2].displayName == "Calculate task graph (:buildB)"
+        taskGraphOps[2].details.buildPath == ":buildB"
+        taskGraphOps[2].parentId == taskGraphOps[1].id
+
+        // Tasks are run for buildB multiple times, once for buildscript dependency and again for production dependency
+        def runTasksOps = operations.all(Pattern.compile("Run tasks.*"))
+        runTasksOps.size() == 3
+        runTasksOps[0].displayName == "Run tasks (:buildB)"
+        runTasksOps[0].parentId == root.id
+        runTasksOps[1].displayName == "Run tasks"
+        runTasksOps[1].parentId == root.id
+        runTasksOps[2].displayName == "Run tasks (:buildB)"
+        runTasksOps[2].parentId == root.id
+
+        // Task graph ready event sent only once
+        def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
+        graphNotifyOps.size() == 2
+        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildB)'
+        graphNotifyOps[0].details.buildPath == ':buildB'
+        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners"
+        graphNotifyOps[1].details.buildPath == ":"
+        graphNotifyOps[1].parentId == runTasksOps[1].id
     }
 
     def assertChildrenNotIn(BuildOperationRecord origin, BuildOperationRecord op, List<BuildOperationRecord> allOps) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildServices.java
@@ -27,6 +27,7 @@ import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
@@ -58,8 +59,8 @@ public class CompositeBuildServices extends AbstractPluginServiceRegistry {
             return new LocalComponentInAnotherBuildProvider(projectRegistry, new IncludedBuildDependencyMetadataBuilder());
         }
 
-        public IncludedBuildControllers createIncludedBuildControllers(ExecutorFactory executorFactory, BuildStateRegistry buildRegistry) {
-            return new DefaultIncludedBuildControllers(executorFactory, buildRegistry);
+        public IncludedBuildControllers createIncludedBuildControllers(ExecutorFactory executorFactory, BuildStateRegistry buildRegistry, ResourceLockCoordinationService coordinationService) {
+            return new DefaultIncludedBuildControllers(executorFactory, buildRegistry, coordinationService);
         }
 
         public IncludedBuildTaskGraph createIncludedBuildTaskGraph(IncludedBuildControllers controllers) {

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildControllers.java
@@ -27,6 +27,7 @@ import org.gradle.internal.concurrent.ManagedExecutor;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
+import org.gradle.internal.resources.ResourceLockCoordinationService;
 
 import java.util.Collection;
 import java.util.Map;
@@ -34,12 +35,14 @@ import java.util.Map;
 class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControllers {
     private final Map<BuildIdentifier, IncludedBuildController> buildControllers = Maps.newHashMap();
     private final ManagedExecutor executorService;
+    private final ResourceLockCoordinationService coordinationService;
     private final BuildStateRegistry buildRegistry;
     private BuildOperationRef rootBuildOperation;
 
-    DefaultIncludedBuildControllers(ExecutorFactory executorFactory, BuildStateRegistry buildRegistry) {
+    DefaultIncludedBuildControllers(ExecutorFactory executorFactory, BuildStateRegistry buildRegistry, ResourceLockCoordinationService coordinationService) {
         this.buildRegistry = buildRegistry;
         this.executorService = executorFactory.create("included builds");
+        this.coordinationService = coordinationService;
     }
 
     @Override
@@ -54,7 +57,7 @@ class DefaultIncludedBuildControllers implements Stoppable, IncludedBuildControl
         }
 
         IncludedBuildState build = buildRegistry.getIncludedBuild(buildId);
-        DefaultIncludedBuildController newBuildController = new DefaultIncludedBuildController(build);
+        DefaultIncludedBuildController newBuildController = new DefaultIncludedBuildController(build, coordinationService);
         buildControllers.put(buildId, newBuildController);
         executorService.submit(new BuildOpRunnable(newBuildController, rootBuildOperation));
         return newBuildController;

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcBuildOperationsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.initialization.buildsrc
 
+import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -79,6 +80,15 @@ class BuildSrcBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         runTasksOps[0].parentId == buildSrcOps[0].id
         runTasksOps[1].displayName == "Run tasks"
         runTasksOps[1].parentId == root.id
+
+        def graphNotifyOps = ops.all(NotifyTaskGraphWhenReadyBuildOperationType)
+        graphNotifyOps.size() == 2
+        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners (:buildSrc)'
+        graphNotifyOps[0].details.buildPath == ':buildSrc'
+        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners"
+        graphNotifyOps[1].details.buildPath == ":"
+        graphNotifyOps[1].parentId == runTasksOps[1].id
 
         def taskOps = ops.all(ExecuteTaskBuildOperationType)
         taskOps.size() > 1

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -20,6 +20,8 @@ import org.gradle.api.GradleException;
 import org.gradle.api.internal.TaskOutputCachingState;
 import org.gradle.api.tasks.TaskState;
 
+import javax.annotation.Nullable;
+
 public class TaskStateInternal implements TaskState {
     private boolean executing;
     private boolean actionable = true;
@@ -44,6 +46,7 @@ public class TaskStateInternal implements TaskState {
         return !getExecuted() && !executing;
     }
 
+    @Nullable
     public TaskExecutionOutcome getOutcome() {
         return outcome;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/LocalTaskInfoExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/LocalTaskInfoExecutor.java
@@ -36,6 +36,11 @@ public class LocalTaskInfoExecutor implements WorkInfoExecutor {
         if (work instanceof LocalTaskInfo) {
             TaskInternal task = ((LocalTaskInfo) work).getTask();
             TaskStateInternal state = task.getState();
+            if (state.getExecuted()) {
+                // Task has already been run. This can happen when the owning build is used both at configuration time and execution time
+                // This should move earlier in task scheduling, so that a worker thread does not even bother trying run this task
+                return true;
+            }
             TaskExecutionContext ctx = new DefaultTaskExecutionContext();
             TaskExecuter taskExecuter = taskExecuterFactory.create();
             assert taskExecuter != null;

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/TaskExecutionPlan.java
@@ -30,6 +30,9 @@ import java.util.Set;
  * Represents a graph of dependent tasks, returned in execution order.
  */
 public interface TaskExecutionPlan extends Describable {
+    /**
+     * Selects a work item to run, returns null if there is no work remaining _or_ if no queued work is ready to run.
+     */
     @Nullable
     WorkInfo selectNext(WorkerLeaseRegistry.WorkerLease workerLease, ResourceLockState resourceLockState);
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleLauncher.java
@@ -29,18 +29,18 @@ public interface GradleLauncher extends Stoppable {
     /**
      * Evaluates the settings for this build.
      *
-     * @throws ReportedException On build failure. The failure will have been logged.
      * @return The loaded settings instance.
+     * @throws ReportedException On build failure. The failure will have been logged.
      */
-    SettingsInternal getLoadedSettings();
+    SettingsInternal getLoadedSettings() throws ReportedException;
 
     /**
      * Configures the build.
      *
-     * @throws ReportedException On build failure. The failure will have been logged.
      * @return The configured Gradle build instance.
+     * @throws ReportedException On build failure. The failure will have been logged.
      */
-    GradleInternal getConfiguredBuild();
+    GradleInternal getConfiguredBuild() throws ReportedException;
 
     /**
      * Schedules the specified tasks for this build.
@@ -50,10 +50,10 @@ public interface GradleLauncher extends Stoppable {
     /**
      * Executes the tasks scheduled for this build.
      *
-     * @throws ReportedException On build failure. The failure will have been logged.
      * @return The configured Gradle build instance.
+     * @throws ReportedException On build failure. The failure will have been logged.
      */
-    GradleInternal executeTasks();
+    GradleInternal executeTasks() throws ReportedException;
 
     /**
      * Stops task execution threads and calls the `buildFinished` listener event.

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -74,7 +74,9 @@ public class GradleBuildController implements BuildController {
         return doBuild(new Callable<GradleInternal>() {
             @Override
             public GradleInternal call() {
-                return getLauncher().executeTasks();
+                GradleInternal gradle = getLauncher().executeTasks();
+                getLauncher().finishBuild();
+                return gradle;
             }
         });
     }

--- a/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/taskgraph/DefaultTaskExecutionGraphSpec.groovy
@@ -335,7 +335,7 @@ class DefaultTaskExecutionGraphSpec extends Specification {
         thrown(CircularReferenceException)
     }
 
-    def "notifies graph listener before execute"() {
+    def "notifies graph listener before first execute"() {
         def taskPlanExecutor = Mock(TaskPlanExecutor)
         def taskGraph = new DefaultTaskExecutionGraph(taskPlanExecutor, [workExecutor], buildOperationExecutor, listenerBuildOperationDecorator, workerLeases, coordinationService, thisBuild, taskInfoFactory, dependencyResolver, graphListeners, taskExecutionListeners)
         TaskExecutionGraphListener listener = Mock(TaskExecutionGraphListener)
@@ -351,9 +351,15 @@ class DefaultTaskExecutionGraphSpec extends Specification {
 
         then:
         1 * taskPlanExecutor.process(_, _, _)
+
+        when:
+        taskGraph.execute(failures)
+
+        then:
+        0 * listener._
     }
 
-    def "executes whenReady listener before execute"() {
+    def "executes whenReady listener before first execute"() {
         def taskPlanExecutor = Mock(TaskPlanExecutor)
         def taskGraph = new DefaultTaskExecutionGraph(taskPlanExecutor, [workExecutor], buildOperationExecutor, listenerBuildOperationDecorator, workerLeases, coordinationService, thisBuild, taskInfoFactory, dependencyResolver, graphListeners, taskExecutionListeners)
         def closure = Mock(Closure)
@@ -379,6 +385,13 @@ class DefaultTaskExecutionGraphSpec extends Specification {
             displayName == 'Notify task graph whenReady listeners'
             details.buildPath == ':'
         }
+
+        when:
+        taskGraph.execute(failures)
+
+        then:
+        0 * closure._
+        0 * action._
     }
 
     def "stops execution on first failure when no failure handler provided"() {

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.initialization
 
 import org.gradle.BuildListener
-import org.gradle.BuildResult
 import org.gradle.StartParameter
 import org.gradle.api.Task
 import org.gradle.api.initialization.ProjectDescriptor
@@ -136,7 +135,7 @@ class DefaultGradleLauncherSpec extends Specification {
             buildServices, [otherService], includedBuildControllers, null)
     }
 
-    void testRun() {
+    void testRunTasks() {
         when:
         isRootBuild()
         expectInitScriptsExecuted()
@@ -150,7 +149,6 @@ class DefaultGradleLauncherSpec extends Specification {
         then:
         result == gradleMock
         expectedBuildOperationsFired()
-
     }
 
     void testRunAsNestedBuild() {
@@ -189,7 +187,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         DefaultGradleLauncher gradleLauncher = launcher()
         def result = gradleLauncher.getConfiguredBuild()
-        gradleLauncher.finishBuild()
 
         then:
         result == gradleMock
@@ -206,7 +203,6 @@ class DefaultGradleLauncherSpec extends Specification {
         then:
         DefaultGradleLauncher gradleLauncher = launcher()
         gradleLauncher.getConfiguredBuild()
-        gradleLauncher.finishBuild()
     }
 
     void testNotifiesListenerOfBuildStages() {
@@ -349,7 +345,6 @@ class DefaultGradleLauncherSpec extends Specification {
     private void expectBuildListenerCallbacks() {
         1 * buildBroadcaster.buildStarted(gradleMock)
         1 * buildBroadcaster.projectsEvaluated(gradleMock)
-        1 * buildBroadcaster.buildFinished({ BuildResult result -> result.failure == null })
         1 * modelListenerMock.onConfigure(gradleMock)
     }
 
@@ -363,7 +358,6 @@ class DefaultGradleLauncherSpec extends Specification {
         1 * includedBuildControllers.startTaskExecution()
         1 * buildExecuter.execute(gradleMock, _)
         1 * includedBuildControllers.awaitTaskCompletion(_)
-        1 * includedBuildControllers.finishBuild()
     }
 
     private void expectTasksRunWithFailure(Throwable failure, Throwable other = null) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/InProcessGradleExecuter.java
@@ -437,12 +437,12 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
     }
 
     public static class InProcessExecutionResult implements ExecutionResult {
-        private final List<String> plannedTasks;
+        private final List<String> executedTasks;
         private final Set<String> skippedTasks;
         private final OutputScrapingExecutionResult outputResult;
 
-        public InProcessExecutionResult(List<String> plannedTasks, Set<String> skippedTasks, OutputScrapingExecutionResult outputResult) {
-            this.plannedTasks = plannedTasks;
+        public InProcessExecutionResult(List<String> executedTasks, Set<String> skippedTasks, OutputScrapingExecutionResult outputResult) {
+            this.executedTasks = executedTasks;
             this.skippedTasks = skippedTasks;
             this.outputResult = outputResult;
         }
@@ -518,33 +518,33 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         }
 
         public List<String> getExecutedTasks() {
-            return new ArrayList<String>(plannedTasks);
+            return new ArrayList<String>(executedTasks);
         }
 
         public ExecutionResult assertTasksExecutedInOrder(Object... taskPaths) {
             Set<String> expected = TaskOrderSpecs.exact(taskPaths).getTasks();
-            assertThat(plannedTasks, containsInAnyOrder(expected.toArray()));
+            assertThat(executedTasks, containsInAnyOrder(expected.toArray()));
             outputResult.assertTasksExecutedInOrder(taskPaths);
             return this;
         }
 
         public ExecutionResult assertTasksExecuted(Object... taskPaths) {
             Set<String> flattenedTasks = new TreeSet<String>(flattenTaskPaths(taskPaths));
-            assertThat(plannedTasks, containsInAnyOrder(flattenedTasks.toArray()));
+            assertThat(executedTasks, containsInAnyOrder(flattenedTasks.toArray()));
             outputResult.assertTasksExecuted(flattenedTasks);
             return this;
         }
 
         @Override
         public ExecutionResult assertTaskExecuted(String taskPath) {
-            assertThat(plannedTasks, hasItem(taskPath));
+            assertThat(executedTasks, hasItem(taskPath));
             outputResult.assertTaskExecuted(taskPath);
             return this;
         }
 
         @Override
         public ExecutionResult assertTaskNotExecuted(String taskPath) {
-            assertThat(plannedTasks, not(hasItem(taskPath)));
+            assertThat(executedTasks, not(hasItem(taskPath)));
             outputResult.assertTaskNotExecuted(taskPath);
             return this;
         }
@@ -552,7 +552,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         @Override
         public ExecutionResult assertTaskOrder(Object... taskPaths) {
             Set<String> expected = TaskOrderSpecs.exact(taskPaths).getTasks();
-            assertThat(plannedTasks, hasItems(expected.toArray(new String[]{})));
+            assertThat(executedTasks, hasItems(expected.toArray(new String[]{})));
             outputResult.assertTaskOrder(taskPaths);
             return this;
         }
@@ -591,7 +591,7 @@ public class InProcessGradleExecuter extends DaemonGradleExecuter {
         }
 
         private Set<String> getNotSkippedTasks() {
-            Set<String> notSkipped = new TreeSet<String>(plannedTasks);
+            Set<String> notSkipped = new TreeSet<String>(executedTasks);
             notSkipped.removeAll(skippedTasks);
             return notSkipped;
         }

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/SourceDependencyBuildOperationIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.vcs.internal
 
 import org.gradle.api.internal.artifacts.configurations.ResolveConfigurationDependenciesBuildOperationType
+import org.gradle.execution.taskgraph.NotifyTaskGraphWhenReadyBuildOperationType
 import org.gradle.initialization.ConfigureBuildBuildOperationType
 import org.gradle.initialization.LoadBuildBuildOperationType
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
@@ -107,6 +108,15 @@ class SourceDependencyBuildOperationIntegrationTest extends AbstractIntegrationS
         runTasksOps[0].parentId == root.id
         runTasksOps[1].displayName == "Run tasks (:${buildName})"
         runTasksOps[1].parentId == root.id
+
+        def graphNotifyOps = operations.all(NotifyTaskGraphWhenReadyBuildOperationType)
+        graphNotifyOps.size() == 2
+        graphNotifyOps[0].displayName == 'Notify task graph whenReady listeners'
+        graphNotifyOps[0].details.buildPath == ':'
+        graphNotifyOps[0].parentId == runTasksOps[0].id
+        graphNotifyOps[1].displayName == "Notify task graph whenReady listeners (:${buildName})"
+        graphNotifyOps[1].details.buildPath == ":${buildName}"
+        graphNotifyOps[1].parentId == runTasksOps[1].id
 
         where:
         settings                     | buildName | display


### PR DESCRIPTION
### Context

This PR changes the lifecycle of included builds so that each build is loaded and configured, and each task executed, at most once per build tree per Gradle invocation. This removes a bunch of edge cases where a build needs to run tasks more than once, for example when it provides libraries or plugins required to configure some other build plus some additional libraries required during execution of some other build.

There's a breaking change here, in that tasks may be added to the task graph (and task container) after the task graph 'when ready' hook has run. For now, a warning is emitted in this case. Some new APIs can be added later to deal with this (also without requiring tasks to be realized in order to check whether or not they are in the graph).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
