### PR TITLE
Require a settings file for an unrelated build that is nested under another build

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/initialization/AbstractProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/AbstractProjectSpec.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public abstract class AbstractProjectSpec implements ProjectSpec {
+    private static final String UNRELATED_BUILD_HINT = " If this is an unrelated build, it must have it's own settings file.";
     public boolean containsProject(ProjectRegistry<? extends ProjectIdentifier> registry) {
         checkPreconditions(registry);
         List<ProjectIdentifier> matches = new ArrayList<ProjectIdentifier>();
@@ -35,7 +36,8 @@ public abstract class AbstractProjectSpec implements ProjectSpec {
         List<T> matches = new ArrayList<T>();
         select(registry, matches);
         if (matches.isEmpty()) {
-            throw new InvalidUserDataException(formatNoMatchesMessage(settingsDescription));
+            String message = formatNoMatchesMessage(settingsDescription) + UNRELATED_BUILD_HINT;
+            throw new InvalidUserDataException(message);
         }
         if (matches.size() != 1) {
             throw new InvalidUserDataException(formatMultipleMatchesMessage(matches));

--- a/subprojects/core/src/main/java/org/gradle/initialization/AbstractProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/AbstractProjectSpec.java
@@ -30,12 +30,12 @@ public abstract class AbstractProjectSpec implements ProjectSpec {
         return !matches.isEmpty();
     }
 
-    public <T extends ProjectIdentifier> T selectProject(ProjectRegistry<? extends T> registry) {
+    public <T extends ProjectIdentifier> T selectProject(String settingsDescription, ProjectRegistry<? extends T> registry) {
         checkPreconditions(registry);
         List<T> matches = new ArrayList<T>();
         select(registry, matches);
         if (matches.isEmpty()) {
-            throw new InvalidUserDataException(formatNoMatchesMessage());
+            throw new InvalidUserDataException(formatNoMatchesMessage(settingsDescription));
         }
         if (matches.size() != 1) {
             throw new InvalidUserDataException(formatMultipleMatchesMessage(matches));
@@ -48,7 +48,7 @@ public abstract class AbstractProjectSpec implements ProjectSpec {
 
     protected abstract String formatMultipleMatchesMessage(Iterable<? extends ProjectIdentifier> matches);
 
-    protected abstract String formatNoMatchesMessage();
+    protected abstract String formatNoMatchesMessage(String settings);
 
     protected abstract <T extends ProjectIdentifier> void select(ProjectRegistry<? extends T> candidates, List<? super T> matches);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/BuildFileProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/BuildFileProjectSpec.java
@@ -29,8 +29,8 @@ public class BuildFileProjectSpec extends AbstractProjectSpec {
         this.buildFile = buildFile;
     }
 
-    protected String formatNoMatchesMessage() {
-        return String.format("No projects in this build have build file '%s'.", buildFile);
+    protected String formatNoMatchesMessage(String settings) {
+        return String.format("Build file '%s' is not part of the build defined by %s.", buildFile, settings);
     }
 
     protected String formatMultipleMatchesMessage(Iterable<? extends ProjectIdentifier> matches) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/CurrentDirectoryProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/CurrentDirectoryProjectSpec.java
@@ -22,11 +22,11 @@ import org.gradle.api.internal.project.ProjectRegistry;
 import java.io.File;
 import java.util.List;
 
-public class DefaultProjectSpec extends AbstractProjectSpec {
+public class CurrentDirectoryProjectSpec extends AbstractProjectSpec {
     private final boolean useRootWhenNoMatch;
     private final File currentDir;
 
-    public DefaultProjectSpec(File currentDir, SettingsInternal settings) {
+    public CurrentDirectoryProjectSpec(File currentDir, SettingsInternal settings) {
         this.currentDir = currentDir;
         this.useRootWhenNoMatch = currentDir.equals(settings.getSettingsDir());
     }

--- a/subprojects/core/src/main/java/org/gradle/initialization/CurrentDirectoryProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/CurrentDirectoryProjectSpec.java
@@ -43,8 +43,8 @@ public class CurrentDirectoryProjectSpec extends AbstractProjectSpec {
         }
     }
 
-    protected String formatNoMatchesMessage() {
-        return String.format("No projects in this build have project directory '%s'.", currentDir);
+    protected String formatNoMatchesMessage(String settings) {
+        return String.format("Project directory '%s' is not part of the build defined by %s.",  currentDir, settings);
     }
 
     protected String formatMultipleMatchesMessage(Iterable<? extends ProjectIdentifier> matches) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -22,9 +22,6 @@ import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
-import org.gradle.util.DeprecationLogger;
-
-import java.io.File;
 
 /**
  * Handles locating and processing setting.gradle files.  Also deals with the buildSrc module, since that modules is
@@ -48,7 +45,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
         SettingsInternal settings = findSettingsAndLoadIfAppropriate(gradle, startParameter);
 
         ProjectSpec spec = ProjectSpecs.forStartParameter(startParameter, settings);
-        if (useEmptySettings(settings, spec, startParameter)) {
+        if (useEmptySettings(spec, settings, startParameter)) {
             settings = createEmptySettings(gradle, startParameter);
         }
 
@@ -56,7 +53,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
         return settings;
     }
 
-    private boolean useEmptySettings(SettingsInternal loadedSettings, ProjectSpec spec, StartParameter startParameter) {
+    private boolean useEmptySettings(ProjectSpec spec, SettingsInternal loadedSettings, StartParameter startParameter) {
         // Never use empty settings when the settings were explicitly set
         if (startParameter.getSettingsFile() != null) {
             return false;
@@ -66,14 +63,12 @@ public class DefaultSettingsLoader implements SettingsLoader {
             return false;
         }
 
-        // Use an empty settings for a secondary build file located in the same directory as the settings file.
-        File projectDir = startParameter.getProjectDir() == null ? startParameter.getCurrentDir() : startParameter.getProjectDir();
-        if (loadedSettings.getSettingsDir().equals(projectDir)) {
+        // Use an empty settings for a target build file located in the same directory as the settings file.
+        if (startParameter.getProjectDir() != null && loadedSettings.getSettingsDir().equals(startParameter.getProjectDir())) {
             return true;
         }
 
-        DeprecationLogger.nagUserWith("Support for nested build without a settings file was deprecated.", "You should create a empty settings file in " + projectDir.getAbsolutePath() + ".");
-        return true;
+        return false;
     }
 
     private SettingsInternal createEmptySettings(GradleInternal gradle, StartParameter startParameter) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsLoader.java
@@ -85,7 +85,7 @@ public class DefaultSettingsLoader implements SettingsLoader {
     }
 
     private void setDefaultProject(ProjectSpec spec, SettingsInternal settings) {
-        settings.setDefaultProject(spec.selectProject(settings.getProjectRegistry()));
+        settings.setDefaultProject(spec.selectProject(settings.getSettingsScript().getDisplayName(), settings.getProjectRegistry()));
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectDirectoryProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectDirectoryProjectSpec.java
@@ -29,8 +29,8 @@ public class ProjectDirectoryProjectSpec extends AbstractProjectSpec {
         this.dir = dir;
     }
 
-    protected String formatNoMatchesMessage() {
-        return String.format("No projects in this build have project directory '%s'.", dir);
+    protected String formatNoMatchesMessage(String settings) {
+        return String.format("Project directory '%s' is not part of the build defined by %s.", dir, settings);
     }
 
     protected String formatMultipleMatchesMessage(Iterable<? extends ProjectIdentifier> matches) {

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectSpec.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectSpec.java
@@ -31,5 +31,5 @@ public interface ProjectSpec {
      * @throws InvalidUserDataException When project cannot be selected due to some user input mismatch, or when there are no matching projects
      * or multiple matching projects.
      */
-    <T extends ProjectIdentifier> T selectProject(ProjectRegistry<? extends T> registry) throws InvalidUserDataException;
+    <T extends ProjectIdentifier> T selectProject(String settingsDescription, ProjectRegistry<? extends T> registry) throws InvalidUserDataException;
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectSpecs.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectSpecs.java
@@ -32,6 +32,6 @@ class ProjectSpecs {
         if (explicitProjectDir != null) {
             return new ProjectDirectoryProjectSpec(explicitProjectDir);
         }
-        return new DefaultProjectSpec(startParameter.getCurrentDir(), settings);
+        return new CurrentDirectoryProjectSpec(startParameter.getCurrentDir(), settings);
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/BuildFileProjectSpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/BuildFileProjectSpecTest.groovy
@@ -54,21 +54,21 @@ class BuildFileProjectSpecTest extends Specification {
         def target = project(file)
 
         then:
-        spec.selectProject(registry(target, project(otherFile))).is(target)
+        spec.selectProject("description", registry(target, project(otherFile))).is(target)
     }
 
     def "selectProject() throws when no project has specified build file"() {
         when:
-        spec.selectProject(registry())
+        spec.selectProject("settings 'foo'", registry())
 
         then:
         InvalidUserDataException e = thrown()
-        e.message == "No projects in this build have build file '$file'.".toString()
+        e.message == "Build file '$file' is not part of the build defined by settings 'foo'.".toString()
     }
 
     def "selectProject() throws when multiple projects have specified build file"() {
         when:
-        spec.selectProject(registry(project(file), project(file)))
+        spec.selectProject("settings 'foo'", registry(project(file), project(file)))
 
         then:
         InvalidUserDataException e = thrown()

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultSettingsLoaderTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.project.ProjectRegistry
+import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.initialization.buildsrc.BuildSourceBuilder
 import org.gradle.internal.FileUtils
 import org.gradle.internal.service.ServiceRegistry
@@ -32,6 +33,7 @@ class DefaultSettingsLoaderTest extends Specification {
     def gradle = Mock(GradleInternal)
     def settings = Mock(SettingsInternal)
     def settingsLocation = new SettingsLocation(FileUtils.canonicalize(new File("someDir")), null);
+    def settingsScript = Mock(ScriptSource)
     def startParameter = new StartParameter();
     def classLoaderScope = Mock(ClassLoaderScope)
     def settingsFinder = Mock(ISettingsFinder)
@@ -60,6 +62,8 @@ class DefaultSettingsLoaderTest extends Specification {
             classLoaderScope
         }
         1 * settingsProcessor.process(gradle, settingsLocation, classLoaderScope, startParameter) >> settings
+        1 * settings.settingsScript >> settingsScript
+        1 * settingsScript.displayName >> "foo"
 
         then:
         settingsHandler.findAndLoadSettings(gradle).is(settings)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectDirectoryProjectSpecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectDirectoryProjectSpecTest.groovy
@@ -32,6 +32,7 @@ public class ProjectDirectoryProjectSpecTest extends Specification {
     private final File dir = temporaryFolder.createDir("build");
     private final ProjectDirectoryProjectSpec spec = new ProjectDirectoryProjectSpec(dir);
     private int counter;
+    def settings = "settings 'foo'"
 
     def "contains match when at least one project has specified project dir"() {
         expect:
@@ -48,16 +49,16 @@ public class ProjectDirectoryProjectSpecTest extends Specification {
         ProjectIdentifier project1 = project(dir);
 
         then:
-        spec.selectProject(registry(project1, project(new File("other")))) == project1;
+        spec.selectProject("settings 'foo'", registry(project1, project(new File("other")))) == project1;
     }
 
     def "select project fails when no project has specified project dir"() {
         when:
-        spec.selectProject(registry())
+        spec.selectProject("settings 'foo'", registry())
 
         then:
         def e = thrown(InvalidUserDataException)
-        e.message == "No projects in this build have project directory '" + dir + "'."
+        e.message == "Project directory '$dir' is not part of the build defined by settings 'foo'."
     }
 
     def "select project fails when multiple projects have specified project dir"() {
@@ -65,7 +66,7 @@ public class ProjectDirectoryProjectSpecTest extends Specification {
         ProjectIdentifier project2 = project(dir);
 
         when:
-        spec.selectProject(registry(project1, project2));
+        spec.selectProject("settings 'foo'", registry(project1, project2));
 
         then:
         def e = thrown(InvalidUserDataException)

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectSpecsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/ProjectSpecsTest.groovy
@@ -63,6 +63,6 @@ class ProjectSpecsTest extends Specification {
         parameter.setCurrentDir(currentDir)
 
         expect:
-        ProjectSpecs.forStartParameter(parameter, Stub(SettingsInternal)).class == DefaultProjectSpec
+        ProjectSpecs.forStartParameter(parameter, Stub(SettingsInternal)).class == CurrentDirectoryProjectSpec
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ProjectLoadingIntegrationTest.java
@@ -177,16 +177,16 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void buildFailsWhenSpecifiedSettingsFileDoesNotContainMatchingProject() {
         TestFile settingsFile = testFile("settings.gradle");
-        settingsFile.write("// empty");
+        settingsFile.write("rootProject.name = 'foo'");
 
         TestFile projectDir = testFile("project dir");
         TestFile buildFile = projectDir.file("build.gradle").createFile();
 
         ExecutionFailure result = usingProjectDir(projectDir).usingSettingsFile(settingsFile).runWithFailure();
-        result.assertHasDescription(String.format("No projects in this build have project directory '%s'.", projectDir));
+        result.assertHasDescription(String.format("Project directory '%s' is not part of the build defined by settings file '%s'.", projectDir, settingsFile));
 
         result = usingBuildFile(buildFile).usingSettingsFile(settingsFile).runWithFailure();
-        result.assertHasDescription(String.format("No projects in this build have build file '%s'.", buildFile));
+        result.assertHasDescription(String.format("Build file '%s' is not part of the build defined by settings file '%s'.", buildFile, settingsFile));
     }
 
     @Test
@@ -229,20 +229,20 @@ public class ProjectLoadingIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void buildFailsWhenNestedBuildHasNoSettingsFile() {
-        testFile("settings.gradle").write("include 'another'");
+        TestFile settingsFile = testFile("settings.gradle").write("include 'another'");
 
         TestFile subDirectory = getTestDirectory().file("sub");
         TestFile subBuildFile = subDirectory.file("sub.gradle").write("");
         subDirectory.file("build.gradle").write("");
 
         ExecutionFailure result = inDirectory(subDirectory).withTasks("help").runWithFailure();
-        result.assertHasDescription(String.format("No projects in this build have project directory '%s'.", subDirectory));
+        result.assertHasDescription(String.format("Project directory '%s' is not part of the build defined by settings file '%s'.", subDirectory, settingsFile));
 
         result = usingBuildFile(subBuildFile).inDirectory(subDirectory).withTasks("help").runWithFailure();
-        result.assertHasDescription(String.format("No projects in this build have build file '%s'.", subBuildFile));
+        result.assertHasDescription(String.format("Build file '%s' is not part of the build defined by settings file '%s'.", subBuildFile, settingsFile));
 
         result = usingProjectDir(subDirectory).withTasks("help").runWithFailure();
-        result.assertHasDescription(String.format("No projects in this build have project directory '%s'.", subDirectory));
+        result.assertHasDescription(String.format("Project directory '%s' is not part of the build defined by settings file '%s'.", subDirectory, settingsFile));
    }
 
     @Test


### PR DESCRIPTION
Previous versions of Gradle permitted a user to execute a `build.gradle` file that was unrelated to the build defined by a `settings.gradle` file found in a parent directory. This behaviour was deprecated in Gradle 4.x, and will now cause an error.