### PR TITLE
Prevent implementation types from leaking into named domain object collection schema

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/NamedDomainObjectCollectionSchemaIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/NamedDomainObjectCollectionSchemaIntegrationTest.groovy
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+class NamedDomainObjectCollectionSchemaIntegrationTest extends AbstractIntegrationSpec {
+    def setup() {
+        buildFile << """
+            def extractSchema(container) {
+                return container.collectionSchema.elements.collectEntries { e ->
+                    [ e.name, e.publicType.simpleName ]
+                }.sort()
+            }
+            def assertSchemaIs(Map expected, NamedDomainObjectCollection container) {
+                def actual = extractSchema(container)
+                def sortedExpected = expected.sort()
+                assert sortedExpected == actual
+            }
+        """
+    }
+
+    def "collection schema from project.container is public type"() {
+        buildFile << """
+            interface PubType {}
+            class Impl implements PubType, Named {
+                String name
+                Impl(String name) {
+                    this.name = name
+                }
+            }
+            def factory = { name -> new Impl(name) }
+            def testContainer = project.container(PubType, factory)
+            
+            testContainer.create("foo")
+            testContainer.register("bar")
+            testContainer.register("baz").get()
+            
+            task assertSchema {
+                doLast {
+                    assertSchemaIs(testContainer,
+                        "foo": "PubType",
+                        "bar": "PubType",
+                        "baz": "PubType",
+                    )
+                }
+            }
+        """
+        expect:
+        succeeds("assertSchema")
+    }
+
+    def "built-in container types presents public type in schema"() {
+        buildFile << """
+            apply plugin: 'java'
+            
+            repositories {
+                maven {}
+                ivy {}
+            }
+            
+            task assertSchema {
+                doLast {
+                    assertSchemaIs(sourceSets, 
+                        "main": "SourceSet",
+                        "test": "SourceSet"
+                    )
+                    assertSchemaIs(repositories, 
+                        // TODO: These should be more specific eventually
+                        "maven": "ArtifactRepository",
+                        "ivy": "ArtifactRepository"
+                    )
+                    assertSchemaIs(configurations, 
+                        'annotationProcessor':'Configuration', 
+                        'apiElements':'Configuration', 
+                        'archives':'Configuration', 
+                        'compile':'Configuration', 
+                        'compileClasspath':'Configuration', 
+                        'compileOnly':'Configuration', 
+                        'default':'Configuration', 
+                        'implementation':'Configuration', 
+                        'runtime':'Configuration', 
+                        'runtimeClasspath':'Configuration', 
+                        'runtimeElements':'Configuration', 
+                        'runtimeOnly':'Configuration', 
+                        'testAnnotationProcessor':'Configuration', 
+                        'testCompile':'Configuration', 
+                        'testCompileClasspath':'Configuration', 
+                        'testCompileOnly':'Configuration', 
+                        'testImplementation':'Configuration', 
+                        'testRuntime':'Configuration', 
+                        'testRuntimeClasspath':'Configuration', 
+                        'testRuntimeOnly':'Configuration'
+                    )
+                }
+            }
+        """
+        expect:
+        succeeds("assertSchema")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -67,13 +67,11 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
-import static org.gradle.api.reflect.TypeOf.typeOf;
-
 public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCollection<T> implements NamedDomainObjectCollection<T>, MethodMixIn, PropertyMixIn {
 
     private final Instantiator instantiator;
     private final Namer<? super T> namer;
-    private final Index<T> index;
+    protected final Index<T> index;
 
     private final ContainerElementsDynamicObject elementsDynamicObject = new ContainerElementsDynamicObject();
 
@@ -407,46 +405,23 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
         return new NamedDomainObjectCollectionSchema() {
             @Override
             public Iterable<? extends NamedDomainObjectSchema> getElements() {
-                return Iterables.concat(
-                    Iterables.transform(index.asMap().entrySet(), new Function<Map.Entry<String, T>, NamedDomainObjectSchema>() {
-                        @Override
-                        public NamedDomainObjectSchema apply(final Map.Entry<String, T> e) {
-                            return new NamedDomainObjectSchema() {
-                                @Override
-                                public String getName() {
-                                    return e.getKey();
-                                }
+                // Simple scheme is to just present the public type of the container
+                return Iterables.transform(getNames(), new Function<String, NamedDomainObjectSchema>() {
+                    @Override
+                    public NamedDomainObjectSchema apply(final String name) {
+                        return new NamedDomainObjectSchema() {
+                            @Override
+                            public String getName() {
+                                return name;
+                            }
 
-                                @Override
-                                public TypeOf<?> getPublicType() {
-                                    // TODO: This returns the wrong public type for domain objects
-                                    // created with the eager APIs or added directly to the container.
-                                    // This can leak internal types.
-                                    // We do not currently keep track of the type used when creating
-                                    // a domain object (via create) or the type of the container when
-                                    // a domain object is added directly (via add).
-                                    return new DslObject(e.getValue()).getPublicType();
-                                }
-                            };
-                        }
-                    }),
-                    Iterables.transform(index.getPendingAsMap().entrySet(), new Function<Map.Entry<String, ProviderInternal<? extends T>>, NamedDomainObjectSchema>() {
-                        @Override
-                        public NamedDomainObjectSchema apply(final Map.Entry<String, ProviderInternal<? extends T>> e) {
-                            return new NamedDomainObjectSchema() {
-                                @Override
-                                public String getName() {
-                                    return e.getKey();
-                                }
-
-                                @Override
-                                public TypeOf<?> getPublicType() {
-                                    return typeOf(e.getValue().getType());
-                                }
-                            };
-                        }
-                    })
-                );
+                            @Override
+                            public TypeOf<?> getPublicType() {
+                                return TypeOf.typeOf(getType());
+                            }
+                        };
+                    }
+                });
             }
         };
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectCollectionTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectCollectionTest.groovy
@@ -247,15 +247,16 @@ class DefaultNamedDomainObjectCollectionTest extends AbstractNamedDomainObjectCo
         container.add(a)
         expect:
         assertSchemaIs(
-            a: "DefaultNamedDomainObjectCollectionTest.BeanSub1"
+            a: "DefaultNamedDomainObjectCollectionTest.Bean"
         )
         // schema isn't cached
         container.add(b)
         container.add(d)
+        // TODO maybe should be based on the type of the add?
         assertSchemaIs(
-            a: "DefaultNamedDomainObjectCollectionTest.BeanSub1",
-            b: "DefaultNamedDomainObjectCollectionTest.BeanSub1",
-            d: "DefaultNamedDomainObjectCollectionTest.BeanSub2"
+            a: "DefaultNamedDomainObjectCollectionTest.Bean",
+            b: "DefaultNamedDomainObjectCollectionTest.Bean",
+            d: "DefaultNamedDomainObjectCollectionTest.Bean"
         )
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -344,6 +344,18 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
         container.registerFactory(Person, { new DefaultPerson(name: it) } as NamedDomainObjectFactory)
         container.registerFactory(AgeAwarePerson, { new DefaultAgeAwarePerson(name: it) } as NamedDomainObjectFactory)
 
+        def expectedSchema = [
+            mike: "DefaultPolymorphicDomainObjectContainerTest.Person",
+            fred: "DefaultPolymorphicDomainObjectContainerTest.Person",
+            alice: "DefaultPolymorphicDomainObjectContainerTest.Person", // TODO: Should be AgeAwarePerson
+            kate: "DefaultPolymorphicDomainObjectContainerTest.Person",
+            bob: "DefaultPolymorphicDomainObjectContainerTest.Person",
+            mary: "DefaultPolymorphicDomainObjectContainerTest.Person", // TODO should be AgeAwarePerson
+            john: "DefaultPolymorphicDomainObjectContainerTest.Person",
+            janis: "DefaultPolymorphicDomainObjectContainerTest.Person", // TODO could be AgeAwarePerson
+            robert: "DefaultPolymorphicDomainObjectContainerTest.Person" // TODO could be DefaultCtorNamedPerson
+        ]
+
         when:
         container.register("mike")
         container.register("fred", Person)
@@ -356,38 +368,14 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
         container.add(new DefaultCtorNamedPerson("robert"))
 
         then:
-        assertSchemaIs(
-            mike: "DefaultPolymorphicDomainObjectContainerTest.Person",
-            fred: "DefaultPolymorphicDomainObjectContainerTest.Person",
-            alice: "DefaultPolymorphicDomainObjectContainerTest.AgeAwarePerson",
-            kate: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson", // TODO should be Person
-            bob: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson", // TODO should be Person
-            mary: "DefaultPolymorphicDomainObjectContainerTest.DefaultAgeAwarePerson", // TODO should be AgeAwarePerson
-            john: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson", // TODO could be Person
-            janis: "DefaultPolymorphicDomainObjectContainerTest.DefaultAgeAwarePerson", // TODO could be AgeAwarePerson
-            robert: "DefaultPolymorphicDomainObjectContainerTest.DefaultCtorNamedPerson"
-        )
+        assertSchemaIs(expectedSchema)
 
         when: "realizing pending elements"
         container.getByName("mike")
         container.getByName("fred")
         container.getByName("alice")
-
-        // TODO this should be fixed
-        //      performance killer: invalidating generated accessors
-        //      surprising behavior: script suddenly don't compile anymore
         then: "schema is the same"
-        assertSchemaIs(
-            mike: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson",
-            fred: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson",
-            alice: "DefaultPolymorphicDomainObjectContainerTest.DefaultAgeAwarePerson",
-            kate: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson",
-            bob: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson",
-            mary: "DefaultPolymorphicDomainObjectContainerTest.DefaultAgeAwarePerson",
-            john: "DefaultPolymorphicDomainObjectContainerTest.DefaultPerson",
-            janis: "DefaultPolymorphicDomainObjectContainerTest.DefaultAgeAwarePerson",
-            robert: "DefaultPolymorphicDomainObjectContainerTest.DefaultCtorNamedPerson"
-        )
+        assertSchemaIs(expectedSchema)
     }
 
     def "can find elements added by rules"() {


### PR DESCRIPTION
This prevents implementation types from leaking into the Kotlin DSL accessors

There are still some cases where we can be more specific for public types.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
