### PR TITLE
Generate a sitemap.xml for Gradle docs

### DIFF
--- a/buildSrc/subprojects/docs/docs.gradle.kts
+++ b/buildSrc/subprojects/docs/docs.gradle.kts
@@ -3,6 +3,7 @@ apply(plugin = "org.gradle.kotlin.kotlin-dsl")
 dependencies {
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
+    implementation("com.github.dfabulich:sitemapgen4j:1.1.1")
     implementation("org.pegdown:pegdown:1.6.0")
     implementation("com.uwyn:jhighlight:1.0") {
         exclude(module = "servlet-api")

--- a/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/SitemapGenerator.kt
+++ b/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/SitemapGenerator.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.docs
+
+import org.gradle.api.file.FileTree
+import org.gradle.api.file.FileVisitDetails
+import org.gradle.api.file.FileVisitor
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+
+import com.redfin.sitemapgenerator.ChangeFreq
+import com.redfin.sitemapgenerator.W3CDateFormat
+import com.redfin.sitemapgenerator.W3CDateFormat.Pattern
+import com.redfin.sitemapgenerator.WebSitemapGenerator
+import com.redfin.sitemapgenerator.WebSitemapUrl
+import com.redfin.sitemapgenerator.WebSitemapUrl.Options
+
+import java.io.File
+import java.util.Date
+import java.util.TimeZone
+import javax.inject.Inject
+
+
+@CacheableTask
+open class SitemapGenerator @Inject constructor() : SourceTask() {
+
+    @Input
+    var urlBase: String = "UNSET"
+
+    @Input
+    var lastModifiedDate: Date = Date()
+
+    @Input
+    var changeFrequency: ChangeFreq = ChangeFreq.MONTHLY
+
+    @OutputDirectory
+    var dest: File = project.file("${project.buildDir}/sitemap")
+
+    fun setDest(input: String) {
+        this.dest = project.file(input)
+    }
+    fun dest(input: String) = setDest(input)
+    fun dest(input: File) = {
+        this.dest = input
+    }
+
+    @TaskAction
+    fun generate() {
+        val dateFormat = W3CDateFormat(Pattern.DAY)
+        dateFormat.setTimeZone(TimeZone.getTimeZone("GMT"))
+
+        val sitemapGenerator = WebSitemapGenerator.builder(urlBase, dest)
+            .dateFormat(dateFormat).build()
+        generateUrls(getSource())
+            .forEach {
+                sitemapGenerator.addUrl(it)
+            }
+        sitemapGenerator.write()
+    }
+
+    private
+    fun generateUrls(sourceTree: FileTree): List<WebSitemapUrl> {
+        val urls = mutableListOf<WebSitemapUrl>()
+        sourceTree.visit(object : FileVisitor {
+            override fun visitDir(visitDetails: FileVisitDetails) {}
+
+            override fun visitFile(visitDetails: FileVisitDetails) {
+                urls.add(
+                    WebSitemapUrl.Options("$urlBase${visitDetails.relativePath}")
+                    .lastMod(lastModifiedDate)
+                    .changeFreq(changeFrequency)
+                    .build())
+            }
+        })
+        return urls.toList()
+    }
+}

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/AllDistributionIntegrationSpec.groovy
@@ -64,11 +64,15 @@ class AllDistributionIntegrationSpec extends DistributionIntegrationSpec {
         contentsDir.file('docs/userguide/userguide.html').assertContents(containsString("Gradle User Manual</h1>"))
         contentsDir.file('docs/userguide/userguide_single.html').assertIsFile()
         contentsDir.file('docs/userguide/userguide_single.html').assertContents(containsString("<h1>Gradle User Manual: Version ${version}</h1>"))
-//        contentsDir.file('docs/userguide/userguide.pdf').assertIsFile()
+        contentsDir.file('docs/userguide/userguide.pdf').assertIsFile()
 
         // DSL reference
         contentsDir.file('docs/dsl/index.html').assertIsFile()
         contentsDir.file('docs/dsl/index.html').assertContents(containsString("<title>Gradle DSL Version ${version}</title>"))
+
+        // Sitemap
+        contentsDir.file('docs/sitemap.xml').assertIsFile()
+        contentsDir.file('docs/sitemap.xml').assertContents(containsString("<urlset xmlns="))
     }
 
 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -27,6 +27,7 @@ import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.ProjectGroups
 import org.gradle.gradlebuild.PublicApi
 import org.gradle.gradlebuild.docs.PegDown
+import org.gradle.gradlebuild.docs.SitemapGenerator
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 
 plugins {
@@ -86,15 +87,16 @@ gradlebuildJava {
 ext {
     srcDocsDir = file('src/docs')
     releaseFeaturesFile = file("$srcDocsDir/release/release-features.txt")
-    userguideSrcDir = new File(srcDocsDir, 'userguide')
-    userguideIntermediateOutputDir = new File(buildDir, 'userguideIntermediate')
-    userguideSinglePageOutputDir = new File(buildDir, 'userguideSinglePage')
-    dslSrcDir = new File(srcDocsDir, 'dsl')
+    userguideSrcDir = file("$srcDocsDir/userguide")
+    userguideIntermediateOutputDir = file("$buildDir/userguideIntermediate")
+    userguideSinglePageOutputDir = file("$buildDir/userguideSinglePage")
+    dslSrcDir = file("$srcDocsDir/dsl")
     docsDir = file("$buildDir/docs")
-    userguideDir = new File(docsDir, 'userguide')
-    distDocsDir = new File(buildDir, 'distDocs')
+    sitemapDir = file("$buildDir/sitemap")
+    userguideDir = file("$docsDir/userguide")
+    distDocsDir = file("$buildDir/distDocs")
     samplesDir = file("$buildDir/samples")
-    docbookSrc = new File(project.buildDir, 'src')
+    docbookSrc = file("$buildDir/src")
     samplesSrcDir = file('src/samples')
 }
 
@@ -106,7 +108,7 @@ outputs.distDocs = files(distDocsDir) {
     builtBy 'distDocs'
 }
 outputs.docs = files(docsDir) {
-    builtBy 'javadocAll', 'userguide', 'dslHtml', 'releaseNotes'
+    builtBy 'javadocAll', 'userguide', 'dslHtml', 'releaseNotes', 'sitemap'
 }
 
 def configureCss = tasks.register("configureCss") {
@@ -402,6 +404,19 @@ releaseNotesMarkdown.configure {
     group = "release notes"
 }
 
+def generateSitemap = tasks.register("generateSitemap", SitemapGenerator) {
+    description = "Generate a sitemap.xml file for generated docs"
+    group = "documentation"
+
+    source docsDir
+    dest
+    urlBase = "https://docs.gradle.org/current/"
+    includes = ["**/*.html"]
+    excludes = ["**/getting-started.html", "**/javadoc/**/*-frame.html", "**/javadoc/**/*-tree.html", "**/javadoc/**/index-all.html", "**/javadoc/**/serialized-form.html"]
+
+    dependsOn userguide
+}
+
 def releaseNotes = tasks.register("releaseNotes", Copy) {
     group = "release notes"
     ext.fileName = "release-notes.html"
@@ -433,6 +448,13 @@ def copyReleaseFeatures = tasks.register("copyReleaseFeatures", Copy) {
     into generatedResourcesDir
 }
 
+def sitemap = tasks.register("sitemap", Copy) {
+    from sitemapDir
+    into docsDir
+
+    dependsOn generateSitemap
+}
+
 sourceSets.main.output.dir generatedResourcesDir, builtBy: [defaultImports, copyReleaseFeatures]
 
 tasks.named("test").configure {
@@ -446,7 +468,7 @@ tasks.named("test").configure {
 }
 
 tasks.register("docs") {
-    dependsOn javadocAll, userguide, distDocs, dslHtml, releaseNotes
+    dependsOn javadocAll, userguide, distDocs, dslHtml, releaseNotes, sitemap
     description = 'Generates all documentation'
     group = 'documentation'
 }


### PR DESCRIPTION
This adds a custom SitemapGenerator task to buildSrc that
uses sitemapgen4j to generate a sitemap.xml file

A sitemap.xml will improve search indexing for both Google and
Algolia search.

Issue: gradle/dotorg-docs#283

### Context
A sitemap.xml will improve search indexing for both Google and
Algolia search significantly.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
