### PR TITLE
Add failed builds to performance result

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -38,6 +38,8 @@ import org.gradle.api.tasks.testing.TestOutputListener
 import org.gradle.initialization.BuildCancellationToken
 import org.gradle.process.CommandLineArgumentProvider
 import org.openmbee.junit.JUnitMarshalling
+import org.openmbee.junit.model.JUnitFailure
+import org.openmbee.junit.model.JUnitTestCase
 import org.openmbee.junit.model.JUnitTestSuite
 
 import javax.inject.Inject
@@ -306,7 +308,12 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
             fireTestListener(testSuite, response)
         } catch (e) {
             e.printStackTrace(System.err)
+            finishedBuilds.put(jobId, new ScenarioResult(name: scheduledBuilds.get(jobId).id, buildResult: response, testSuite: testSuiteWithFailureText(response.statusText)))
         }
+    }
+
+    private static JUnitTestSuite testSuiteWithFailureText(String failureText) {
+        new JUnitTestSuite(testCases: [new JUnitTestCase(failures: [new JUnitFailure(value: failureText)])])
     }
 
     void cancel(String buildId) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -45,11 +45,15 @@ class ScenarioBuildResultData {
     }
 
     double getRegressionSortKey() {
-        double signum = Math.signum(executions[0].regressionPercentage)
+        if (executions.empty) {
+            return Double.NEGATIVE_INFINITY
+        }
+        def firstExecution = executions[0]
+        double signum = Math.signum(firstExecution.regressionPercentage)
         if (signum == 0.0d) {
             signum = -1.0
         }
-        return executions.empty ? Double.NEGATIVE_INFINITY : executions[0].confidencePercentage * signum
+        return firstExecution.confidencePercentage * signum
     }
 
     double getRegressionPercentage() {


### PR DESCRIPTION
When a performance build fails without producing a JUnit xml we silently ignore the build.

See https://e.grdev.net/s/czhtus5lwqnuc/console-log#L1514-L1615

We should fail the coordinator build and the test should show up as failed.