### PR TITLE
Add test coverage for `matching.configureEach` for containers

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
@@ -78,6 +78,22 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
     }
 
     @Unroll
+    def "can execute query method #queryMethod.key from matching.configureEach"() {
+        buildFile << """
+            testContainer.matching({ it in testContainer.type }).configureEach {
+                ${queryMethod.value}
+            }
+            toBeRealized.get()
+        """
+
+        expect:
+        succeeds "help"
+
+        where:
+        queryMethod << getQueryMethods()
+    }
+
+    @Unroll
     def "can execute query method #queryMethod.key from Provider.configure"() {
         buildFile << """
             toBeRealized.configure {
@@ -137,6 +153,23 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
     def "cannot execute mutation method #mutationMethod.key from withType.configureEach"() {
         buildFile << """
             testContainer.withType(testContainer.type).configureEach {
+                ${mutationMethod.value}
+            }
+            toBeRealized.get()
+        """
+
+        expect:
+        fails "help"
+        failure.assertHasCause(disallowMutationMessage(mutationMethod.key))
+
+        where:
+        mutationMethod << getMutationMethods()
+    }
+
+    @Unroll
+    def "cannot execute mutation method #mutationMethod.key from matching.configureEach"() {
+        buildFile << """
+            testContainer.matching({ it in testContainer.type }).configureEach {
                 ${mutationMethod.value}
             }
             toBeRealized.get()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -1450,6 +1450,12 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         ex = thrown(Throwable)
         assertDoesNotAllowMethod(ex, methodUnderTest)
 
+        when:
+        container.matching({ it in container.type }).configureEach(method)
+        then:
+        ex = thrown(Throwable)
+        assertDoesNotAllowMethod(ex, methodUnderTest)
+
         where:
         mutatingMethods << getMutatingMethods()
     }
@@ -1492,6 +1498,11 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
 
         when:
         container.withType(container.type).configureEach(method)
+        then:
+        noExceptionThrown()
+
+        when:
+        container.matching({ it in container.type }).configureEach(method)
         then:
         noExceptionThrown()
 


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/709

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fcontainer-matching-configureEach)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
