### PR TITLE
Detect competing force from resolutionStrategy

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -117,7 +117,7 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         fails ':checkDeps'
 
         then:
-        failureCauseContains("Multiple competing force for virtual platform org:platform")
+        failureCauseContains("Multiple forces on different versions for virtual platform org:platform")
 
         where:
         dep1                 | dep2
@@ -159,7 +159,7 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         fails ':checkDeps'
 
         then:
-        failureCauseContains("Multiple competing force for virtual platform org:platform")
+        failureCauseContains("Multiple forces on different versions for virtual platform org:platform")
     }
 
     def "fails if forcing a virtual platform version and forcing a leaf with different version"() {
@@ -195,7 +195,7 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         fails ':checkDeps'
 
         then:
-        failureCauseContains("Multiple competing force for virtual platform org:platform")
+        failureCauseContains("Multiple forces on different versions for virtual platform org:platform")
     }
 
     def "fails if forcing a virtual platform version and forcing a leaf with different version through resolutionStrategy"() {
@@ -234,7 +234,7 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         fails ':checkDeps'
 
         then:
-        failureCauseContains("Multiple competing force for virtual platform org:platform")
+        failureCauseContains("Multiple forces on different versions for virtual platform org:platform")
     }
 
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions, including transitively"() {
@@ -282,7 +282,7 @@ include 'other'
         fails ':checkDeps'
 
         then:
-        failureCauseContains("Multiple competing force for virtual platform org:platform")
+        failureCauseContains("Multiple forces on different versions for virtual platform org:platform")
     }
 
     def "succeeds if forcing a virtual platform version by forcing multiple leaves with same version"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -43,7 +43,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.specs.Spec;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.model.DependencyMetadata;
-import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.id.IdGenerator;
 import org.gradle.internal.id.LongIdGenerator;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -340,12 +339,7 @@ public class DependencyGraphBuilder {
                 if (incomingEdge.getSelector().isForce()) {
                     // Filter out platform originating edges
                     if (!incomingEdge.getFrom().getComponent().getModule().equals(module)) {
-                        // Only account for force coming from metadata
-                        if (incomingEdge.getDependencyMetadata() instanceof ForcingDependencyMetadata) {
-                            if (((ForcingDependencyMetadata) incomingEdge.getDependencyMetadata()).isForce()) {
-                                forcedEdges.add(incomingEdge);
-                            }
-                        }
+                        forcedEdges.add(incomingEdge);
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -344,7 +344,7 @@ public class DependencyGraphBuilder {
                 }
             }
         }
-        attachFailureToEdges(new GradleException("Multiple competing force for virtual platform " + module.getId()), forcedEdges);
+        attachFailureToEdges(new GradleException("Multiple forces on different versions for virtual platform " + module.getId()), forcedEdges);
     }
 
     /**


### PR DESCRIPTION
Prior to this change, a `ResolutionStrategy.force` based force was not
handled the same as setting `force = true` on a dependency.
This caused virtual platforms alignment to not properly detect there
were competing force in action.
With this change, a `SelectorState` is marked as force also for a forced
substitution.