### PR TITLE
Clean up project locking service and add convenience methods

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/Factories.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Factories.java
@@ -15,7 +15,9 @@
  */
 package org.gradle.internal;
 
+import javax.annotation.Nullable;
 import java.lang.ref.SoftReference;
+import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class Factories {
@@ -24,6 +26,20 @@ public abstract class Factories {
             public T create() {
                 runnable.run();
                 return null;
+            }
+        };
+    }
+
+    public static <T> Factory<T> toFactory(final Callable<T> callable) {
+        return new Factory<T>() {
+            @Nullable
+            @Override
+            public T create() {
+                try {
+                    return callable.call();
+                } catch (Exception e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
             }
         };
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Factories.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Factories.java
@@ -15,9 +15,7 @@
  */
 package org.gradle.internal;
 
-import javax.annotation.Nullable;
 import java.lang.ref.SoftReference;
-import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 
 public abstract class Factories {
@@ -26,20 +24,6 @@ public abstract class Factories {
             public T create() {
                 runnable.run();
                 return null;
-            }
-        };
-    }
-
-    public static <T> Factory<T> toFactory(final Callable<T> callable) {
-        return new Factory<T>() {
-            @Nullable
-            @Override
-            public T create() {
-                try {
-                    return callable.call();
-                } catch (Exception e) {
-                    throw UncheckedException.throwAsUncheckedException(e);
-                }
             }
         };
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/DefaultBuildOperationQueue.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.operations;
 
+import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.work.WorkerLeaseRegistry;
 import org.gradle.internal.work.WorkerLeaseService;
@@ -24,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedList;
-import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -200,9 +200,9 @@ class DefaultBuildOperationQueue<T extends BuildOperation> implements BuildOpera
             // condition where the pending count is 0, but a child worker lease is still held when
             // the parent lease is released.
             completeOperations(
-                workerLeases.withLocks(Collections.singleton(parentWorkerLease.createChild()), new Callable<Integer>() {
+                workerLeases.withLocks(Collections.singleton(parentWorkerLease.createChild()), new Factory<Integer>() {
                     @Override
-                    public Integer call() throws Exception {
+                    public Integer create() {
                         int operationCount = 0;
                         T operation = firstOperation;
                         while (operation != null) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ProjectLeaseRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ProjectLeaseRegistry.java
@@ -16,17 +16,20 @@
 
 package org.gradle.internal.resources;
 
+import org.gradle.util.Path;
+
+import java.util.Collection;
 import java.util.concurrent.Callable;
 
 public interface ProjectLeaseRegistry {
     /**
      * Get a lock for the specified project.
      *
-     * @param gradlePath
-     * @param projectPath
+     * @param buildIdentityPath
+     * @param projectIdentityPath
      * @return the requested {@link ResourceLock}
      */
-    ResourceLock getProjectLock(String gradlePath, String projectPath);
+    ResourceLock getProjectLock(Path buildIdentityPath, Path projectIdentityPath);
 
     /**
      * Releases all project locks held by the current thread and executes the {@link Callable}.  Upon completion of the
@@ -43,4 +46,9 @@ public interface ProjectLeaseRegistry {
      * lock, all worker leases held by the thread will be released and reacquired once the project lock is obtained.
      */
     void withoutProjectLock(Runnable action);
+
+    /**
+     * Returns any projects locks currently held by this thread.
+     */
+    Collection<? extends ResourceLock> getCurrentProjectLocks();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/resources/ProjectLeaseRegistry.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/resources/ProjectLeaseRegistry.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.resources;
 
+import org.gradle.internal.Factory;
 import org.gradle.util.Path;
 
 import java.util.Collection;
@@ -33,11 +34,11 @@ public interface ProjectLeaseRegistry {
 
     /**
      * Releases all project locks held by the current thread and executes the {@link Callable}.  Upon completion of the
-     * {@link Callable}, if a lock was held at the time the method was called, then it will be reacquired.  If no locks were held at the
+     * {@link Factory}, if a lock was held at the time the method was called, then it will be reacquired.  If no locks were held at the
      * time the method was called, then no attempt will be made to reacquire a lock on completion.  While blocking to reacquire the project
      * lock, all worker leases held by the thread will be released and reacquired once the project lock is obtained.
      */
-    <T> T withoutProjectLock(Callable<T> action);
+    <T> T withoutProjectLock(Factory<T> action);
 
     /**
      * Releases all project locks held by the current thread and executes the {@link Runnable}.  Upon completion of the

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -23,6 +23,8 @@ import org.gradle.api.Describable;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
 import org.gradle.concurrent.ParallelismConfiguration;
+import org.gradle.internal.Factories;
+import org.gradle.internal.Factory;
 import org.gradle.internal.MutableBoolean;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.concurrent.ParallelismConfigurationListener;
@@ -35,10 +37,12 @@ import org.gradle.internal.resources.ResourceLock;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.resources.ResourceLockState;
 import org.gradle.util.CollectionUtils;
+import org.gradle.util.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 
@@ -108,7 +112,7 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
         try {
             action.run();
         } finally {
-            workerLeaseLockRegistry.unassociatResourceLock(sharedLease);
+            workerLeaseLockRegistry.unassociateResourceLock(sharedLease);
             coordinationService.notifyStateChange();
         }
     }
@@ -131,8 +135,13 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     }
 
     @Override
-    public ResourceLock getProjectLock(String gradlePath, String projectPath) {
-        return projectLockRegistry.getResourceLock(gradlePath, projectPath);
+    public ResourceLock getProjectLock(Path buildIdentityPath, Path projectIdentityPath) {
+        return projectLockRegistry.getResourceLock(buildIdentityPath, projectIdentityPath);
+    }
+
+    @Override
+    public Collection<? extends ResourceLock> getCurrentProjectLocks() {
+        return projectLockRegistry.getResourceLocksByCurrentThread();
     }
 
     @Override
@@ -148,54 +157,69 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     }
 
     @Override
-    public <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
-        coordinationService.withStateLock(lock(locks));
-        try {
-            return action.call();
-        } catch (Exception e) {
-            throw UncheckedException.throwAsUncheckedException(e);
-        } finally {
-            coordinationService.withStateLock(unlock(locks));
-        }
+    public <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> callable) {
+        return withLocks(locks, Factories.toFactory(callable));
     }
 
     @Override
-    public void withLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
-        coordinationService.withStateLock(lock(locks));
-        try {
-            action.run();
-        } finally {
-            coordinationService.withStateLock(unlock(locks));
-        }
+    public void withLocks(Iterable<? extends ResourceLock> locks, Runnable runnable) {
+        withLocks(locks, Factories.toFactory(runnable));
     }
 
     @Override
-    public <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
-        if (!allLockedByCurrentThread(locks)) {
-            throw new IllegalStateException("Not all of the locks specified are currently held by the current thread.  This could lead to orphaned locks.");
+    public <T> T withLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
+        Iterable<? extends ResourceLock> locksToAcquire = locksNotHeld(locks);
+        if (!Iterables.isEmpty(locksToAcquire)) {
+            coordinationService.withStateLock(lock(locksToAcquire));
         }
-
-        coordinationService.withStateLock(unlock(locks));
         try {
-            return action.call();
-        } catch (Exception e) {
-            throw UncheckedException.throwAsUncheckedException(e);
+            return factory.create();
         } finally {
-            if (!coordinationService.withStateLock(tryLock(locks))) {
-                releaseWorkerLeaseAndWaitFor(locks);
+            if (!Iterables.isEmpty(locksToAcquire)) {
+                coordinationService.withStateLock(unlock(locksToAcquire));
             }
         }
     }
 
+    private Iterable<? extends ResourceLock> locksNotHeld(final Iterable<? extends ResourceLock> locks) {
+        final List<ResourceLock> locksNotHeld = Lists.newArrayList(locks);
+        coordinationService.withStateLock(new Transformer<ResourceLockState.Disposition, ResourceLockState>() {
+            @Override
+            public ResourceLockState.Disposition transform(ResourceLockState resourceLockState) {
+                Iterator<ResourceLock> iterator = locksNotHeld.iterator();
+                while (iterator.hasNext()) {
+                    ResourceLock lock = iterator.next();
+                    if (lock.isLockedByCurrentThread()) {
+                        iterator.remove();
+                    }
+                }
+                return FINISHED;
+            }
+        });
+        return locksNotHeld;
+    }
+
     @Override
-    public void withoutLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
+    public <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> callable) {
+        return withoutLocks(locks, Factories.toFactory(callable));
+    }
+
+    @Override
+    public void withoutLocks(Iterable<? extends ResourceLock> locks, Runnable runnable) {
+        withoutLocks(locks, Factories.toFactory(runnable));
+    }
+
+    @Override
+    public <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
         if (!allLockedByCurrentThread(locks)) {
             throw new IllegalStateException("Not all of the locks specified are currently held by the current thread.  This could lead to orphaned locks.");
         }
 
         coordinationService.withStateLock(unlock(locks));
         try {
-            action.run();
+            return factory.create();
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
         } finally {
             if (!coordinationService.withStateLock(tryLock(locks))) {
                 releaseWorkerLeaseAndWaitFor(locks);
@@ -229,10 +253,10 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
         return allLocked.get();
     }
 
-    private static class ProjectLockRegistry extends AbstractResourceLockRegistry<ExclusiveAccessResourceLock> {
+    private static class ProjectLockRegistry extends AbstractResourceLockRegistry<Path, ExclusiveAccessResourceLock> {
         private volatile boolean parallelEnabled;
 
-        ProjectLockRegistry(ResourceLockCoordinationService coordinationService, boolean parallelEnabled) {
+        public ProjectLockRegistry(ResourceLockCoordinationService coordinationService, boolean parallelEnabled) {
             super(coordinationService);
             this.parallelEnabled = parallelEnabled;
         }
@@ -241,29 +265,28 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
             this.parallelEnabled = parallelEnabled;
         }
 
-        ResourceLock getResourceLock(String gradlePath, String projectPath) {
-            String displayName = projectPath;
-            if (!parallelEnabled) {
-                displayName = gradlePath;
-            }
+        ResourceLock getResourceLock(Path buildIdentityPath, Path projectIdentityPath) {
+            return getResourceLock(parallelEnabled ? projectIdentityPath : buildIdentityPath);
+        }
 
-            return getOrRegisterResourceLock(displayName, new ResourceLockProducer<ExclusiveAccessResourceLock>() {
+        ResourceLock getResourceLock(final Path lockPath) {
+            return getOrRegisterResourceLock(lockPath, new ResourceLockProducer<Path, ExclusiveAccessResourceLock>() {
                 @Override
-                public ExclusiveAccessResourceLock create(String displayName, ResourceLockCoordinationService coordinationService, Action<ResourceLock> lockAction, Action<ResourceLock> unlockAction) {
-                    return new ExclusiveAccessResourceLock(displayName, coordinationService, lockAction, unlockAction);
+                public ExclusiveAccessResourceLock create(Path projectPath, ResourceLockCoordinationService coordinationService, Action<ResourceLock> lockAction, Action<ResourceLock> unlockAction) {
+                    return new ExclusiveAccessResourceLock(lockPath.getPath(), coordinationService, lockAction, unlockAction);
                 }
             });
         }
     }
 
-    private class WorkerLeaseLockRegistry extends AbstractResourceLockRegistry<DefaultWorkerLease> {
+    private class WorkerLeaseLockRegistry extends AbstractResourceLockRegistry<String, DefaultWorkerLease> {
         WorkerLeaseLockRegistry(ResourceLockCoordinationService coordinationService) {
             super(coordinationService);
         }
 
         DefaultWorkerLease getResourceLock(final LeaseHolder parent, int workerId, final Thread ownerThread) {
             String displayName = parent.getDisplayName() + '.' + workerId;
-            return getOrRegisterResourceLock(displayName, new ResourceLockProducer<DefaultWorkerLease>() {
+            return getOrRegisterResourceLock(displayName, new ResourceLockProducer<String, DefaultWorkerLease>() {
                 @Override
                 public DefaultWorkerLease create(String displayName, ResourceLockCoordinationService coordinationService, Action<ResourceLock> lockAction, Action<ResourceLock> unlockAction) {
                     return new DefaultWorkerLease(displayName, coordinationService, lockAction, unlockAction, parent, ownerThread);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/StopShieldingWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/StopShieldingWorkerLeaseService.java
@@ -16,8 +16,11 @@
 
 package org.gradle.internal.work;
 
+import org.gradle.internal.Factory;
 import org.gradle.internal.resources.ResourceLock;
+import org.gradle.util.Path;
 
+import java.util.Collection;
 import java.util.concurrent.Callable;
 
 public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
@@ -39,6 +42,11 @@ public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
+    public <T> T withLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
+        return delegate.withLocks(locks, factory);
+    }
+
+    @Override
     public void withLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
         delegate.withLocks(locks, action);
     }
@@ -46,6 +54,11 @@ public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
     @Override
     public <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
         return delegate.withoutLocks(locks, action);
+    }
+
+    @Override
+    public <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
+        return delegate.withoutLocks(locks, factory);
     }
 
     @Override
@@ -69,8 +82,13 @@ public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    public ResourceLock getProjectLock(String gradlePath, String projectPath) {
-        return delegate.getProjectLock(gradlePath, projectPath);
+    public ResourceLock getProjectLock(Path buildIdentityPath, Path projectPath) {
+        return delegate.getProjectLock(buildIdentityPath, projectPath);
+    }
+
+    @Override
+    public Collection<? extends ResourceLock> getCurrentProjectLocks() {
+        return delegate.getCurrentProjectLocks();
     }
 
     @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/StopShieldingWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/StopShieldingWorkerLeaseService.java
@@ -21,7 +21,6 @@ import org.gradle.internal.resources.ResourceLock;
 import org.gradle.util.Path;
 
 import java.util.Collection;
-import java.util.concurrent.Callable;
 
 public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
 
@@ -37,11 +36,6 @@ public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    public <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
-        return delegate.withLocks(locks, action);
-    }
-
-    @Override
     public <T> T withLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
         return delegate.withLocks(locks, factory);
     }
@@ -49,11 +43,6 @@ public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
     @Override
     public void withLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
         delegate.withLocks(locks, action);
-    }
-
-    @Override
-    public <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
-        return delegate.withoutLocks(locks, action);
     }
 
     @Override
@@ -92,8 +81,8 @@ public class StopShieldingWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    public <T> T withoutProjectLock(Callable<T> action) {
-        return delegate.withoutProjectLock(action);
+    public <T> T withoutProjectLock(Factory<T> factory) {
+        return delegate.withoutProjectLock(factory);
     }
 
     @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.work;
 
+import org.gradle.internal.Factory;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLock;
@@ -32,25 +33,38 @@ public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseReg
      * Runs a given {@link Callable} while the specified locks are being held, releasing
      * the locks upon completion.  Blocks until the specified locks can be obtained.
      */
-    <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> action);
+    <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> callable);
+
+    /**
+     * Runs a given {@link Factory} while the specified locks are being held, releasing
+     * the locks upon completion.  Blocks until the specified locks can be obtained.
+     */
+    <T> T withLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory);
 
     /**
      * Runs a given {@link Runnable} while the specified locks are being held, releasing
      * the locks upon completion.  Blocks until the specified locks can be obtained.
      */
-    void withLocks(Iterable<? extends ResourceLock> locks, Runnable action);
+    void withLocks(Iterable<? extends ResourceLock> locks, Runnable runnable);
 
     /**
      * Runs a given {@link Callable} while the specified locks are released and then reacquire the locks
      * upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
      * and the method will block until the locks are reacquired.
      */
-    <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action);
+    <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> callable);
+
+    /**
+     * Runs a given {@link Factory} while the specified locks are released and then reacquire the locks
+     * upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
+     * and the method will block until the locks are reacquired.
+     */
+    <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory);
 
     /**
      * Runs a given {@link Runnable} while the specified locks are released and then reacquire the locks
      * upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
      * and the method will block until the locks are reacquired.
      */
-    void withoutLocks(Iterable<? extends ResourceLock> locks, Runnable action);
+    void withoutLocks(Iterable<? extends ResourceLock> locks, Runnable runnable);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/WorkerLeaseService.java
@@ -21,19 +21,11 @@ import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.resources.ProjectLeaseRegistry;
 import org.gradle.internal.resources.ResourceLock;
 
-import java.util.concurrent.Callable;
-
 public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseRegistry, Stoppable {
     /**
      * Returns the maximum number of worker leases that this service will grant at any given time. Note that the actual limit may vary over time but will never _exceed_ the value returned by this method.
      */
     int getMaxWorkerCount();
-
-    /**
-     * Runs a given {@link Callable} while the specified locks are being held, releasing
-     * the locks upon completion.  Blocks until the specified locks can be obtained.
-     */
-    <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> callable);
 
     /**
      * Runs a given {@link Factory} while the specified locks are being held, releasing
@@ -46,13 +38,6 @@ public interface WorkerLeaseService extends WorkerLeaseRegistry, ProjectLeaseReg
      * the locks upon completion.  Blocks until the specified locks can be obtained.
      */
     void withLocks(Iterable<? extends ResourceLock> locks, Runnable runnable);
-
-    /**
-     * Runs a given {@link Callable} while the specified locks are released and then reacquire the locks
-     * upon completion.  If the locks cannot be immediately reacquired, the current worker lease will be released
-     * and the method will block until the locks are reacquired.
-     */
-    <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> callable);
 
     /**
      * Runs a given {@link Factory} while the specified locks are released and then reacquire the locks

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/AbstractResourceLockRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/resources/AbstractResourceLockRegistryTest.groovy
@@ -70,13 +70,13 @@ class AbstractResourceLockRegistryTest extends Specification {
         thread.join()
     }
 
-    static class TestRegistry extends AbstractResourceLockRegistry {
+    static class TestRegistry extends AbstractResourceLockRegistry<String, ResourceLock> {
         TestRegistry(ResourceLockCoordinationService coordinationService) {
             super(coordinationService)
         }
 
         def getResourceLock(String displayName) {
-            return getOrRegisterResourceLock(displayName, new AbstractResourceLockRegistry.ResourceLockProducer() {
+            return getOrRegisterResourceLock(displayName, new AbstractResourceLockRegistry.ResourceLockProducer<String, ResourceLock>() {
                 @Override
                 ResourceLock create(String name, ResourceLockCoordinationService coordinationService, Action<ResourceLock> lockAction, Action<ResourceLock> unlockAction) {
                     return new TestTrackedResourceLock(name, coordinationService, lockAction, unlockAction)

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceProjectLockTest.groovy
@@ -31,13 +31,14 @@ import java.util.concurrent.locks.ReentrantLock
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.lock
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.tryLock
 import static org.gradle.internal.resources.DefaultResourceLockCoordinationService.unlock
+import static org.gradle.util.Path.path
 
 class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
-    def coordinationService = new DefaultResourceLockCoordinationService();
+    def coordinationService = new DefaultResourceLockCoordinationService()
     def workerLeaseService = new DefaultWorkerLeaseService(coordinationService, parallel())
 
     def "can cleanly lock and unlock a project"() {
-        def projectLock = workerLeaseService.getProjectLock("root", ":project")
+        def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
 
         given:
         assert !lockIsHeld(projectLock)
@@ -61,7 +62,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                 start {
                     started.countDown()
                     thread.blockUntil.releaseAll
-                    def projectLock = workerLeaseService.getProjectLock("root", ":project")
+                    def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
                     workerLeaseService.withLocks([projectLock]) {
                         assert lockIsHeld(projectLock)
                     }
@@ -86,7 +87,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                     started.countDown()
                     thread.blockUntil.releaseAll
                     while (true) {
-                        def projectLock = workerLeaseService.getProjectLock("root", ":project")
+                        def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
                         boolean success = coordinationService.withStateLock(tryLock(projectLock))
                         try {
                             if (success) {
@@ -117,7 +118,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
         async {
             threadCount.times { i ->
                 start {
-                    def projectLock = workerLeaseService.getProjectLock("root", ":project${i}")
+                    def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project${i}"))
                     workerLeaseService.withLocks([projectLock]) {
                         started.countDown()
                         thread.blockUntil.releaseAll
@@ -145,7 +146,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                 start {
                     started.countDown()
                     thread.blockUntil.releaseAll
-                    def projectLock = projectLockService.getProjectLock("root", ":project${i}")
+                    def projectLock = projectLockService.getProjectLock(path("root"), path(":project${i}"))
                     workerLeaseService.withLocks([projectLock]) {
                         assert testLock.tryLock()
                         try {
@@ -179,7 +180,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
                     started.countDown()
                     thread.blockUntil.releaseAll
                     def buildIndex = i % buildCount
-                    def projectLock = projectLockService.getProjectLock("build${buildIndex}", ":project${i}")
+                    def projectLock = projectLockService.getProjectLock(path("build${buildIndex}"), path(":project${i}"))
                     workerLeaseService.withLocks([projectLock]) {
                         assert testLock[buildIndex].tryLock()
                         try {
@@ -200,7 +201,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
 
     def "can use withoutProjectLock to temporarily release a lock"() {
         boolean executed = false
-        def projectLock = workerLeaseService.getProjectLock("root", ":project")
+        def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
 
         given:
         assert !lockIsHeld(projectLock)
@@ -222,8 +223,8 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
 
     def "can use withoutProjectLock to temporarily release multiple locks"() {
         boolean executed = false
-        def projectLock = workerLeaseService.getProjectLock("root", ":project")
-        def otherProjectLock = workerLeaseService.getProjectLock("root", ":otherProject")
+        def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
+        def otherProjectLock = workerLeaseService.getProjectLock(path("root"), path(":otherProject"))
 
         given:
         assert !lockIsHeld(projectLock)
@@ -260,7 +261,7 @@ class DefaultWorkerLeaseServiceProjectLockTest extends ConcurrentSpec {
     }
 
     def "withoutProjectLock releases worker leases when waiting on a project lock"() {
-        def projectLock = workerLeaseService.getProjectLock("root", ":project")
+        def projectLock = workerLeaseService.getProjectLock(path("root"), path(":project"))
 
         when:
         async {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/work/DefaultWorkerLeaseServiceTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.work
 
 import org.gradle.api.Action
+import org.gradle.internal.Factory
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration
 import org.gradle.internal.concurrent.ParallelismConfigurationManager
 import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
@@ -24,8 +25,6 @@ import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ResourceLockCoordinationService
 import org.gradle.internal.resources.TestTrackedResourceLock
 import spock.lang.Specification
-
-import java.util.concurrent.Callable
 
 
 class DefaultWorkerLeaseServiceTest extends Specification {
@@ -60,7 +59,7 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         def lock2 = resourceLock("lock2", false)
 
         when:
-        executed = workerLeaseService.withLocks([lock1, lock2], callable {
+        executed = workerLeaseService.withLocks([lock1, lock2], factory {
             assert lock1.lockedState
             assert lock2.lockedState
             assert lock1.doIsLockedByCurrentThread()
@@ -113,7 +112,7 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         workerLeaseService.withLocks([lock1, lock2]) {
             assert lock1.lockedState
             assert lock2.lockedState
-            executed = workerLeaseService.withoutLocks([lock1, lock2], callable {
+            executed = workerLeaseService.withoutLocks([lock1, lock2], factory {
                 assert !lock1.lockedState
                 assert !lock2.lockedState
                 assert !lock1.doIsLockedByCurrentThread()
@@ -204,10 +203,10 @@ class DefaultWorkerLeaseServiceTest extends Specification {
         }
     }
 
-    Callable callable(Closure closure) {
-        return new Callable() {
+    Factory factory(Closure closure) {
+        return new Factory() {
             @Override
-            Object call() throws Exception {
+            Object create() {
                 return closure.call()
             }
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1442,4 +1442,9 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     public FileCollection immutableFiles(Object... paths) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public ProjectState getMutationState() {
+        return services.get(ProjectStateRegistry.class).stateFor(this);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -132,4 +132,6 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasFileOper
      */
     @Nullable
     ProjectEvaluationListener stepEvaluationListener(ProjectEvaluationListener listener, Action<ProjectEvaluationListener> action);
+
+    ProjectState getMutationState();
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -652,9 +652,9 @@ public class DefaultExecutionPlan implements ExecutionPlan {
     }
 
     private ResourceLock getOrCreateProjectLock(Project project) {
-        String gradlePath = ((GradleInternal) project.getGradle()).getIdentityPath().toString();
-        String projectPath = ((ProjectInternal) project).getIdentityPath().toString();
-        return workerLeaseService.getProjectLock(gradlePath, projectPath);
+        Path buildPath = ((ProjectInternal) project).getMutationState().getOwner().getIdentityPath();
+        Path projectPath = ((ProjectInternal) project).getIdentityPath();
+        return workerLeaseService.getProjectLock(buildPath, projectPath);
     }
 
     private boolean canRunWithCurrentlyExecutedNodes(Node node, MutationInfo mutations) {

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/GradleBuildController.java
@@ -17,10 +17,10 @@ package org.gradle.internal.invocation;
 
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.initialization.GradleLauncher;
+import org.gradle.internal.Factory;
 import org.gradle.internal.work.WorkerLeaseService;
 
 import java.util.Collections;
-import java.util.concurrent.Callable;
 
 public class GradleBuildController implements BuildController {
     private enum State {Created, Completed}
@@ -71,9 +71,9 @@ public class GradleBuildController implements BuildController {
     }
 
     public GradleInternal run() {
-        return doBuild(new Callable<GradleInternal>() {
+        return doBuild(new Factory<GradleInternal>() {
             @Override
-            public GradleInternal call() {
+            public GradleInternal create() {
                 GradleInternal gradle = getLauncher().executeTasks();
                 getLauncher().finishBuild();
                 return gradle;
@@ -82,9 +82,9 @@ public class GradleBuildController implements BuildController {
     }
 
     public GradleInternal configure() {
-        return doBuild(new Callable<GradleInternal>() {
+        return doBuild(new Factory<GradleInternal>() {
             @Override
-            public GradleInternal call() throws Exception {
+            public GradleInternal create() {
                 GradleInternal gradle = getLauncher().getConfiguredBuild();
                 getLauncher().finishBuild();
                 return gradle;
@@ -92,7 +92,7 @@ public class GradleBuildController implements BuildController {
         });
     }
 
-    private GradleInternal doBuild(final Callable<GradleInternal> build) {
+    private GradleInternal doBuild(final Factory<GradleInternal> build) {
         try {
             // TODO:pm Move this to RunAsBuildOperationBuildActionRunner when BuildOperationWorkerRegistry scope is changed
             return workerLeaseService.withLocks(Collections.singleton(workerLeaseService.getWorkerLease()), build);

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -146,9 +146,9 @@ class DefaultProjectTest extends Specification {
     BuildOperationExecutor buildOperationExecutor = new TestBuildOperationExecutor()
     ListenerBuildOperationDecorator listenerBuildOperationDecorator = new TestListenerBuildOperationDecorator()
     CrossProjectConfigurator crossProjectConfigurator = new BuildOperationCrossProjectConfigurator(buildOperationExecutor)
-
     ClassLoaderScope baseClassLoaderScope = new RootClassLoaderScope(getClass().classLoader, getClass().classLoader, new DummyClassLoaderCache())
     ClassLoaderScope rootProjectClassLoaderScope = baseClassLoaderScope.createChild("root-project")
+    ProjectStateRegistry projectStateRegistryMock = Stub(ProjectStateRegistry)
 
     def setup() {
         rootDir = new File("/path/root").absoluteFile
@@ -213,6 +213,9 @@ class DefaultProjectTest extends Specification {
         ModelRegistry modelRegistry = Stub(ModelRegistry)
         serviceRegistryMock.get((Type) ModelRegistry) >> modelRegistry
         serviceRegistryMock.get(ModelRegistry) >> modelRegistry
+
+        serviceRegistryMock.get((Type) ProjectStateRegistry) >> projectStateRegistryMock
+        serviceRegistryMock.get(ProjectStateRegistry) >> projectStateRegistryMock
 
         ModelSchemaStore modelSchemaStore = Stub(ModelSchemaStore)
         serviceRegistryMock.get((Type) ModelSchemaStore) >> modelSchemaStore

--- a/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/execution/plan/DefaultExecutionPlanParallelTest.groovy
@@ -37,6 +37,7 @@ import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testfixtures.internal.NativeServicesTestFixture
+import org.gradle.util.Path
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Unroll
@@ -698,7 +699,6 @@ class DefaultExecutionPlanParallelTest extends AbstractProjectBuilderSpec {
         }
     }
 
-
     private TaskInternal selectNextTask() {
         selectNextTaskNode()?.task
     }
@@ -707,15 +707,15 @@ class DefaultExecutionPlanParallelTest extends AbstractProjectBuilderSpec {
         def nextTaskNode = executionPlan.selectNext(lockSetup.workerLease, lockSetup.createResourceLockState())
         if (nextTaskNode?.task instanceof Async) {
             def project = (ProjectInternal) nextTaskNode.task.project
-            lockSetup.projectLocks.get(project.identityPath.toString()).unlock()
+            lockSetup.projectLocks.get(project.identityPath).unlock()
         }
         return nextTaskNode
     }
 
     class LockSetup {
         int availableWorkerLeases = 5
-        Set<String> lockedProjects = [] as Set
-        Map<String, ResourceLock> projectLocks = [:]
+        Set<Path> lockedProjects = [] as Set
+        Map<Path, ResourceLock> projectLocks = [:]
         ResourceLockState currentState
 
         ResourceLockState createResourceLockState() {
@@ -742,7 +742,7 @@ class DefaultExecutionPlanParallelTest extends AbstractProjectBuilderSpec {
             return currentState
         }
         WorkerLeaseService workerLeaseService = [
-            getProjectLock: { gradlePath, projectPath ->
+            getProjectLock: { Path gradlePath, Path projectPath ->
                 if (!projectLocks.containsKey(projectPath)) {
                     projectLocks[projectPath] = new StubProjectLock(lockedProjects, projectPath)
                 }
@@ -758,9 +758,9 @@ class DefaultExecutionPlanParallelTest extends AbstractProjectBuilderSpec {
     class StubProjectLock implements ResourceLock {
         boolean locked = false
         private final String projectPath
-        private final Set<String> lockedProjects
+        private final Set<Path> lockedProjects
 
-        StubProjectLock(Set<String> lockedProjects, String projectPath) {
+        StubProjectLock(Set<Path> lockedProjects, Path projectPath) {
             this.lockedProjects = lockedProjects
             this.projectPath = projectPath
         }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -16,16 +16,23 @@
 
 package org.gradle.test.fixtures.work
 
+import org.gradle.internal.Factory
 import org.gradle.internal.resources.ResourceLock
 import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.work.WorkerLeaseService
+import org.gradle.util.Path
 
 import java.util.concurrent.Callable
 
 
 class TestWorkerLeaseService implements WorkerLeaseService {
     @Override
-    ResourceLock getProjectLock(String gradlePath, String projectPath) {
+    ResourceLock getProjectLock(Path buildIdentityPath, Path projectPath) {
+        return null
+    }
+
+    @Override
+    Collection<? extends ResourceLock> getCurrentProjectLocks() {
         return null
     }
 
@@ -69,6 +76,11 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
+    def <T> T withLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
+        return factory.create()
+    }
+
+    @Override
     void withLocks(Iterable<? extends ResourceLock> locks, Runnable action) {
         action.run()
     }
@@ -76,6 +88,11 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     @Override
     def <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
         return action.call()
+    }
+
+    @Override
+    def <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {
+        return factory.create()
     }
 
     @Override

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/work/TestWorkerLeaseService.groovy
@@ -22,8 +22,6 @@ import org.gradle.internal.work.WorkerLeaseRegistry
 import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.util.Path
 
-import java.util.concurrent.Callable
-
 
 class TestWorkerLeaseService implements WorkerLeaseService {
     @Override
@@ -61,18 +59,13 @@ class TestWorkerLeaseService implements WorkerLeaseService {
     }
 
     @Override
-    def <T> T withoutProjectLock(Callable<T> action) {
+    def <T> T withoutProjectLock(Factory<T> action) {
         return action.call()
     }
 
     @Override
     WorkerLeaseRegistry.WorkerLease getWorkerLease() {
         return workerLease()
-    }
-
-    @Override
-    def <T> T withLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
-        return action.call()
     }
 
     @Override
@@ -85,10 +78,6 @@ class TestWorkerLeaseService implements WorkerLeaseService {
         action.run()
     }
 
-    @Override
-    def <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Callable<T> action) {
-        return action.call()
-    }
 
     @Override
     def <T> T withoutLocks(Iterable<? extends ResourceLock> locks, Factory<T> factory) {


### PR DESCRIPTION
This is preliminary work for changing things to use a single project lock to control mutation of project state.

This cleans up some things with respect to project locking and adds some convenience methods:
- Change project locks to be centered around `Path` objects rather than strings
- Allow a thread to query its current locks
- Allow the project mutation state to be accessible from `ProjectInternal`
- Allow `Factory` objects to be run from lock methods
- Use the build identity path instead of the path associated with the `Gradle` object when running without `--parallel`