### PR TITLE
Removed a bunch of deprecation warnings when building gradle

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/FilteringClassLoader.java
@@ -103,6 +103,7 @@ public class FilteringClassLoader extends ClassLoader implements ClassLoaderHier
         return cl;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Package getPackage(String name) {
         Package p = super.getPackage(name);

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
@@ -82,6 +82,7 @@ public class MultiParentClassLoader extends ClassLoader implements ClassLoaderHi
         throw new ClassNotFoundException(String.format("%s not found.", name));
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     protected Package getPackage(String name) {
         for (ClassLoader parent : parents) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/TransformingClassLoader.java
@@ -76,7 +76,7 @@ public abstract class TransformingClassLoader extends VisitableURLClassLoader {
         }
 
         String packageName = StringUtils.substringBeforeLast(name, ".");
-        Package p = getPackage(packageName);
+        @SuppressWarnings("deprecation") Package p = getPackage(packageName);
         if (p == null) {
             definePackage(packageName, null, null, null, null, null, null, null);
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.time;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 public class TimeFormatting {
 
@@ -78,7 +79,7 @@ public class TimeFormatting {
             result.append("m");
         }
         int secondsScale = result.length() > 0 ? 2 : 3;
-        result.append(BigDecimal.valueOf(duration).divide(BigDecimal.valueOf(MILLIS_PER_SECOND)).setScale(secondsScale, BigDecimal.ROUND_HALF_UP));
+        result.append(BigDecimal.valueOf(duration).divide(BigDecimal.valueOf(MILLIS_PER_SECOND)).setScale(secondsScale, RoundingMode.HALF_UP));
         result.append("s");
         return result.toString();
     }

--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -16,8 +16,8 @@
 package org.gradle.util;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.IoActions;
 import org.gradle.util.internal.LimitedDescription;
 
 import javax.annotation.Nullable;
@@ -231,8 +231,8 @@ public class GFileUtils {
         } catch (Exception e) {
             throw new TailReadingException(e);
         } finally {
-            IOUtils.closeQuietly(fileReader);
-            IOUtils.closeQuietly(reader);
+            IoActions.closeQuietly(fileReader);
+            IoActions.closeQuietly(reader);
         }
     }
 

--- a/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/outcome/internal/archive/entry/FileToArchiveEntrySetTransformer.java
+++ b/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/outcome/internal/archive/entry/FileToArchiveEntrySetTransformer.java
@@ -18,11 +18,16 @@ package org.gradle.api.plugins.buildcomparison.outcome.internal.archive.entry;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.IoActions;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -81,7 +86,7 @@ public class FileToArchiveEntrySetTransformer implements Transformer<Set<Archive
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } finally {
-            IOUtils.closeQuietly(zipStream);
+            IoActions.closeQuietly(zipStream);
         }
 
         return entries.build();

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsImpl.java
@@ -27,6 +27,7 @@ import org.gradle.api.reporting.internal.TaskReportContainer;
 
 import javax.inject.Inject;
 
+@SuppressWarnings("deprecation")
 public class FindBugsReportsImpl extends TaskReportContainer<SingleFileReport> implements FindBugsReportsInternal {
     @Inject
     public FindBugsReportsImpl(Task task) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsInternal.java
@@ -22,6 +22,7 @@ import org.gradle.api.tasks.Internal;
 
 import javax.annotation.Nullable;
 
+@SuppressWarnings("deprecation")
 public interface FindBugsReportsInternal extends FindBugsReports {
     @Internal
     @Nullable

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/JDependReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/JDependReportsImpl.java
@@ -24,6 +24,7 @@ import org.gradle.api.reporting.internal.TaskReportContainer;
 
 import javax.inject.Inject;
 
+@SuppressWarnings("deprecation")
 public class JDependReportsImpl extends TaskReportContainer<SingleFileReport> implements JDependReports {
     @Inject
     public JDependReportsImpl(Task task) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsSpecBuilder.java
@@ -32,6 +32,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
 
+@SuppressWarnings("deprecation")
 public class FindBugsSpecBuilder {
     private static final Set<String> VALID_EFFORTS = ImmutableSet.of("min", "default", "max");
     private static final Set<String> VALID_REPORT_LEVELS = ImmutableSet.of("experimental", "low", "medium", "high");

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsXmlReportImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/findbugs/FindBugsXmlReportImpl.java
@@ -20,6 +20,7 @@ import org.gradle.api.Task;
 import org.gradle.api.plugins.quality.FindBugsXmlReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 
+@SuppressWarnings("deprecation")
 public class FindBugsXmlReportImpl extends TaskGeneratedSingleFileReport implements FindBugsXmlReport {
 
     private boolean withMessages;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/JarHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/JarHasher.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.collect.Lists;
-import org.apache.commons.io.IOUtils;
 import org.gradle.internal.Factory;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.file.FilePathUtil;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
@@ -100,7 +100,7 @@ public class JarHasher implements RegularFileHasher, ConfigurableNormalizer {
 
             return fingerprints;
         } finally {
-            IOUtils.closeQuietly(fileInputStream);
+            IoActions.closeQuietly(fileInputStream);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/compression/Bzip2Archiver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/compression/Bzip2Archiver.java
@@ -16,10 +16,10 @@
 
 package org.gradle.api.internal.file.archive.compression;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.tools.bzip2.CBZip2InputStream;
 import org.apache.tools.bzip2.CBZip2OutputStream;
 import org.gradle.api.resources.internal.ReadableResourceInternal;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.resource.ResourceExceptions;
 
 import java.io.BufferedInputStream;
@@ -50,7 +50,7 @@ public class Bzip2Archiver extends AbstractArchiver {
                     outStr.write('Z');
                     return new CBZip2OutputStream(outStr);
                 } catch (Exception e) {
-                    IOUtils.closeQuietly(outStr);
+                    IoActions.closeQuietly(outStr);
                     String message = String.format("Unable to create bzip2 output stream for file %s", destination);
                     throw new RuntimeException(message, e);
                 }
@@ -66,7 +66,7 @@ public class Bzip2Archiver extends AbstractArchiver {
             input.read(skip);
             return new CBZip2InputStream(input);
         } catch (Exception e) {
-            IOUtils.closeQuietly(input);
+            IoActions.closeQuietly(input);
             throw ResourceExceptions.readFailed(resource.getDisplayName(), e);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/compression/GzipArchiver.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/archive/compression/GzipArchiver.java
@@ -16,8 +16,8 @@
 
 package org.gradle.api.internal.file.archive.compression;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.resources.internal.ReadableResourceInternal;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.resource.ResourceExceptions;
 
 import java.io.BufferedInputStream;
@@ -47,7 +47,7 @@ public class GzipArchiver extends AbstractArchiver {
                 try {
                     return new GZIPOutputStream(outStr);
                 } catch (Exception e) {
-                    IOUtils.closeQuietly(outStr);
+                    IoActions.closeQuietly(outStr);
                     String message = String.format("Unable to create gzip output stream for file %s.", destination);
                     throw new RuntimeException(message, e);
                 }
@@ -60,7 +60,7 @@ public class GzipArchiver extends AbstractArchiver {
         try {
             return new GZIPInputStream(input);
         } catch (Exception e) {
-            IOUtils.closeQuietly(input);
+            IoActions.closeQuietly(input);
             throw ResourceExceptions.readFailed(resource.getDisplayName(), e);
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultZipCompressor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/DefaultZipCompressor.java
@@ -15,10 +15,10 @@
  */
 package org.gradle.api.internal.file.copy;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.tools.zip.Zip64Mode;
 import org.apache.tools.zip.ZipOutputStream;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.IoActions;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,7 +39,7 @@ public class DefaultZipCompressor implements ZipCompressor {
             outStream.setMethod(entryCompressionMethod);
             return outStream;
         } catch (Exception e) {
-            IOUtils.closeQuietly(outStream);
+            IoActions.closeQuietly(outStream);
             String message = String.format("Unable to create ZIP output stream for file %s.", destination);
             throw new UncheckedIOException(message, e);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/AntBuilderDelegate.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/AntBuilderDelegate.java
@@ -20,9 +20,9 @@ import groovy.util.BuilderSupport;
 import groovy.util.Node;
 import groovy.util.NodeList;
 import groovy.util.XmlParser;
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.internal.DynamicObjectUtil;
 import org.gradle.internal.Cast;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.metaobject.DynamicObject;
 
@@ -70,7 +70,7 @@ public class AntBuilderDelegate extends BuilderSupport {
             } catch (Exception ex) {
                 throw UncheckedException.throwAsUncheckedException(ex);
             } finally {
-                IOUtils.closeQuietly(instr);
+                IoActions.closeQuietly(instr);
             }
         } else {
             throw new RuntimeException("Unsupported parameters for taskdef(): " + args);

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -19,8 +19,8 @@ package org.gradle.api.tasks;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.util.PropertiesUtils;
 
@@ -218,7 +218,7 @@ public class WriteProperties extends DefaultTask {
             propertiesToWrite.putAll(getProperties());
             PropertiesUtils.store(propertiesToWrite, out, getComment(), charset, getLineSeparator());
         } finally {
-            IOUtils.closeQuietly(out);
+            IoActions.closeQuietly(out);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -24,12 +24,12 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.cache.CleanupProgressMonitor;
+import org.gradle.internal.IoActions;
 import org.gradle.util.GradleVersion;
 
 import javax.annotation.Nonnull;
@@ -167,7 +167,7 @@ public class WrapperDistributionCleanupAction implements DirectoryCleanupAction 
             zipFile = new ZipFile(jarFile);
             return readGradleVersionFromBuildReceipt(zipFile);
         } finally {
-            IOUtils.closeQuietly(zipFile);
+            IoActions.closeQuietly(zipFile);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/GZipTaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/GZipTaskOutputPacker.java
@@ -16,11 +16,11 @@
 
 package org.gradle.caching.internal.tasks;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginReader;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginWriter;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class GZipTaskOutputPacker implements TaskOutputPacker {
         try {
             return delegate.pack(propertySpecs, outputFingerprints, gzipOutput, writeOrigin);
         } finally {
-            IOUtils.closeQuietly(gzipOutput);
+            IoActions.closeQuietly(gzipOutput);
         }
     }
 
@@ -65,7 +65,7 @@ public class GZipTaskOutputPacker implements TaskOutputPacker {
         try {
             return delegate.unpack(propertySpecs, gzipInput, readOrigin);
         } finally {
-            IOUtils.closeQuietly(gzipInput);
+            IoActions.closeQuietly(gzipInput);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TarTaskOutputPacker.java
+++ b/subprojects/core/src/main/java/org/gradle/caching/internal/tasks/TarTaskOutputPacker.java
@@ -37,6 +37,7 @@ import org.gradle.api.internal.tasks.ResolvedTaskOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.TaskFilePropertySpec;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginReader;
 import org.gradle.caching.internal.tasks.origin.TaskOutputOriginWriter;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.hash.HashCode;
@@ -116,7 +117,7 @@ public class TarTaskOutputPacker implements TaskOutputPacker {
             long entryCount = pack(propertySpecs, outputFingerprints, tarOutput);
             return new PackResult(entryCount + 1);
         } finally {
-            IOUtils.closeQuietly(tarOutput);
+            IoActions.closeQuietly(tarOutput);
         }
     }
 
@@ -166,7 +167,7 @@ public class TarTaskOutputPacker implements TaskOutputPacker {
         try {
             return unpack(propertySpecs, tarInput, readOrigin);
         } finally {
-            IOUtils.closeQuietly(tarInput);
+            IoActions.closeQuietly(tarInput);
         }
     }
 
@@ -271,7 +272,7 @@ public class TarTaskOutputPacker implements TaskOutputPacker {
             hash = streamHasher.hashCopy(input, output);
             chmodUnpackedFile(entry, outputFile);
         } finally {
-            IOUtils.closeQuietly(output);
+            IoActions.closeQuietly(output);
         }
         String outputPath = stringInterner.intern(absolutePath);
         String outputFileName = stringInterner.intern(fileName);
@@ -454,7 +455,7 @@ public class TarTaskOutputPacker implements TaskOutputPacker {
                 try {
                     IOUtils.copyLarge(input, tarOutput, COPY_BUFFERS.get());
                 } finally {
-                    IOUtils.closeQuietly(input);
+                    IoActions.closeQuietly(input);
                 }
                 tarOutput.closeArchiveEntry();
             } catch (IOException e) {

--- a/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/hash/DefaultFileHasher.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.internal.hash;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.FileTreeElement;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.file.FileMetadataSnapshot;
 
 import java.io.File;
@@ -39,7 +39,7 @@ public class DefaultFileHasher implements FileHasher {
             try {
                 return streamHasher.hash(inputStream);
             } finally {
-                IOUtils.closeQuietly(inputStream);
+                IoActions.closeQuietly(inputStream);
             }
         } catch (FileNotFoundException e) {
             throw new UncheckedIOException(String.format("Failed to create MD5 hash for file '%s' as it does not exist.", file), e);

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/logging/DefaultBuildOperationLogger.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/logging/DefaultBuildOperationLogger.java
@@ -16,9 +16,9 @@
 
 package org.gradle.internal.operations.logging;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.logging.Logger;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.logging.ConsoleRenderer;
 
@@ -87,7 +87,7 @@ class DefaultBuildOperationLogger implements BuildOperationLogger {
             }
             logInBoth(LogLevel.INFO, String.format("Finished %s, see full log %s.", configuration.getTaskName(), getLogLocation()));
         } finally {
-            IOUtils.closeQuietly(logWriter);
+            IoActions.closeQuietly(logWriter);
             started = false;
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/util/JarUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/JarUtil.java
@@ -17,6 +17,7 @@
 package org.gradle.util;
 
 import org.apache.commons.io.IOUtils;
+import org.gradle.internal.IoActions;
 
 import java.io.*;
 import java.util.zip.ZipEntry;
@@ -48,8 +49,8 @@ public class JarUtil {
                 }
             }
         } finally {
-            IOUtils.closeQuietly(zipStream);
-            IOUtils.closeQuietly(extractTargetStream);
+            IoActions.closeQuietly(zipStream);
+            IoActions.closeQuietly(extractTargetStream);
         }
 
         return entryExtracted;

--- a/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
+++ b/subprojects/ear/src/main/java/org/gradle/plugins/ear/descriptor/internal/DefaultDeploymentDescriptor.java
@@ -19,13 +19,13 @@ import groovy.lang.Closure;
 import groovy.util.Node;
 import groovy.util.XmlParser;
 import groovy.xml.QName;
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.Action;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.internal.DomNode;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Cast;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.xml.XmlTransformer;
@@ -329,7 +329,7 @@ public class DefaultDeploymentDescriptor implements DeploymentDescriptor {
         } catch (SAXException ex) {
             throw UncheckedException.throwAsUncheckedException(ex);
         } finally {
-            IOUtils.closeQuietly(reader);
+            IoActions.closeQuietly(reader);
         }
         return this;
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/measure/DataSeries.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/measure/DataSeries.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import org.apache.commons.math3.stat.inference.MannWhitneyUTest;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -80,7 +81,7 @@ public class DataSeries<Q> extends ArrayList<Amount<Q>> {
             sumSquares = sumSquares.add(diff);
         }
         // This isn't quite right, as we may lose precision when converting to a double
-        BigDecimal result = BigDecimal.valueOf(Math.sqrt(sumSquares.divide(BigDecimal.valueOf(size()), BigDecimal.ROUND_HALF_UP).doubleValue())).setScale(2, BigDecimal.ROUND_HALF_UP);
+        BigDecimal result = BigDecimal.valueOf(Math.sqrt(sumSquares.divide(BigDecimal.valueOf(size()), RoundingMode.HALF_UP).doubleValue())).setScale(2, RoundingMode.HALF_UP);
 
         standardError = Amount.valueOf(result, baseUnits);
     }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/envjs/http/simple/internal/SimpleFileServerContainer.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/envjs/http/simple/internal/SimpleFileServerContainer.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.javascript.envjs.http.simple.internal;
 
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.internal.IoActions;
 import org.simpleframework.http.Request;
 import org.simpleframework.http.Response;
 import org.simpleframework.http.core.Container;
@@ -67,16 +68,16 @@ public class SimpleFileServerContainer implements Container {
                 resp.set("Content-Encoding", Charset.defaultCharset().name());
                 Reader input = new FileReader(requestIndex.getFile());
                 IOUtils.copy(input, output);
-                IOUtils.closeQuietly(input);
+                IoActions.closeQuietly(input);
             } else {
                 InputStream input = new FileInputStream(requestIndex.getFile());
                 IOUtils.copy(input, output);
-                IOUtils.closeQuietly(input);
+                IoActions.closeQuietly(input);
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         } finally {
-            IOUtils.closeQuietly(output);
+            IoActions.closeQuietly(output);
         }
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/cli/CommandLineActionFactory.java
@@ -36,6 +36,7 @@ import org.gradle.initialization.LayoutCommandLineConverter;
 import org.gradle.initialization.ParallelismConfigurationCommandLineConverter;
 import org.gradle.initialization.layout.BuildLayoutFactory;
 import org.gradle.internal.Actions;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.buildevents.BuildExceptionReporter;
 import org.gradle.internal.concurrent.DefaultParallelismConfiguration;
 import org.gradle.internal.jvm.Jvm;
@@ -206,7 +207,7 @@ public class CommandLineActionFactory {
                 } catch (IOException e) {
                     // do not fail the build as feature is non-critical
                 } finally {
-                    IOUtils.closeQuietly(inputStream);
+                    IoActions.closeQuietly(inputStream);
                 }
             }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonBuildOptions.java
@@ -70,7 +70,7 @@ public class DaemonBuildOptions {
         @Override
         public void applyTo(String value, DaemonParameters settings, Origin origin) {
             try {
-                settings.setIdleTimeout(new Integer(value));
+                settings.setIdleTimeout(Integer.valueOf(value));
             } catch (NumberFormatException e) {
                 origin.handleInvalidValue(value, "the value should be an int");
             }
@@ -87,7 +87,7 @@ public class DaemonBuildOptions {
         @Override
         public void applyTo(String value, DaemonParameters settings, Origin origin) {
             try {
-                settings.setPeriodicCheckInterval(new Integer(value));
+                settings.setPeriodicCheckInterval(Integer.valueOf(value));
             } catch (NumberFormatException e) {
                 origin.handleInvalidValue(value, "the value should be an int");
             }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/exec/ForwardClientInput.java
@@ -15,9 +15,9 @@
  */
 package org.gradle.launcher.daemon.server.exec;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.launcher.daemon.protocol.ForwardInput;
 import org.gradle.launcher.daemon.server.api.DaemonCommandAction;
@@ -77,8 +77,8 @@ public class ForwardClientInput implements DaemonCommandAction {
                 });
             } finally {
                 execution.getConnection().onStdin(null);
-                IOUtils.closeQuietly(replacementStdin);
-                IOUtils.closeQuietly(inputSource);
+                IoActions.closeQuietly(replacementStdin);
+                IoActions.closeQuietly(inputSource);
             }
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);

--- a/subprojects/osgi/src/main/java/org/gradle/api/internal/plugins/osgi/DefaultOsgiManifest.java
+++ b/subprojects/osgi/src/main/java/org/gradle/api/internal/plugins/osgi/DefaultOsgiManifest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.util.*;
 import java.util.jar.Manifest;
 
+@SuppressWarnings("deprecation")
 public class DefaultOsgiManifest extends DefaultManifest implements OsgiManifest {
 
     // Because these properties can be convention mapped we need special handling in here.

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/RepeatableInputStreamEntity.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/RepeatableInputStreamEntity.java
@@ -19,6 +19,7 @@ package org.gradle.internal.resource.transport.http;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.entity.AbstractHttpEntity;
 import org.apache.http.entity.ContentType;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.resource.ReadableContent;
 
 import java.io.IOException;
@@ -53,7 +54,7 @@ public class RepeatableInputStreamEntity extends AbstractHttpEntity {
         try {
             IOUtils.copyLarge(content, outstream);
         } finally {
-            IOUtils.closeQuietly(content);
+            IoActions.closeQuietly(content);
         }
     }
 

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGenerator.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/Binary2JUnitXmlReportGenerator.java
@@ -16,17 +16,17 @@
 
 package org.gradle.api.internal.tasks.testing.junit.result;
 
-import org.apache.commons.io.IOUtils;
 import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.FileUtils;
+import org.gradle.internal.IoActions;
 import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.gradle.util.GFileUtils;
@@ -119,7 +119,7 @@ public class Binary2JUnitXmlReportGenerator {
             } catch (Exception e) {
                 throw new GradleException(String.format("Could not write XML test results for %s to file %s.", result.getClassName(), reportFile), e);
             } finally {
-                IOUtils.closeQuietly(output);
+                IoActions.closeQuietly(output);
             }
         }
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/CompositeTestResults.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/CompositeTestResults.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.tasks.testing.report;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -132,7 +133,7 @@ public abstract class CompositeTestResults extends TestResultModel {
         BigDecimal runTests = BigDecimal.valueOf(getRunTestCount());
         BigDecimal successful = BigDecimal.valueOf(getRunTestCount() - getFailureCount());
 
-        return successful.divide(runTests, 2, BigDecimal.ROUND_DOWN).multiply(BigDecimal.valueOf(100)).intValue();
+        return successful.divide(runTests, 2, RoundingMode.DOWN).multiply(BigDecimal.valueOf(100)).intValue();
     }
 
     protected void failed(TestResult failedTest) {

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/AbstractTestFrameworkDetector.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/detection/AbstractTestFrameworkDetector.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang.StringUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.tasks.testing.DefaultTestClassRunInfo;
 import org.gradle.api.internal.tasks.testing.TestClassProcessor;
+import org.gradle.internal.IoActions;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.Type;
 import org.slf4j.Logger;
@@ -125,7 +126,7 @@ public abstract class AbstractTestFrameworkDetector<T extends TestClassVisitor> 
         } catch (Throwable e) {
             throw new GradleException("failed to read class file " + testClassFile.getAbsolutePath(), e);
         } finally {
-            IOUtils.closeQuietly(classStream);
+            IoActions.closeQuietly(classStream);
         }
 
         return classVisitor;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ActionAwareConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ActionAwareConsumerConnection.java
@@ -36,6 +36,7 @@ import java.io.File;
  *
  * <p>Used for providers >= 1.8 and <= 2.0</p>
  */
+@SuppressWarnings("deprecation")
 public class ActionAwareConsumerConnection extends AbstractPost12ConsumerConnection {
     private final ActionRunner actionRunner;
     private final ModelProducer modelProducer;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/BuildActionRunnerBackedConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/BuildActionRunnerBackedConsumerConnection.java
@@ -29,6 +29,7 @@ import org.gradle.tooling.model.internal.Exceptions;
  *
  * <p>Used for providers >= 1.2 and <= 1.6.</p>
  */
+@SuppressWarnings("deprecation")
 public class BuildActionRunnerBackedConsumerConnection extends AbstractPost12ConsumerConnection {
     private final ModelProducer modelProducer;
     private final UnsupportedActionRunner actionRunner;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/CancellableActionRunner.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/CancellableActionRunner.java
@@ -58,6 +58,7 @@ class CancellableActionRunner implements ActionRunner {
         return result.getModel();
     }
 
+    @SuppressWarnings("deprecation")
     protected <T> BuildResult<T> execute(InternalBuildActionAdapter<T> buildActionAdapter, InternalCancellationToken cancellationTokenAdapter, BuildParameters operationParameters) {
         return executor.run(buildActionAdapter, cancellationTokenAdapter, operationParameters);
     }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/InternalBuildActionAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/InternalBuildActionAdapter.java
@@ -37,6 +37,7 @@ import java.io.File;
  * from an instance of {@link org.gradle.tooling.BuildAction}.
  * Used by consumer connections 1.8+.
  */
+@SuppressWarnings("deprecation")
 public class InternalBuildActionAdapter<T> implements InternalBuildAction<T>, InternalBuildActionVersion2<T> {
     private final BuildAction<T> action;
     private final File rootDir;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ModelBuilderBackedConsumerConnection.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ModelBuilderBackedConsumerConnection.java
@@ -27,6 +27,7 @@ import org.gradle.tooling.internal.protocol.ModelBuilder;
  *
  * <p>Used for providers >= 1.6 and <= 1.8</p>
  */
+@SuppressWarnings("deprecation")
 public class ModelBuilderBackedConsumerConnection extends AbstractPost12ConsumerConnection {
     private final ModelProducer modelProducer;
     private final ActionRunner actionRunner;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ModelBuilderBackedModelProducer.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/connection/ModelBuilderBackedModelProducer.java
@@ -26,6 +26,7 @@ import org.gradle.tooling.internal.protocol.ModelBuilder;
 import org.gradle.tooling.internal.protocol.ModelIdentifier;
 import org.gradle.tooling.model.internal.Exceptions;
 
+@SuppressWarnings("deprecation")
 public class ModelBuilderBackedModelProducer extends HasCompatibilityMapping implements ModelProducer {
     private final ProtocolToModelAdapter adapter;
     private final VersionDetails versionDetails;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/IdeaModuleDependencyTargetNameMixin.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/converters/IdeaModuleDependencyTargetNameMixin.java
@@ -26,6 +26,7 @@ public class IdeaModuleDependencyTargetNameMixin {
         this.ideaModuleDependency = ideaModuleDependency;
     }
 
+    @SuppressWarnings("deprecation")
     public String getTargetModuleName() {
         if (ideaModuleDependency instanceof IdeaModuleDependency) {
             IdeaModuleDependency dependency = (IdeaModuleDependency) ideaModuleDependency;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/loader/DefaultToolingImplementationLoader.java
@@ -61,6 +61,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
+@SuppressWarnings("deprecation")
 public class DefaultToolingImplementationLoader implements ToolingImplementationLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultToolingImplementationLoader.class);
     private final ClassLoader classLoader;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/ConsumerOperationParameters.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/ConsumerOperationParameters.java
@@ -43,6 +43,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("deprecation")
 public class ConsumerOperationParameters implements BuildOperationParametersVersion1, BuildParametersVersion1, BuildParameters {
 
     public static Builder builder() {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -140,7 +140,7 @@ public class WorkerDaemonClientsManager implements Stoppable {
             List<WorkerDaemonClient> sortedClients = CollectionUtils.sort(idleClients, new Comparator<WorkerDaemonClient>() {
                 @Override
                 public int compare(WorkerDaemonClient o1, WorkerDaemonClient o2) {
-                    return new Integer(o1.getUses()).compareTo(o2.getUses());
+                    return Integer.compare(o1.getUses(), o2.getUses());
                 }
             });
             List<WorkerDaemonClient> clientsToStop = selectionFunction.transform(new ArrayList<WorkerDaemonClient>(sortedClients));


### PR DESCRIPTION
When building in the IDE, these warnings are noisy and can mask more important warnings

- Converted a few uses of deprecated JDK methods to the recommended replacements
- Suppressed some warnings where we are using/implementing internal types that have been deprecated