### PR TITLE
Abort Gradle handle upon timeout

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy
@@ -80,6 +80,10 @@ class BuildSourceBuilderIntegrationTest extends AbstractIntegrationSpec {
         def firstTaskTimeFromSecondBuildSrcBuild = startedTaskTimes(secondBuildResult.output).values().min()
 
         lastTaskTimeFromFirstBuildSrcBuild < firstTaskTimeFromSecondBuildSrcBuild
+
+        cleanup:
+        runReleaseHandle.abort()
+        runBlockingHandle.abort()
     }
 
     Map<String, Long> startedTaskTimes(String output) {


### PR DESCRIPTION
We had a [timeouted execution](https://builds.gradle.org/viewLog.html?buildId=16114618&buildTypeId=Gradle_Check_Platform_Java10_Oracle_Windows_integTest) yesterday. The test worker process hangs at exit hooks:

```
at java.lang.Thread.join(java.base@10.0.2/Thread.java:1427)
 	at java.lang.ApplicationShutdownHooks.runHooks(java.base@10.0.2/ApplicationShutdownHooks.java:107)
 	at java.lang.ApplicationShutdownHooks$1.run(java.base@10.0.2/ApplicationShutdownHooks.java:46)
```

And the daemon itself hangs at `sleep`:

```
 "Daemon worker" #20 prio=5 os_prio=0 tid=0x00000000669ab000 nid=0x3668 waiting on condition  [0x00000000676ca000]
 java.lang.Thread.State: TIMED_WAITING (sleeping)
 	at java.lang.Thread.sleep(java.base@10.0.2/Native Method)
 	at org.codehaus.groovy.runtime.DefaultGroovyStaticMethods.sleepImpl(DefaultGroovyStaticMethods.java:126)
 	at org.codehaus.groovy.runtime.DefaultGroovyStaticMethods.sleep(DefaultGroovyStaticMethods.java:148)
 	at jdk.internal.reflect.GeneratedMethodAccessor52.invoke(Unknown Source)
 	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(java.base@10.0.2/DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(java.base@10.0.2/Method.java:564)
```

Seems like the build slept indefinitely [here](https://github.com/gradle/gradle/blob/87ddd53f651172051e14919d13c7849a048df789/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/BuildSourceBuilderIntegrationTest.groovy#L49).

This commit aborts the Gradle handles in cleanup phase.
