### PR TITLE
Use symmetric nullable annotations on BuildCache

### DIFF
--- a/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
+++ b/subprojects/build-cache-http/src/main/java/org/gradle/caching/http/HttpBuildCache.java
@@ -70,7 +70,7 @@ public class HttpBuildCache extends AbstractBuildCache {
     /**
      * Sets the URL of the cache. The URL must end in a '/'.
      */
-    public void setUrl(URI url) {
+    public void setUrl(@Nullable URI url) {
         this.url = url;
     }
 

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/local/DirectoryBuildCache.java
@@ -44,7 +44,7 @@ public class DirectoryBuildCache extends AbstractBuildCache {
      *
      * The directory is evaluated as per {@code Project.file(Object)}.
      */
-    public void setDirectory(Object directory) {
+    public void setDirectory(@Nullable Object directory) {
         this.directory = directory;
     }
 


### PR DESCRIPTION
`@Nullable` should be both on the getter and the setter or on neither.
Mixing `@Nullable` causes problems with Kotlin, Intellij shows
`val cannot be reassigned` when trying to do this
```
buildCache {
    remote(HttpBuildCache::class) {
        url = <some URI>
    }
}
```
