### PR TITLE
Try to clarify danger of using `new File()`

### DIFF
--- a/subprojects/docs/src/docs/userguide/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_files.adoc
@@ -302,7 +302,7 @@ Relative paths are resolved relative to the project directory, while absolute pa
 
 [CAUTION]
 ====
-Never use `new File(relative path)`, as this creates a path relative to the current working directory, which could be anywhere.
+Never use `new File(relative path)` because this creates a path relative to the current working directory (CWD). Gradle can make no guarantees about the location of the CWD, which means builds that rely on it may break at any time.
 ====
 
 Here are some examples of using the `file()` method with different types of argument:
@@ -336,6 +336,11 @@ The recommended way to specify a collection of files is to use the link:{javadoc
 This method is very flexible and allows you to pass multiple strings, `File` instances, collections of strings, collections of ``File``s, and more.
 You can even pass in tasks as arguments if they have <<more_about_tasks.adoc#sec:task_inputs_outputs,defined outputs>>.
 Learn about all the supported argument types in the reference guide.
+
+[CAUTION]
+====
+Although the `files()` method accepts `File` instances, never use `new File(relative path)` with it because this creates a path relative to the current working directory (CWD). Gradle can make no guarantees about the location of the CWD, which means builds that rely on it may break at any time.
+====
 
 As with the link:{groovyDslPath}/org.gradle.api.Project.html#org.gradle.api.Project:file(java.lang.Object)[Project.file(java.lang.Object)] method covered in the <<#sec:single_file_paths,previous section>>, all relative paths are evaluated relative to the current project directory. The following example demonstrates some of the variety of argument types you can use — strings, `File` instances, a list and a `{javaApi}/java/nio/file/Path.html[Path]`:
 


### PR DESCRIPTION
I feel like ", which could be anywhere" is a little ambiguous and the caution
message doesn't properly explain why not to use `new File()`. I also added the
caution to the section on `files()` in case readers see that before the one on
single file paths.
