### PR TITLE
Fix Spock Specification

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/Specification.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/Specification.groovy
@@ -16,34 +16,34 @@
 
 package org.gradle.testing.internal.util
 
-import groovy.transform.CompileStatic
+import groovy.transform.stc.ClosureParams
+import groovy.transform.stc.SecondParam
+
 /**
  * This fixes Spock's Mock() and Stub() methods to be understandable by IDEA.
  * By using this subclass, IDEA knows the closure delegate type when using Mock() or Stub().
  * This means that you get editing assistance in said blocks WRT the type being mocked/stubbed.
  */
-// TODO:lptr Either remove this class, or fix the two methods with Groovy 2.5
-@CompileStatic
 class Specification extends spock.lang.Specification {
 
-//    @SuppressWarnings(['MethodName', 'UnnecessaryOverridingMethod', 'GrUnnecessaryPublicModifier'])
-//    @Override
-//    public <T> T Mock(
-//        @DelegatesTo.Target Class<T> type,
-//        @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
-//        @ClosureParams(SecondParam.FirstGenericType) Closure closure
-//    ) {
-//        super.Mock(type, closure)
-//    }
-//
-//    @SuppressWarnings(['MethodName', 'UnnecessaryOverridingMethod', 'GrUnnecessaryPublicModifier'])
-//    @Override
-//    public <T> T Stub(
-//        @DelegatesTo.Target Class<T> type,
-//        @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
-//        @ClosureParams(SecondParam.FirstGenericType) Closure closure
-//    ) {
-//        super.Stub(type, closure)
-//    }
-//
+    @SuppressWarnings(['MethodName', 'UnnecessaryOverridingMethod', 'GrUnnecessaryPublicModifier'])
+    @Override
+    public <T> T Mock(
+        @DelegatesTo.Target Class<T> type,
+        @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
+        @ClosureParams(SecondParam.FirstGenericType) Closure closure
+    ) {
+        super.Mock(type, closure)
+    }
+
+    @SuppressWarnings(['MethodName', 'UnnecessaryOverridingMethod', 'GrUnnecessaryPublicModifier'])
+    @Override
+    public <T> T Stub(
+        @DelegatesTo.Target Class<T> type,
+        @DelegatesTo(strategy = Closure.DELEGATE_FIRST, genericTypeIndex = 0)
+        @ClosureParams(SecondParam.FirstGenericType) Closure closure
+    ) {
+        super.Stub(type, closure)
+    }
+
 }


### PR DESCRIPTION
Re-add our custom overrides for Mock() and Stub() to give IntelliJ more context for type inference. These overrides stopped working with Groovy 2.5, but apparently removing @CompileStatic solves that issue.
