### PR TITLE
Log when publishing Ivy or Maven metadata with known incompatible features from Gradle

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/MavenVersionSelectorScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/MavenVersionSelectorScheme.java
@@ -23,6 +23,16 @@ public class MavenVersionSelectorScheme implements VersionSelectorScheme {
     private static final String LATEST_INTEGRATION = "latest.integration";
     private static final String LATEST_RELEASE = "latest.release";
 
+    public static boolean isSubstituableLatest(String version) {
+        if (version.equals(LATEST_INTEGRATION) || version.equals(LATEST_RELEASE)) {
+            return true;
+        }
+        if (!version.contains("latest")) {
+            throw new IllegalArgumentException("The provided version does not contain 'latest'");
+        }
+        return false;
+    }
+
     private final VersionSelectorScheme defaultVersionSelectorScheme;
 
     public MavenVersionSelectorScheme(VersionSelectorScheme defaultVersionSelectorScheme) {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -163,7 +163,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublished()
         if (ivyConfiguration == 'compile') {
             javaLibrary.assertApiDependencies('org.gradle.test:b:1.2')
@@ -304,7 +304,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublishedAsJavaModule()
 
         def dep = javaLibrary.parsedIvy.expectDependency("org.springframework:spring-core:2.5.6")
@@ -449,7 +449,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublishedAsJavaModule()
         javaLibrary.assertApiDependencies("org.test:default-dependency:1.1")
     }
@@ -494,7 +494,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublishedAsJavaModule()
         javaLibrary.assertApiDependencies('org.test:dep1:X', 'org.test:dep2:X')
     }
@@ -527,7 +527,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -597,7 +597,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputContains('commons-logging:commons-logging:1.1 declared as a dependency constraint')
         javaLibrary.assertPublished()
 
@@ -675,7 +675,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
-        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputContains('commons-collections:commons-collections declared without version')
         javaLibrary.assertPublished()
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -745,7 +745,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -802,7 +802,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         outputContains('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
 
@@ -875,7 +875,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultIvyPublication.UNSUPPORTED_FEATURE)
         javaLibrary.assertPublished()
 
         and:

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -163,6 +163,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
+        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
         if (ivyConfiguration == 'compile') {
             javaLibrary.assertApiDependencies('org.gradle.test:b:1.2')
@@ -303,6 +304,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublishedAsJavaModule()
 
         def dep = javaLibrary.parsedIvy.expectDependency("org.springframework:spring-core:2.5.6")
@@ -447,6 +449,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
+        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublishedAsJavaModule()
         javaLibrary.assertApiDependencies("org.test:default-dependency:1.1")
     }
@@ -491,6 +494,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
+        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublishedAsJavaModule()
         javaLibrary.assertApiDependencies('org.test:dep1:X', 'org.test:dep2:X')
     }
@@ -523,6 +527,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputDoesNotContain(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -593,6 +598,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains('commons-logging:commons-logging:1.1 declared as a dependency constraint')
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -670,6 +676,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains('commons-collections:commons-collections declared without version')
         javaLibrary.assertPublished()
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
         javaLibrary.parsedIvy.assertDependsOn("commons-collections:commons-collections:@runtime")
@@ -796,6 +803,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
         then:
         outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
+        outputContains('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
 
         and:

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -17,6 +17,7 @@
 
 package org.gradle.api.publish.ivy
 
+import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublication
 import org.gradle.test.fixtures.ivy.IvyJavaModule
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -46,7 +47,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                 }
             }
 
