### PR TITLE
Fix unit tests that use Spock mocks/stubs/spies on JDK 11

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -155,7 +155,7 @@ fun Project.applyGroovyProjectConventions() {
     dependencies {
         compile(localGroovy())
         val spockGroovyVersion = groovy.lang.GroovySystem.getVersion().substring(0, 3)
-        testCompile("org.spockframework:spock-core:1.2-RC2-groovy-${spockGroovyVersion}") {
+        testCompile("org.spockframework:spock-core:1.2-RC3-groovy-${spockGroovyVersion}") {
             exclude(group = "org.codehaus.groovy")
         }
         testCompile("cglib:cglib:3.2.7")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -158,8 +158,8 @@ fun Project.applyGroovyProjectConventions() {
         testCompile("org.spockframework:spock-core:1.2-RC3-groovy-${spockGroovyVersion}") {
             exclude(group = "org.codehaus.groovy")
         }
-        testCompile("cglib:cglib:3.2.7")
-        testCompile("org.objenesis:objenesis:2.4")
+        testCompile("net.bytebuddy:byte-buddy:1.8.21")
+        testCompile("org.objenesis:objenesis:2.6")
     }
 
     tasks.withType<GroovyCompile>().configureEach {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -155,7 +155,7 @@ fun Project.applyGroovyProjectConventions() {
     dependencies {
         compile(localGroovy())
         val spockGroovyVersion = groovy.lang.GroovySystem.getVersion().substring(0, 3)
-        testCompile("org.spockframework:spock-core:1.2-RC3-groovy-${spockGroovyVersion}") {
+        testCompile("org.spockframework:spock-core:1.2-groovy-${spockGroovyVersion}") {
             exclude(group = "org.codehaus.groovy")
         }
         testCompile("net.bytebuddy:byte-buddy:1.8.21")

--- a/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
+++ b/buildSrc/subprojects/integration-testing/src/main/kotlin/org/gradle/gradlebuild/test/fixtures/TestFixturesPlugin.kt
@@ -123,10 +123,12 @@ open class TestFixturesPlugin : Plugin<Project> {
 
         dependencies {
             val testFixturesApi by configurations
+            val testFixturesRuntimeOnly by configurations
 
             testFixturesApi(project(path))
             testFixturesApi(library("junit"))
             testFixturesApi(testLibrary("spock"))
+            testFixturesRuntimeOnly(testLibrary("bytebuddy"))
             testLibraries("jmock").forEach { testFixturesApi(it) }
         }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -122,9 +122,11 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
     fun Project.addDependencies() {
         dependencies {
             val testCompile = configurations.getByName("testCompile")
+            val testRuntime = configurations.getByName("testRuntime")
             testCompile(library("junit"))
             testCompile(library("groovy"))
             testCompile(testLibrary("spock"))
+            testRuntime(testLibrary("bytebuddy"))
             testLibraries("jmock").forEach { testCompile(it) }
         }
     }

--- a/gradle/testDependencies.gradle
+++ b/gradle/testDependencies.gradle
@@ -18,7 +18,7 @@ ext {
 }
 
 // Test classpath libraries
-testLibraries.spock =   'org.spockframework:spock-core:1.2-RC3-groovy-2.5'
+testLibraries.spock =   'org.spockframework:spock-core:1.2-groovy-2.5'
 testLibraries.bytebuddy = 'net.bytebuddy:byte-buddy:1.8.21'
 testLibraries.jsoup =   'org.jsoup:jsoup:1.11.3'
 testLibraries.xmlunit = 'xmlunit:xmlunit:1.6'

--- a/gradle/testDependencies.gradle
+++ b/gradle/testDependencies.gradle
@@ -19,6 +19,7 @@ ext {
 
 // Test classpath libraries
 testLibraries.spock =   'org.spockframework:spock-core:1.2-RC3-groovy-2.5'
+testLibraries.bytebuddy = 'net.bytebuddy:byte-buddy:1.8.21'
 testLibraries.jsoup =   'org.jsoup:jsoup:1.11.3'
 testLibraries.xmlunit = 'xmlunit:xmlunit:1.6'
 testLibraries.jetty =   'org.mortbay.jetty:jetty:6.1.26'

--- a/gradle/testDependencies.gradle
+++ b/gradle/testDependencies.gradle
@@ -18,7 +18,7 @@ ext {
 }
 
 // Test classpath libraries
-testLibraries.spock =   'org.spockframework:spock-core:1.2-RC2-groovy-2.5'
+testLibraries.spock =   'org.spockframework:spock-core:1.2-RC3-groovy-2.5'
 testLibraries.jsoup =   'org.jsoup:jsoup:1.11.3'
 testLibraries.xmlunit = 'xmlunit:xmlunit:1.6'
 testLibraries.jetty =   'org.mortbay.jetty:jetty:6.1.26'

--- a/subprojects/internal-testing/internal-testing.gradle.kts
+++ b/subprojects/internal-testing/internal-testing.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     compile(library("junit"))
     testLibraries("jmock").forEach { compile(it) }
     compile(testLibrary("spock"))
+    runtime(testLibrary("bytebuddy"))
     compile(testLibrary("jsoup"))
 }
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
@@ -67,7 +67,7 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
     static String spockDependency() {
         """
             dependencies {
-                testCompile('org.spockframework:spock-core:1.2-RC3-groovy-2.5') {
+                testCompile('org.spockframework:spock-core:1.2-groovy-2.5') {
                     exclude module: 'groovy-all'
                 }
             }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/BaseGradleImplDepsIntegrationTest.groovy
@@ -67,7 +67,7 @@ abstract class BaseGradleImplDepsIntegrationTest extends AbstractIntegrationSpec
     static String spockDependency() {
         """
             dependencies {
-                testCompile('org.spockframework:spock-core:1.2-RC2-groovy-2.5') {
+                testCompile('org.spockframework:spock-core:1.2-RC3-groovy-2.5') {
                     exclude module: 'groovy-all'
                 }
             }


### PR DESCRIPTION
Spock 1.2-RC3 now supports JDK 11 when used with Byte Buddy.