### PR TITLE
Resolve buildSrc classpath only after buildSrc build is complete

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildBuildSrcIdentityIntegrationTest.groovy
@@ -103,7 +103,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         fails(buildA, ":assemble")
 
         then:
-        failure.assertHasDescription("Could not resolve all files for configuration ':buildB:buildSrc:runtimeClasspath'.")
+        failure.assertHasDescription("Could not resolve all files for configuration ':buildB:buildSrc:compileClasspath'.")
         failure.assertHasCause("""Cannot resolve external dependency test:test:1.2 because no repositories are defined.
 Required by:
     project :buildB:buildSrc""")

--- a/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/initialization/buildsrc/BuildSrcIdentityIntegrationTest.groovy
@@ -95,7 +95,7 @@ runtimeClasspath - Runtime classpath of source set 'main'.
         fails()
 
         then:
-        failure.assertHasDescription("Could not resolve all files for configuration ':buildSrc:runtimeClasspath'.")
+        failure.assertHasDescription("Could not resolve all files for configuration ':buildSrc:compileClasspath'.")
         failure.assertHasCause("""Could not find org.test:test:1.2.
 Searched in the following locations:
   - ${m.pom.file.toURL()}
@@ -110,7 +110,7 @@ Required by:
         fails()
 
         then:
-        failure.assertHasDescription("Could not resolve all files for configuration ':buildSrc:runtimeClasspath'.")
+        failure.assertHasDescription("Could not resolve all files for configuration ':buildSrc:compileClasspath'.")
         failure.assertHasCause("Could not find test.jar (org.test:test:1.2).")
 
         where:

--- a/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/buildsrc/BuildSrcBuildListenerFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.initialization.buildsrc;
 
 import org.gradle.api.Action;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
@@ -28,7 +29,6 @@ import org.gradle.internal.InternalBuildAdapter;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.Set;
 
 public class BuildSrcBuildListenerFactory {
 
@@ -46,8 +46,12 @@ public class BuildSrcBuildListenerFactory {
         return new Listener(buildSrcRootProjectConfiguration);
     }
 
+    /**
+     * Inspects the build when configured, and adds the appropriate task to build the "main" `buildSrc` component.
+     * On build completion, makes the runtime classpath of the main `buildSrc` component available.
+     */
     public static class Listener extends InternalBuildAdapter implements ModelConfigurationListener {
-        private Set<File> classpath;
+        private FileCollection classpath;
         private final Action<ProjectInternal> rootProjectConfiguration;
 
         private Listener(Action<ProjectInternal> rootProjectConfiguration) {
@@ -63,11 +67,11 @@ public class BuildSrcBuildListenerFactory {
         public void onConfigure(GradleInternal gradle) {
             BuildableJavaComponent mainComponent = mainComponentOf(gradle);
             gradle.getStartParameter().setTaskNames(mainComponent.getBuildTasks());
-            classpath = mainComponent.getRuntimeClasspath().getFiles();
+            classpath = mainComponent.getRuntimeClasspath();
         }
 
         public Collection<File> getRuntimeClasspath() {
-            return classpath;
+            return classpath.getFiles();
         }
 
         private BuildableJavaComponent mainComponentOf(GradleInternal gradle) {


### PR DESCRIPTION
The buildSrc builder injects logic to a) determine which tasks to execute, and to b) extract the classpath to use for executing the main build. The former needs to be done after the model is configured, but before the task graph is calculated. Previously, we were also doing step b) at this stage, which resulted in dependency resolution during the configuration phase.

This PR fixes this, by deferring the resolution of the buildSrc runtime configuration until after the build has completed execution.