### PR TITLE
Use json instead of xml in distributed performance test

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/JUnitXmlTestEventsGenerator.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.testing
 
-import groovy.util.slurpersupport.NodeChildren
 import org.gradle.api.internal.tasks.testing.DecoratingTestDescriptor
 import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor
 import org.gradle.api.internal.tasks.testing.DefaultTestMethodDescriptor
@@ -55,7 +54,7 @@ class JUnitXmlTestEventsGenerator {
     }
 
     @CompileStatic
-    void processTestSuite(JUnitTestSuite testSuite, Object build) {
+    void processTestSuite(JUnitTestSuite testSuite, Map buildResult) {
         String suiteName = testSuite.name
         DecoratingTestDescriptor testSuiteDescriptor = new DecoratingTestDescriptor(new DefaultTestClassDescriptor(0, suiteName), createWorkerSuite())
         testListener.beforeSuite(testSuiteDescriptor.parent.parent)
@@ -72,7 +71,7 @@ class JUnitXmlTestEventsGenerator {
 
             if (failures && failures.size() > 0) {
                 testListener.beforeTest(testCaseDescriptor)
-                publishAdditionalMetadata(testCaseDescriptor, build)
+                publishAdditionalMetadata(testCaseDescriptor, buildResult)
                 try {
                     String systemErr = testSuite.systemErr
                     if (systemErr) {
@@ -86,7 +85,7 @@ class JUnitXmlTestEventsGenerator {
                 testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.FAILURE, startTime, endTime, 1, 0, 1, [assertionError(failureText) as Throwable]))
             } else if (notSkipped(testCase)) {
                 testListener.beforeTest(testCaseDescriptor)
-                publishAdditionalMetadata(testCaseDescriptor, build)
+                publishAdditionalMetadata(testCaseDescriptor, buildResult)
                 testListener.afterTest(testCaseDescriptor, new DefaultTestResult(TestResult.ResultType.SUCCESS, startTime, endTime, 1, 1, 0, []))
             }
         }
@@ -104,25 +103,24 @@ class JUnitXmlTestEventsGenerator {
         return testCase.skipped == null
     }
 
-    private void publishAdditionalMetadata(DecoratingTestDescriptor testCaseDescriptor, Object build) {
+    private void publishAdditionalMetadata(DecoratingTestDescriptor testCaseDescriptor, Map buildResult) {
         List<String> outputs = []
-        def scenarioId = getScenarioId(build)
+        def scenarioId = getScenarioId(buildResult)
         outputs.add("Scenario: ${scenarioId}")
         if (coordinatorBuild) {
             outputs.add("Performance report: " +
                 "https://builds.gradle.org/repository/download/${coordinatorBuild.buildTypeId}/${coordinatorBuild.id}:id/results/performance/build/performance-tests/" +
                 "report/tests/${scenarioId.replaceAll(" ", "-")}.html")
         }
-        def buildUrl = build.@webUrl
+        def buildUrl = buildResult.webUrl
         if (buildUrl) {
             outputs.add("Worker build url: ${buildUrl}")
         }
         testOutputListener.onOutput(testCaseDescriptor, new DefaultTestOutputEvent(TestOutputEvent.Destination.StdOut, outputs.join("\n")))
     }
 
-    private String getScenarioId(Object build) {
-        NodeChildren properties = build.properties.children()
-        properties.find { it.@name == 'scenario' }.@value.text()
+    private String getScenarioId(Map buildResult) {
+        return buildResult.properties.property.find { it.name == 'scenario'} .value
     }
 
     /**

--- a/buildSrc/subprojects/performance/src/test/groovy/org/gradle/testing/JUnitXmlTestEventsGeneratorTest.groovy
+++ b/buildSrc/subprojects/performance/src/test/groovy/org/gradle/testing/JUnitXmlTestEventsGeneratorTest.groovy
@@ -62,7 +62,15 @@ class JUnitXmlTestEventsGeneratorTest extends Specification {
         TestOutputListener testOutputListener = Mock()
         TestDescriptorInternal testDescriptor = null
         TestResult testResult = null
-        Object build = new XmlSlurper().parseText("""<build webUrl="http://some.url"><properties><property name="scenario" value="configuration of ktsManyProjects (--recompile-scripts)" inherited="false"/></properties></build>""")
+        Map build = [
+            webUrl: "http://some.url",
+            properties: [
+                count: 1,
+                property: [[name: 'scenario',
+                           value: 'configuration of ktsManyProjects (--recompile-scripts)',
+                           inherited: 'false']]
+            ]
+        ]
 
         when:
         new JUnitXmlTestEventsGenerator(testListenerBroadcast, testOutputListenerBroadcast).processTestSuite(testSuite, build)


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/1359 .

Also partially fixes https://github.com/gradle/gradle-private/issues/1422 because of adding catch blocks to http operations.