### PR TITLE
Add license information to docs clarifying software licenses

### DIFF
--- a/subprojects/docs/src/docs/userguide/licenses.adoc
+++ b/subprojects/docs/src/docs/userguide/licenses.adoc
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-= Documentation licenses
+[[licenses]]
+= License Information
 
 
 [[sec:gradle_documentation]]
@@ -20,5 +21,13 @@
 
 _Copyright © 2007-2018 Gradle, Inc._
 
-Gradle build tool source code is open and licensed under the link:https://github.com/gradle/gradle/blob/master/LICENSE[Apache License 2.0].
+Gradle build tool source code is open-source and licensed under the link:https://github.com/gradle/gradle/blob/master/LICENSE[Apache License 2.0].
+
+
 Gradle user manual and DSL references are licensed under link:http://creativecommons.org/licenses/by-nc-sa/4.0/[Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License].
+
+
+[[licenses:build_scan_plugin]]
+== Gradle Build Scan Plugin
+
+Use of the link:https://scans.gradle.com/plugin/[build scan plugin] is subject to link:https://gradle.com/legal/terms-of-service/[Gradle's Terms of Service].


### PR DESCRIPTION
### Context
This was asked for by a number of folks [on the forums](https://discuss.gradle.org/t/what-is-the-license-of-a-gradle-plugins-meta-plugin-pom-xml/27610/2) and in Gradle Community Slack.

I inspected the JAR files of closed-source plugins to find the license information, and declare the license of generated POM files from the plugin portal to be the same (APL v2.0). 

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
