### PR TITLE
Implement variant derivation strategy

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ComponentReplacementIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.TestDependency
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
@@ -42,6 +43,7 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
         """
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
     }
 
     //publishes and declares the dependencies

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationMutationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ConfigurationMutationIntegrationTest.groovy
@@ -23,6 +23,7 @@ class ConfigurationMutationIntegrationTest extends AbstractDependencyResolutionT
 
     def setup() {
         resolve = new ResolveTestFixture(buildFile).expectDefaultConfiguration("runtime")
+        resolve.addDefaultVariantDerivationStrategy()
 
         mavenRepo.module("org", "foo").publish()
         mavenRepo.module("org", "bar").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -30,6 +30,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
     def setup() {
         settingsFile << "rootProject.name = 'test'"
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         buildFile << """
             repositories {
                 maven { url "${mavenRepo.uri}" }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyConstraintsIntegrationTest.groovy
@@ -37,6 +37,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 conf
             }
         """
+        resolve.addDefaultVariantDerivationStrategy()
     }
 
     void "dependency constraint is not included in resolution without a hard dependency"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -28,6 +28,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
     def setup() {
         settingsFile << "rootProject.name='depsub'\n"
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
     }
 
     void "forces multiple modules by rule"()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ForcedModulesIntegrationTest.groovy
@@ -22,6 +22,10 @@ import spock.lang.Unroll
 
 class ForcedModulesIntegrationTest extends AbstractIntegrationSpec {
 
+    def setup() {
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
+    }
+
     void "can force the version of a particular module"() {
         mavenRepo.module("org", "foo", '1.3.3').publish()
         mavenRepo.module("org", "foo", '1.4.4').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/IvySpecificComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/IvySpecificComponentMetadataRulesIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.artifacts.ivyservice.NamespaceId
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.encoding.Identifier
 import spock.lang.Unroll
 
@@ -47,6 +48,7 @@ task resolve {
     }
 }
 """
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
     }
 
     def "can access Ivy metadata"() {
@@ -138,7 +140,7 @@ dependencies {
 
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
-        failure.assertHasLineNumber(47)
+        failure.assertHasLineNumber(51)
         failure.assertHasCause("Could not resolve all files for configuration ':conf'.")
         failure.assertHasCause("Could not resolve org.test:projectA:1.0.")
         failure.assertHasCause("Cannot get extra info element named 'foo' by name since elements with this name were found from multiple namespaces (http://my.extra.info/foo, http://some.other.ns).  Use get(String namespace, String name) instead.")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -26,6 +26,10 @@ import spock.lang.Issue
 
 @RunWith(FluidDependenciesResolveRunner)
 class ProjectDependencyResolveIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
+    }
+
     def "project dependency includes artifacts and transitive dependencies of default configuration in target project"() {
         given:
         mavenRepo.module("org.other", "externalA", "1.2").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -100,6 +100,7 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
                 $conf
             }
         """
+        resolve.addDefaultVariantDerivationStrategy()
 
         repoTypes.each { repoType ->
             repository(repoType) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
 class ResolvedFilesApiIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -39,6 +40,7 @@ allprojects {
     }
 }
 """
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
     }
 
     def "result includes files from local and external components and file dependencies in a fixed order"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -28,6 +28,7 @@ class VersionConflictResolutionIntegrationTest extends AbstractIntegrationSpec {
         settingsFile << """
             rootProject.name = 'test'
 """
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
     }
 
 
