### PR TITLE
Faster classloader filtering

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -163,7 +163,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
 
         return classNames.contains(className)
             || packagePrefixes.find(className)
-            || packagePrefixes.contains(DEFAULT_PACKAGE) && isInDefaultPackage(className);
+            || (packagePrefixes.contains(DEFAULT_PACKAGE + ".") && isInDefaultPackage(className));
     }
 
     private boolean isInDefaultPackage(String className) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -16,12 +16,16 @@
 
 package org.gradle.internal.classloader;
 
+import org.gradle.internal.util.Trie;
+
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -33,13 +37,13 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
     private static final ClassLoader EXT_CLASS_LOADER;
     private static final Set<String> SYSTEM_PACKAGES = new HashSet<String>();
     public static final String DEFAULT_PACKAGE = "DEFAULT";
-    private final Set<String> packageNames = new HashSet<String>();
-    private final Set<String> packagePrefixes = new HashSet<String>();
-    private final Set<String> resourcePrefixes = new HashSet<String>();
-    private final Set<String> resourceNames = new HashSet<String>();
-    private final Set<String> classNames = new HashSet<String>();
-    private final Set<String> disallowedClassNames = new HashSet<String>();
-    private final Set<String> disallowedPackagePrefixes = new HashSet<String>();
+    private final Set<String> packageNames;
+    private final TrieSet packagePrefixes;
+    private final TrieSet resourcePrefixes;
+    private final Set<String> resourceNames;
+    private final Set<String> classNames;
+    private final Set<String> disallowedClassNames;
+    private final TrieSet disallowedPackagePrefixes;
 
     static {
         EXT_CLASS_LOADER = ClassLoaderUtils.getPlatformClassLoader();
@@ -65,13 +69,13 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
 
     public FilteringClassLoader(ClassLoader parent, Spec spec) {
         super(parent);
-        packageNames.addAll(spec.packageNames);
-        packagePrefixes.addAll(spec.packagePrefixes);
-        resourceNames.addAll(spec.resourceNames);
-        resourcePrefixes.addAll(spec.resourcePrefixes);
-        classNames.addAll(spec.classNames);
-        disallowedClassNames.addAll(spec.disallowedClassNames);
-        disallowedPackagePrefixes.addAll(spec.disallowedPackagePrefixes);
+        packageNames = new HashSet<String>(spec.packageNames);
+        packagePrefixes = new TrieSet(spec.packagePrefixes);
+        resourceNames = new HashSet<String>(spec.resourceNames);
+        resourcePrefixes = new TrieSet(spec.resourcePrefixes);
+        classNames = new HashSet<String>(spec.classNames);
+        disallowedClassNames = new HashSet<String>(spec.disallowedClassNames);
+        disallowedPackagePrefixes = new TrieSet(spec.disallowedPackagePrefixes);
     }
 
     public void visit(ClassLoaderVisitor visitor) {
@@ -136,61 +140,30 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
     }
 
     private boolean allowed(String resourceName) {
-        if (resourceNames.contains(resourceName)) {
-            return true;
-        }
-        for (String resourcePrefix : resourcePrefixes) {
-            if (resourceName.startsWith(resourcePrefix)) {
-                return true;
-            }
-        }
-        return false;
+        return resourceNames.contains(resourceName)
+            || resourcePrefixes.find(resourceName);
     }
 
     private boolean allowed(Package pkg) {
-        for (String packagePrefix : disallowedPackagePrefixes) {
-            if (pkg.getName().startsWith(packagePrefix)) {
-                return false;
-            }
+        String packageName = pkg.getName();
+        if (disallowedPackagePrefixes.find(packageName)) {
+            return false;
         }
 
-        if (SYSTEM_PACKAGES.contains(pkg.getName())) {
-            return true;
-        }
-        if (packageNames.contains(pkg.getName())) {
-            return true;
-        }
-        for (String packagePrefix : packagePrefixes) {
-            if (pkg.getName().startsWith(packagePrefix)) {
-                return true;
-            }
-        }
-        return false;
+        return SYSTEM_PACKAGES.contains(packageName)
+            || packageNames.contains(packageName)
+            || packagePrefixes.find(packageName);
     }
 
     private boolean classAllowed(String className) {
-        if (disallowedClassNames.contains(className)) {
+        if (disallowedClassNames.contains(className)
+            || disallowedPackagePrefixes.find(className)) {
             return false;
         }
-        for (String packagePrefix : disallowedPackagePrefixes) {
-            if (className.startsWith(packagePrefix)) {
-                return false;
-            }
-        }
 
-        if (classNames.contains(className)) {
-            return true;
-        }
-        for (String packagePrefix : packagePrefixes) {
-            if (className.startsWith(packagePrefix)) {
-                return true;
-            }
-
-            if (packagePrefix.startsWith(DEFAULT_PACKAGE) && isInDefaultPackage(className)) {
-                return true;
-            }
-        }
-        return false;
+        return classNames.contains(className)
+            || packagePrefixes.find(className)
+            || packagePrefixes.contains(DEFAULT_PACKAGE) && isInDefaultPackage(className);
     }
 
     private boolean isInDefaultPackage(String className) {
@@ -222,14 +195,20 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
             );
         }
 
-        public Spec(Collection<String> classNames, Collection<String> packageNames, Collection<String> packagePrefixes, Collection<String> resourcePrefixes, Collection<String> resourceNames, Collection<String> disallowedClassNames, Collection<String> disallowedPackagePrefixes) {
-            this.classNames.addAll(classNames);
-            this.packageNames.addAll(packageNames);
-            this.packagePrefixes.addAll(packagePrefixes);
-            this.resourcePrefixes.addAll(resourcePrefixes);
-            this.resourceNames.addAll(resourceNames);
-            this.disallowedClassNames.addAll(disallowedClassNames);
-            this.disallowedPackagePrefixes.addAll(disallowedPackagePrefixes);
+        public Spec(Iterable<String> classNames, Iterable<String> packageNames, Iterable<String> packagePrefixes, Iterable<String> resourcePrefixes, Iterable<String> resourceNames, Iterable<String> disallowedClassNames, Iterable<String> disallowedPackagePrefixes) {
+            addAll(this.classNames, classNames);
+            addAll(this.packageNames, packageNames);
+            addAll(this.packagePrefixes, packagePrefixes);
+            addAll(this.resourcePrefixes, resourcePrefixes);
+            addAll(this.resourceNames, resourceNames);
+            addAll(this.disallowedClassNames, disallowedClassNames);
+            addAll(this.disallowedPackagePrefixes, disallowedPackagePrefixes);
+        }
+
+        private static void addAll(Collection<String> collection, Iterable<String> elements) {
+            for (String element : elements) {
+                collection.add(element);
+            }
         }
 
         /**
@@ -343,6 +322,30 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
 
         Set<String> getDisallowedPackagePrefixes() {
             return disallowedPackagePrefixes;
+        }
+    }
+
+    private static class TrieSet implements Iterable<String> {
+        private final Trie trie;
+        private final Set<String> set;
+
+        public TrieSet(Collection<String> words) {
+            this.trie = Trie.from(words);
+            this.set = new HashSet<String>(words);
+        }
+
+        public boolean find(CharSequence seq) {
+            return trie.find(seq);
+        }
+
+        public boolean contains(String seq) {
+            return set.contains(seq);
+        }
+
+        @Nonnull
+        @Override
+        public Iterator<String> iterator() {
+            return set.iterator();
         }
     }
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/Trie.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/Trie.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.runtimeshaded;
+package org.gradle.internal.util;
 
 import org.gradle.api.Action;
 
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 
-class Trie {
+public class Trie {
     private final char c;
     private final boolean terminal;
     private final Trie[] transitions;
@@ -111,7 +111,7 @@ class Trie {
             this.c = c;
         }
 
-        public Builder addTransition(char c, boolean terminal) {
+        private Builder addTransition(char c, boolean terminal) {
             Builder b = null;
             for (Builder transition : transitions) {
                 if (transition.c == c) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/Trie.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/Trie.java
@@ -27,6 +27,22 @@ public class Trie {
     private final boolean terminal;
     private final Trie[] transitions;
 
+    public static Trie from(String... words) {
+        return from(Arrays.asList(words));
+    }
+
+    public static Trie from(Iterable<String> words) {
+        Builder builder = new Builder();
+        for (String word : words) {
+            builder.addWord(word);
+        }
+        return builder.build();
+    }
+
+    public static Builder builder() {
+        return new Trie.Builder();
+    }
+
     private Trie(char c, boolean terminal, Trie[] transitions) {
         this.c = c;
         this.terminal = terminal;
@@ -36,10 +52,6 @@ public class Trie {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        return toString(sb);
-    }
-
-    private String toString(StringBuilder sb) {
         sb.append(c).append(terminal ? "(terminal)\n" : "\n");
         sb.append("Next: ");
         for (Trie transition : transitions) {
@@ -49,6 +61,9 @@ public class Trie {
         return sb.toString();
     }
 
+    /**
+     * Checks if the trie contains the given character sequence or any prefixes of the sequence.
+     */
     public boolean find(CharSequence seq) {
         if (seq.length() == 0) {
             return false;

--- a/subprojects/base-services/src/main/java/org/gradle/internal/util/Trie.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/util/Trie.java
@@ -17,12 +17,12 @@ package org.gradle.internal.util;
 
 import org.gradle.api.Action;
 
+import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.List;
 
-public class Trie {
+public class Trie implements Comparable<Trie> {
     private final char c;
     private final boolean terminal;
     private final Trie[] transitions;
@@ -59,6 +59,11 @@ public class Trie {
         }
         sb.append("\n");
         return sb.toString();
+    }
+
+    @Override
+    public int compareTo(@Nonnull Trie o) {
+        return c - o.c;
     }
 
     /**
@@ -157,12 +162,7 @@ public class Trie {
                 Builder transition = this.transitions.get(i);
                 transitions[i] = transition.build();
             }
-            Arrays.sort(transitions, new Comparator<Trie>() {
-                @Override
-                public int compare(Trie o1, Trie o2) {
-                    return o1.c - o2.c;
-                }
-            });
+            Arrays.sort(transitions);
             return new Trie(c, terminal, transitions);
         }
     }

--- a/subprojects/base-services/src/test/groovy/ClassInDefaultPackage.groovy
+++ b/subprojects/base-services/src/test/groovy/ClassInDefaultPackage.groovy
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class ClassInDefaultPackage {
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/FilteringClassLoaderTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/FilteringClassLoaderTest.groovy
@@ -164,6 +164,19 @@ class FilteringClassLoaderTest extends Specification {
         canSeePackage('org.junit.runner')
     }
 
+    void passesThroughDefaultPackage() {
+        given:
+        cannotLoadClass(ClassInDefaultPackage)
+
+        and:
+        withSpec { FilteringClassLoader.Spec spec ->
+            spec.allowPackage(FilteringClassLoader.DEFAULT_PACKAGE)
+        }
+
+        expect:
+        canLoadClass(ClassInDefaultPackage)
+    }
+
     void passesThroughResourcesInSpecifiedPackages() {
         given:
         cannotSeeResource('org/gradle/util/ClassLoaderTest.txt')

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/util/TrieTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/util/TrieTest.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.util
+
+import spock.lang.Specification
+
+class TrieTest extends Specification {
+
+    def "empty trie is empty"() {
+        def empty = Trie.from()
+        expect:
+        !empty.find("")
+        !empty.find("alma")
+    }
+
+    def "can find exact match"() {
+        def trie = Trie.from("aaa", "bbb")
+        expect:
+        trie.find("aaa")
+        trie.find("bbb")
+        !trie.find("ccc")
+    }
+
+    def "can find prefix match"() {
+        def trie = Trie.from("aaa", "bbb")
+        expect:
+        !trie.find("a")
+        !trie.find("aa")
+        trie.find("aaaa")
+        trie.find("aaab")
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/child/WorkerProcessClassPathProvider.java
@@ -39,6 +39,7 @@ import org.gradle.internal.reflect.NoSuchMethodException;
 import org.gradle.internal.reflect.NoSuchPropertyException;
 import org.gradle.internal.reflect.PropertyAccessor;
 import org.gradle.internal.reflect.PropertyMutator;
+import org.gradle.internal.util.Trie;
 import org.gradle.process.internal.streams.EncodedStream;
 import org.gradle.process.internal.worker.GradleWorkerMain;
 import org.objectweb.asm.ClassReader;
@@ -154,6 +155,8 @@ public class WorkerProcessClassPathProvider implements ClassPathProvider, Closea
                 PropertyMutator.class,
                 Factory.class,
                 Spec.class,
+                Action.class,
+                Trie.class,
                 JavaVersion.class);
             Set<Class<?>> result = new HashSet<Class<?>>(classes);
             for (Class<?> klass : classes) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/ImplementationDependencyRelocator.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.runtimeshaded;
 
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
+import org.gradle.internal.util.Trie;
 import org.objectweb.asm.commons.Remapper;
 
 import java.io.BufferedReader;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/runtimeshaded/PackageListGenerator.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
+import org.gradle.internal.util.Trie;
 
 import javax.inject.Inject;
 import java.io.BufferedWriter;

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
@@ -30,7 +30,7 @@ class ToolingApiClasspathIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.classpath.size() == 2
         resolve.classpath.any {it.name ==~ /slf4j-api-.*\.jar/}
-        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 1.9 * 1024 * 1024
+        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 1.95 * 1024 * 1024
 
         cleanup:
         resolver.stop()


### PR DESCRIPTION
Use a trie to check for allowed/disallowed package prefixes in `FilteringClassLoader`.