### PR TITLE
Use Files.setLastModifiedTime to touch files

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -28,6 +28,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -64,8 +66,10 @@ public class GFileUtils {
      * (or directory) must exist.
      */
     public static void touchExisting(File file) {
-        if (!file.setLastModified(System.currentTimeMillis())) {
-            throw new UncheckedIOException("Could not update time stamp for " + file);
+        try {
+            Files.setLastModifiedTime(file.toPath(), FileTime.fromMillis(System.currentTimeMillis()));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not update time stamp for " + file, e);
         }
     }
 

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/ModificationTimeFileAccessTimeJournal.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/ModificationTimeFileAccessTimeJournal.java
@@ -17,11 +17,18 @@
 package org.gradle.internal.resource.local;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
 
 public class ModificationTimeFileAccessTimeJournal implements FileAccessTimeJournal {
     @Override
     public void setLastAccessTime(File file, long millis) {
-        file.setLastModified(millis);
+        try {
+            Files.setLastModifiedTime(file.toPath(), FileTime.fromMillis(millis));
+        } catch (IOException ignore) {
+            // ignore
+        }
     }
 
     @Override

--- a/subprojects/resources/src/main/java/org/gradle/internal/resource/local/ModificationTimeFileAccessTimeJournal.java
+++ b/subprojects/resources/src/main/java/org/gradle/internal/resource/local/ModificationTimeFileAccessTimeJournal.java
@@ -16,18 +16,24 @@
 
 package org.gradle.internal.resource.local;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
 
 public class ModificationTimeFileAccessTimeJournal implements FileAccessTimeJournal {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ModificationTimeFileAccessTimeJournal.class);
+
     @Override
     public void setLastAccessTime(File file, long millis) {
         try {
             Files.setLastModifiedTime(file.toPath(), FileTime.fromMillis(millis));
-        } catch (IOException ignore) {
-            // ignore
+        } catch (IOException e) {
+            LOGGER.debug("Ignoring failure to set last access time of " + file, e);
         }
     }
 


### PR DESCRIPTION
While, `File.setLastModified` always uses `utimes` on Unix,
`Files.setLastModifiedTime` uses `futimes`, if available, which seems to
be able to set the timestamp for writable files owned by another user.

Resolves #6971.