@@ -1693,9 +1694,7 @@ task checkDeps(dependsOn: configurations.compile) {
         bom.publish()
 
         buildFile << """
-plugins {
-    id 'java'
-}
+apply plugin: 'java'
 
 repositories {
     maven {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
@@ -49,7 +49,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failure.assertHasDescription("Execution failed for task ':checkDeps'.")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(36)
+        failure.assertHasLineNumber(38)
         failure.assertHasCause("There was an error while evaluating a component selection rule for org.utils:api:1.2.")
         failure.assertHasCause("Could not find method foo()")
     }
@@ -80,7 +80,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failureDescriptionStartsWith("A problem occurred evaluating root project")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(35)
+        failure.assertHasLineNumber(37)
         failureHasCause("The closure provided is not valid as a rule for 'ComponentSelectionRules'.")
         failureHasCause(message)
 
@@ -118,7 +118,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failure.assertHasDescription("Execution failed for task ':checkDeps'.")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(35)
+        failure.assertHasLineNumber(37)
         failure.assertHasCause("There was an error while evaluating a component selection rule for org.utils:api:1.2.")
         failure.assertHasCause("From test")
     }
@@ -149,7 +149,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failureDescriptionStartsWith("A problem occurred evaluating root project")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(35)
+        failure.assertHasLineNumber(37)
         failureHasCause("Could not add a component selection rule for module 'org.utils'.")
         failureHasCause("Cannot convert the provided notation to an object of type ModuleIdentifier: org.utils")
     }
@@ -176,7 +176,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failureDescriptionStartsWith("A problem occurred evaluating root project")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(31)
+        failure.assertHasLineNumber(33)
         failureHasCause("""Type BadRuleSource is not a valid rule source:
 - Method select(java.lang.String) is not a valid rule method: First parameter of a rule method must be of type org.gradle.api.artifacts.ComponentSelection""")
     }
@@ -218,7 +218,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failure.assertHasDescription("Execution failed for task ':checkDeps'.")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(47)
+        failure.assertHasLineNumber(49)
         failure.assertHasCause("There was an error while evaluating a component selection rule for org.utils:api:1.2.")
         failure.assertHasCause("java.lang.Exception: thrown from rule")
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyDynamicRevisionRemoteResolveIntegrationTest.groovy
@@ -31,6 +31,7 @@ class IvyDynamicRevisionRemoteResolveIntegrationTest extends AbstractHttpDepende
 
         resolve = new ResolveTestFixture(buildFile)
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
     }
 
     @Issue("GRADLE-3264")
@@ -797,6 +798,7 @@ dependencies {
 }
 """
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
 
         and:
         mavenRepo.getModuleMetaData("org.test", "a").expectGet()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -29,6 +29,7 @@ class DependencyLockingIntegrationTest extends AbstractDependencyResolutionTest 
         settingsFile << "rootProject.name = 'depLock'"
         resolve = new ResolveTestFixture(buildFile, "lockedConf")
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
     }
 
     def 'succeeds when lock file does not conflict from declared versions'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -28,6 +28,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
 
     def setup() {
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         settingsFile << "rootProject.name = 'testproject'"
         buildFile << """
             repositories { maven { url "${mavenHttpRepo.uri}" } }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenProfileResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenProfileResolveIntegrationTest.groovy
@@ -29,6 +29,7 @@ class MavenProfileResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve = new ResolveTestFixture(buildFile)
         resolve.prepare()
         resolve.expectDefaultConfiguration('runtime')
+        resolve.addDefaultVariantDerivationStrategy()
     }
 
     def "uses properties from active profile to resolve dependency"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRealProjectsDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRealProjectsDependencyResolveIntegrationTest.groovy
@@ -26,6 +26,7 @@ class MavenRealProjectsDependencyResolveIntegrationTest extends AbstractDependen
 
     def setup() {
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         settingsFile << """
             rootProject.name = 'testproject'
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -28,6 +28,7 @@ class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends A
 
     def setup() {
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         server.start()
 
         settingsFile << "rootProject.name = 'test'"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesAndProjectDependencySubstitutionIntegrationTest.groovy
@@ -24,6 +24,7 @@ class MavenScopesAndProjectDependencySubstitutionIntegrationTest extends Abstrac
 
     def setup() {
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         resolve.expectDefaultConfiguration("runtime")
         settingsFile << """
             rootProject.name = 'testproject'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenScopesIntegrationTest.groovy
@@ -24,6 +24,7 @@ class MavenScopesIntegrationTest extends AbstractDependencyResolutionTest {
 
     def setup() {
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         settingsFile << """
             rootProject.name = 'testproject'
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenSnapshotResolveIntegrationTest.groovy
@@ -21,6 +21,10 @@ import org.gradle.test.fixtures.server.http.MavenHttpModule
 import spock.lang.Issue
 
 class MavenSnapshotResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    def setup() {
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
+    }
+
     def "can resolve unique and non-unique snapshots"() {
         given:
         settingsFile << "rootProject.name = 'test'"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenVersionRangeResolveIntegrationTest.groovy
@@ -22,6 +22,10 @@ import spock.lang.Issue
 
 class MavenVersionRangeResolveIntegrationTest extends AbstractDependencyResolutionTest {
 
+    def setup() {
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
+    }
+
     @Issue("GRADLE-3334")
     def "can resolve version range with single value specified"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
@@ -24,6 +24,7 @@ class MixedMavenAndIvyModulesIntegrationTest extends AbstractDependencyResolutio
 
     def setup() {
         resolve.prepare()
+        resolve.addDefaultVariantDerivationStrategy()
         settingsFile << """
             rootProject.name = 'testproject'
         """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataHandlerInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataHandlerInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dsl;
+
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
+
+public interface ComponentMetadataHandlerInternal {
+    void setVariantDerivationStrategy(VariantDerivationStrategy strategy);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/ComponentMetadataRuleContainer.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.artifacts.dsl;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ComponentMetadataDetails;
+import org.gradle.internal.component.external.model.NoOpDerivationStrategy;
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.rules.SpecRuleAction;
 
 import java.util.Collection;
@@ -31,6 +33,7 @@ class ComponentMetadataRuleContainer implements Iterable<MetadataRuleWrapper> {
     private final List<MetadataRuleWrapper> rules = Lists.newArrayListWithExpectedSize(10);
     private MetadataRuleWrapper lastAdded;
     private boolean classBasedRulesOnly = true;
+    private VariantDerivationStrategy variantDerivationStrategy = new NoOpDerivationStrategy();
 
     void addRule(SpecRuleAction<? super ComponentMetadataDetails> ruleAction) {
         lastAdded = new ActionBasedMetadataRuleWrapepr(ruleAction);
@@ -65,5 +68,13 @@ class ComponentMetadataRuleContainer implements Iterable<MetadataRuleWrapper> {
             throw new IllegalStateException("This method cannot be used unless there is at least one rule and they are all class based");
         }
         return rules.get(0).getClassRules();
+    }
+
+    public VariantDerivationStrategy getVariantDerivationStrategy() {
+        return variantDerivationStrategy;
+    }
+
+    public void setVariantDerivationStrategy(VariantDerivationStrategy variantDerivationStrategy) {
+        this.variantDerivationStrategy = variantDerivationStrategy;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataHandler.java
@@ -43,6 +43,7 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.action.ConfigurableRule;
 import org.gradle.internal.action.DefaultConfigurableRule;
+import org.gradle.internal.component.external.model.VariantDerivationStrategy;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.resolve.caching.ComponentMetadataRuleExecutor;
 import org.gradle.internal.rules.DefaultRuleActionAdapter;
@@ -58,7 +59,7 @@ import org.gradle.internal.typeconversion.UnsupportedNotationException;
 import java.util.Collections;
 import java.util.List;
 
-public class DefaultComponentMetadataHandler implements ComponentMetadataHandler, ComponentMetadataProcessorFactory {
+public class DefaultComponentMetadataHandler implements ComponentMetadataHandler, ComponentMetadataHandlerInternal, ComponentMetadataProcessorFactory {
     private static final String ADAPTER_NAME = ComponentMetadataHandler.class.getSimpleName();
     private static final List<Class<?>> VALIDATOR_PARAM_LIST = Collections.<Class<?>>singletonList(IvyModuleDescriptor.class);
     private static final String INVALID_SPEC_ERROR = "Could not add a component metadata rule for module '%s'.";
@@ -196,6 +197,11 @@ public class DefaultComponentMetadataHandler implements ComponentMetadataHandler
     @Override
     public ComponentMetadataProcessor createComponentMetadataProcessor(MetadataResolutionContext resolutionContext) {
         return new DefaultComponentMetadataProcessor(metadataRuleContainer, instantiator, dependencyMetadataNotationParser, dependencyConstraintMetadataNotationParser, componentIdentifierNotationParser, attributesFactory, ruleExecutor, resolutionContext);
+    }
+
+    @Override
+    public void setVariantDerivationStrategy(VariantDerivationStrategy strategy) {
+        metadataRuleContainer.setVariantDerivationStrategy(strategy);
     }
 
     static class ComponentMetadataDetailsMatchingSpec implements Spec<ComponentMetadataDetails> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -160,6 +160,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
 
     @Override
     public ModuleComponentResolveMetadata processMetadata(ModuleComponentResolveMetadata metadata) {
+        metadata.getVariantMetadataRules().setVariantDerivationStrategy(metadataRuleContainer.getVariantDerivationStrategy());
         ModuleComponentResolveMetadata updatedMetadata;
         if (metadataRuleContainer.isEmpty()) {
             updatedMetadata = maybeForceRealisation(metadata);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -34,6 +34,7 @@ import org.gradle.internal.component.external.model.ModuleComponentResolveMetada
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.RealisedConfigurationMetadata;
+import org.gradle.internal.component.external.model.VariantMetadataRules;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ModuleSource;
@@ -168,6 +169,11 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     @Override
     public ImmutableAttributesFactory getAttributesFactory() {
         return null;
+    }
+
+    @Override
+    public VariantMetadataRules getVariantMetadataRules() {
+        return VariantMetadataRules.noOp();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractLazyModuleComponentResolveMetadata.java
@@ -78,7 +78,7 @@ public abstract class AbstractLazyModuleComponentResolveMetadata extends Abstrac
         target.putAll(configurations);
     }
 
-    protected VariantMetadataRules getVariantMetadataRules() {
+    public VariantMetadataRules getVariantMetadataRules() {
         return variantMetadataRules;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -90,6 +90,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.attributesFactory = metadata.getAttributesFactory();
         this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
         this.variantMetadataRules = new VariantMetadataRules(attributesFactory);
+        this.variantMetadataRules.setVariantDerivationStrategy(metadata.getVariantMetadataRules().getVariantDerivationStrategy());
     }
 
     private static AttributeContainerInternal defaultAttributes(ImmutableAttributesFactory attributesFactory) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleComponentResolveMetadata.java
@@ -68,6 +68,11 @@ public abstract class AbstractRealisedModuleComponentResolveMetadata extends Abs
     }
 
     @Override
+    public VariantMetadataRules getVariantMetadataRules() {
+        return VariantMetadataRules.noOp();
+    }
+
+    @Override
     public Set<String> getConfigurationNames() {
         return configurations.keySet();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+
+public class JavaEcosystemVariantDerivationStrategy implements VariantDerivationStrategy {
+    @Override
+    public boolean derivesVariants() {
+        return true;
+    }
+
+    @Override
+    public ImmutableList<? extends ConfigurationMetadata> derive(ModuleComponentResolveMetadata metadata) {
+        if (metadata instanceof DefaultMavenModuleResolveMetadata) {
+            DefaultMavenModuleResolveMetadata md = (DefaultMavenModuleResolveMetadata) metadata;
+            ImmutableAttributes attributes = md.getAttributes();
+            MavenImmutableAttributesFactory attributesFactory = (MavenImmutableAttributesFactory) md.getAttributesFactory();
+            DefaultConfigurationMetadata compileConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("compile");
+            DefaultConfigurationMetadata runtimeConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("runtime");
+            return ImmutableList.of(
+                libraryWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API),
+                libraryWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME),
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false),
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true));
+        }
+        return null;
+    }
+
+    private static ConfigurationMetadata libraryWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage) {
+        ImmutableAttributes attributes = attributesFactory.libraryWithUsage(originAttributes, usage);
+        return conf.withAttributes(attributes).withoutConstraints();
+    }
+
+    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, boolean enforcedPlatform) {
+        ImmutableAttributes attributes = attributesFactory.platformWithUsage(originAttributes, usage, enforcedPlatform);
+        String prefix = enforcedPlatform ? "enforced-platform-" : "platform-";
+        DefaultConfigurationMetadata metadata = conf.withAttributes(prefix + conf.getName(), attributes);
+        metadata = metadata.withConstraintsOnly();
+        if (enforcedPlatform) {
+            metadata = metadata.withForcedDependencies();
+        }
+        return metadata;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleComponentResolveMetadata.java
@@ -64,4 +64,5 @@ public interface ModuleComponentResolveMetadata extends ComponentResolveMetadata
 
     ImmutableAttributesFactory getAttributesFactory();
 
+    VariantMetadataRules getVariantMetadataRules();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/NoOpDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/NoOpDerivationStrategy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+
+public class NoOpDerivationStrategy implements VariantDerivationStrategy {
+
+    @Override
+    public boolean derivesVariants() {
+        return false;
+    }
+
+    @Override
+    public ImmutableList<? extends ConfigurationMetadata> derive(ModuleComponentResolveMetadata metadata) {
+        throw new UnsupportedOperationException("This method should not have been called.");
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantDerivationStrategy.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.external.model;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+
+public interface VariantDerivationStrategy {
+    boolean derivesVariants();
+    ImmutableList<? extends ConfigurationMetadata> derive(ModuleComponentResolveMetadata metadata);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -47,9 +47,18 @@ public class VariantMetadataRules {
     private DependencyMetadataRules dependencyMetadataRules;
     private VariantAttributesRules variantAttributesRules;
     private CapabilitiesRules capabilitiesRules;
+    private VariantDerivationStrategy variantDerivationStrategy = new NoOpDerivationStrategy();
 
     public VariantMetadataRules(ImmutableAttributesFactory attributesFactory) {
         this.attributesFactory = attributesFactory;
+    }
+
+    public VariantDerivationStrategy getVariantDerivationStrategy() {
+        return variantDerivationStrategy;
+    }
+
+    public void setVariantDerivationStrategy(VariantDerivationStrategy variantDerivationStrategy) {
+        this.variantDerivationStrategy = variantDerivationStrategy;
     }
 
     public ImmutableAttributes applyVariantAttributeRules(VariantResolveMetadata variant, AttributeContainerInternal source) {
@@ -137,6 +146,11 @@ public class VariantMetadataRules {
 
         private ImmutableRules() {
             super(null);
+        }
+
+        @Override
+        public void setVariantDerivationStrategy(VariantDerivationStrategy variantDerivationStrategy) {
+            throw new UnsupportedOperationException("You are probably to set the derivation strategy to something that wasn't supposed to be mutable");
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/VariantMetadataRules.java
@@ -150,7 +150,7 @@ public class VariantMetadataRules {
 
         @Override
         public void setVariantDerivationStrategy(VariantDerivationStrategy variantDerivationStrategy) {
-            throw new UnsupportedOperationException("You are probably to set the derivation strategy to something that wasn't supposed to be mutable");
+            throw new UnsupportedOperationException("You are probably trying to set the derivation strategy to something that wasn't supposed to be mutable");
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultIvyModuleResolveMetadata.java
@@ -159,12 +159,6 @@ public class DefaultIvyModuleResolveMetadata extends AbstractLazyModuleComponent
     }
 
     @Override
-    protected VariantMetadataRules getVariantMetadataRules() {
-        // Added for package visibility
-        return super.getVariantMetadataRules();
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -149,6 +149,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
         def componentTypeAttribute = PlatformSupport.COMPONENT_CATEGORY
         def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], new DefaultMavenImmutableAttributesFactory(TestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE), TestUtil.objectInstantiator())
         metadata.packaging = packaging
+        metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()
 
         when:
         def immutableMetadata = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DependencyConstraintMetadataRulesTest.groovy
@@ -51,6 +51,7 @@ class DependencyConstraintMetadataRulesTest extends AbstractDependencyMetadataRu
         ])
 
         when:
+        mavenMetadata.variantMetadataRules.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy())
         mavenMetadata.variantMetadataRules.addDependencyAction(instantiator, notationParser, constraintNotationParser, variantAction("default", {
             assert it.size() == 1
             assert it[0].name == "notOptional"

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -164,6 +164,7 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
                 $testConfiguration
             }
         """
+        resolve.addDefaultVariantDerivationStrategy()
     }
 
     void repository(@DelegatesTo(RemoteRepositorySpec) Closure<Void> spec) {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.tasks.diagnostics
 import groovy.transform.CompileStatic
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.locking.LockfileFixture
 import spock.lang.Ignore
 import spock.lang.Unroll
@@ -29,6 +30,7 @@ class DependencyInsightReportTaskIntegrationTest extends AbstractIntegrationSpec
         settingsFile << """
             rootProject.name = 'insight-test'
         """
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
     }
 
     def "requires use of configuration flag if Java plugin isn't applied"() {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.tasks.diagnostics
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
 class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractIntegrationSpec {
@@ -26,6 +27,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
 
         // detector confuses attributes with stack traces
         executer.withStackTraceChecksDisabled()
+        new ResolveTestFixture(buildFile).addDefaultVariantDerivationStrategy()
     }
 
     @Unroll

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyInsightReport/dependencyInsightReport.out
@@ -1,8 +1,6 @@
 commons-codec:commons-codec:1.7
-   variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+   variant "default" [
+      org.gradle.status = release (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.7 and 1.6

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -745,6 +745,15 @@ allprojects {
             this
         }
     }
+
+    /**
+     * Enables Maven derived variants, as if the Java plugin was applied
+     */
+    void addDefaultVariantDerivationStrategy() {
+        buildFile << """
+            allprojects { dependencies.components.variantDerivationStrategy = new org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy() }
+        """
+    }
 }
 
 class GenerateGraphTask extends DefaultTask {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -45,8 +45,8 @@ class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChai
 
         where:
         repoType << [
-            //'maven',
-            'ivy'
+            'maven',
+//            'ivy'
         ]
     }
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -46,7 +46,7 @@ class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChai
         where:
         repoType << [
             'maven',
-//            'ivy'
+            'ivy'
         ]
     }
 

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -107,6 +107,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
         def externalRepo = requiresExternalDependencies?mavenCentralRepositoryDefinition():''
 
         buildFile.text = """
+            apply plugin: 'java-base' // to get the standard Java library derivation strategy
             configurations {
                 resolve {
                     ${attributes}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.ReusableAction;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -50,6 +51,7 @@ import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
+import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.model.RuleBasedPluginListener;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -97,6 +99,12 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         configureBuildDependents(project);
         configureSchema(project);
         bridgeToSoftwareModelIfNecessary(project);
+        configureVariantDerivationStrategy(project);
+    }
+
+    private void configureVariantDerivationStrategy(ProjectInternal project) {
+        ComponentMetadataHandlerInternal metadataHandler = (ComponentMetadataHandlerInternal) project.getDependencies().getComponents();
+        metadataHandler.setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy());
     }
 
     private JavaPluginConvention addExtensions(final ProjectInternal project) {


### PR DESCRIPTION
### Context

This commit changes how Maven metadata is derived into variants. Now we will
only derive variants if the Java plugin is applied (the "base Java" plugin).
This is implemented via a variant derivation strategy, and allows fixing
the problem that a native component is unlikely to find sense in the derivation
of Java variants. This fixes a bug where the native plugins wouldn't be able
to consume native libraries published on Maven repositories, without Gradle
metadata.

