### PR TITLE
Handle unrecoverable errors in worker processes

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/process/internal/ErrorInWorkerSocketIntegrationTest.groovy
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.process.internal
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
+
+@IntegrationTestTimeout(60)
+class ErrorInWorkerSocketIntegrationTest extends AbstractIntegrationSpec {
+    private static final String MESSAGE = 'This breaks socket connection threads in worker process deliberately'
+
+    def "worker won't hang when error occurs in socket connection"() {
+        given:
+        requireOwnGradleUserHomeDir()
+        executer.getGradleUserHomeDir().file()
+
+        file('buildSrc/src/main/java/Param.java') << """
+import java.io.*;
+public class Param implements Serializable {
+    private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+        throw new IllegalStateException("$MESSAGE");
+    }
+}
+"""
+
+        file('buildSrc/src/main/java/TestWorkerProcess.java') << '''
+import org.gradle.api.Action;
+import org.gradle.process.internal.worker.WorkerControl;
+public interface TestWorkerProcess extends Action, WorkerControl {}
+'''
+        file('buildSrc/src/main/java/TestWorkerProcessImpl.java') << '''
+import org.gradle.process.ExecResult;
+import org.gradle.process.internal.worker.WorkerProcess;
+
+public class TestWorkerProcessImpl implements TestWorkerProcess {
+    public WorkerProcess start() { return null; }
+    public ExecResult stop() { return null; }
+    public void execute(Object param) { } 
+}   
+'''
+        buildFile << '''
+import org.gradle.process.internal.worker.WorkerProcessFactory
+import org.gradle.workers.internal.WorkerDaemonProcess
+import org.gradle.workers.internal.WorkerProtocol
+import org.gradle.workers.internal.WorkerDaemonServer
+
+task runBrokenWorker {
+    doLast {
+        WorkerProcessFactory workerProcessFactory = rootProject.services.get(WorkerProcessFactory)
+        def builder = workerProcessFactory.multiRequestWorker(TestWorkerProcess, Action, TestWorkerProcessImpl)
+        builder.getJavaCommand().setWorkingDir(project.rootDir)
+
+        def workerDaemonProcess = builder.build()
+        workerDaemonProcess.start()
+        workerDaemonProcess.execute(new Param())
+    }
+}
+'''
+        when:
+        fails('runBrokenWorker')
+
+        then:
+        failureCauseContains('No response was received from Gradle Worker but the worker process has finished')
+        executer.getGradleUserHomeDir().file('workers').listFiles().find { it.name.startsWith('worker-error') }.text.contains(MESSAGE)
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/SystemApplicationClassLoaderWorker.java
@@ -51,7 +51,11 @@ import org.gradle.process.internal.worker.WorkerLoggingSerializer;
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.ObjectInputStream;
+import java.io.PrintStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.concurrent.Callable;
 
 /**
@@ -96,6 +100,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
 
         ObjectConnection connection = null;
         WorkerLogEventListener workerLogEventListener = null;
+        PrintUnrecoverableErrorToFileHandler unrecoverableErrorHandler = new PrintUnrecoverableErrorToFileHandler(workerServices.get(WorkerDirectoryProvider.class));
         try {
             // Read serialized worker
             byte[] serializedWorker = decoder.readBinary();
@@ -110,6 +115,7 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
             }
 
             connection = messagingServices.get(MessagingClient.class).getConnection(serverAddress);
+            connection.addUnrecoverableErrorHandler(unrecoverableErrorHandler);
             workerLogEventListener = configureLogging(loggingManager, connection);
             if (shouldPublishJvmMemoryInfo) {
                 configureWorkerJvmMemoryInfoEvents(workerServices, connection);
@@ -138,11 +144,44 @@ public class SystemApplicationClassLoaderWorker implements Callable<Void> {
             if (connection != null) {
                 connection.stop();
             }
+            unrecoverableErrorHandler.close();
             messagingServices.close();
             loggingManager.stop();
         }
 
         return null;
+    }
+
+    private class PrintUnrecoverableErrorToFileHandler implements Action<Throwable> {
+        private final File workerDirectory;
+        private PrintStream ps;
+
+        private PrintUnrecoverableErrorToFileHandler(WorkerDirectoryProvider workerDirectoryProvider) {
+            this.workerDirectory = workerDirectoryProvider.getIdleWorkingDirectory();
+        }
+
+        @Override
+        public void execute(Throwable throwable) {
+            if (ps == null) {
+                String fileName = "worker-error-" + new SimpleDateFormat("yyyyMMddHHmmss").format(new Date()) + ".txt";
+                try {
+                    ps = new PrintStream(new File(workerDirectory, fileName));
+                } catch (FileNotFoundException ignored) {
+                    // ignored
+                }
+            }
+            if (ps != null) {
+                ps.println("Encountered unrecoverable error:");
+                throwable.printStackTrace(ps);
+            }
+        }
+
+        private void close() {
+            if (ps != null) {
+                ps.close();
+            }
+        }
+
     }
 
     private WorkerLogEventListener configureLogging(LoggingManagerInternal loggingManager, ObjectConnection connection) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/request/WorkerAction.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.DefaultInstantiatorFactory;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
@@ -34,7 +35,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
 
-public class WorkerAction implements Action<WorkerProcessContext>, Serializable, RequestProtocol, StreamFailureHandler {
+public class WorkerAction implements Action<WorkerProcessContext>, Serializable, RequestProtocol, StreamFailureHandler, Stoppable {
     private final String workerImplementationName;
     private transient CountDownLatch completed;
     private transient ResponseProtocol responder;

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/ObjectConnection.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/ObjectConnection.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.remote;
 
+import org.gradle.api.Action;
 import org.gradle.internal.concurrent.AsyncStoppable;
 
 /**
@@ -45,4 +46,11 @@ public interface ObjectConnection extends AsyncStoppable, ObjectConnectionBuilde
      * Indicate that the execution containing this {@code ObjectConnection} has been prematurely stopped.
      */
     void abort();
+
+    /**
+     * Add a callback upon unrecoverable errors, e.g. broken connection. Should not throw any exceptions because
+     * this is the last line of defense.
+     * @param handler the callback
+     */
+    void addUnrecoverableErrorHandler(Action<Throwable> handler);
 }

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java
@@ -29,6 +29,7 @@ import org.gradle.internal.dispatch.MethodInvocation;
 import org.gradle.internal.dispatch.ProxyDispatchAdapter;
 import org.gradle.internal.dispatch.ReflectionDispatch;
 import org.gradle.internal.dispatch.StreamCompletion;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.remote.ObjectConnection;
 import org.gradle.internal.remote.internal.ConnectCompletion;
 import org.gradle.internal.remote.internal.RemoteConnection;
@@ -47,6 +48,7 @@ import java.util.Set;
 public class MessageHubBackedObjectConnection implements ObjectConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(MessageHubBackedObjectConnection.class);
     private final MessageHub hub;
+    private final List<Action<Throwable>> unrecoverableErrorHandlers = new ArrayList<Action<Throwable>>();
     private ConnectCompletion completion;
     private RemoteConnection<InterHubMessage> connection;
     //    private ClassLoader methodParamClassLoader;
@@ -57,13 +59,26 @@ public class MessageHubBackedObjectConnection implements ObjectConnection {
     public MessageHubBackedObjectConnection(ExecutorFactory executorFactory, ConnectCompletion completion) {
         Action<Throwable> errorHandler = new Action<Throwable>() {
             public void execute(Throwable throwable) {
-                if (!aborted && !Thread.currentThread().isInterrupted()) {
-                    LOGGER.error("Unexpected exception thrown.", throwable);
+                Throwable current = throwable;
+                for (Action<Throwable> handler : unrecoverableErrorHandlers) {
+                    try {
+                        handler.execute(current);
+                    } catch (Throwable e) {
+                        current = new DefaultMultiCauseException("Error in unrecoverable error handler: " + handler, e, throwable);
+                    }
                 }
             }
         };
         this.hub = new MessageHub(completion.toString(), executorFactory, errorHandler);
         this.completion = completion;
+        this.addUnrecoverableErrorHandler(new Action<Throwable>() {
+            @Override
+            public void execute(Throwable throwable) {
+                if (!aborted && !Thread.currentThread().isInterrupted()) {
+                    LOGGER.error("Unexpected exception thrown.", throwable);
+                }
+            }
+        });
     }
 
     @Override
@@ -132,6 +147,11 @@ public class MessageHubBackedObjectConnection implements ObjectConnection {
     public void abort() {
         aborted = true;
         stop();
+    }
+
+    @Override
+    public void addUnrecoverableErrorHandler(Action<Throwable> handler) {
+        unrecoverableErrorHandlers.add(handler);
     }
 
     private static class DispatchWrapper<T> implements BoundedDispatch<MethodInvocation>, StreamFailureHandler {

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/SocketConnection.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/SocketConnection.java
@@ -89,7 +89,7 @@ public class SocketConnection<T> implements RemoteConnection<T> {
             throw new RecoverableMessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
         } catch (IOException e) {
             throw new RecoverableMessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw new MessageIOException(String.format("Could not read message from '%s'.", remoteAddress), e);
         }
     }
@@ -121,7 +121,7 @@ public class SocketConnection<T> implements RemoteConnection<T> {
             throw new RecoverableMessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
         } catch (IOException e) {
             throw new RecoverableMessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw new MessageIOException(String.format("Could not write message %s to '%s'.", message, remoteAddress), e);
         }
     }
@@ -131,7 +131,7 @@ public class SocketConnection<T> implements RemoteConnection<T> {
         try {
             encoder.flush();
             outstr.flush();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             throw new MessageIOException(String.format("Could not write '%s'.", remoteAddress), e);
         }
     }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayWorkerServer.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/run/PlayWorkerServer.java
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logging;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classpath.DefaultClassPath;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.process.internal.worker.WorkerProcessContext;
 
 import java.io.Serializable;
@@ -33,7 +34,7 @@ import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-public class PlayWorkerServer implements Action<WorkerProcessContext>, PlayRunWorkerServerProtocol, Reloader, Serializable {
+public class PlayWorkerServer implements Action<WorkerProcessContext>, PlayRunWorkerServerProtocol, Reloader, Serializable, Stoppable {
     private static final Logger LOGGER = Logging.getLogger(PlayWorkerServer.class);
 
     private final PlayRunSpec runSpec;

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/TestWorker.java
@@ -26,6 +26,7 @@ import org.gradle.internal.actor.ActorFactory;
 import org.gradle.internal.actor.internal.DefaultActorFactory;
 import org.gradle.internal.concurrent.DefaultExecutorFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.dispatch.ContextClassLoaderProxy;
 import org.gradle.internal.id.CompositeIdGenerator;
 import org.gradle.internal.id.IdGenerator;
@@ -42,7 +43,7 @@ import java.io.Serializable;
 import java.security.AccessControlException;
 import java.util.concurrent.CountDownLatch;
 
-public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClassProcessor, Serializable {
+public class TestWorker implements Action<WorkerProcessContext>, RemoteTestClassProcessor, Serializable, Stoppable {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestWorker.class);
     public static final String WORKER_ID_SYS_PROPERTY = "org.gradle.test.worker";
     private final WorkerTestClassProcessorFactory factory;


### PR DESCRIPTION
### Context

We fork worker processes to do necessary work, such as test/start play application/run worker daemons, and control these worker processes via socket. However, if something is wrong in the worker processes' socket connection threads, the worker process might be stuck forever. We've already seen this in https://github.com/gradle/gradle/issues/3526 and https://github.com/gradle/gradle-private/issues/1486 . Also, in my observation, at least 50% of execution timeouts are caused by this issue.

In worker processes' connection threads, if an unrecoverable exception is thrown, the "last line of defence" is only a [log statement](https://github.com/gradle/gradle/blob/506aa2182392c562c2a0a61e4ad44ccbf8888ff0/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/hub/MessageHubBackedObjectConnection.java#L61):

```
        Action<Throwable> errorHandler = new Action<Throwable>() {
            public void execute(Throwable throwable) {
                if (!aborted && !Thread.currentThread().isInterrupted()) {
                    LOGGER.error("Unexpected exception thrown.", throwable);
                }
            }
        };
```

When socket connection threads are disrupted, this log statement makes no sense. Two things may happen:

- The worker can't send messages back to the daemon any more, so the daemon doesn't know what's happening in the worker. 
- The daemon can't send stop commands to the worker, so the worker waits forever.

This PR makes an attempt by registering an "unrecoverable error handler" to `ObjectConnection`. If something unexpected happens, the worker can exit instead of hanging forever. This is not a perfect solution, but it's better than hanging forever. Also, the worker process can record the exceptions into a file to help people understand what's going on there.

@ghale @big-guy I'd appreciate your suggestion here.

cc/ @wolfs 