### PR TITLE
Quote all IntelliJ run parameters that contain variables

### DIFF
--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -555,7 +555,7 @@ open class IdePlugin : Plugin<Project> {
             vmParameter.add("-XX:MaxPermSize=512m")
         }
         return vmParameter.joinToString(" ") {
-            if (it.contains(" ")) "\"$it\""
+            if (it.contains(" ") || it.contains("\$")) "\"$it\""
             else it
         }
     }


### PR DESCRIPTION
...because they can in turn contain spaces that need quoting on the Windows command-line. This typically happens when the project directory is under the user's home that is under a path like 'C:\Users\John Doe\...'.