### PR TITLE
Always derive variants for Maven modules

### DIFF
--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/integrationtests/shared-configuration.kt
@@ -69,6 +69,12 @@ fun Project.createTasks(sourceSet: SourceSet, testType: TestType) {
     }
     // Use the default executer for the simply named task. This is what most developers will run when running check
     val testTask = createTestTask(prefix + "Test", defaultExecuter, sourceSet, testType, Action {})
+    // Create a variant of the test suite to force realization of component metadata
+    if (testType == TestType.INTEGRATION) {
+        val forceRealizeTestTask = createTestTask(prefix + "ForceRealizeTest", defaultExecuter, sourceSet, testType, Action {
+            systemProperties["org.gradle.integtest.force.realize.metadata"] = "true"
+        })
+    }
     tasks.named("check").configure { dependsOn(testTask) }
 }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -51,7 +51,7 @@ public enum CacheLayout {
         .changedTo(56, "4.7-rc-1")
         .changedTo(58, "4.8-rc-1")
         .changedTo(63, "4.10-rc-1")
-        .changedTo(67, "5.0-rc-1")),
+        .changedTo(68, "5.0-rc-1")),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -44,7 +44,8 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
     protected static final byte GRADLE_DEPENDENCY_METADATA = 1;
     protected static final byte MAVEN_DEPENDENCY_METADATA = 2;
     protected static final byte IVY_DEPENDENCY_METADATA = 3;
-    private final AttributeContainerSerializer attributeContainerSerializer;
+    protected static final byte FORCED_DEPENDENCY_METADATA = 4;
+    protected final AttributeContainerSerializer attributeContainerSerializer;
     private final ModuleComponentSelectorSerializer componentSelectorSerializer;
     private final ExcludeRuleConverter excludeRuleConverter;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
@@ -85,12 +86,16 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         encoder.writeSmallInt(transformed.getConfigurationNames().size());
         for (String configurationName: transformed.getConfigurationNames()) {
             ConfigurationMetadata configuration = transformed.getConfiguration(configurationName);
-            assert configuration != null;
-            encoder.writeString(configurationName);
-            attributeContainerSerializer.write(encoder, configuration.getAttributes());
-            writeCapabilities(encoder, configuration.getCapabilities().getCapabilities());
+            writeConfiguration(encoder, configuration);
             writeDependencies(encoder, configuration);
         }
+    }
+
+    protected void writeConfiguration(Encoder encoder, ConfigurationMetadata configuration) throws IOException {
+        assert configuration != null;
+        encoder.writeString(configuration.getName());
+        attributeContainerSerializer.write(encoder, configuration.getAttributes());
+        writeCapabilities(encoder, configuration.getCapabilities().getCapabilities());
     }
 
     protected Map<String, List<GradleDependencyMetadata>> readVariantDependencies(Decoder decoder) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -135,6 +135,10 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason);
     }
 
+    public ConfigurationBoundExternalDependencyMetadata withDescriptor(ExternalDependencyDescriptor descriptor) {
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, descriptor);
+    }
+
     private ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {
         ExternalDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
         return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, newDelegate);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -18,20 +18,13 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.artifacts.VersionConstraint;
-import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
-import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
-import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Factory;
-import org.gradle.internal.component.model.ComponentResolveMetadata;
-import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
-import org.gradle.internal.component.model.IvyArtifactName;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -204,79 +197,6 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
             return configDependencies;
         }
         return filtered == null ? ImmutableList.<ModuleDependencyMetadata>of() : filtered.build();
