### PR TITLE
Remove Incubating from PluginAware::getPluginManager

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/plugins/PluginAware.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/plugins/PluginAware.java
@@ -18,7 +18,6 @@ package org.gradle.api.plugins;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.internal.HasInternalProtocol;
 
 import java.util.Map;
@@ -96,7 +95,6 @@ public interface PluginAware {
      * @return the plugin manager
      * @since 2.3
      */
-    @Incubating
     PluginManager getPluginManager();
 
 }


### PR DESCRIPTION
### Context
`PluginAware::getPluginManager` has been around since Gradle version 2.3.
It's one of the most widely used API's in plugins to find other plugins. It's also extensively used internally in Gradle.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
