### PR TITLE
Allow inner class pattern match an outer class

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcher.java
@@ -158,7 +158,7 @@ public class TestSelectionMatcher {
         }
 
         private boolean lastClassNameElementMatchesPenultimatePatternElement(String[] className, int index) {
-            return index == segments.length - 2 && index == className.length - 1 && className[index].equals(segments[index]);
+            return index == segments.length - 2 && index == className.length - 1 && classNameMatch(className[index], segments[index]);
         }
 
         private boolean lastClassNameElementMatchesLastPatternElement(String[] className, int index) {
@@ -186,6 +186,18 @@ public class TestSelectionMatcher {
         return simpleName;
     }
 
+    // Foo can match both Foo and Foo$NestedClass
+    // https://github.com/gradle/gradle/issues/5763
+    private static boolean classNameMatch(String simpleClassName, String patternSimpleClassName) {
+        if (simpleClassName.equals(patternSimpleClassName)) {
+            return true;
+        } else if (patternSimpleClassName.contains("$")) {
+            return simpleClassName.equals(patternSimpleClassName.substring(0, patternSimpleClassName.indexOf('$')));
+        } else {
+            return false;
+        }
+    }
+
     private interface LastElementMatcher {
         boolean match(String classElement, String patternElement);
     }
@@ -193,14 +205,14 @@ public class TestSelectionMatcher {
     private static class NoWildcardMatcher implements LastElementMatcher {
         @Override
         public boolean match(String classElement, String patternElement) {
-            return classElement.equals(patternElement);
+            return classNameMatch(classElement, patternElement);
         }
     }
 
     private static class WildcardMatcher implements LastElementMatcher {
         @Override
         public boolean match(String classElement, String patternElement) {
-            return classElement.startsWith(patternElement);
+            return classElement.startsWith(patternElement) || classNameMatch(classElement, patternElement);
         }
     }
 

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/filter/TestSelectionMatcherTest.groovy
@@ -197,6 +197,12 @@ class TestSelectionMatcherTest extends Specification {
         ['Foo']                           | 'FooTest'            | false
         ['org.gradle.Foo']                | 'org.gradle.FooTest' | false
         ['org.gradle.Foo.*']              | 'org.gradle.FooTest' | false
+
+        ['org.gradle.Foo$Bar.*test']      | 'Foo'                | false
+        ['org.gradle.Foo$Bar.*test']      | 'org.Foo'            | false
+        ['org.gradle.Foo$Bar.*test']      | 'org.gradle.Foo'     | true
+        ['Enclosing$Nested.test']         | "Enclosing"          | true
+        ['org.gradle.Foo$1$2.test']       | "org.gradle.Foo"     | true
     }
 
     @Unroll

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformNestedPatternMatchingIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformNestedPatternMatchingIntegrationTest.groovy
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junitplatform
+
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+
+class JUnitPlatformNestedPatternMatchingIntegrationTest extends JUnitPlatformIntegrationSpec {
+    def 'can use nested class as test pattern'() {
+        given:
+        file('src/test/java/EnclosingClass.java') << '''
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class EnclosingClass {
+    @Nested
+    class NestedClass {
+        @Test
+        void nestedTest() {
+        }
+        @Test
+        void anotherTest() {
+        }
+    }
+    @Nested
+    class AnotherNestedClass {
+        @Test
+        void foo() {
+        }
+    }
+    @Test
+    void foo() {
+    }
+}
+'''
+        when:
+        succeeds('test', '--tests', 'EnclosingClass$NestedClass.nestedTest')
+
+        then:
+        new DefaultTestExecutionResult(testDirectory)
+            .assertTestClassesExecuted('EnclosingClass$NestedClass')
+            .testClass('EnclosingClass$NestedClass')
+            .assertTestCount(1, 0, 0)
+            .assertTestPassed('nestedTest')
+    }
+}


### PR DESCRIPTION
### Context

This fixes #5763 .

In Gradle 4.7 we made a change https://github.com/gradle/gradle/pull/4597 which pre-excludes some classes if test pattern is provided. For example, if a test pattern `org.gradle.Foo.testMethod` is provided, we can definitely exclude `org.gradle.Bar` class. However, this introduced one issue: if test pattern `EnclosingClass$NestedClass.nestedTest` is provided, we exclude `EnclosingClass` - this prevents `JUnitPlatformClassProcessor` from discovering its inner class.

This PR fixes this issue by allowing `EnclosingClass` to match a `EnclosingClass$NestedClass` pattern. 