### PR TITLE
Only Checkstyle config from rootProject

### DIFF
--- a/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
+++ b/subprojects/code-quality/src/integTest/groovy/org/gradle/api/plugins/quality/checkstyle/CheckstylePluginMultiProjectTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.api.plugins.quality.checkstyle
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
@@ -23,8 +24,6 @@ import static org.gradle.util.TextUtil.getPlatformLineSeparator
 
 @Requires(TestPrecondition.JDK8_OR_LATER)
 class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
-
-    private static final EXPECTED_DEPRECATION_MESSAGE = "Setting the Checkstyle configuration file under 'config/checkstyle' of a sub project has been deprecated.";
 
     def "configures checkstyle extension to read config from root project in a single project build"() {
         given:
@@ -37,18 +36,16 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
         checkStyleReportFile(testDirectory).text.contains('Dummy.java')
     }
 
-    def "configures checkstyle extension to read config just from sub project in a multi-project build and renders deprecation warning"() {
+    def "fails when root project does contain config in default location"() {
         given:
-        executer.expectDeprecationWarning()
         settingsFile << "include 'child'"
         file('child/build.gradle') << javaProjectUsingCheckstyle()
         file('child/src/main/java/Dummy.java') << javaClassWithNewLineAtEnd()
         file('child/config/checkstyle/checkstyle.xml') << simpleCheckStyleConfig()
 
         expect:
-        succeeds(':child:checkstyleMain')
-        checkStyleReportFile(file('child')).text.contains('Dummy.java')
-        outputContains(EXPECTED_DEPRECATION_MESSAGE)
+        fails(':child:checkstyleMain')
+        checkStyleReportFile(file('child')).assertDoesNotExist()
     }
 
     def "configures checkstyle extension to read config from root project in a flat multi-project build"() {
@@ -75,22 +72,20 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
         checkStyleReportFile(file('a/b/c')).text.contains('Dummy.java')
     }
 
-    def "configures checkstyle extension to read config from sub project in a multi-project build even if root project config is available and renders deprecation warning"() {
+    def "configures checkstyle extension to read config from root project in a multi-project build even if sub project config is available"() {
         given:
-        executer.expectDeprecationWarning()
         settingsFile << "include 'child:grand'"
         file('child/grand/build.gradle') << javaProjectUsingCheckstyle()
         file('child/grand/src/main/java/Dummy.java') << javaClassWithNewLineAtEnd()
-        file('child/grand/config/checkstyle/checkstyle.xml') << simpleCheckStyleConfig()
-        file('config/checkstyle/checkstyle.xml') << invalidCheckStyleConfig()
+        file('child/grand/config/checkstyle/checkstyle.xml') << invalidCheckStyleConfig()
+        file('config/checkstyle/checkstyle.xml') << simpleCheckStyleConfig()
 
         expect:
         succeeds(':child:grand:checkstyleMain')
         checkStyleReportFile(file('child/grand')).text.contains('Dummy.java')
-        outputContains(EXPECTED_DEPRECATION_MESSAGE)
     }
 
-    def "explicitly configures checkstyle extension to point to config directory and does not render deprecation message"() {
+    def "explicitly configures checkstyle extension to point to config directory"() {
         given:
         settingsFile << "include 'child'"
         file('child/build.gradle') << javaProjectUsingCheckstyle()
@@ -122,8 +117,8 @@ class CheckstylePluginMultiProjectTest extends AbstractIntegrationSpec {
         'INVALID AND SHOULD NEVER BE READ'
     }
 
-    static File checkStyleReportFile(File projectDir) {
-        new File(projectDir, 'build/reports/checkstyle/main.html')
+    static TestFile checkStyleReportFile(File projectDir) {
+        new TestFile(projectDir, 'build/reports/checkstyle/main.html')
     }
 
     static String javaProjectUsingCheckstyle() {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.java
@@ -108,7 +108,7 @@ public class CheckstyleExtension extends CodeQualityExtension {
     }
 
     /**
-     * Path to other Checkstyle configuration files. By default, this path is {@code $projectDir/config/checkstyle}
+     * Path to other Checkstyle configuration files. By default, this path is {@code $rootProject.projectDir/config/checkstyle}
      * <p>
      * This path will be exposed as the variable {@code config_loc} in Checkstyle's configuration files.
      * </p>

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstylePlugin.java
@@ -26,7 +26,6 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.resources.TextResource;
 import org.gradle.api.tasks.SourceSet;
-import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 import java.util.Map;
@@ -69,21 +68,9 @@ public class CheckstylePlugin extends AbstractCodeQualityPlugin<Checkstyle> {
         return project.provider(new Callable<Directory>() {
             @Override
             public Directory call() {
-                if (usesSubprojectCheckstyleConfiguration()) {
-                    DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("Setting the Checkstyle configuration file under 'config/checkstyle' of a sub project", "Use the root project's 'config/checkstyle' directory instead.");
-                    return project.getLayout().getProjectDirectory().dir(CONFIG_DIR_NAME);
-                }
                 return project.getRootProject().getLayout().getProjectDirectory().dir(CONFIG_DIR_NAME);
             }
         });
-    }
-
-    private boolean usesSubprojectCheckstyleConfiguration() {
-        return !isRootProject() && project.file(CONFIG_DIR_NAME).isDirectory();
-    }
-
-    private boolean isRootProject() {
-        return project.equals(project.getRootProject());
     }
 
     @Override

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -206,6 +206,13 @@ The previously deprecated support for Play Framework 2.2 has been removed.
 
 See [above](#jacoco-plugin-now-works-with-the-build-cache-and-parallel-test-execution) for details.
 
+### Checkstyle plugin config directory in multi-project builds
+
+Gradle will now, by convention, only look for Checkstyle configuration files in the root project's _config/checkstyle_ directory.
+Checkstyle configuration files in subprojects — the old by-convention location — will be ignored unless you explicitly configure their path
+via [`checkstyle.configDir`](dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:configDir)
+or [`checkstyle.config`](dsl/org.gradle.api.plugins.quality.CheckstyleExtension.html#org.gradle.api.plugins.quality.CheckstyleExtension:config).
+
 ### Updated default tool versions
 
 The default tool versions of the following code quality plugins have been updated:


### PR DESCRIPTION
Prior to this commit, each subproject was checked for having a
Checkstyle config in `config/checkstyle`. Now, unless explicitly
configured, only the root project is taken into account.

Resolves #6263.