### PR TITLE
LifecycleBasePlugin implement Plugin<Project> and remove Incubating

### DIFF
--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LifecycleBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LifecycleBasePlugin.java
@@ -17,7 +17,6 @@
 package org.gradle.language.base.plugins;
 
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -38,8 +37,7 @@ import java.util.concurrent.Callable;
 /**
  * <p>A {@link org.gradle.api.Plugin} which defines a basic project lifecycle.</p>
  */
-@Incubating
-public class LifecycleBasePlugin implements Plugin<ProjectInternal> {
+public class LifecycleBasePlugin implements Plugin<Project> {
     public static final String CLEAN_TASK_NAME = "clean";
     public static final String ASSEMBLE_TASK_NAME = "assemble";
     public static final String CHECK_TASK_NAME = "check";
@@ -48,8 +46,9 @@ public class LifecycleBasePlugin implements Plugin<ProjectInternal> {
     public static final String VERIFICATION_GROUP = "verification";
 
     @Override
-    public void apply(final ProjectInternal project) {
-        addClean(project);
+    public void apply(final Project project) {
+        final ProjectInternal projectInternal = (ProjectInternal) project;
+        addClean(projectInternal);
         addCleanRule(project);
         addAssemble(project);
         addCheck(project);
@@ -94,7 +93,7 @@ public class LifecycleBasePlugin implements Plugin<ProjectInternal> {
         project.getTasks().addRule(new CleanRule(project.getTasks()));
     }
 
-    private void addAssemble(ProjectInternal project) {
+    private void addAssemble(Project project) {
         project.getTasks().register(ASSEMBLE_TASK_NAME, new Action<Task>() {
             @Override
             public void execute(Task assembleTask) {
@@ -104,7 +103,7 @@ public class LifecycleBasePlugin implements Plugin<ProjectInternal> {
         });
     }
 
-    private void addCheck(ProjectInternal project) {
+    private void addCheck(Project project) {
         project.getTasks().register(CHECK_TASK_NAME, new Action<Task>() {
             @Override
             public void execute(Task checkTask) {
@@ -114,7 +113,7 @@ public class LifecycleBasePlugin implements Plugin<ProjectInternal> {
         });
     }
 
-    private void addBuild(final ProjectInternal project) {
+    private void addBuild(final Project project) {
         project.getTasks().register(BUILD_TASK_NAME, new Action<Task>() {
             @Override
             public void execute(Task buildTask) {


### PR DESCRIPTION
### Context
The `LifecycleBasePlugin` has been arround since at least 2014. I think that at this point it makes sense to remove the `@Incubating` annotation.

Part of this work is related to #5964.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
