### PR TITLE
Remove org.gradle.readLoggingConfigFile

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -325,11 +325,11 @@ This is not the case anymore as the `source` filed is now declared as `private`.
 - `BasePluginConvention` is now abstract.
 - `ProjectReportsPluginConvention` is now abstract.
 
-### System properties `test.single` and `test.debug` have been removed
+### Removed system properties
 
-The `test.single` filter mechanism has been removed. You must select tests from the command-line with [`--tests`](userguide/java_testing.html#simple_name_pattern).
-
-The `test.debug` mechanism to enable debugging of JVM tests from the command-line has been removed.  You must use [`--debug-jvm`](userguide/java_testing.html#sec:debugging_java_tests) to enable debugging of test execution.
+- The `test.single` filter mechanism has been removed. You must select tests from the command-line with [`--tests`](userguide/java_testing.html#simple_name_pattern).
+- The `test.debug` mechanism to enable debugging of JVM tests from the command-line has been removed. You must use [`--debug-jvm`](userguide/java_testing.html#sec:debugging_java_tests) to enable debugging of test execution.
+- The `org.gradle.readLoggingConfigFile` system property no longer does anything — please update affected tests to work with your `java.util.logging` settings.
 
 ### Replacing built-in tasks
 

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/api/internal/tasks/testing/JULRedirectorIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/api/internal/tasks/testing/JULRedirectorIntegrationTest.groovy
@@ -71,28 +71,4 @@ class JULRedirectorIntegrationTest extends AbstractSampleIntegrationTest {
             testResult.testClass("com.example.LumberJackTest").assertStderr(containsString(it));
         }
     }
-
-    /* Relies on the resources directory:
-     * integTest/resources/org/gradle/api/internal/tasks/testing/loggingConfig
-     */
-    def defaultLoggingConfigNoFineLevelWhenDisabled() {
-        given:
-        testResources.maybeCopy('JULRedirectorIntegrationTest/loggingConfig')
-        buildFile << """
-            test {
-                systemProperty 'java.util.logging.config.file', 'src/test/resources/logging.properties'
-                systemProperty 'org.gradle.readLoggingConfigFile', 'false'
-            }
-        """
-
-        when:
-        executer.expectDeprecationWarning()
-        run("test")
-
-        then:
-        DefaultTestExecutionResult testResult = new DefaultTestExecutionResult(testDirectory);
-        LYRICS.each {
-            testResult.testClass("com.example.LumberJackTest").assertStderr(not(containsString(it)));
-        }
-    }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/JULRedirector.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/JULRedirector.java
@@ -16,11 +16,8 @@
 
 package org.gradle.api.internal.tasks.testing;
 
-import com.google.common.annotations.VisibleForTesting;
-import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.api.internal.tasks.testing.processors.DefaultStandardOutputRedirector;
-import org.gradle.process.JavaForkOptions;
-import org.gradle.util.SingleMessageLogger;
+import org.gradle.internal.logging.StandardOutputCapture;
 
 import java.io.IOException;
 import java.util.logging.ConsoleHandler;
@@ -31,8 +28,6 @@ import java.util.logging.Logger;
  * Some hackery to get JUL output redirected to test output
  */
 public class JULRedirector extends DefaultStandardOutputRedirector {
-    @VisibleForTesting
-    public static final String READ_LOGGING_CONFIG_FILE_PROPERTY = "org.gradle.readLoggingConfigFile";
     private boolean reset;
 
     @Override
@@ -40,28 +35,13 @@ public class JULRedirector extends DefaultStandardOutputRedirector {
         super.start();
         if (!reset) {
             LogManager.getLogManager().reset();
-            if (shouldReadLoggingConfigFile()) {
-                try {
-                    LogManager.getLogManager().readConfiguration();
-                } catch (IOException error) {
-                    Logger.getLogger("").addHandler(new ConsoleHandler());
-                }
-            } else {
+            try {
+                LogManager.getLogManager().readConfiguration();
+            } catch (IOException error) {
                 Logger.getLogger("").addHandler(new ConsoleHandler());
             }
             reset = true;
         }
         return this;
-    }
-
-    private boolean shouldReadLoggingConfigFile() {
-        return System.getProperty(READ_LOGGING_CONFIG_FILE_PROPERTY, "true").equals("true");
-    }
-
-    public static void checkDeprecatedProperty(JavaForkOptions options) {
-        if ("false".equals(options.getSystemProperties().get(READ_LOGGING_CONFIG_FILE_PROPERTY))) {
-            SingleMessageLogger.nagUserOfDiscontinuedProperty(READ_LOGGING_CONFIG_FILE_PROPERTY,
-                "Change your test to work with your java.util.logging configuration file settings.");
-        }
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/worker/ForkingTestClassProcessor.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.tasks.testing.worker;
 import org.gradle.api.Action;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.classpath.ModuleRegistry;
-import org.gradle.api.internal.tasks.testing.JULRedirector;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
 import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestResultProcessor;
@@ -80,7 +79,6 @@ public class ForkingTestClassProcessor implements TestClassProcessor {
             }
 
             if (remoteProcessor == null) {
-                JULRedirector.checkDeprecatedProperty(options);
                 completion = currentWorkerLease.startChild();
                 try {
                     remoteProcessor = forkProcess();

--- a/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/JULRedirectorTest.groovy
+++ b/subprojects/testing-base/src/test/groovy/org/gradle/api/internal/tasks/testing/processors/JULRedirectorTest.groovy
@@ -143,33 +143,4 @@ class JULRedirectorTest extends Specification {
         System.out == outputs.stdOutPrintStream
         System.err == outputs.stdErrPrintStream
     }
-
-    def "start and stop output with default logging readLoggingConfigFile is not true."() {
-        System.setProperty("java.util.logging.config.class", JULCustomInit.class.name)
-        System.setProperty(JULRedirector.READ_LOGGING_CONFIG_FILE_PROPERTY, "false")
-
-        when:
-        redirector.redirectStandardOutputTo(stdOutListener)
-        redirector.redirectStandardErrorTo(stdErrListener)
-
-        redirector.start()
-        [Level.SEVERE, Level.WARNING, Level.INFO, Level.CONFIG, Level.FINE, Level.FINER, Level.FINEST].each {
-            logger1.log(it, "Test");
-            logger2.log(it, "Test");
-            logger3.log(it, "Test");
-        }
-        redirector.stop()
-
-        then:
-        3 * stdErrListener.onOutput("${Level.SEVERE.getLocalizedName()}: Test$EOL")
-        3 * stdErrListener.onOutput("${Level.WARNING.getLocalizedName()}: Test$EOL")
-        3 * stdErrListener.onOutput("${Level.INFO.getLocalizedName()}: Test$EOL")
-        0 * stdErrListener.onOutput("${Level.CONFIG.getLocalizedName()}: Test$EOL")
-        0 * stdErrListener.onOutput("${Level.FINE.getLocalizedName()}: Test$EOL")
-        0 * stdErrListener.onOutput("${Level.FINER.getLocalizedName()}: Test$EOL")
-        0 * stdErrListener.onOutput("${Level.FINEST.getLocalizedName()}: Test$EOL")
-
-        System.out == outputs.stdOutPrintStream
-        System.err == outputs.stdErrPrintStream
-    }
 }


### PR DESCRIPTION
The previously deprecated system property is no longer supported and
simply ignored from now on.

Resolves #6301.