-    }
-
-    private static class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {
-        private final ModuleDependencyMetadata delegate;
-
-        private ForcedDependencyMetadataWrapper(ModuleDependencyMetadata delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public ModuleComponentSelector getSelector() {
-            return delegate.getSelector();
-        }
-
-        @Override
-        public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
-            return new ForcedDependencyMetadataWrapper(delegate.withRequestedVersion(requestedVersion));
-        }
-
-        @Override
-        public ModuleDependencyMetadata withReason(String reason) {
-            return new ForcedDependencyMetadataWrapper(delegate.withReason(reason));
-        }
-
-        @Override
-        public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-            return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
-        }
-
-        @Override
-        public List<ExcludeMetadata> getExcludes() {
-            return delegate.getExcludes();
-        }
-
-        @Override
-        public List<IvyArtifactName> getArtifacts() {
-            return delegate.getArtifacts();
-        }
-
-        @Override
-        public DependencyMetadata withTarget(ComponentSelector target) {
-            return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) delegate.withTarget(target));
-        }
-
-        @Override
-        public boolean isChanging() {
-            return delegate.isChanging();
-        }
-
-        @Override
-        public boolean isTransitive() {
-            return delegate.isTransitive();
-        }
-
-        @Override
-        public boolean isConstraint() {
-            return delegate.isConstraint();
-        }
-
-        @Override
-        public String getReason() {
-            return delegate.getReason();
-        }
-
-        @Override
-        public boolean isForce() {
-            return true;
-        }
-
-        @Override
-        public ForcingDependencyMetadata forced() {
-            return this;
-        }
     }
 
     private enum DependencyFilter {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.DependencyMetadata;
+import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.component.model.ForcingDependencyMetadata;
+import org.gradle.internal.component.model.IvyArtifactName;
+
+import java.util.List;
+
+public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {
+    private final ModuleDependencyMetadata delegate;
+
+    public ForcedDependencyMetadataWrapper(ModuleDependencyMetadata delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ModuleComponentSelector getSelector() {
+        return delegate.getSelector();
+    }
+
+    @Override
+    public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
+        return new ForcedDependencyMetadataWrapper(delegate.withRequestedVersion(requestedVersion));
+    }
+
+    @Override
+    public ModuleDependencyMetadata withReason(String reason) {
+        return new ForcedDependencyMetadataWrapper(delegate.withReason(reason));
+    }
+
+    @Override
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+    }
+
+    @Override
+    public List<ExcludeMetadata> getExcludes() {
+        return delegate.getExcludes();
+    }
+
+    @Override
+    public List<IvyArtifactName> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public DependencyMetadata withTarget(ComponentSelector target) {
+        return new ForcedDependencyMetadataWrapper((ModuleDependencyMetadata) delegate.withTarget(target));
+    }
+
+    @Override
+    public boolean isChanging() {
+        return delegate.isChanging();
+    }
+
+    @Override
+    public boolean isTransitive() {
+        return delegate.isTransitive();
+    }
+
+    @Override
+    public boolean isConstraint() {
+        return delegate.isConstraint();
+    }
+
+    @Override
+    public String getReason() {
+        return delegate.getReason();
+    }
+
+    @Override
+    public boolean isForce() {
+        return true;
+    }
+
+    @Override
+    public ForcingDependencyMetadata forced() {
+        return this;
+    }
+
+    public ModuleDependencyMetadata unwrap() {
+        return delegate;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
@@ -31,11 +31,21 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
     public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible,
                                          ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
                                          ImmutableList<ExcludeMetadata> excludes,
-                                         ImmutableAttributes componentLevelAttributes, ImmutableCapabilities capabilities) {
+                                         ImmutableAttributes componentLevelAttributes,
+                                         ImmutableCapabilities capabilities) {
         this(componentId, name, transitive, visible, hierarchy, artifacts, excludes, componentLevelAttributes, capabilities, null);
     }
 
-    public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts, ImmutableList<ExcludeMetadata> excludes, ImmutableAttributes attributes, ImmutableCapabilities capabilities, ImmutableList<ModuleDependencyMetadata> configDependencies) {
+    public RealisedConfigurationMetadata(ModuleComponentIdentifier componentId,
+                                         String name,
+                                         boolean transitive,
+                                         boolean visible,
+                                         ImmutableSet<String> hierarchy,
+                                         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         ImmutableList<ExcludeMetadata> excludes,
+                                         ImmutableAttributes attributes,
+                                         ImmutableCapabilities capabilities,
+                                         ImmutableList<ModuleDependencyMetadata> configDependencies) {
         super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependencies, capabilities);
     }
 
