### PR TITLE
TestKit will search upwards for settings.gradle

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -352,6 +352,11 @@ The full list of built-in tasks that cannot be replaced:
 - Removed the internal class `SimpleWorkResult`.
 - Removed the internal method `getAddAction` from `BroadcastingCollectionEventRegister`.
 
+### Gradle TestKit will search upwards for `settings.gradle`
+
+When invoking a build, Gradle TestKit now behaves like a regular Gradle invocation, and will search upwards for a `settings.gradle` file that defines the build. 
+Please ensure that all builds being executed with Gradle TestKit define `settings.gradle`, even if this is an empty file.
+
 ## External contributions
 
 We would like to thank the following community members for making contributions to this release of Gradle.

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/BaseGradleRunnerIntegrationTest.groovy
@@ -146,6 +146,10 @@ abstract class BaseGradleRunnerIntegrationTest extends AbstractIntegrationSpec {
         DaemonLogsAnalyzer.newAnalyzer(daemonDir, version.version)
     }
 
+    def setup() {
+        settingsFile.createFile()
+    }
+
     def cleanup() {
         if (requireIsolatedTestKitDir) {
             testKitDaemons().killAll()

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
@@ -181,7 +181,6 @@ public class ToolingApiGradleExecutor implements GradleExecutor {
         gradleConnector.useGradleUserHomeDir(gradleUserHome);
         gradleConnector.daemonBaseDir(new File(gradleUserHome, TEST_KIT_DAEMON_DIR_NAME));
         gradleConnector.forProjectDirectory(projectDir);
-        gradleConnector.searchUpwards(false);
         gradleConnector.daemonMaxIdleTime(120, TimeUnit.SECONDS);
         gradleConnector.embedded(embedded);
         return gradleConnector;


### PR DESCRIPTION
Now that --no-search-upwards has been deprecated, users should expect
Gradle to search for a `settings.gradle` file whenever a build is
invoked. This change updates TestKit to match this behaviour.

Fixes #5838