### PR TITLE
In IDEA configuration ignore resource dir declaration if the target is a source dir

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Module.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Module.java
@@ -428,6 +428,9 @@ public class Module extends XmlPersistableConfigurationObject {
             content.appendNode("sourceFolder", attributes);
         }
         for (Path path : resourceFolders) {
+            if (sourceFolders.contains(path)) {
+                continue;
+            }
             Map<String, Object> attributes = Maps.newLinkedHashMap();
             attributes.put("url", path.getUrl());
             attributes.put("type", "java-resource");
@@ -437,6 +440,9 @@ public class Module extends XmlPersistableConfigurationObject {
             content.appendNode("sourceFolder", attributes);
         }
         for (Path path : testResourceFolders) {
+            if (testSourceFolders.contains(path)) {
+                continue;
+            }
             Map<String, Object> attributes = Maps.newLinkedHashMap();
             attributes.put("url", path.getUrl());
             attributes.put("type", "java-test-resource");


### PR DESCRIPTION
As explained at https://github.com/gradle/gradle/issues/654 if a
directory is both declared as a source and a resource directory, then
the resource flag was added to it. This makes IDEA unusable as the
source editing is disabled for the contained source files. To overcome
that, this commit makes the resource declaration omitted if the target
is a source directory.
