### PR TITLE
Fix concurrent configuration access

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -112,12 +112,12 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         if (populated != null) {
             return populated;
         }
-        ConfigurationMetadata md = populateConfigurationFromDescriptor(name, configurationDefinitions, configurations);
+        ConfigurationMetadata md = populateConfigurationFromDescriptor(name, configurationDefinitions);
         configurations.put(name, md);
         return md;
     }
 
-    protected ConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions, Map<String, ConfigurationMetadata> configurations) {
+    protected ConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions) {
         Configuration descriptorConfiguration = configurationDefinitions.get(name);
         if (descriptorConfiguration == null) {
             return null;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -70,8 +70,12 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
      */
     protected void copyCachedState(AbstractLazyModuleComponentResolveMetadata metadata) {
         // Copy built-on-demand state
-        configurations.putAll(metadata.configurations);
+        metadata.copyCachedConfigurations(this.configurations);
         this.graphVariants = metadata.graphVariants;
+    }
+
+    private synchronized void copyCachedConfigurations(Map<String, ConfigurationMetadata> target) {
+        target.putAll(configurations);
     }
 
     protected VariantMetadataRules getVariantMetadataRules() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/DefaultMavenModuleResolveMetadata.java
@@ -128,8 +128,8 @@ public class DefaultMavenModuleResolveMetadata extends AbstractLazyModuleCompone
     }
 
     @Override
-    protected ConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions, Map<String, ConfigurationMetadata> configurations) {
-        DefaultConfigurationMetadata md = (DefaultConfigurationMetadata) super.populateConfigurationFromDescriptor(name, configurationDefinitions, configurations);
+    protected ConfigurationMetadata populateConfigurationFromDescriptor(String name, Map<String, Configuration> configurationDefinitions) {
+        DefaultConfigurationMetadata md = (DefaultConfigurationMetadata) super.populateConfigurationFromDescriptor(name, configurationDefinitions);
         if (filterConstraints && md != null) {
             // if the first call to getConfiguration is done before getDerivedVariants() is called
             // then it means we're using the legacy matching, without attributes, and that the metadata


### PR DESCRIPTION
The underlying Map is not thread safe and is already protected by a
`synchronized` in `getConfiguration(String)` so a similar protection is
needed when reading the whole map content in `copyCachedState`.
To do so a synchronized `copyCachedConfigurations` has been added.
In its call, the calling instance can access its own configurations
safely because it is under construction.