### PR TITLE
Prevent calling `Project` and `Gradle` hooks from lazy configuration actions

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/AbstractDomainObjectContainerIntegrationTest.groovy
@@ -21,28 +21,46 @@ import spock.lang.Unroll
 
 abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractIntegrationSpec {
     abstract String makeContainer()
+    abstract String getContainerStringRepresentation()
 
-    abstract String disallowMutationMessage(String assertingMethod)
+    String disallowMutationMessage(String assertingMethod) {
+        return "$assertingMethod on ${targetStringRepresentation(assertingMethod)} cannot be executed in the current context."
+    }
+
+    private String targetStringRepresentation(String method) {
+        if (method.startsWith("Project")) {
+            return "root project 'root'"
+        } else if (method.startsWith("Gradle")) {
+            return "build 'root'"
+        } else {
+            return containerStringRepresentation
+        }
+    }
 
     def setup() {
-        buildFile << """
-            def testContainer = ${makeContainer()}
-            def toBeRealized = testContainer.register('toBeRealized')
-            def unrealized = testContainer.register('unrealized')
-            def realized = testContainer.register('realized')
-            realized.get()
+        settingsFile << """
+            rootProject.name = 'root'
+            gradle.projectsLoaded {
+                it.rootProject {
+                    ext.testContainer = ${makeContainer()}
+                    ext.toBeRealized = testContainer.register('toBeRealized')
+                    ext.unrealized = testContainer.register('unrealized')
+                    ext.realized = testContainer.register('realized')
+                    realized.get()
+                }
+            }
         """
     }
 
     Map<String, String> getQueryMethods() {
         [
-            "getByName(String)": "testContainer.getByName('unrealized')",
-            "named(String)": "testContainer.named('unrealized')",
-            "named(String, Class)": "testContainer.named('unrealized', testContainer.type)",
-            "findAll(Closure)": "testContainer.findAll { it.name == 'unrealized' }",
-            "findByName(String)": "testContainer.findByName('unrealized')",
-            "TaskProvider.get()": "unrealized.get()",
-            "iterator()": "for (def element : testContainer) { println element.name }",
+            "${containerType}#getByName(String)":    "testContainer.getByName('unrealized')",
+            "${containerType}#named(String)":        "testContainer.named('unrealized')",
+            "${containerType}#named(String, Class)": "testContainer.named('unrealized', testContainer.type)",
+            "${containerType}#findAll(Closure)":     "testContainer.findAll { it.name == 'unrealized' }",
+            "${containerType}#findByName(String)":   "testContainer.findByName('unrealized')",
+            "${containerType}#TaskProvider.get()":   "unrealized.get()",
+            "${containerType}#iterator()":           "for (def element : testContainer) { println element.name }",
         ]
     }
 
@@ -142,12 +160,18 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
 
     Map<String, String> getMutationMethods() {
         [
-            "create(String)": "testContainer.create('mutate')",
-            "register(String)": "testContainer.register('mutate')",
-            "getByName(String, Action)": "testContainer.getByName('realized') {}",
-            "configureEach(Action)": "testContainer.configureEach {}",
-            "NamedDomainObjectProvider.configure(Action)": "toBeRealized.configure {}",
-            "named(String, Action)": "testContainer.named('realized') {}"
+            "${containerType}#create(String)": "testContainer.create('mutate')",
+            "${containerType}#register(String)": "testContainer.register('mutate')",
+            "${containerType}#getByName(String, Action)": "testContainer.getByName('realized') {}",
+            "${containerType}#configureEach(Action)": "testContainer.configureEach {}",
+            "${containerType}#NamedDomainObjectProvider.configure(Action)": "toBeRealized.configure {}",
+            "${containerType}#named(String, Action)": "testContainer.named('realized') {}",
+            "Project#afterEvaluate(Closure)": "afterEvaluate {}",
+            "Project#beforeEvaluate(Closure)": "beforeEvaluate {}",
+            "Gradle#beforeProject(Closure)": "gradle.beforeProject {}",
+            "Gradle#afterProject(Closure)": "gradle.afterProject {}",
+            "Gradle#projectsLoaded(Closure)": "gradle.projectsLoaded {}",
+            "Gradle#projectsEvaluated(Closure)": "gradle.projectsEvaluated {}",
         ]
     }
 
@@ -323,11 +347,103 @@ abstract class AbstractDomainObjectContainerIntegrationTest extends AbstractInte
                 ${method.value}
             }
         """
-
         expect:
         succeeds "help"
-
         where:
         method << getQueryMethods() + getMutationMethods()
+    }
+
+    def "can mutate containers inside Project hooks"() {
+        settingsFile << """
+            include 'nested'
+        """
+        buildFile << """
+            project(':nested').afterEvaluate {
+                testContainer.create("afterEvaluate")
+            }
+
+            project(':nested').beforeEvaluate {
+                testContainer.create("beforeEvaluate")
+            }
+
+            task verify {
+                doLast {
+                    assert testContainer.findByName("afterEvaluate") != null
+                    assert testContainer.findByName("beforeEvaluate") != null
+                }
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can mutate containers inside Gradle hooks"() {
+        settingsFile << """
+            include 'nested'
+            gradle.projectsLoaded {
+                it.rootProject {
+                    testContainer.create("projectsLoaded")
+                }
+            }
+        """
+        buildFile << """
+            gradle.beforeProject {
+                if (it.name == 'nested') {
+                    testContainer.create("beforeProject")
+                }
+            }
+
+            gradle.afterProject {
+                if (it.name == 'nested') {
+                    testContainer.create("afterProject")
+                }
+            }
+
+            gradle.projectsEvaluated {
+                testContainer.create("projectsEvaluated")
+            }
+
+            task verify {
+                doLast {
+                    assert testContainer.findByName("beforeProject") != null
+                    assert testContainer.findByName("afterProject") != null
+                    assert testContainer.findByName("projectsLoaded") != null
+                    assert testContainer.findByName("projectsEvaluated") != null
+                }
+            }
+        """
+
+        expect:
+        succeeds "verify"
+    }
+
+    def "can mutate other containers"() {
+        buildFile << """
+            class SomeOtherType implements Named {
+                final String name
+                SomeOtherType(String name) {
+                    this.name = name
+                }
+            }
+
+            def otherContainer = project.container(SomeOtherType)
+            testContainer.configureEach {
+                if (it.name != "verify") {
+                    otherContainer.create(it.name)
+                }
+            }
+            toBeRealized.get()
+
+            task verify {
+                doLast {
+                    assert otherContainer.findByName("realized") != null
+                    assert otherContainer.findByName("toBeRealized") != null
+                }
+            }
+        """
+
+        expect:
+        succeeds "verify"
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NamedDomainObjectContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NamedDomainObjectContainerIntegrationTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.api
 
 class NamedDomainObjectContainerIntegrationTest extends AbstractDomainObjectContainerIntegrationTest {
     @Override
-    String disallowMutationMessage(String assertingMethod) {
-        return "NamedDomainObjectContainer#$assertingMethod on SomeType container cannot be executed in the current context."
+    String getContainerStringRepresentation() {
+        return "SomeType container"
     }
 
     @Override
@@ -27,8 +27,12 @@ class NamedDomainObjectContainerIntegrationTest extends AbstractDomainObjectCont
         return "project.container(SomeType)"
     }
 
+    static String getContainerType() {
+        return "NamedDomainObjectContainer"
+    }
+
     def setup() {
-        buildFile << """
+        settingsFile << """
             class SomeType implements Named {
                 final String name
 
@@ -37,5 +41,24 @@ class NamedDomainObjectContainerIntegrationTest extends AbstractDomainObjectCont
                 }
             } 
         """
+    }
+
+    def "can mutate the task container from named container"() {
+        buildFile << """
+            testContainer.configureEach {
+                tasks.create(it.name)
+            }
+            toBeRealized.get()
+
+            task verify {
+                doLast {
+                    assert tasks.findByName("realized") != null
+                    assert tasks.findByName("toBeRealized") != null
+                }
+            }
+        """
+
+        expect:
+        succeeds "verify"
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/TaskContainerIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/TaskContainerIntegrationTest.groovy
@@ -23,7 +23,11 @@ class TaskContainerIntegrationTest extends AbstractDomainObjectContainerIntegrat
     }
 
     @Override
-    String disallowMutationMessage(String assertingMethod) {
-        return "DefaultTaskContainer#$assertingMethod on task set cannot be executed in the current context."
+    String getContainerStringRepresentation() {
+        return "task set"
+    }
+
+    static String getContainerType() {
+        return "DefaultTaskContainer"
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -166,7 +166,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
     @Override
     public void configureEach(Action<? super T> action) {
         assertMutable("configureEach(Action)");
-        Action<? super T> wrappedAction = getMutationGuard().withMutationDisabled(action);
+        Action<? super T> wrappedAction = withMutationDisabled(action);
         eventRegister.registerLazyAddAction(wrappedAction);
 
         // copy in case any actions mutate the store
@@ -185,6 +185,10 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
                 wrappedAction.execute(next);
             }
         }
+    }
+
+    protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
+        return getMutationGuard().withMutationDisabled(action);
     }
 
     public void all(Closure action) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -883,10 +883,6 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         public I getOrNull() {
             return Cast.uncheckedCast(findByNameWithoutRules(getName()));
         }