@@ -49,5 +59,20 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
         return new RealisedConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(),
             getHierarchy(), ImmutableList.copyOf(getArtifacts()), getExcludes(), attributes,
             ImmutableCapabilities.of(getCapabilities().getCapabilities()), getConfigDependencies());
+    }
+
+    public RealisedConfigurationMetadata withDependencies(ImmutableList<ModuleDependencyMetadata> dependencies) {
+        return new RealisedConfigurationMetadata(
+            getComponentId(),
+            getName(),
+            isTransitive(),
+            isVisible(),
+            getHierarchy(),
+            getArtifacts(),
+            getExcludes(),
+            getAttributes(),
+            ImmutableCapabilities.of(getCapabilities().getCapabilities()),
+            dependencies
+        );
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadata.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
-import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
@@ -30,6 +29,7 @@ import org.gradle.internal.component.external.descriptor.Artifact;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.ComponentVariant;
+import org.gradle.internal.component.external.model.ConfigurationBoundExternalDependencyMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.component.external.model.ImmutableCapabilities;
 import org.gradle.internal.component.external.model.LazyToRealisedModuleComponentResolveMetadataHelper;
@@ -38,15 +38,16 @@ import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.RealisedConfigurationMetadata;
 import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.model.ConfigurationMetadata;
+import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.Exclude;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ModuleSource;
-import org.gradle.util.CollectionUtils;
 
 import javax.annotation.Nullable;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * {@link AbstractRealisedModuleComponentResolveMetadata Realised version} of a {@link IvyModuleResolveMetadata}.
@@ -95,8 +96,8 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
     private final DefaultIvyModuleResolveMetadata metadata;
     private final String branch;
 
-    private RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, List<IvyDependencyDescriptor> dependencies) {
-        super(metadata);
+    private RealisedIvyModuleResolveMetadata(RealisedIvyModuleResolveMetadata metadata, List<IvyDependencyDescriptor> dependencies, Map<String, ConfigurationMetadata> transformedConfigurations) {
+        super(metadata, metadata.getVariants(), transformedConfigurations);
         this.configurationDefinitions = metadata.getConfigurationDefinitions();
         this.branch = metadata.getBranch();
         this.artifactDefinitions = metadata.getArtifactDefinitions();
@@ -117,8 +118,9 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
         this.metadata = metadata.metadata.withSource(source);
     }
 
-    RealisedIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants,
-                                            Map<String, ConfigurationMetadata> configurations) {
+    RealisedIvyModuleResolveMetadata(DefaultIvyModuleResolveMetadata metadata,
+                                     ImmutableList<? extends ComponentVariant> variants,
+                                     Map<String, ConfigurationMetadata> configurations) {
         super(metadata, variants, configurations);
         this.configurationDefinitions = metadata.getConfigurationDefinitions();
         this.branch = metadata.getBranch();
@@ -175,16 +177,18 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
 
     @Override
     public IvyModuleResolveMetadata withDynamicConstraintVersions() {
-        List<IvyDependencyDescriptor> transformed = CollectionUtils.collect(getDependencies(), new Transformer<IvyDependencyDescriptor, IvyDependencyDescriptor>() {
-            @Override
-            public IvyDependencyDescriptor transform(IvyDependencyDescriptor dependency) {
-                ModuleComponentSelector selector = dependency.getSelector();
-                String dynamicConstraintVersion = dependency.getDynamicConstraintVersion();
-                ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), dynamicConstraintVersion);
-                return dependency.withRequested(newSelector);
-            }
-        });
-        return this.withDependencies(transformed);
+        ImmutableList<IvyDependencyDescriptor> descriptors = getDependencies();
+        if (descriptors.isEmpty()) {
+            return this;
+        }
+        Map<IvyDependencyDescriptor, IvyDependencyDescriptor> transformedDescriptors = Maps.newHashMapWithExpectedSize(descriptors.size());
+        for (IvyDependencyDescriptor dependency : descriptors) {
+            ModuleComponentSelector selector = dependency.getSelector();
+            String dynamicConstraintVersion = dependency.getDynamicConstraintVersion();
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), dynamicConstraintVersion);
+            transformedDescriptors.put(dependency, dependency.withRequested(newSelector));
+        }
+        return this.withDependencies(transformedDescriptors);
     }
 
     @Override
