### PR TITLE
Remove -a/--no-rebuild command line option

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
+++ b/subprojects/core-api/src/main/java/org/gradle/StartParameter.java
@@ -455,8 +455,12 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
 
     /**
      * Returns true if project dependencies are to be built, false if they should not be. The default is true.
+     *
+     * @deprecated This flag is no longer used and simply defaults to 'true'.
      */
+    @Deprecated
     public boolean isBuildProjectDependencies() {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("StartParameter.isBuildProjectDependencies()");
         return buildProjectDependencies;
     }
 
@@ -464,8 +468,11 @@ public class StartParameter implements LoggingConfiguration, ParallelismConfigur
      * Specifies whether project dependencies should be built. Defaults to true.
      *
      * @return this
+     * @deprecated This flag is no longer used.
      */
+    @Deprecated
     public StartParameter setBuildProjectDependencies(boolean build) {
+        DeprecationLogger.nagUserOfDiscontinuedMethod("StartParameter.setBuildProjectDependencies()");
         this.buildProjectDependencies = build;
         return this;
     }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ConfigurationOnDemandIntegrationTest.groovy
@@ -255,34 +255,6 @@ project(':api') {
         fixture.assertProjectsConfigured(":", ":impl", ":api")
     }
 
-    def "respects buildProjectDependencies setting"() {
-        settingsFile << "include 'api', 'impl', 'other'"
-        file("impl/build.gradle") << """
-            apply plugin: 'java'
-            dependencies { compile project(":api") }
-        """
-        file("api/build.gradle") << "apply plugin: 'java'"
-        // Provide a source file so that the compile task doesn't skip resolving inputs
-        file("impl/src/main/java/Foo.java") << "public class Foo {}"
-
-        when:
-        run("impl:build")
-
-        then:
-        executed ":api:jar", ":impl:jar"
-        fixture.assertProjectsConfigured(":", ":impl", ":api")
-
-        when:
-        executer.expectDeprecationWarning()
-        run("impl:build", "--no-rebuild") // impl -> api
-
-        then:
-        executed ":impl:jar"
-        notExecuted ":api:jar"
-        // :api is configured to resolve impl.compile configuration
-        fixture.assertProjectsConfigured(":", ":impl", ":api")
-    }
-
     def "respects external task dependencies"() {
         settingsFile << "include 'api', 'impl', 'other'"
         file("build.gradle") << "allprojects { task foo }"

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/CommandLineArgDeprecationIntegrationTest.groovy
@@ -25,7 +25,6 @@ import spock.lang.Unroll
 class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
 
     private static final String RECOMPILE_SCRIPTS_MESSAGE = '--recompile-scripts has been deprecated. This is scheduled to be removed in Gradle'
-    private static final String NO_REBUILD_MESSAGE = '--no-rebuild/-a has been deprecated. This is scheduled to be removed in Gradle'
 
     @Unroll
     def "deprecation warning appears when using #deprecatedArgs"() {
@@ -40,8 +39,6 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
         where:
         issue                                          | deprecatedArgs        | message
         'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | RECOMPILE_SCRIPTS_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | NO_REBUILD_MESSAGE
     }
 
     @Unroll
@@ -65,10 +62,5 @@ class CommandLineArgDeprecationIntegrationTest extends AbstractIntegrationSpec {
         where:
         issue                                          | deprecatedArgs        | warningsType     | warningCountInConsole | warningCountInSummary | message
         'https://github.com/gradle/gradle/issues/1425' | '--recompile-scripts' | WarningMode.All  | 1                     | 0                     | RECOMPILE_SCRIPTS_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '--no-rebuild'        | WarningMode.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningMode.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningMode.All  | 1                     | 0                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | null             | 0                     | 1                     | NO_REBUILD_MESSAGE
-        'https://github.com/gradle/gradle/issues/3077' | '-a'                  | WarningMode.None | 0                     | 0                     | NO_REBUILD_MESSAGE
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -38,19 +38,17 @@ import java.util.Set;
 
 public class DefaultProjectDependency extends AbstractModuleDependency implements ProjectDependencyInternal {
     private final ProjectInternal dependencyProject;
-    private final boolean buildProjectDependencies;
     private final ProjectAccessListener projectAccessListener;
 
-    public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
-        this(dependencyProject, null, projectAccessListener, buildProjectDependencies);
+    public DefaultProjectDependency(ProjectInternal dependencyProject, ProjectAccessListener projectAccessListener) {
+        this(dependencyProject, null, projectAccessListener);
     }
 
     public DefaultProjectDependency(ProjectInternal dependencyProject, String configuration,
-                                    ProjectAccessListener projectAccessListener, boolean buildProjectDependencies) {
+                                    ProjectAccessListener projectAccessListener) {
         super(configuration);
         this.dependencyProject = dependencyProject;
         this.projectAccessListener = projectAccessListener;
-        this.buildProjectDependencies = buildProjectDependencies;
     }
 
     public Project getDependencyProject() {
@@ -82,7 +80,7 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
 
     public ProjectDependency copy() {
         DefaultProjectDependency copiedProjectDependency = new DefaultProjectDependency(dependencyProject,
-            getTargetConfiguration(), projectAccessListener, buildProjectDependencies);
+            getTargetConfiguration(), projectAccessListener);
         copyTo(copiedProjectDependency);
         return copiedProjectDependency;
     }
@@ -152,15 +150,12 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
             : that.getTargetConfiguration() != null) {
             return false;
         }
-        if (this.buildProjectDependencies != that.buildProjectDependencies) {
-            return false;
-        }
         return true;
     }
 
     @Override
     public int hashCode() {
-        return getDependencyProject().hashCode() ^ (getTargetConfiguration() != null ? getTargetConfiguration().hashCode() : 31) ^ (buildProjectDependencies ? 1 : 0);
+        return getDependencyProject().hashCode() ^ (getTargetConfiguration() != null ? getTargetConfiguration().hashCode() : 31);
     }
 
     @Override
@@ -172,9 +167,6 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
     private class TaskDependencyImpl extends AbstractTaskDependency {
         @Override
         public void visitDependencies(TaskDependencyResolveContext context) {
-            if (!buildProjectDependencies) {
-                return;
-            }
             projectAccessListener.beforeResolvingProjectDependency(dependencyProject);
 
             Configuration configuration = findProjectConfiguration();

--- a/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/StartParameterBuildOptions.java
@@ -48,7 +48,6 @@ public class StartParameterBuildOptions {
         options.add(new RefreshDependenciesOption());
         options.add(new DryRunOption());
         options.add(new ContinuousOption());
-        options.add(new NoProjectDependenciesRebuildOption());
         options.add(new BuildFileOption());
         options.add(new SettingsFileOption());
         options.add(new InitScriptOption());
@@ -172,21 +171,6 @@ public class StartParameterBuildOptions {
         @Override
         public void applyTo(StartParameterInternal settings, Origin origin) {
             settings.setContinuous(true);
-        }
-    }
-
-    public static class NoProjectDependenciesRebuildOption extends EnabledOnlyBooleanBuildOption<StartParameterInternal> {
-        private static final String LONG_OPTION = "no-rebuild";
-        private static final String SHORT_OPTION = "a";
-
-        public NoProjectDependenciesRebuildOption() {
-            super(null, CommandLineOptionConfiguration.create(LONG_OPTION, SHORT_OPTION, "Do not rebuild project dependencies.").deprecated());
-        }
-
-        @Override
-        public void applyTo(StartParameterInternal settings, Origin origin) {
-            settings.setBuildProjectDependencies(false);
-            settings.addDeprecation(String.format("--%s/-%s", LONG_OPTION, SHORT_OPTION));
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyTest.groovy
@@ -36,7 +36,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
     private projectDependency
 
     def setup() {
-        projectDependency = new DefaultProjectDependency(project, null, false)
+        projectDependency = new DefaultProjectDependency(project, null)
         project.version = "1.2"
         project.group = "org.gradle"
     }
@@ -61,7 +61,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         conf.dependencies.add(dep1)
         superConf.dependencies.add(dep2)
 
-        projectDependency = new DefaultProjectDependency(project, "conf", null, true)
+        projectDependency = new DefaultProjectDependency(project, "conf", null)
 
         when:
         projectDependency.resolve(context)
@@ -75,7 +75,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
 
     void "if resolution context is not transitive it will not contain all dependencies"() {
         def context = Mock(DependencyResolveContext)
-        projectDependency = new DefaultProjectDependency(project, null, true)
+        projectDependency = new DefaultProjectDependency(project, null)
 
         when:
         projectDependency.resolve(context)
@@ -87,7 +87,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
 
     void "if dependency is not transitive the resolution context will not contain all dependencies"() {
         def context = Mock(DependencyResolveContext)
-        projectDependency = new DefaultProjectDependency(project, null, true)
+        projectDependency = new DefaultProjectDependency(project, null)
         projectDependency.setTransitive(false)
 
         when:
@@ -102,7 +102,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
 
         def conf = project.configurations.create('conf')
         def listener = Mock(ProjectAccessListener)
-        projectDependency = new DefaultProjectDependency(project, 'conf', listener, true)
+        projectDependency = new DefaultProjectDependency(project, 'conf', listener)
 
         when:
         projectDependency.buildDependencies.visitDependencies(context)
@@ -121,7 +121,7 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
             canBeConsumed = false
         }
         def listener = Mock(ProjectAccessListener)
-        projectDependency = new DefaultProjectDependency(project, 'conf', listener, true)
+        projectDependency = new DefaultProjectDependency(project, 'conf', listener)
 
         when:
         projectDependency.buildDependencies.visitDependencies(context)
@@ -131,22 +131,10 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
         e.message == "Selected configuration 'conf' on 'root project 'test'' but it can't be used as a project dependency because it isn't intended for consumption by other components."
     }
 
-    void "does not build project dependencies if configured so"() {
-         def context = Mock(TaskDependencyResolveContext)
-         project.configurations.create('conf')
-         projectDependency = new DefaultProjectDependency(project, 'conf', listener, false)
-
-         when:
-         projectDependency.buildDependencies.visitDependencies(context)
-
-         then:
-         0 * _
-     }
-
     void "is self resolving dependency"() {
         def conf = project.configurations.create('conf')
         def listener = Mock(ProjectAccessListener)
-        projectDependency = new DefaultProjectDependency(project, 'conf', listener, true)
+        projectDependency = new DefaultProjectDependency(project, 'conf', listener)
 
         when:
         def files = projectDependency.resolve()
@@ -185,28 +173,26 @@ class DefaultProjectDependencyTest extends AbstractProjectBuilderSpec {
     }
 
     private createProjectDependency() {
-        def out = new DefaultProjectDependency(project, "conf", listener, true)
+        def out = new DefaultProjectDependency(project, "conf", listener)
         out.addArtifact(new DefaultDependencyArtifact("name", "type", "ext", "classifier", "url"))
         out
     }
 
     void "knows if is equal"() {
         expect:
-        assertThat(new DefaultProjectDependency(project, listener, true),
-                strictlyEqual(new DefaultProjectDependency(project, listener, true)))
+        assertThat(new DefaultProjectDependency(project, listener),
+                strictlyEqual(new DefaultProjectDependency(project, listener)))
 
-        assertThat(new DefaultProjectDependency(project, "conf1", listener, false),
-                strictlyEqual(new DefaultProjectDependency(project, "conf1", listener, false)))
+        assertThat(new DefaultProjectDependency(project, "conf1", listener),
+                strictlyEqual(new DefaultProjectDependency(project, "conf1", listener)))
 
         when:
-        def base = new DefaultProjectDependency(project, "conf1", listener, true)
-        def differentConf = new DefaultProjectDependency(project, "conf2", listener, true)
-        def differentBuildDeps = new DefaultProjectDependency(project, "conf1", listener, false)
-        def differentProject = new DefaultProjectDependency(Mock(ProjectInternal), "conf1", listener, true)
+        def base = new DefaultProjectDependency(project, "conf1", listener)
+        def differentConf = new DefaultProjectDependency(project, "conf2", listener)
+        def differentProject = new DefaultProjectDependency(Stub(ProjectInternal), "conf1", listener)
 
         then:
         base != differentConf
-        base != differentBuildDeps
         base != differentProject
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/CommandLineConverterTestSupport.java
@@ -42,7 +42,6 @@ public class CommandLineConverterTestSupport {
     protected File expectedProjectDir;
     protected List<String> expectedTaskNames = WrapUtil.toList();
     protected Set<String> expectedExcludedTasks = WrapUtil.toSet();
-    protected boolean buildProjectDependencies = true;
     protected Map<String, String> expectedSystemProperties = new HashMap<String, String>();
     protected Map<String, String> expectedProjectProperties = new HashMap<String, String>();
     protected List<File> expectedInitScripts = new ArrayList<File>();
@@ -77,7 +76,6 @@ public class CommandLineConverterTestSupport {
     protected void checkStartParameter(StartParameter startParameter) {
         assertEquals(expectedBuildFile, startParameter.getBuildFile());
         assertEquals(expectedTaskNames, startParameter.getTaskNames());
-        assertEquals(buildProjectDependencies, startParameter.isBuildProjectDependencies());
         if(expectedCurrentDir != null) {
             assertEquals(expectedCurrentDir.getAbsoluteFile(), startParameter.getCurrentDir().getAbsoluteFile());
         }

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultCommandLineConverterTest.java
@@ -223,18 +223,6 @@ public class DefaultCommandLineConverterTest extends CommandLineConverterTestSup
     }
 
     @Test
-    public void withNoProjectDependencyRebuild() {
-        buildProjectDependencies = false;
-        checkConversion("--no-rebuild");
-    }
-
-    @Test
-    public void withNoProjectDependencyRebuildShortFlag() {
-        buildProjectDependencies = false;
-        checkConversion("-a");
-    }
-
-    @Test
     public void withQuietLoggingOptions() {
         expectedLogLevel = LogLevel.QUIET;
         checkConversion("-q");

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -294,7 +294,6 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                             repositories,
                             metadataHandler,
                             resolutionResultsStoreFactory,
-                            startParameter.isBuildProjectDependencies(),
                             attributesSchema,
                             new DefaultArtifactTransforms(
                                 new ConsumerProvidedVariantFinder(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultProjectDependencyFactory.java
@@ -26,19 +26,17 @@ import org.gradle.internal.reflect.Instantiator;
 public class DefaultProjectDependencyFactory {
     private final ProjectAccessListener projectAccessListener;
     private final Instantiator instantiator;
-    private final boolean buildProjectDependencies;
 
-    public DefaultProjectDependencyFactory(ProjectAccessListener projectAccessListener, Instantiator instantiator, boolean buildProjectDependencies) {
+    public DefaultProjectDependencyFactory(ProjectAccessListener projectAccessListener, Instantiator instantiator) {
         this.projectAccessListener = projectAccessListener;
         this.instantiator = instantiator;
-        this.buildProjectDependencies = buildProjectDependencies;
     }
 
     public ProjectDependency create(ProjectInternal project, String configuration) {
-        return instantiator.newInstance(DefaultProjectDependency.class, project, configuration, projectAccessListener, buildProjectDependencies);
+        return instantiator.newInstance(DefaultProjectDependency.class, project, configuration, projectAccessListener);
     }
 
     public ProjectDependency create(Project project) {
-        return instantiator.newInstance(DefaultProjectDependency.class, project, projectAccessListener, buildProjectDependencies);
+        return instantiator.newInstance(DefaultProjectDependency.class, project, projectAccessListener);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -146,7 +146,7 @@ class DependencyManagementBuildScopeServices {
         ImmutableAttributesFactory attributesFactory,
         SimpleMapInterner stringInterner) {
         DefaultProjectDependencyFactory factory = new DefaultProjectDependencyFactory(
-            projectAccessListener, instantiator, startParameter.isBuildProjectDependencies());
+            projectAccessListener, instantiator);
 
         ProjectDependencyFactory projectDependencyFactory = new ProjectDependencyFactory(factory);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -83,7 +83,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     private final RepositoryHandler repositories;
     private final GlobalDependencyResolutionRules metadataHandler;
     private final ResolutionResultsStoreFactory storeFactory;
-    private final boolean buildProjectDependencies;
     private final AttributesSchemaInternal attributesSchema;
     private final ArtifactTransforms artifactTransforms;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
@@ -96,7 +95,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     public DefaultConfigurationResolver(ArtifactDependencyResolver resolver, RepositoryHandler repositories,
                                         GlobalDependencyResolutionRules metadataHandler,
                                         ResolutionResultsStoreFactory storeFactory,
-                                        boolean buildProjectDependencies,
                                         AttributesSchemaInternal attributesSchema,
                                         ArtifactTransforms artifactTransforms,
                                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
@@ -109,7 +107,6 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         this.repositories = repositories;
         this.metadataHandler = metadataHandler;
         this.storeFactory = storeFactory;
-        this.buildProjectDependencies = buildProjectDependencies;
         this.attributesSchema = attributesSchema;
         this.artifactTransforms = artifactTransforms;
         this.moduleIdentifierFactory = moduleIdentifierFactory;
@@ -124,7 +121,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
         ResolutionStrategyInternal resolutionStrategy = configuration.getResolutionStrategy();
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
-        DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(currentBuild, buildProjectDependencies, resolutionStrategy.getSortOrder());
+        DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(currentBuild, resolutionStrategy.getSortOrder());
         resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, failureCollector, artifactsVisitor, attributesSchema, artifactTypeRegistry);
         result.graphResolved(new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.<UnresolvedDependency>emptySet()), artifactsVisitor.complete(), artifactTransforms));
     }
@@ -146,7 +143,7 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
         ResolvedLocalComponentsResultGraphVisitor localComponentsVisitor = new ResolvedLocalComponentsResultGraphVisitor(currentBuild);
 
         ResolutionStrategyInternal resolutionStrategy = configuration.getResolutionStrategy();
-        DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(currentBuild, buildProjectDependencies, resolutionStrategy.getSortOrder());
+        DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(currentBuild, resolutionStrategy.getSortOrder());
         FileDependencyCollectingGraphVisitor fileDependencyVisitor = new FileDependencyCollectingGraphVisitor();
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
         DependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(newModelBuilder, localComponentsVisitor, failureCollector);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -64,6 +64,6 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
         dependencyProject.setGroup("someGroup")
         dependencyProject.setVersion("someVersion")
         dependencyProject.configurations.create(dependencyConfiguration)
-        return new DefaultProjectDependency(dependencyProject, dependencyConfiguration, {} as ProjectAccessListener, true)
+        return new DefaultProjectDependency(dependencyProject, dependencyConfiguration, {} as ProjectAccessListener)
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ProjectDependencyFactoryTest.groovy
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.notations;
+package org.gradle.api.internal.notations
 
 
 import org.gradle.api.InvalidUserDataException
@@ -25,24 +25,24 @@ import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.util.GUtil
 import spock.lang.Specification
 
-public class ProjectDependencyFactoryTest extends Specification {
+class ProjectDependencyFactoryTest extends Specification {
 
     def projectDummy = Mock(ProjectInternal)
     def projectFinder = Mock(ProjectFinder)
 
-    def depFactory = new DefaultProjectDependencyFactory(Mock(ProjectAccessListener), DirectInstantiator.INSTANCE, true)
+    def depFactory = new DefaultProjectDependencyFactory(Mock(ProjectAccessListener), DirectInstantiator.INSTANCE)
     def factory = new ProjectDependencyFactory(depFactory)
 
     def "creates project dependency with map notation"() {
         given:
-        boolean expectedTransitive = false;
-        final Map<String, Object> mapNotation = GUtil.map("path", ":foo:bar", "configuration", "compile", "transitive", expectedTransitive);
+        boolean expectedTransitive = false
+        final Map<String, Object> mapNotation = GUtil.map("path", ":foo:bar", "configuration", "compile", "transitive", expectedTransitive)
 
         and:
         projectFinder.getProject(':foo:bar') >> projectDummy
 
         when:
-        def projectDependency = factory.createFromMap(projectFinder, mapNotation);
+        def projectDependency = factory.createFromMap(projectFinder, mapNotation)
 
         then:
         projectDependency.getDependencyProject() == projectDummy
@@ -55,7 +55,7 @@ public class ProjectDependencyFactoryTest extends Specification {
         projectFinder.getProject(':foo:bar') >> projectDummy
 
         when:
-        factory.createFromMap(projectFinder, GUtil.map("paths", ":foo:bar"));
+        factory.createFromMap(projectFinder, GUtil.map("paths", ":foo:bar"))
 
         then:
         def ex = thrown(InvalidUserDataException)

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -110,9 +110,12 @@ in the next major Gradle version (Gradle 6.0). See the User guide section on the
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
 
-### StartParameter.interactive flag
+### StartParameter properties
 
-The `interactive` flag is deprecated and will be removed in Gradle 6.0.
+The following properties are deprecated and will be removed in Gradle 6.0.
+
+- `interactive`
+- `buildProjectDependencies`
 
 ### Removing tasks from TaskContainer
 
@@ -191,6 +194,12 @@ Now when the last non-constraint edge to a dependency disappears, all constraint
 
 Gradle can no longer be run on Java 7, but requires Java 8 as the minimum build JVM version.
 However, you can still use forked compilation and testing to build and test software for Java 6 and above.
+
+### Removed command-line options
+
+- The `-a`/`--no-rebuild` command-line option has been removed.
+  It avoided a full rebuild of dependent projects in a multi-project builds and was introduced in a very early version of Gradle.
+  Since then Gradle optimized its up-to-date checking for project dependencies which rendered the option obsolete.
 
 ### Java Library Distribution Plugin utilizes Java Library Plugin
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/SamplesJavaMultiProjectIntegrationTest.groovy
@@ -211,20 +211,6 @@ class SamplesJavaMultiProjectIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Unroll
-    def "no rebuild of project dependencies with #dsl dsl"() {
-        TestFile dslDir = sample.dir.file(dsl)
-        executer.inDirectory(dslDir).withTasks(":$API_NAME:classes").run()
-        TestFile sharedJar = dslDir.file("shared/build/libs/shared-1.0.jar")
-        TestFile.Snapshot snapshot = sharedJar.snapshot()
-        executer.expectDeprecationWarning()
-        executer.inDirectory(dslDir).withTasks(":$API_NAME:clean", ":$API_NAME:classes").withArguments("-a").run()
-        sharedJar.assertHasNotChangedSince(snapshot)
-
-        where:
-        dsl << ['groovy', 'kotlin']
-    }
-
-    @Unroll
     def "should not use cache for project dependencies with #dsl dsl"() {
         TestFile dslDir = sample.dir.file(dsl)
         executer.inDirectory(dslDir).withTasks(":$API_NAME:checkProjectDependency").run()

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/action/BuildActionSerializer.java
@@ -104,7 +104,6 @@ public class BuildActionSerializer {
             stringListSerializer.write(encoder, startParameter.getLockedDependenciesToUpdate());
 
             // Flags
-            encoder.writeBoolean(startParameter.isBuildProjectDependencies());
             encoder.writeBoolean(startParameter.isDryRun());
             encoder.writeBoolean(startParameter.isRerunTasks());
             encoder.writeBoolean(startParameter.isProfile());
@@ -175,7 +174,6 @@ public class BuildActionSerializer {
             startParameter.setLockedDependenciesToUpdate(stringListSerializer.read(decoder));
 
             // Flags
-            startParameter.setBuildProjectDependencies(decoder.readBoolean());
             startParameter.setDryRun(decoder.readBoolean());
             startParameter.setRerunTasks(decoder.readBoolean());
             startParameter.setProfile(decoder.readBoolean());

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/pom/ProjectDependencyArtifactIdExtractorHackTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/pom/ProjectDependencyArtifactIdExtractorHackTest.groovy
@@ -27,7 +27,7 @@ class ProjectDependencyArtifactIdExtractorHackTest extends AbstractProjectBuilde
     def extractor
 
     def setup() {
-        extractor = new ProjectDependencyArtifactIdExtractorHack(new DefaultProjectDependency(project, null, true))
+        extractor = new ProjectDependencyArtifactIdExtractorHack(new DefaultProjectDependency(project, null))
     }
 
     def "artifact ID defaults to project name if neither archivesBaseName nor mavenDeployer.pom.artifactId is configured"() {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -203,7 +203,7 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
 
     class ResolveResult implements DependencyGraphVisitor, DependencyArtifactsVisitor {
         public final List<Throwable> notFound = new LinkedList<Throwable>();
-        public DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(thisBuild, true, ResolutionStrategy.SortOrder.DEFAULT);
+        public DefaultResolvedArtifactsBuilder artifactsBuilder = new DefaultResolvedArtifactsBuilder(thisBuild, ResolutionStrategy.SortOrder.DEFAULT);
         public SelectedArtifactResults artifactsResults;
 
         @Override


### PR DESCRIPTION
The command-line option is deleted and the corresponding
`StartParameter` property is deprecated and no longer used.

Resolves #6305.