### PR TITLE
Remove suppressed warnings for Java 7 features

### DIFF
--- a/subprojects/base-services-groovy/src/main/java/org/gradle/api/specs/Specs.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/api/specs/Specs.java
@@ -56,7 +56,6 @@ public class Specs {
     /**
      * Returns a spec that selects the intersection of those items selected by the given specs. Returns a spec that selects everything when no specs provided.
      */
-    @SuppressWarnings("Since15") //Only here for @SafeVarargs which is just a compiler hint
     @SafeVarargs
     public static <T> Spec<T> intersect(Spec<? super T>... specs) {
         if (specs.length == 0) {
@@ -100,7 +99,6 @@ public class Specs {
     /**
      * Returns a spec that selects the union of those items selected by the provided spec. Selects everything when no specs provided.
      */
-    @SuppressWarnings("Since15") //Only here for @SafeVarargs which is just a compiler hint
     @SafeVarargs
     public static <T> Spec<T> union(Spec<? super T>... specs) {
         if (specs.length == 0) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/CachingClassLoader.java
@@ -32,7 +32,6 @@ public class CachingClassLoader extends ClassLoader implements ClassLoaderHierar
 
     static {
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -47,7 +47,6 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
             SYSTEM_PACKAGES.add(p.getName());
         }
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
@@ -40,7 +40,6 @@ public class MultiParentClassLoader extends ClassLoader implements ClassLoaderHi
 
     static {
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
@@ -32,7 +32,6 @@ import java.util.Collection;
 public abstract class TransformingClassLoader extends VisitableURLClassLoader {
     static {
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
@@ -27,7 +27,6 @@ import java.util.List;
 public class VisitableURLClassLoader extends URLClassLoader implements ClassLoaderHierarchy {
     static {
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractFileAccessor.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractFileAccessor.java
@@ -25,7 +25,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
-@SuppressWarnings("Since15")
 public abstract class AbstractFileAccessor implements DataAccessor {
     private final DirectoryProvider directoryProvider;
 

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractTaskOutputPackagingBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractTaskOutputPackagingBenchmark.java
@@ -148,7 +148,6 @@ public abstract class AbstractTaskOutputPackagingBenchmark {
         packer.unpack(sample, accessor.createTargetFactory("unpack-" + accessorName, Level.Iteration));
     }
 
-    @SuppressWarnings("Since15")
     private static class DefaultDirectoryProvider implements DirectoryProvider {
         private Path tempDir;
         private Path iterationDir;

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/BufferedFileAccessor.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/BufferedFileAccessor.java
@@ -24,7 +24,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-@SuppressWarnings("Since15")
 public class BufferedFileAccessor extends AbstractFileAccessor {
     private final int bufferSize;
 

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/ChmodBenchmark.java
@@ -46,7 +46,7 @@ import static java.nio.file.attribute.PosixFilePermission.*;
 @Warmup(iterations = 10)
 @Measurement(iterations = 10)
 @State(Scope.Benchmark)
-@SuppressWarnings({"Since15", "OctalInteger"})
+@SuppressWarnings("OctalInteger")
 public class ChmodBenchmark {
     private static final int DEFAULT_JAVA6_FILE_PERMISSIONS = 0644;
     private static final Set<PosixFilePermission> DEFAULT_JAVA7_FILE_PERMISSIONS = EnumSet.of(

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/DirectFileFileAccessor.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/DirectFileFileAccessor.java
@@ -22,7 +22,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-@SuppressWarnings("Since15")
 public class DirectFileFileAccessor extends AbstractFileAccessor {
 
     public DirectFileFileAccessor(DirectoryProvider directoryProvider) {

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/DirectoryProvider.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/DirectoryProvider.java
@@ -20,7 +20,6 @@ import org.openjdk.jmh.annotations.Level;
 
 import java.nio.file.Path;
 
-@SuppressWarnings("Since15")
 public interface DirectoryProvider {
     Path getRoot(Level level);
 }

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/FileWalkingBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/FileWalkingBenchmark.java
@@ -38,7 +38,6 @@ import java.nio.file.Path;
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
 @State(Scope.Benchmark)
-@SuppressWarnings("Since15")
 public class FileWalkingBenchmark {
     Path tempDirPath;
     Path missingPath;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
@@ -35,7 +35,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.zip.ZipEntry;
 
-@SuppressWarnings("Since15")
 public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
     private static final Logger LOGGER = Logging.getLogger(AbiExtractingClasspathResourceHasher.class);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/JarHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/JarHasher.java
@@ -78,7 +78,6 @@ public class JarHasher implements RegularFileHasher, ConfigurableNormalizer {
         }
     }
 
-    @SuppressWarnings("Since15")
     private List<FileSystemLocationFingerprint> fingerprintZipEntries(String jarFile) throws IOException {
         List<FileSystemLocationFingerprint> fingerprints = Lists.newArrayList();
         InputStream fileInputStream = null;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
@@ -220,7 +220,6 @@ public class PropertyValidationAccess {
     }
 
     private static class InputOnFileTypeValidator implements PropertyValidator {
-        @SuppressWarnings("Since15")
         @Nullable
         @Override
         public String validate(boolean cacheable, PropertyMetadata metadata) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/InputPropertyAnnotationHandler.java
@@ -35,7 +35,6 @@ public class InputPropertyAnnotationHandler implements PropertyAnnotationHandler
     }
 
     @Override
-    @SuppressWarnings("Since15")
     public void visitPropertyValue(PropertyValue propertyValue, PropertyVisitor visitor, PropertySpecFactory specFactory, BeanPropertyContext context) {
         DefaultTaskInputPropertySpec declaration = specFactory.createInputPropertySpec(propertyValue.getPropertyName(), propertyValue);
         declaration.optional(propertyValue.isOptional());

--- a/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/MixInLegacyTypesClassLoader.java
@@ -75,7 +75,6 @@ public class MixInLegacyTypesClassLoader extends TransformingClassLoader {
 
     static {
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/core/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/snapshot/impl/DirectorySnapshotter.java
@@ -56,7 +56,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.EnumSet;
 import java.util.List;
 
-@SuppressWarnings("Since15")
 public class DirectorySnapshotter {
     private final FileHasher hasher;
     private final FileSystem fileSystem;

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompileTransformingClassLoader.java
@@ -38,7 +38,6 @@ class GroovyCompileTransformingClassLoader extends TransformingClassLoader {
 
     static {
         try {
-            //noinspection Since15
             ClassLoader.registerAsParallelCapable();
         } catch (NoSuchMethodError ignore) {
             // Not supported on Java 6

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/ClientSidePayloadClassLoaderFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/ClientSidePayloadClassLoaderFactory.java
@@ -55,7 +55,6 @@ public class ClientSidePayloadClassLoaderFactory implements PayloadClassLoaderFa
     private static class MixInClassLoader extends TransformingClassLoader {
         static {
             try {
-                //noinspection Since15
                 ClassLoader.registerAsParallelCapable();
             } catch (NoSuchMethodError ignore) {
                 // Not supported on Java 6

--- a/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
+++ b/subprojects/native/src/jmh/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessorBenchmark.java
@@ -41,7 +41,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Map;
 import java.util.UUID;
 
-@SuppressWarnings("Since15")
 @Threads(2)
 @Warmup(iterations = 5)
 @Measurement(iterations = 5)
@@ -113,7 +112,6 @@ public class FileMetadataAccessorBenchmark {
         bh.consume(getAccessor(accessorClassName).stat(realFilePath));
     }
 
-    @SuppressWarnings("Since15")
     private static class NioFileMetadataAccessor implements FileMetadataAccessor {
 
         @Override

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/FileMetadataAccessor.java
@@ -24,6 +24,5 @@ import java.nio.file.Path;
 
 public interface FileMetadataAccessor {
     FileMetadataSnapshot stat(File f);
-    @SuppressWarnings("Since15")
     FileMetadataSnapshot stat(Path path) throws IOException;
 }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7FileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7FileMetadataAccessor.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 
-@SuppressWarnings("Since15")
 public class Jdk7FileMetadataAccessor implements FileMetadataAccessor {
     @Override
     public FileMetadataSnapshot stat(File f) {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/PosixFilePermissionConverter.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/PosixFilePermissionConverter.java
@@ -22,7 +22,6 @@ import java.util.Set;
 
 import static java.nio.file.attribute.PosixFilePermission.*;
 
-@SuppressWarnings("Since15")
 public class PosixFilePermissionConverter {
 
     public static Set<PosixFilePermission> convertToPermissionsSet(int mode) {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/FallbackFileMetadataAccessor.java
@@ -37,7 +37,6 @@ public class FallbackFileMetadataAccessor implements FileMetadataAccessor {
     }
 
     @Override
-    @SuppressWarnings("Since15")
     public FileMetadataSnapshot stat(Path path) throws IOException {
         return stat(path.toFile());
     }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedFileMetadataAccessor.java
@@ -49,7 +49,6 @@ public class NativePlatformBackedFileMetadataAccessor implements FileMetadataAcc
     }
 
     @Override
-    @SuppressWarnings("Since15")
     public FileMetadataSnapshot stat(Path path) throws IOException {
         return stat(path.toFile());
     }

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/SingleDepthFileAccessTracker.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/SingleDepthFileAccessTracker.java
@@ -29,7 +29,6 @@ import java.util.Set;
  * timestamp, files and directory at the supplied depth within the supplied base
  * directory.
  */
-@SuppressWarnings("Since15")
 public class SingleDepthFileAccessTracker implements FileAccessTracker {
 
     private final Path baseDir;


### PR DESCRIPTION
Now that we use Java 7 source level, we no longer have to suppress warnings for using Java 7 APIs in IDEA.