### PR TITLE
Fix failing 'help on the gradle build comparing the build'

### DIFF
--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -27,7 +27,7 @@ tasks.register("gradleBuildBaseline", RemoteProject) {
     remoteUri = rootDir.absolutePath
     // Remember to update accordingly when rebasing/squashing
     // Do not use the "Rebase and merge" nor "Squash and merge" Github buttons when merging a PR that change the baseline
-    ref = '68ad5c8379a4efc308df7fe17c1de3c20225f15c'
+    ref = '289c3f0e0862f8a2596a1c8a0488b2916f2a06ee'
 }
 
 // === Java ===


### PR DESCRIPTION
by using the merge commit for Kotlin DSL 1.0-rc-11