### PR TITLE
Do not warn about possible weaker access in IntelliJ

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -6,5 +6,10 @@
     <inspection_tool class="SafeVarargsDetector" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TryWithIdenticalCatches" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="WeakerAccess" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_MEMBERS" value="true" />
+      <option name="SUGGEST_PACKAGE_LOCAL_FOR_TOP_CLASSES" value="true" />
+      <option name="SUGGEST_PRIVATE_FOR_INNERS" value="false" />
+    </inspection_tool>
   </profile>
 </component>


### PR DESCRIPTION
We don't use package local much, so no need to warn about this. We also use a "public" constructor inside a "private" class to avoid redundantly declaring privacy.