-
-        protected Action<? super I> withMutationDisabled(Action<? super I> action) {
-            return getMutationGuard().withMutationDisabled(action);
-        }
     }
 
     public abstract class AbstractDomainObjectCreatingProvider<I extends T> extends AbstractNamedDomainObjectProvider<I> {
@@ -920,10 +916,6 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
             }
             // Collect any container level add actions then add the object specific action
             onCreate = onCreate.mergeFrom(getEventRegister().getAddActions()).add(wrappedAction);
-        }
-
-        protected Action<? super I> withMutationDisabled(Action<? super I> action) {
-            return getMutationGuard().withMutationDisabled(action);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -16,14 +16,18 @@
 package org.gradle.api.internal;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Namer;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.internal.collections.CollectionFilter;
+import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.internal.reflect.Instantiator;
 
 public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObjectContainer<T> {
 
     private final NamedDomainObjectFactory<T> factory;
+    private final MutationGuard crossProjectConfiguratorMutationGuard;
 
     /**
      * <p>Creates a container that instantiates reflectively, expecting a 1 arg constructor taking the name.<p>
@@ -34,7 +38,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param instantiator The instantiator to use to create any other collections based on this one
      */
     public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-        this(type, instantiator, Named.Namer.forType(type));
+        this(type, instantiator, Named.Namer.forType(type), MutationGuards.identity());
     }
 
     /**
@@ -44,8 +48,8 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param instantiator The instantiator to use to create any other collections based on this one
      * @param namer The naming strategy to use
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
-        this(type, instantiator, namer, new ReflectiveNamedDomainObjectFactory<T>(type));
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, MutationGuard crossProjectConfiguratorMutationGuard) {
+        this(type, instantiator, namer, new ReflectiveNamedDomainObjectFactory<T>(type), crossProjectConfiguratorMutationGuard);
     }
 
     /**
@@ -56,7 +60,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param factory The factory responsible for creating new instances on demand
      */
     public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, NamedDomainObjectFactory<T> factory) {
-        this(type, instantiator, Named.Namer.forType(type), factory);
+        this(type, instantiator, Named.Namer.forType(type), factory, MutationGuards.identity());
     }
 
     /**
@@ -67,9 +71,10 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param namer The naming strategy to use
      * @param factory The factory responsible for creating new instances on demand
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, NamedDomainObjectFactory<T> factory) {
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, NamedDomainObjectFactory<T> factory, MutationGuard crossProjectConfiguratorMutationGuard) {
         super(type, instantiator, namer);
         this.factory = factory;
+        this.crossProjectConfiguratorMutationGuard = crossProjectConfiguratorMutationGuard;
     }
 
     /**
@@ -80,7 +85,7 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param factoryClosure The closure responsible for creating new instances on demand
      */
     public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, final Closure factoryClosure) {
-        this(type, instantiator, Named.Namer.forType(type), factoryClosure);
+        this(type, instantiator, Named.Namer.forType(type), factoryClosure, MutationGuards.identity());
     }
 
     /**
@@ -91,8 +96,18 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param namer The naming strategy to use
      * @param factoryClosure The factory responsible for creating new instances on demand
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, final Closure factoryClosure) {
-        this(type, instantiator, namer, new ClosureObjectFactory<T>(type, factoryClosure));
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, final Closure factoryClosure, MutationGuard mutationGuard) {
+        this(type, instantiator, namer, new ClosureObjectFactory<T>(type, factoryClosure), mutationGuard);
+    }
+
+    @Override
+    protected <S extends T> DefaultNamedDomainObjectSet<S> filtered(CollectionFilter<S> filter) {
+        return getInstantiator().newInstance(DefaultNamedDomainObjectSet.class, this, filter, getInstantiator(), getNamer(), crossProjectConfiguratorMutationGuard);
+    }
+
+    @Override
+    protected <I extends T> Action<? super I> withMutationDisabled(Action<? super I> action) {
+        return crossProjectConfiguratorMutationGuard.withMutationDisabled(super.withMutationDisabled(action));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -17,11 +17,10 @@ package org.gradle.api.internal;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Namer;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.Namer;
 import org.gradle.api.internal.collections.CollectionFilter;
-import org.gradle.api.internal.project.CrossProjectConfigurator;
 import org.gradle.internal.reflect.Instantiator;
 
 public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObjectContainer<T> {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuards.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/MutationGuards.java
@@ -68,6 +68,13 @@ public class MutationGuards {
     };
 
     /**
+     * Returns the identity mutation guard. It protect and do nothing.
+     */
+    public static MutationGuard identity() {
+        return IDENTITY_MUTATION_GUARD;
+    }
+
+    /**
      * Retrieves the {@code MutationGuard} of the target if it implements {@code WithMutationGuard}, else returns an identity mutation guard performing no guard operations.
      */
     public static MutationGuard of(Object target) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -1307,19 +1307,19 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type) {
         Instantiator instantiator = getServices().get(Instantiator.class);
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer());
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), MutationGuards.of(getProjectConfigurator()));
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, NamedDomainObjectFactory<T> factory) {
         Instantiator instantiator = getServices().get(Instantiator.class);
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factory);
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factory, MutationGuards.of(getProjectConfigurator()));
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, Closure factoryClosure) {
         Instantiator instantiator = getServices().get(Instantiator.class);
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure);
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure, MutationGuards.of(getProjectConfigurator()));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskContainer.java
@@ -29,7 +29,6 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
-import org.gradle.api.internal.MutationGuard;
 import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.NamedDomainObjectContainerConfigureDelegate;
 import org.gradle.api.internal.TaskInternal;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/FactoryNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/FactoryNamedDomainObjectContainerSpec.groovy
@@ -28,7 +28,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
     final namer = { it } as Namer
 
     def usesFactoryToCreateContainerElements() {
-        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, factory)
+        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, factory, MutationGuards.identity())
 
         when:
         def result = container.create('a')
@@ -40,7 +40,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
     }
 
     def usesPublicConstructorWhenNoFactorySupplied() {
-        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer)
+        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, MutationGuards.identity())
 
         when:
         def result = container.create('a')
@@ -52,7 +52,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
 
     def usesClosureToCreateContainerElements() {
         def cl = { name -> "element $name" as String }
-        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, cl)
+        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, cl, MutationGuards.identity())
 
         when:
         def result = container.create('a')

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/NestedConfigureAutoCreateNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/NestedConfigureAutoCreateNamedDomainObjectContainerSpec.groovy
@@ -26,7 +26,7 @@ class NestedConfigureAutoCreateNamedDomainObjectContainerSpec extends Specificat
         String parentName
         String name
         Container(String parentName, String name, Closure factory) {
-            super(Object, new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE), new DynamicPropertyNamer(), factory)
+            super(Object, new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE), new DynamicPropertyNamer(), factory, MutationGuards.identity())
             this.parentName = parentName
             this.name = name
         }


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/768

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fpull-mutation-guard-higher)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
