### PR TITLE
Mark `SelectorState` resolved on `resolve()` call

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -178,23 +178,26 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     private ComponentIdResolveResult resolve(VersionSelector selector, VersionSelector rejector, ComponentIdResolveResult previousResult) {
-        if (!requiresResolve(previousResult, rejector)) {
-            return previousResult;
-        }
+        try {
+            if (!requiresResolve(previousResult, rejector)) {
+                return previousResult;
+            }
 
-        BuildableComponentIdResolveResult idResolveResult = new DefaultBuildableComponentIdResolveResult();
-        if (dependencyState.failure != null) {
-            idResolveResult.failed(dependencyState.failure);
-        } else {
-            resolver.resolve(firstSeenDependency, selector, rejector, idResolveResult);
-        }
+            BuildableComponentIdResolveResult idResolveResult = new DefaultBuildableComponentIdResolveResult();
+            if (dependencyState.failure != null) {
+                idResolveResult.failed(dependencyState.failure);
+            } else {
+                resolver.resolve(firstSeenDependency, selector, rejector, idResolveResult);
+            }
 
-        if (idResolveResult.getFailure() != null) {
-            failure = idResolveResult.getFailure();
-        }
+            if (idResolveResult.getFailure() != null) {
+                failure = idResolveResult.getFailure();
+            }
 
-        this.resolved = true;
-        return idResolveResult;
+            return idResolveResult;
+        } finally {
+            this.resolved = true;
+        }
     }
 
     @Override


### PR DESCRIPTION
Previously we would mark a `SelectorState` as not resolved when it moved
from non forced to forced. However it never moved back to resolved.
This commit makes sure we always mark a `SelectorState` as resolved when
`resolve()` is invoked, whatever the outcome.