### PR TITLE
Shorten subproject names better

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -217,12 +217,26 @@ data class Stage(val stageName: StageName, val specificBuilds: List<SpecificBuil
 
 data class TestCoverage(val testType: TestType, val os: OS, val testJvmVersion: JvmVersion, val vendor: JvmVendor = JvmVendor.oracle, val buildJvmVersion: JvmVersion = JvmVersion.java9) {
     fun asId(model : CIBuildModel): String {
-        return "${model.projectPrefix}${testType.name.capitalize()}_${testJvmVersion.name.capitalize()}_${vendor.name.capitalize()}_${os.name.capitalize()}"
+        return "${model.projectPrefix}$testCoveragePrefix"
     }
 
+    private
+    val testCoveragePrefix
+        get() = "${testType.name.capitalize()}_${testJvmVersion.name.capitalize()}_${vendor.name.capitalize()}_${os.name.capitalize()}"
+
     fun asConfigurationId(model : CIBuildModel, subproject: String = ""): String {
-        val shortenedSubprojectName = subproject.replace("internal", "i").replace("Testing", "T")
-        return asId(model) + "_" + if (!subproject.isEmpty()) shortenedSubprojectName else "0"
+        val prefix = "${testCoveragePrefix}_"
+        val shortenedSubprojectName = shortenSubprojectName(model.projectPrefix, prefix + subproject)
+        return "${model.projectPrefix}" + if (!subproject.isEmpty()) shortenedSubprojectName else "0"
+    }
+
+    private
+    fun shortenSubprojectName(prefix: String, subprojectName: String): String {
+        val shortenedSubprojectName = subprojectName.replace("internal", "i").replace("Testing", "T")
+        if (shortenedSubprojectName.length + prefix.length <= 80) {
+            return shortenedSubprojectName
+        }
+        return shortenedSubprojectName.replace(Regex("[aeiou]"), "")
     }
 
     fun asName(): String {

--- a/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
+++ b/.teamcityTest/Gradle_Check_Tests/CIConfigIntegrationTests.kt
@@ -3,6 +3,7 @@ import configurations.shouldBeSkipped
 import jetbrains.buildServer.configs.kotlin.v2018_1.Project
 import model.CIBuildModel
 import model.GradleSubproject
+import model.JvmVendor
 import model.JvmVersion
 import model.NoBuildCache
 import model.OS
@@ -231,6 +232,17 @@ class CIConfigIntegrationTests {
         projectFoldersWithFunctionalTests.forEach {
             assertFalse(containsSrcFileWithString(File(it, "src/integTest"), "CrossVersion", listOf("package org.gradle.testkit" ,"CrossVersionPerformanceTest")))
         }
+    }
+
+    @Test
+    fun long_ids_are_shortened() {
+        val shortenedId = TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java11, JvmVendor.oracle).asConfigurationId(CIBuildModel(), "veryLongSubprojectNameLongerThanEverythingWeHave")
+        assertTrue(shortenedId.length < 80)
+        assertEquals(shortenedId, "Gradle_Check_QckFdbckCrssVrsn_Jv11_Orcl_Wndws_vryLngSbprjctNmLngrThnEvrythngWHv")
+
+        assertEquals(TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java11, JvmVendor.oracle).asConfigurationId(CIBuildModel(), "internalIntegTesting"), "Gradle_Check_QuickFeedbackCrossVersion_Java11_Oracle_Windows_iIntegT")
+
+        assertEquals(TestCoverage(TestType.quickFeedbackCrossVersion, OS.windows, JvmVersion.java11, JvmVendor.oracle).asConfigurationId(CIBuildModel(), "buildCache"), "Gradle_Check_QuickFeedbackCrossVersion_Java11_Oracle_Windows_buildCache")
     }
 
     private fun containsSrcFileWithString(srcRoot: File, content: String, exceptions: List<String>): Boolean {


### PR DESCRIPTION
Ids in Teamcity are allowed to have at most 80 characters.