### PR TITLE
Make `PreferJavaRuntime` choose JAVA_RUNTIME if its present

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.internal.component.external.model;
 
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.DisambiguationRule;
@@ -39,8 +38,6 @@ import java.util.Set;
  */
 public class PreferJavaRuntimeVariant extends EmptySchema {
     private static final Usage RUNTIME_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME);
-    private static final Usage API_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_API);
-    private static final Set<Usage> DEFAULT_JAVA_USAGES = ImmutableSet.of(API_USAGE, RUNTIME_USAGE);
     private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Collections.<Attribute<?>>singleton(Usage.USAGE_ATTRIBUTE);
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
 
@@ -75,15 +72,7 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
         public void execute(MultipleCandidatesResult<Usage> details) {
             if (details.getConsumerValue() == null) {
                 Set<Usage> candidates = details.getCandidateValues();
-                if (DEFAULT_JAVA_USAGES.equals(candidates)) {
-                    details.closestMatch(RUNTIME_USAGE);
-                } else {
-                    // slower path: let's see if the candidates are either null (missing) or one of the standard usages
-                    for (Usage candidate : candidates) {
-                        if (candidate != null && !DEFAULT_JAVA_USAGES.contains(candidate)) {
-                            return;
-                        }
-                    }
+                if (candidates.contains(RUNTIME_USAGE)) {
                     details.closestMatch(RUNTIME_USAGE);
                 }
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/PreferJavaRuntimeVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/PreferJavaRuntimeVariantTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.external.model
+
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.attributes.MultipleCandidatesResult
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class PreferJavaRuntimeVariantTest extends Specification {
+
+    final PreferJavaRuntimeVariant schema = PreferJavaRuntimeVariant.schema()
+
+    @Unroll
+    def "should prefer the runtime variant if the consumer doesn't express any preference and that runtime is in the candidates"() {
+        given:
+        def rule = schema.disambiguationRules(Usage.USAGE_ATTRIBUTE)
+        MultipleCandidatesResult<Usage> candidates = Mock(MultipleCandidatesResult)
+        candidates.getConsumerValue() >> consumerValue
+        candidates.getCandidateValues() >> candidateValues.collect { usage(it) }
+
+        when:
+        rule.execute(candidates)
+
+        then:
+        count * candidates.closestMatch({ it.name == Usage.JAVA_RUNTIME })
+
+        where:
+        consumerValue      | candidateValues                                 | choosesRuntime
+        null               | [Usage.JAVA_API]                                | false
+        null               | [Usage.JAVA_RUNTIME]                            | true
+        null               | [Usage.JAVA_RUNTIME, Usage.JAVA_API]            | true
+        null               | [Usage.JAVA_API, Usage.JAVA_RUNTIME]            | true
+        null               | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | true
+        null               | [Usage.JAVA_API, Usage.JAVA_API_CLASSES]        | false
+        Usage.JAVA_API     | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | false
+        Usage.JAVA_RUNTIME | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | false
+        "unknown"          | [Usage.JAVA_API, "unknown", Usage.JAVA_RUNTIME] | false
+
+        count = choosesRuntime ? 1 : 0
+    }
+
+    private static Usage usage(String name) {
+        TestUtil.objectFactory().named(Usage, name)
+    }
+}


### PR DESCRIPTION
### Context

This commit changes the prefer java runtime disambiguation rule, so that
it's more tolerant of unexpected candidate values. Before this change, the
rule would prefer the runtime variant if, and only if:

- the consumer expressed no preference for `Usage` and
   - the candidate values are _exactly_ `JAVA_RUNTIME` or `JAVA_API` or
   - the candidate values were only of the above or missing

Now that we cannot have missing (`null`) candidate values, the rule above
could already have been simplified. However, this commit change it to an
even simpler rule:

- if the consumer expressed no preference and the candidate values contain
`JAVA_RUNTIME`, use it.

This should allow us to be more tolerant whenever new candidate values are
introduced by plugins. Without this change, any external dependency from
Maven would suddenly start failing if the type of the component was unexpected.
This is because we would use derived variants, and that we do it whatever
the type of component is (jar, pom, bom, aar, ...)

This change will therefore restore the previous behavior, which was to choose
the "runtime" variant of an unknown component type (for external Maven dependencies).

This is related to #6800 too.