### PR TITLE
Support reading java9Home from enviroment variable

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -120,7 +120,7 @@ open class AvailableJavaInstallations(private val project: Project, private val 
     fun validateCompilationJdks(): Map<String, Boolean> =
         mapOf(
             "Must use JDK 9+ to perform compilation in this build. It's currently ${javaInstallationForCompilation.vendorAndMajorVersion} at ${javaInstallationForCompilation.javaHome}. " +
-                "You can either run the build on JDK 9+ or set a project or system property '$java9HomePropertyName' to a Java9-compatible JDK home path" to
+                "You can either run the build on JDK 9+ or set a project, system property, or environment variable '$java9HomePropertyName' to a Java9-compatible JDK home path" to
                 !javaInstallationForCompilation.javaVersion.isJava9Compatible
         )
 
@@ -145,10 +145,6 @@ open class AvailableJavaInstallations(private val project: Project, private val 
             }).joinToString("\n")
 
     private
-    fun validationMessage(propertyName: String, javaInstallation: JavaInstallation?, requiredVersion: String) =
-        "Must set project or system property '$propertyName' to the path of an $requiredVersion, is currently ${javaInstallation?.vendorAndMajorVersion} at ${javaInstallation?.javaHome}."
-
-    private
     fun detectJavaInstallation(javaHomePath: String) =
         Jvm.forHome(File(javaHomePath)).let {
             JavaInstallation(false, Jvm.forHome(File(javaHomePath)), jvmVersionDetector.getJavaVersion(it), javaInstallationProbe)
@@ -158,6 +154,7 @@ open class AvailableJavaInstallations(private val project: Project, private val 
     fun resolveJavaHomePath(propertyName: String): String? = when {
         project.hasProperty(propertyName) -> project.property(propertyName) as String
         System.getProperty(propertyName) != null -> System.getProperty(propertyName)
+        System.getenv(propertyName) != null -> System.getenv(propertyName)
         else -> null
     }
 }


### PR DESCRIPTION
### Context
This way, contributors don't need to constantly remember to add `-Djava9Home=$java9Home` to running the Gradle build..

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
