### PR TITLE
Fail resolution when competing force declared on a virtual platform

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Issue
 import spock.lang.Unroll
 
 
-class ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponentSelectionRulesIntegrationTest {
+class  ComponentSelectionRulesDependencyResolveIntegTest extends AbstractComponentSelectionRulesIntegrationTest {
     boolean isWellBehaved(boolean mavenCompatible, boolean gradleCompatible = true) {
         (GradleMetadataResolveRunner.useIvy() || mavenCompatible) && (!GradleMetadataResolveRunner.gradleMetadataEnabled || gradleCompatible)
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CandidateModule;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.SelectorStateResolver;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -56,6 +57,7 @@ class ModuleResolveState implements CandidateModule {
     private final ImmutableAttributesFactory attributesFactory;
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
+    private SelectorStateResolver<ComponentState> selectorStateResolver;
     private final PendingDependencies pendingDependencies;
     private ComponentState selected;
     private ImmutableAttributes mergedAttributes = ImmutableAttributes.EMPTY;
@@ -68,7 +70,8 @@ class ModuleResolveState implements CandidateModule {
                        VariantNameBuilder variantNameBuilder,
                        ImmutableAttributesFactory attributesFactory,
                        Comparator<Version> versionComparator,
-                       VersionParser versionParser) {
+                       VersionParser versionParser,
+                       SelectorStateResolver<ComponentState> selectorStateResolver) {
         this.idGenerator = idGenerator;
         this.id = id;
         this.metaDataResolver = metaDataResolver;
@@ -77,6 +80,11 @@ class ModuleResolveState implements CandidateModule {
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
         this.pendingDependencies = new PendingDependencies();
+        this.selectorStateResolver = selectorStateResolver;
+    }
+
+    void setSelectorStateResolver(SelectorStateResolver<ComponentState> selectorStateResolver) {
+        this.selectorStateResolver = selectorStateResolver;
     }
 
     @Override
@@ -310,4 +318,16 @@ class ModuleResolveState implements CandidateModule {
         pendingDependencies.addNode(node);
     }
 
+
+    public boolean maybeUpdateSelection() {
+        ComponentState newSelected = selectorStateResolver.selectBest(getId(), getSelectors());
+        if (selected == null) {
+            select(newSelected);
+            return true;
+        } else if (newSelected != selected) {
+            changeSelection(newSelected);
+            return true;
+        }
+        return false;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -302,6 +302,10 @@ class ModuleResolveState implements CandidateModule {
         return platformState;
     }
 
+    boolean isVirtualPlatform() {
+        return platformState != null && !platformState.getParticipatingModules().isEmpty();
+    }
+
     void decreaseHardEdgeCount() {
         pendingDependencies.decreaseHardEdgeCount();
     }
@@ -327,6 +331,17 @@ class ModuleResolveState implements CandidateModule {
         } else if (newSelected != selected) {
             changeSelection(newSelected);
             return true;
+        }
+        return false;
+    }
+
+    boolean hasCompetingForceSelectors() {
+        if (selectors.size() > 1) {
+            for (SelectorState selector : selectors) {
+                if (selector.isForce() && !selector.getRequested().matchesStrictly(selected.getComponentId())) {
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -27,8 +27,10 @@ import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.Depen
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusions;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ComponentStateFactory;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.SelectorStateResolver;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
@@ -72,13 +74,14 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     private final VersionSelectorScheme versionSelectorScheme;
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
+    private final SelectorStateResolver<ComponentState> selectorStateResolver;
 
     public ResolveState(IdGenerator<Long> idGenerator, ComponentResolveResult rootResult, String rootConfigurationName, DependencyToComponentIdResolver idResolver,
                         ComponentMetaDataResolver metaDataResolver, Spec<? super DependencyMetadata> edgeFilter, AttributesSchemaInternal attributesSchema,
                         ModuleExclusions moduleExclusions, ModuleReplacementsData moduleReplacementsData,
                         ComponentSelectorConverter componentSelectorConverter, ImmutableAttributesFactory attributesFactory,
                         DependencySubstitutionApplicator dependencySubstitutionApplicator, VersionSelectorScheme versionSelectorScheme,
-                        Comparator<Version> versionComparator, VersionParser versionParser,
+                        Comparator<Version> versionComparator, VersionParser versionParser, ModuleConflictResolver conflictResolver,
                         int graphSize) {
         this.idGenerator = idGenerator;
         this.idResolver = idResolver;
@@ -104,6 +107,8 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
         nodes.put(root.getResolvedConfigurationId(), root);
         root.getComponent().getModule().select(root.getComponent());
         this.replaceSelectionWithConflictResultAction = new ReplaceSelectionWithConflictResultAction(this);
+        selectorStateResolver = new SelectorStateResolver<ComponentState>(conflictResolver, this, rootVersion);
+        getModule(rootResult.getModuleVersionId().getModule()).setSelectorStateResolver(selectorStateResolver);
     }
 
     public Collection<ModuleResolveState> getModules() {
@@ -121,7 +126,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     public ModuleResolveState getModule(ModuleIdentifier id) {
         ModuleResolveState module = modules.get(id);
         if (module == null) {
-            module = new ModuleResolveState(idGenerator, id, metaDataResolver, variantNameBuilder, attributesFactory, versionComparator, versionParser);
+            module = new ModuleResolveState(idGenerator, id, metaDataResolver, variantNameBuilder, attributesFactory, versionComparator, versionParser, selectorStateResolver);
             modules.put(id, module);
         }
         return module;


### PR DESCRIPTION
When a virtual platform is used and competing force are declared on
leaves, resolution will now fail, indicating that all forced modules
could not be resolved as they cause a conflict.