### PR TITLE
Unignore/rebaseline performance tests after kotlin-dsl-1.0-rc-11

### DIFF
--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.performance.regression.inception
 
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
-import spock.lang.Ignore
 import spock.lang.Issue
 import spock.lang.Unroll
 
@@ -34,13 +33,12 @@ import spock.lang.Unroll
 @Issue('https://github.com/gradle/gradle-private/issues/1313')
 class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest {
 
-    @Ignore("WIP: kotlin-dsl upgrade")
     @Unroll
     def "#tasks on the gradle build comparing gradle"() {
         given:
         runner.testProject = "gradleBuildCurrent"
         runner.tasksToRun = tasks.split(' ')
-        runner.targetVersions = ["5.0-20180926235905+0000"]
+        runner.targetVersions = ["5.0-20180930035444+0000"]
         runner.args = ["-Djava9Home=${System.getProperty('java9Home')}"]
 
         when:

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaConfigurationPerformanceTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import spock.lang.Unroll
 
 import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT
-//import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL
+import static org.gradle.performance.generator.JavaTestProject.LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL
 import static org.gradle.performance.generator.JavaTestProject.LARGE_MONOLITHIC_JAVA_PROJECT
 
 class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTest {
@@ -31,7 +31,7 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         runner.testProject = testProject
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['help']
-        runner.targetVersions = ["5.0-20180926235905+0000"]
+        runner.targetVersions = ["5.0-20180930035444+0000"]
 
         when:
         def result = runner.run()
@@ -43,6 +43,6 @@ class JavaConfigurationPerformanceTest extends AbstractCrossVersionPerformanceTe
         testProject                              | _
         LARGE_MONOLITHIC_JAVA_PROJECT            | _
         LARGE_JAVA_MULTI_PROJECT                 | _
-//        LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL      | _ //TODO:kotlin-dsl
+        LARGE_JAVA_MULTI_PROJECT_KOTLIN_DSL      | _
     }
 }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/java/JavaFirstUsePerformanceTest.groovy
@@ -41,7 +41,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.tasksToRun = ['tasks']
         runner.runs = runs
         runner.useDaemon = false
-        runner.targetVersions = ["5.0-20180920090625+0000"]
+        runner.targetVersions = ["5.0-20180930035444+0000"]
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
             @Override
             void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
@@ -73,7 +73,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
         runner.useDaemon = false
-        runner.targetVersions = ["5.0-20180920090625+0000"]
+        runner.targetVersions = ["5.0-20180930035444+0000"]
         runner.addBuildExperimentListener(new BuildExperimentListenerAdapter() {
             @Override
             void afterInvocation(BuildExperimentInvocationInfo invocationInfo, MeasuredOperation operation, BuildExperimentListener.MeasurementCallback measurementCallback) {
@@ -104,7 +104,7 @@ class JavaFirstUsePerformanceTest extends AbstractCrossVersionPerformanceTest {
         runner.gradleOpts = ["-Xms${testProject.daemonMemory}", "-Xmx${testProject.daemonMemory}"]
         runner.tasksToRun = ['tasks']
         runner.useDaemon = false
-        runner.targetVersions = ["5.0-20180920090625+0000"]
+        runner.targetVersions = ["5.0-20180930035444+0000"]
 
         when:
         def result = runner.run()


### PR DESCRIPTION
Unignore/rebaseline those broken by the upgrade (inception builds).
Rebaseline those impacted <2% by the extra EAP repo configuration.

