### PR TITLE
Fix broken buildScanPerformance tests

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
@@ -37,6 +37,11 @@ class BuildScanPerformanceTest extends ReportGenerationPerformanceTest {
     }
 
     @Override
+    File getReportDir() {
+        return new File(project.getBuildDir(), "reports/performance")
+    }
+
+    @Override
     protected List<ScenarioBuildResultData> getResultsForReport() {
         Collection<File> xmls = reports.junitXml.destination.listFiles().findAll { it.path.endsWith(".xml") }
         List<JUnitTestSuite> testSuites = xmls.collect { JUnitMarshalling.unmarshalTestSuite(new FileInputStream(it)) }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+
+import groovy.transform.CompileStatic
+import org.openmbee.junit.JUnitMarshalling
+import org.openmbee.junit.model.JUnitTestCase
+import org.openmbee.junit.model.JUnitTestSuite
+
+@CompileStatic
+class BuildScanPerformanceTest extends ReportGenerationPerformanceTest {
+    private static final String TC_URL = "https://builds.gradle.org/viewLog.html?buildId="
+
+    @Override
+    String getResultStoreClass() {
+        return "org.gradle.performance.results.BuildScanResultsStore"
+    }
+
+    @Override
+    String getChannel() {
+        return "commits"
+    }
+
+    @Override
+    protected List<ScenarioBuildResultData> getResultsForReport() {
+        Collection<File> xmls = reports.junitXml.destination.listFiles().findAll { it.path.endsWith(".xml") }
+        List<JUnitTestSuite> testSuites = xmls.collect { JUnitMarshalling.unmarshalTestSuite(new FileInputStream(it)) }
+        return testSuites.collect(this.&extractResultFromTestCase).flatten() as List<ScenarioBuildResultData>
+    }
+
+    private List<ScenarioBuildResultData> extractResultFromTestCase(JUnitTestSuite testSuite) {
+        List<JUnitTestCase> testCases = testSuite.testCases ?: []
+        return testCases.collect {
+            new ScenarioBuildResultData(scenarioName: it.name,
+                webUrl: TC_URL + buildId,
+                successful: !it.errors && !it.failures,
+                testFailure: collectFailures(testSuite))
+        }
+    }
+}

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.testing
 
 
 import groovy.transform.CompileStatic
+import org.gradle.api.tasks.CacheableTask
 import org.openmbee.junit.JUnitMarshalling
 import org.openmbee.junit.model.JUnitTestCase
 import org.openmbee.junit.model.JUnitTestSuite
 
 @CompileStatic
+@CacheableTask
 class BuildScanPerformanceTest extends ReportGenerationPerformanceTest {
     private static final String TC_URL = "https://builds.gradle.org/viewLog.html?buildId="
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
@@ -45,10 +45,10 @@ class BuildScanPerformanceTest extends ReportGenerationPerformanceTest {
     protected List<ScenarioBuildResultData> getResultsForReport() {
         Collection<File> xmls = reports.junitXml.destination.listFiles().findAll { it.path.endsWith(".xml") }
         List<JUnitTestSuite> testSuites = xmls.collect { JUnitMarshalling.unmarshalTestSuite(new FileInputStream(it)) }
-        return testSuites.collect(this.&extractResultFromTestCase).flatten() as List<ScenarioBuildResultData>
+        return testSuites.collect { extractResultFromTestSuite(it) }.flatten() as List<ScenarioBuildResultData>
     }
 
-    private List<ScenarioBuildResultData> extractResultFromTestCase(JUnitTestSuite testSuite) {
+    private List<ScenarioBuildResultData> extractResultFromTestSuite(JUnitTestSuite testSuite) {
         List<JUnitTestCase> testCases = testSuite.testCases ?: []
         return testCases.collect {
             new ScenarioBuildResultData(scenarioName: it.name,

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/BuildScanPerformanceTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.testing
 
 import groovy.transform.CompileStatic
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.TaskAction
 import org.openmbee.junit.JUnitMarshalling
 import org.openmbee.junit.model.JUnitTestCase
 import org.openmbee.junit.model.JUnitTestSuite
@@ -41,6 +42,16 @@ class BuildScanPerformanceTest extends ReportGenerationPerformanceTest {
     @Override
     File getReportDir() {
         return new File(project.getBuildDir(), "reports/performance")
+    }
+
+    @TaskAction
+    @Override
+    void executeTests() {
+        try {
+            super.executeTests()
+        } finally {
+            generatePerformanceReport()
+        }
     }
 
     @Override

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -114,10 +114,12 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
     }
 
     @TaskAction
+    @Override
     void executeTests() {
         try {
             doExecuteTests()
         } finally {
+            generatePerformanceReport()
             testEventsGenerator.release()
         }
     }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing
+
+import groovy.json.JsonOutput
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.gradle.api.Action
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.JavaExecSpec
+import org.openmbee.junit.model.JUnitFailure
+import org.openmbee.junit.model.JUnitTestCase
+import org.openmbee.junit.model.JUnitTestSuite
+
+abstract class ReportGenerationPerformanceTest extends PerformanceTest {
+    @Internal
+    String buildId
+
+    @OutputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
+    File reportDir
+
+    @TaskAction
+    @Override
+    void executeTests() {
+        try {
+            super.executeTests()
+        } finally {
+            generatePerformanceReport()
+        }
+    }
+
+    protected abstract List<ScenarioBuildResultData> getResultsForReport()
+
+    private void generatePerformanceReport() {
+        File resultJson = generateResultJson()
+        project.delete(reportDir)
+        try {
+            project.javaexec(new Action<JavaExecSpec>() {
+                void execute(JavaExecSpec spec) {
+                    spec.setMain("org.gradle.performance.results.ReportGenerator")
+                    spec.args(resultStoreClass, reportDir.path, resultJson.path)
+                    spec.systemProperties(databaseParameters)
+                    spec.systemProperty("org.gradle.performance.execution.channel", channel)
+                    spec.setClasspath(ReportGenerationPerformanceTest.this.getClasspath())
+                }
+            })
+        } finally {
+            project.delete(resultJson)
+        }
+    }
+
+    private File generateResultJson() {
+        File resultJson = File.createTempFile('performanceTest', 'results.json')
+        resultJson.text = JsonOutput.toJson(resultsForReport)
+        return resultJson
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    protected String collectFailures(JUnitTestSuite testSuite) {
+        List<JUnitTestCase> testCases = testSuite.testCases ?: []
+        List<JUnitFailure> failures = testCases.collect { it.failures ?: [] }.flatten()
+        return failures.collect { it.value }.join("\n")
+    }
+
+    // Modify this class with care, see class org.gradle.performance.results.ScenarioBuildResultData
+    static class ScenarioBuildResultData {
+        String scenarioName
+        String webUrl
+        String testFailure
+        boolean successful
+    }
+}

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.testing
 
 import groovy.json.JsonOutput
+import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.gradle.api.Action
@@ -30,6 +31,7 @@ import org.openmbee.junit.model.JUnitFailure
 import org.openmbee.junit.model.JUnitTestCase
 import org.openmbee.junit.model.JUnitTestSuite
 
+@CompileStatic
 abstract class ReportGenerationPerformanceTest extends PerformanceTest {
     @Internal
     String buildId

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
 import org.gradle.process.JavaExecSpec
 import org.openmbee.junit.model.JUnitFailure
 import org.openmbee.junit.model.JUnitTestCase
@@ -40,19 +39,9 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
     @PathSensitive(PathSensitivity.RELATIVE)
     File reportDir
 
-    @TaskAction
-    @Override
-    void executeTests() {
-        try {
-            super.executeTests()
-        } finally {
-            generatePerformanceReport()
-        }
-    }
-
     protected abstract List<ScenarioBuildResultData> getResultsForReport()
 
-    private void generatePerformanceReport() {
+    protected void generatePerformanceReport() {
         File resultJson = generateResultJson()
         project.delete(reportDir)
         try {

--- a/subprojects/build-scan-performance/build-scan-performance.gradle
+++ b/subprojects/build-scan-performance/build-scan-performance.gradle
@@ -33,23 +33,7 @@ gradlebuildJava {
 }
 
 tasks.withType(org.gradle.testing.PerformanceTest).configureEach {
-    resultStoreClass = "org.gradle.performance.results.BuildScanResultsStore"
     systemProperties += [incomingArtifactDir: "${rootDir}/incoming/"]
-}
-
-tasks.named('performanceReport').configure {
-    doLast {
-        project.delete("build/reports/performance")
-        project.javaexec(new Action<JavaExecSpec>() {
-            void execute(JavaExecSpec spec) {
-                spec.setMain("org.gradle.performance.results.ReportGenerator")
-                spec.args("org.gradle.performance.results.BuildScanResultsStore", "build/reports/performance")
-                spec.systemProperties(performanceTest.databaseParameters)
-                spec.systemProperty("org.gradle.performance.execution.channel", "commits")
-                spec.setClasspath(performanceTest.classpath)
-            }
-        })
-    }
 }
 
 tasks.withType(org.gradle.testing.PerformanceTest).configureEach{

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -51,7 +51,7 @@ class BuildScanPluginPerformanceTest extends Specification {
     CrossBuildPerformanceTestRunner runner
 
     private int warmupBuilds = 1
-    private int measuredBuilds = 7
+    private int measuredBuilds = 1
 
     void setup() {
         def incomingDir = "../../incoming" // System.getProperty('incomingArtifactDir')

--- a/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
+++ b/subprojects/build-scan-performance/src/performanceTest/groovy/org/gradle/performance/BuildScanPluginPerformanceTest.groovy
@@ -51,7 +51,7 @@ class BuildScanPluginPerformanceTest extends Specification {
     CrossBuildPerformanceTestRunner runner
 
     private int warmupBuilds = 1
-    private int measuredBuilds = 1
+    private int measuredBuilds = 7
 
     void setup() {
         def incomingDir = "../../incoming" // System.getProperty('incomingArtifactDir')
@@ -72,7 +72,7 @@ class BuildScanPluginPerformanceTest extends Specification {
         }
     }
 
-    def "build scan plugin comparison"() {
+    def "large java project with and without build scan"() {
         given:
         def sourceProject = "largeJavaProjectWithBuildScanPlugin"
         def tasks = ['clean', 'build']


### PR DESCRIPTION
### Context

In https://github.com/gradle/gradle/pull/6642 we start to read data from individual performance test workers' xml files, which broke `buildScanPerformance` because it depends on `ReportGenerator`: https://github.com/gradle/gradle/blob/d25ed4809934df572d12179aba3e1ea37709133b/subprojects/build-scan-performance/build-scan-performance.gradle#L40

We don't want an isolated `performanceReport` task any more because of cacheablity. This PR extracts report generation logic from `DistributedPerformanceTest` to a base class `ReportGenerationPerformanceTest` so `buildScanPerformance` can benefit from it without need to write duplicate logic.