### PR TITLE
fix issue with arraylist being converted to immutablelist

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -74,7 +74,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         if (maybeDeriveVariants.isPresent()) {
             ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<>();
             for (ConfigurationMetadata derivedVariant : maybeDeriveVariants.get()) {
-                ImmutableList<ModuleDependencyMetadata> dependencies = Cast.uncheckedCast(derivedVariant.getDependencies());
+                ImmutableList<ModuleDependencyMetadata> dependencies = new ImmutableList.Builder<ModuleDependencyMetadata>().addAll((List<ModuleDependencyMetadata>) derivedVariant.getDependencies()).build();
                 RealisedConfigurationMetadata derivedVariantMetadata = new RealisedConfigurationMetadata(
                     metadata.getId(),
                     derivedVariant.getName(),


### PR DESCRIPTION
### Context
While trying to use `@CachedRule` with `ComponentMetadataRule` got the following exception:

```
org.gradle.api.GradleException: Build aborted because of an internal error.
	at nebula.test.functional.internal.DefaultExecutionResult.rethrowFailure(DefaultExecutionResult.groovy:97)
	at nebula.test.IntegrationSpec.runTasksSuccessfully(IntegrationSpec.groovy:149)
	at gradle5.rc.issue.MyPluginSpec.specific transitive candidates or snapshots resolved(MyPluginSpec.groovy:79)
Caused by: org.gradle.internal.exceptions.LocationAwareException: Could not add entry '60665ab74198089febc169942a6cdb17' to cache md-rule.bin (/Users/rperezalcolea/.gradle/caches/5.0-20180930235830+0000/md-rule/md-rule.bin).
	at org.gradle.initialization.DefaultExceptionAnalyser.transform(DefaultExceptionAnalyser.java:74)
	at org.gradle.initialization.MultipleBuildFailuresExceptionAnalyser.transform(MultipleBuildFailuresExceptionAnalyser.java:49)
	at org.gradle.initialization.StackTraceSanitizingExceptionAnalyser.transform(StackTraceSanitizingExceptionAnalyser.java:30)
	at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:72)
	at org.gradle.tooling.internal.provider.SessionFailureReportingActionExecuter.execute(SessionFailureReportingActionExecuter.java:44)
	at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:46)
	at org.gradle.tooling.internal.provider.SetupLoggingActionExecuter.execute(SetupLoggingActionExecuter.java:30)
	at org.gradle.tooling.internal.provider.DaemonBuildActionExecuter.execute(DaemonBuildActionExecuter.java:60)
	at org.gradle.tooling.internal.provider.DaemonBuildActionExecuter.execute(DaemonBuildActionExecuter.java:41)
	at org.gradle.tooling.internal.provider.LoggingBridgingBuildActionExecuter.execute(LoggingBridgingBuildActionExecuter.java:58)
	at org.gradle.tooling.internal.provider.LoggingBridgingBuildActionExecuter.execute(LoggingBridgingBuildActionExecuter.java:37)
	at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:181)
	at org.gradle.tooling.internal.provider.ProviderConnection.run(ProviderConnection.java:124)
	at org.gradle.tooling.internal.provider.DefaultConnection.getModel(DefaultConnection.java:208)
	at org.gradle.tooling.internal.consumer.connection.CancellableModelBuilderBackedModelProducer.produceModel(CancellableModelBuilderBackedModelProducer.java:53)
	at org.gradle.tooling.internal.consumer.connection.PluginClasspathInjectionSupportedCheckModelProducer.produceModel(PluginClasspathInjectionSupportedCheckModelProducer.java:41)
	at org.gradle.tooling.internal.consumer.connection.AbstractConsumerConnection.run(AbstractConsumerConnection.java:59)
	at org.gradle.tooling.internal.consumer.connection.ParameterValidatingConsumerConnection.run(ParameterValidatingConsumerConnection.java:47)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher$1.run(DefaultBuildLauncher.java:89)
	at org.gradle.tooling.internal.consumer.DefaultBuildLauncher$1.run(DefaultBuildLauncher.java:83)
	at org.gradle.tooling.internal.consumer.connection.LazyConsumerActionExecutor.run(LazyConsumerActionExecutor.java:84)
	at org.gradle.tooling.internal.consumer.connection.CancellableConsumerActionExecutor.run(CancellableConsumerActionExecutor.java:45)
	at org.gradle.tooling.internal.consumer.connection.ProgressLoggingConsumerActionExecutor.run(ProgressLoggingConsumerActionExecutor.java:58)
	at org.gradle.tooling.internal.consumer.connection.RethrowingErrorsConsumerActionExecutor.run(RethrowingErrorsConsumerActionExecutor.java:38)
	at org.gradle.tooling.internal.consumer.async.DefaultAsyncConsumerActionExecutor$1$1.run(DefaultAsyncConsumerActionExecutor.java:55)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
Caused by: org.gradle.api.UncheckedIOException: Could not add entry '60665ab74198089febc169942a6cdb17' to cache md-rule.bin (/Users/rperezalcolea/.gradle/caches/5.0-20180930235830+0000/md-rule/md-rule.bin).
	at org.gradle.cache.internal.btree.BTreePersistentIndexedCache.put(BTreePersistentIndexedCache.java:160)
	at org.gradle.cache.internal.DefaultMultiProcessSafePersistentIndexedCache$2.run(DefaultMultiProcessSafePersistentIndexedCache.java:72)
	at org.gradle.cache.internal.DefaultFileLockManager$DefaultFileLock.doWriteAction(DefaultFileLockManager.java:207)
	at org.gradle.cache.internal.DefaultFileLockManager$DefaultFileLock.writeFile(DefaultFileLockManager.java:197)
	at org.gradle.cache.internal.DefaultCacheAccess$UnitOfWorkFileAccess.writeFile(DefaultCacheAccess.java:411)
	at org.gradle.cache.internal.DefaultMultiProcessSafePersistentIndexedCache.put(DefaultMultiProcessSafePersistentIndexedCache.java:70)
	at org.gradle.cache.internal.AsyncCacheAccessDecoratedCache$2.run(AsyncCacheAccessDecoratedCache.java:64)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
	at org.gradle.cache.internal.CacheAccessWorker$2.run(CacheAccessWorker.java:184)
	at org.gradle.internal.Factories$1.create(Factories.java:25)
	at org.gradle.cache.internal.DefaultCacheAccess.useCache(DefaultCacheAccess.java:222)
	at org.gradle.cache.internal.DefaultCacheAccess.useCache(DefaultCacheAccess.java:203)
	at org.gradle.cache.internal.CacheAccessWorker.flushOperations(CacheAccessWorker.java:174)
	at org.gradle.cache.internal.CacheAccessWorker.run(CacheAccessWorker.java:144)
	... 3 more
Caused by: java.lang.ClassCastException: java.util.ArrayList cannot be cast to com.google.common.collect.ImmutableList
	at org.gradle.internal.component.external.model.maven.RealisedMavenModuleResolveMetadata.transform(RealisedMavenModuleResolveMetadata.java:77)
	at org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer.transformToRealisedForSerialization(ModuleComponentResolveMetadataSerializer.java:91)
	at org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer.write(ModuleComponentResolveMetadataSerializer.java:72)
	at org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer.write(ModuleComponentResolveMetadataSerializer.java:42)
	at org.gradle.internal.resolve.caching.CrossBuildCachingRuleExecutor$CacheEntrySerializer.write(CrossBuildCachingRuleExecutor.java:292)
	at org.gradle.internal.resolve.caching.CrossBuildCachingRuleExecutor$CacheEntrySerializer.write(CrossBuildCachingRuleExecutor.java:237)
	at org.gradle.cache.internal.btree.BTreePersistentIndexedCache$DataBlock.setValue(BTreePersistentIndexedCache.java:669)
	at org.gradle.cache.internal.btree.BTreePersistentIndexedCache$DataBlock.<init>(BTreePersistentIndexedCache.java:656)
	at org.gradle.cache.internal.btree.BTreePersistentIndexedCache.put(BTreePersistentIndexedCache.java:152)
	... 16 more
```

This change is to create the immutable list explicity

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