-            $dependencies            
+            $dependencies
 """)
 
         when:
@@ -580,7 +581,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
             publishing {
                 publications {
-                    maven(IvyPublication) {
+                    ivy(IvyPublication) {
                         from components.java
                     }
                 }
@@ -591,6 +592,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -656,7 +658,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
             publishing {
                 publications {
-                    maven(IvyPublication) {
+                    ivy(IvyPublication) {
                         from components.java
                     }
                 }
@@ -667,6 +669,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         succeeds "publish"
 
         then:
+        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
         javaLibrary.parsedIvy.assertDependsOn("commons-collections:commons-collections:@runtime")
@@ -735,6 +738,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
 
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
@@ -791,6 +795,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
 
         and:
@@ -862,6 +867,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         run "publish"
 
         then:
+        outputContains(DefaultIvyPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.assertPublished()
 
         and:

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyJavaProjectPublishIntegrationTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyJavaProjectPublishIntegrationTest.groovy
@@ -42,6 +42,9 @@ dependencies {
     compile("commons-beanutils:commons-beanutils:1.8.3") {
         exclude group: 'commons-logging'
     }
+    constraints {
+        compile "org.apache.commons:commons-math3:3.0"
+    }
 }
 
 uploadArchives {
@@ -61,11 +64,13 @@ uploadArchives {
 
         ivyModule.assertArtifactsPublished("ivy-1.9.xml", "publishTest-1.9.jar")
 
-        ivyModule.parsedIvy.dependencies.size() == 4
+        ivyModule.parsedIvy.dependencies.size() == 5
         ivyModule.parsedIvy.dependencies["commons-collections:commons-collections:3.2.2"].hasConf("compile->default")
         ivyModule.parsedIvy.dependencies["commons-io:commons-io:1.4"].hasConf("runtime->default")
         ivyModule.parsedIvy.dependencies["javax.servlet:servlet-api:2.5"].hasConf("compileOnly->default")
         ivyModule.parsedIvy.dependencies["commons-beanutils:commons-beanutils:1.8.3"].exclusions[0].org == 'commons-logging'
+        // Not ideal, but documents the way this works for now
+        ivyModule.parsedIvy.dependencies["org.apache.commons:commons-math3:3.0"].hasConf("compile->default")
 
         ivyModule.parsedIvy.exclusions.collect { it.org + ":" + it.module + "@" + it.conf} == ["foo:bar@compile"]
     }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -108,7 +108,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         }
     };
     @VisibleForTesting
-    public static final String INCOMPATIBLE_FEATURE = " uses dependency management feature(s) that will most likely make the produced Ivy file incomplete and/or not consumable by Ivy compatible solutions";
+    public static final String UNSUPPORTED_FEATURE = " contains dependencies that cannot be represented in a published ivy descriptor.";
 
     private final String name;
     private final IvyModuleDescriptorSpecInternal descriptor;
@@ -240,7 +240,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         if (component == null) {
             return;
         }
-        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, INCOMPATIBLE_FEATURE);
+        PublicationWarningsCollector publicationWarningsCollector = new PublicationWarningsCollector(LOG, UNSUPPORTED_FEATURE, "");
         configurations.maybeCreate("default");
 
         Set<PublishArtifact> seenArtifacts = Sets.newHashSet();
@@ -263,17 +263,17 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                 // TODO: When we support multiple components or configurable dependencies, we'll need to merge the confs of multiple dependencies with same id.
                     String confMapping = String.format("%s->%s", conf, dependency.getTargetConfiguration() == null ? Dependency.DEFAULT_CONFIGURATION : dependency.getTargetConfiguration());
                     if (!dependency.getAttributes().isEmpty()) {
-                        publicationWarningsCollector.add(String.format("%s:%s:%s declared with Gradle attributes", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                        publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared with Gradle attributes", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                     }
                     if (dependency instanceof ProjectDependency) {
                         addProjectDependency((ProjectDependency) dependency, confMapping);
                     } else {
                         ExternalDependency externalDependency = (ExternalDependency) dependency;
                         if (PlatformSupport.isTargettingPlatform(dependency)) {
-                            publicationWarningsCollector.add(String.format("%s:%s:%s declared as platform", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                            publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared as platform", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                         }
                         if (externalDependency.getVersion() == null) {
-                            publicationWarningsCollector.add(String.format("%s:%s declared without version", externalDependency.getGroup(), externalDependency.getName()));
+                            publicationWarningsCollector.addUnsupported(String.format("%s:%s declared without version", externalDependency.getGroup(), externalDependency.getName()));
                         }
                         addExternalDependency(externalDependency, confMapping);
                     }
@@ -281,12 +281,12 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             }
             if (!usageContext.getDependencyConstraints().isEmpty()) {
                 for (DependencyConstraint constraint : usageContext.getDependencyConstraints()) {
-                    publicationWarningsCollector.add(String.format("%s:%s:%s declared as a dependency constraint", constraint.getGroup(), constraint.getName(), constraint.getVersion()));
+                    publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared as a dependency constraint", constraint.getGroup(), constraint.getName(), constraint.getVersion()));
                 }
             }
             if (!usageContext.getCapabilities().isEmpty()) {
                 for (Capability capability : usageContext.getCapabilities()) {
-                    publicationWarningsCollector.add(String.format("Declares capability %s:%s:%s", capability.getGroup(), capability.getName(), capability.getVersion()));
+                    publicationWarningsCollector.addUnsupported(String.format("Declares capability %s:%s:%s", capability.getGroup(), capability.getName(), capability.getVersion()));
                 }
             }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -262,6 +262,9 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                 if (seenDependencies.add(dependency)) {
                 // TODO: When we support multiple components or configurable dependencies, we'll need to merge the confs of multiple dependencies with same id.
                     String confMapping = String.format("%s->%s", conf, dependency.getTargetConfiguration() == null ? Dependency.DEFAULT_CONFIGURATION : dependency.getTargetConfiguration());
+                    if (!dependency.getAttributes().isEmpty()) {
+                        publicationWarningsCollector.add(String.format("%s:%s:%s declared with Gradle attributes", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                    }
                     if (dependency instanceof ProjectDependency) {
                         addProjectDependency((ProjectDependency) dependency, confMapping);
                     } else {

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
@@ -133,6 +134,7 @@ class DefaultIvyPublicationTest extends Specification {
         moduleDependency.targetConfiguration >> "dep-configuration"
         moduleDependency.artifacts >> [artifact]
         moduleDependency.excludeRules >> [exclude]
+        moduleDependency.attributes >> ImmutableAttributes.EMPTY
 
         and:
         publication.from(componentWithDependency(moduleDependency))

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -167,6 +167,7 @@ class DefaultIvyPublicationTest extends Specification {
         projectDependencyResolver.resolve(ModuleVersionIdentifier, projectDependency) >> DefaultModuleVersionIdentifier.newId("pub-org", "pub-module", "pub-revision")
         projectDependency.targetConfiguration >> "dep-configuration"
         projectDependency.excludeRules >> [exclude]
+        projectDependency.attributes >> ImmutableAttributes.EMPTY
 
         when:
         publication.from(componentWithDependency(projectDependency))

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -863,6 +863,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.assertPublished()
 
         and:
+        outputContains(DefaultMavenPublication.INCOMPATIBLE_FEATURE)
         javaLibrary.parsedModuleMetadata.variant('api') {
             dependency('org.test:bar:1.0') {
                 hasAttribute('custom', 'hello')

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -697,7 +697,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         run "publish"
 
         then:
-        outputContains(DefaultMavenPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultMavenPublication.UNSUPPORTED_FEATURE)
         outputContains('Declares capability org:foo:1.0')
         javaLibrary.assertPublished()
 
@@ -863,7 +863,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
         javaLibrary.assertPublished()
 
         and:
-        outputContains(DefaultMavenPublication.INCOMPATIBLE_FEATURE)
+        outputContains(DefaultMavenPublication.UNSUPPORTED_FEATURE)
         javaLibrary.parsedModuleMetadata.variant('api') {
             dependency('org.test:bar:1.0') {
                 hasAttribute('custom', 'hello')

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -276,17 +276,22 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                             addImportDependencyConstraint((ProjectDependency) dependency);
                         } else {
                             if (isVersionMavenIncompatible(dependency.getVersion())) {
-                                publicationWarningsCollector.add(String.format("%s:%s:%s declared with a Maven incompatible notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                                publicationWarningsCollector.add(String.format("%s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                             }
                             addImportDependencyConstraint(dependency);
                         }
-                    } else if (dependency instanceof ProjectDependency) {
-                        addProjectDependency((ProjectDependency) dependency, globalExcludes, dependencies);
                     } else {
-                        if (isVersionMavenIncompatible(dependency.getVersion())) {
-                            publicationWarningsCollector.add(String.format("%s:%s:%s declared with a Maven incompatible notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                        if (!dependency.getAttributes().isEmpty()) {
+                            publicationWarningsCollector.add(String.format("%s:%s:%s declared with Gradle attributes", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                         }
-                        addModuleDependency(dependency, globalExcludes, dependencies);
+                        if (dependency instanceof ProjectDependency) {
+                            addProjectDependency((ProjectDependency) dependency, globalExcludes, dependencies);
+                        } else {
+                            if (isVersionMavenIncompatible(dependency.getVersion())) {
+                                publicationWarningsCollector.add(String.format("%s:%s:%s declared with a Maven incompatible version notation", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
+                            }
+                            addModuleDependency(dependency, globalExcludes, dependencies);
+                        }
                     }
                 }
             }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.internal.validation;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.logging.Logger;
+import org.gradle.internal.DisplayName;
+import org.gradle.internal.logging.text.TreeFormatter;
+
+import java.util.Set;
+
+public class PublicationWarningsCollector {
+
+    private final Logger logger;
+    private final String incompatibleFeature;
+    Set<String> unsupportedUsages = null;
+
+    public PublicationWarningsCollector(Logger logger, String incompatibleFeature) {
+        this.logger = logger;
+        this.incompatibleFeature = incompatibleFeature;
+    }
+
+    public void add(String text) {
+        if (unsupportedUsages == null) {
+            unsupportedUsages = Sets.newHashSet();
+        }
+        unsupportedUsages.add(text);
+    }
+
+    public void complete(DisplayName displayName) {
+        if (unsupportedUsages != null) {
+            TreeFormatter formatter = new TreeFormatter();
+            formatter.node(displayName + incompatibleFeature);
+            formatter.startChildren();
+            for (String usage : unsupportedUsages) {
+                formatter.node(usage);
+            }
+            formatter.endChildren();
+            logger.lifecycle(formatter.toString());
+        }
+
+    }
+}

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/validation/PublicationWarningsCollector.java
@@ -26,32 +26,49 @@ import java.util.Set;
 public class PublicationWarningsCollector {
 
     private final Logger logger;
+    private final String unsupportedFeature;
     private final String incompatibleFeature;
     Set<String> unsupportedUsages = null;
+    Set<String> incompatibleUsages = null;
 
-    public PublicationWarningsCollector(Logger logger, String incompatibleFeature) {
+    public PublicationWarningsCollector(Logger logger, String unsupportedFeature, String incompatibleFeature) {
         this.logger = logger;
+        this.unsupportedFeature = unsupportedFeature;
         this.incompatibleFeature = incompatibleFeature;
     }
 
-    public void add(String text) {
+    public void addUnsupported(String text) {
         if (unsupportedUsages == null) {
             unsupportedUsages = Sets.newHashSet();
         }
         unsupportedUsages.add(text);
     }
 
+    public void addIncompatible(String text) {
+        if (incompatibleUsages == null) {
+            incompatibleUsages = Sets.newHashSet();
+        }
+        incompatibleUsages.add(text);
+    }
+
     public void complete(DisplayName displayName) {
         if (unsupportedUsages != null) {
-            TreeFormatter formatter = new TreeFormatter();
-            formatter.node(displayName + incompatibleFeature);
-            formatter.startChildren();
-            for (String usage : unsupportedUsages) {
-                formatter.node(usage);
-            }
-            formatter.endChildren();
-            logger.lifecycle(formatter.toString());
+            formatAndLog(displayName, unsupportedFeature, unsupportedUsages);
+        }
+        if (incompatibleUsages != null) {
+            formatAndLog(displayName, incompatibleFeature, incompatibleUsages);
         }
 
+    }
+
+    private void formatAndLog(DisplayName displayName, String unsupportedFeature, Set<String> unsupportedUsages) {
+        TreeFormatter formatter = new TreeFormatter();
+        formatter.node(displayName + unsupportedFeature);
+        formatter.startChildren();
+        for (String usage : unsupportedUsages) {
+            formatter.node(usage);
+        }
+        formatter.endChildren();
+        logger.lifecycle(formatter.toString());
     }
 }


### PR DESCRIPTION
Features like constraints, platforms or declared capabilities are not
supported in the ivy.xml file format.

Features like dynamic versions, with `latest.<status>` or `1.+`, and capabilities are not
supported in the pom.xml file format.