### PR TITLE
Make sure relocated POMs are visible in the `Compile` scope

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
@@ -114,12 +114,12 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
 
     def createBuildFileWithDependency(String groupId, String artifactId) {
         buildFile << """
+apply plugin: 'java-library'
 repositories { maven { url '${mavenHttpRepo.uri}' } }
-configurations { compile }
-dependencies { compile '${groupId}:${artifactId}:1.0' }
+dependencies { implementation '${groupId}:${artifactId}:1.0' }
 task retrieve(type: Sync) {
     into 'libs'
-    from configurations.compile
+    from configurations.compileClasspath
 }
 """
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenPomRelocationIntegrationTest.groovy
@@ -23,11 +23,21 @@ import spock.lang.Unroll
 @Issue('https://github.com/gradle/gradle/issues/1789')
 class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
+    def setup() {
+        file("compileClasspath").mkdir()
+        file("runtimeClasspath").mkdir()
+    }
+
     @Unroll
     def "can resolve relocated module"() {
         given:
         def original = publishPomWithRelocation('groupA', 'artifactA', relocationGroupId, relocationArtifactId)
-        def newModule = mavenHttpRepo.module(newGroupId, newArtifactId, "1.0").publish()
+        def apiDep = mavenHttpRepo.module("org", "api", "1.0").publish()
+        def implDep = mavenHttpRepo.module("org", "impl", "1.0").publish()
+        def newModule = mavenHttpRepo.module(newGroupId, newArtifactId, "1.0")
+            .dependsOn(apiDep, scope: 'compile')
+            .dependsOn(implDep, scope: 'runtime')
+            .publish()
 
         and:
         createBuildFileWithDependency('groupA', 'artifactA')
@@ -36,12 +46,17 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
         original.pom.expectGet()
         newModule.pom.expectGet()
         newModule.artifact.expectGet()
+        apiDep.pom.expectGet()
+        apiDep.artifact.expectGet()
+        implDep.pom.expectGet()
+        implDep.artifact.expectGet()
 
         when:
         run "retrieve"
 
         then:
-        file("libs").assertHasDescendants("${newArtifactId}-1.0.jar")
+        file("compileClasspath").assertHasDescendants("${newArtifactId}-1.0.jar", "api-1.0.jar")
+        file("runtimeClasspath").assertHasDescendants("${newArtifactId}-1.0.jar", "api-1.0.jar", "impl-1.0.jar")
 
         where:
         relocationGroupId | relocationArtifactId | newGroupId | newArtifactId
@@ -69,7 +84,7 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
         run "retrieve"
 
         then:
-        file("libs").assertHasDescendants("artifactB-1.0.jar")
+        file("compileClasspath").assertHasDescendants("artifactB-1.0.jar")
     }
 
     def "can resolve module from a nested relocation"() {
@@ -91,7 +106,7 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
         run "retrieve"
 
         then:
-        file("libs").assertHasDescendants("artifactC-1.0.jar")
+        file("compileClasspath").assertHasDescendants("artifactC-1.0.jar")
     }
 
     def "fails to resolve module if published artifact does not exist with relocated coordinates"() {
@@ -117,9 +132,12 @@ class MavenPomRelocationIntegrationTest extends AbstractHttpDependencyResolution
 apply plugin: 'java-library'
 repositories { maven { url '${mavenHttpRepo.uri}' } }
 dependencies { implementation '${groupId}:${artifactId}:1.0' }
-task retrieve(type: Sync) {
-    into 'libs'
-    from configurations.compileClasspath
+task retrieve {}
+['compile', 'runtime'].each { cp ->
+   retrieve.dependsOn(tasks.create("retrieve\${cp.capitalize()}Classpath", Sync) {
+      into "\${cp}Classpath"
+      from configurations.getByName("\${cp}Classpath")
+   })
 }
 """
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorBuilder.java
@@ -253,7 +253,7 @@ public class GradlePomModuleDescriptorBuilder {
             return;
         }
 
-        dependencies.add(new MavenDependencyDescriptor(MavenScope.Runtime, MavenDependencyType.RELOCATION, selector, null, ImmutableList.<ExcludeMetadata>of()));
+        dependencies.add(new MavenDependencyDescriptor(MavenScope.Compile, MavenDependencyType.RELOCATION, selector, null, ImmutableList.<ExcludeMetadata>of()));
     }
 
     private String getDefaultVersion(PomDependencyMgt dep) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserTest.groovy
@@ -1929,7 +1929,7 @@ class GradlePomModuleDescriptorParserTest extends AbstractGradlePomModuleDescrip
         then:
         MavenDependencyDescriptor dep = single(metadata.dependencies) as MavenDependencyDescriptor
         dep.selector == moduleId('group-relocated', 'relocated', 'version-one')
-        dep.scope == MavenScope.Runtime
+        dep.scope == MavenScope.Compile
         dep.dependencyArtifact == null
     }
 


### PR DESCRIPTION
### Context

This commit changes the dependency scope for relocated POM files. Previously,
we added a dependency using the `Runtime` scope. But since we activated derived
variants by default, we're using attribute based matching, which has the consequence
that a dependency added in the `compile` (`implementation`) configuration will
not get runtime dependencies anymore. Since the runtime classpath extends the
compile classpath, this commit changes the default mapped scope to `compile`, so
that relocated dependencies are visible to both scopes. It should have no
impact on leaking dependencies since the transitive, relocated, dependency will
have its `runtime` or `compile` dependencies selected appropriately.

Fixes gradle/gradle-private#1527