@@ -192,8 +196,24 @@ public class RealisedIvyModuleResolveMetadata extends AbstractRealisedModuleComp
         return dependencies;
     }
 
-    private IvyModuleResolveMetadata withDependencies(List<IvyDependencyDescriptor> transformed) {
-        return new RealisedIvyModuleResolveMetadata(this, transformed);
+    private IvyModuleResolveMetadata withDependencies(Map<IvyDependencyDescriptor, IvyDependencyDescriptor> transformed) {
+        ImmutableList<IvyDependencyDescriptor> transformedDescriptors = ImmutableList.copyOf(transformed.values());
+        Set<String> configurationNames = getConfigurationNames();
+        Map<String, ConfigurationMetadata> transformedConfigurations = Maps.newHashMapWithExpectedSize(configurationNames.size());
+        for (String name : configurationNames) {
+            RealisedConfigurationMetadata configuration = (RealisedConfigurationMetadata) getConfiguration(name);
+            List<? extends DependencyMetadata> dependencies = configuration.getDependencies();
+            ImmutableList.Builder<ModuleDependencyMetadata> transformedConfigurationDependencies = ImmutableList.builder();
+            for (DependencyMetadata dependency : dependencies) {
+                if (dependency instanceof ConfigurationBoundExternalDependencyMetadata) {
+                    transformedConfigurationDependencies.add(((ConfigurationBoundExternalDependencyMetadata) dependency).withDescriptor(transformed.get(((ConfigurationBoundExternalDependencyMetadata) dependency).getDependencyDescriptor())));
+                } else {
+                    transformedConfigurationDependencies.add((ModuleDependencyMetadata) dependency);
+                }
+            }
+            transformedConfigurations.put(name, configuration.withDependencies(transformedConfigurationDependencies.build()));
+        }
+        return new RealisedIvyModuleResolveMetadata(this, transformedDescriptors, transformedConfigurations);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -256,10 +256,6 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
         return objectInstantiator;
     }
 
-    private boolean isJavaLibrary() {
-        return isKnownJarPackaging() || isPomPackaging();
-    }
-
     @Nullable
     public String getSnapshotTimestamp() {
         return snapshotTimestamp;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -108,7 +108,7 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
 
     @Override
     protected Optional<ImmutableList<? extends ConfigurationMetadata>> maybeDeriveVariants() {
-        return isJavaLibrary() ? Optional.<ImmutableList<? extends ConfigurationMetadata>>of(getDerivedVariants()) : Optional.<ImmutableList<? extends ConfigurationMetadata>>absent();
+        return Optional.<ImmutableList<? extends ConfigurationMetadata>>of(getDerivedVariants());
     }
 
     private ImmutableList<? extends ConfigurationMetadata> getDerivedVariants() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,10 +54,10 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.67'
-        cacheLayout.version == CacheVersion.parse("2.67")
-        cacheLayout.version.toString() == '2.67'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.67')
+        cacheLayout.key == 'metadata-2.68'
+        cacheLayout.version == CacheVersion.parse("2.68")
+        cacheLayout.version.toString() == '2.68'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.68')
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -179,7 +179,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
 
         where:
-        packaging << ["pom", "jar", "maven-plugin", "war"]
+        packaging << ["pom", "jar", "maven-plugin", "war", "aar"]
     }
 
     def dependency(String org, String module, String version, String scope) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -43,7 +43,8 @@ import static org.gradle.internal.component.external.model.DefaultModuleComponen
 
 class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentResolveMetadataTest {
 
-    private final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
+    private
+    final mavenMetadataFactory = new MavenMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), TestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())
 
     @Override
     ModuleComponentResolveMetadata createMetadata(ModuleComponentIdentifier id, List<Configuration> configurations, List dependencies) {
@@ -159,34 +160,26 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         assertHasOnlyStatusAttribute(compileConf.attributes)
         assertHasOnlyStatusAttribute(runtimeConf.attributes)
 
-        if (isJavaLibrary) {
-            assert variantsForGraphTraversal.size() == 6
-            assert variantsForGraphTraversal[0].name == "compile"
-            assert variantsForGraphTraversal[0].attributes.getAttribute(stringUsageAttribute) == "java-api"
-            assert variantsForGraphTraversal[1].name == "runtime"
-            assert variantsForGraphTraversal[1].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-            assert variantsForGraphTraversal[2].name == "platform-compile"
-            assert variantsForGraphTraversal[2].attributes.getAttribute(stringUsageAttribute) == "java-api"
-            assert variantsForGraphTraversal[2].attributes.getAttribute(componentTypeAttribute) == "platform"
-            assert variantsForGraphTraversal[3].name == "platform-runtime"
-            assert variantsForGraphTraversal[3].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-            assert variantsForGraphTraversal[3].attributes.getAttribute(componentTypeAttribute) == "platform"
-            assert variantsForGraphTraversal[4].name == "enforced-platform-compile"
-            assert variantsForGraphTraversal[4].attributes.getAttribute(stringUsageAttribute) == "java-api"
-            assert variantsForGraphTraversal[4].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
-            assert variantsForGraphTraversal[5].name == "enforced-platform-runtime"
-            assert variantsForGraphTraversal[5].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
-            assert variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
-        } else {
-            assert !variantsForGraphTraversal
-        }
+        variantsForGraphTraversal.size() == 6
+        variantsForGraphTraversal[0].name == "compile"
+        variantsForGraphTraversal[0].attributes.getAttribute(stringUsageAttribute) == "java-api"
+        variantsForGraphTraversal[1].name == "runtime"
+        variantsForGraphTraversal[1].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+        variantsForGraphTraversal[2].name == "platform-compile"
+        variantsForGraphTraversal[2].attributes.getAttribute(stringUsageAttribute) == "java-api"
+        variantsForGraphTraversal[2].attributes.getAttribute(componentTypeAttribute) == "platform"
+        variantsForGraphTraversal[3].name == "platform-runtime"
+        variantsForGraphTraversal[3].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+        variantsForGraphTraversal[3].attributes.getAttribute(componentTypeAttribute) == "platform"
+        variantsForGraphTraversal[4].name == "enforced-platform-compile"
+        variantsForGraphTraversal[4].attributes.getAttribute(stringUsageAttribute) == "java-api"
+        variantsForGraphTraversal[4].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
+        variantsForGraphTraversal[5].name == "enforced-platform-runtime"
+        variantsForGraphTraversal[5].attributes.getAttribute(stringUsageAttribute) == "java-runtime"
+        variantsForGraphTraversal[5].attributes.getAttribute(componentTypeAttribute) == "enforced-platform"
 
         where:
-        packaging      | isJavaLibrary
-        "pom"          | true
-        "jar"          | true
-        "maven-plugin" | true
-        "war"          | false
+        packaging << ["pom", "jar", "maven-plugin", "war"]
     }
 
     def dependency(String org, String module, String version, String scope) {


### PR DESCRIPTION
### Context

Before this change, we would only compute derived variants if the POM file is recognized as a "Java Library", which was effectively either a jar or a pom (and therefore BOMs too, which are effectively not libraries, but well...). This PR changes this so that we always derive variants.

This effectively removes one path in our codebase, legacy configuration matching isn't used anymore with Maven modules.

Fixes #6537 