### PR TITLE
Allow tested code to reference SLF4J when gradle types are not available on the classpath

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -67,7 +67,7 @@ class JUnitPlatformTestRewriter {
     }
 
     static rewriteBuildFileWithJupiter(File buildFile, String dependencyVersion) {
-        rewriteBuildFileInDir(buildFile, "org.junit.jupiter:junit-jupiter-api:${dependencyVersion}','org.junit.jupiter:junit-jupiter-engine:${dependencyVersion}")
+        rewriteBuildFileInDir(buildFile, "org.junit.jupiter:junit-jupiter-api:${dependencyVersion}','org.junit.jupiter:junit-jupiter-engine:${dependencyVersion}", "org.junit.jupiter.api")
     }
 
     static rewriteBuildFileWithVintage(File buildFile, String dependencyVersion) {
@@ -120,10 +120,10 @@ test {
                 '''
             }
         }
-        if (text.contains("--add-modules")) {
+        if (moduleName != null && text.contains("--add-modules")) {
             // This is a bit aggressive but it works for now
-            text = text.replace('"junit"', '"org.junit.jupiter.api"')
-            text = text.replace('=junit"', '=org.junit.jupiter.api"')
+            text = text.replace('"junit"', '"' + moduleName + '"')
+            text = text.replace('=junit"', '=' + moduleName + '"')
         }
         buildFile.text = text
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/junitplatform/JUnitPlatformTestRewriter.groovy
@@ -84,21 +84,22 @@ class JUnitPlatformTestRewriter {
         }
     }
 
-    static rewriteBuildFileInDir(File dir, String dependencies) {
+    static rewriteBuildFileInDir(File dir, String dependencies, String moduleName = null) {
         def dirs = [dir]
         dirs.addAll(dir.listFiles().findAll { it.isDirectory() })
         dirs.each {
             File buildFile = new File(it, 'build.gradle')
             if (buildFile.exists()) {
-                rewriteBuildFile(buildFile, dependencies)
+                rewriteBuildFile(buildFile, dependencies, moduleName)
             }
         }
     }
 
-    static rewriteBuildFile(File buildFile, String dependenciesReplacement) {
+    static rewriteBuildFile(File buildFile, String dependenciesReplacement, String moduleName) {
         String text = buildFile.text
-        // compile/testCompile
+        // compile/testCompile/implementation/testImplementation
         text = text.replaceFirst(/ompile ['"]junit:junit:4\.12['"]/, "ompile '${dependenciesReplacement}'")
+        text = text.replaceFirst(/mplementation ['"]junit:junit:4\.12['"]/, "mplementation '${dependenciesReplacement}'")
         if (!text.contains('useTestNG')) {
             // we only hack build with JUnit 4
             // See IncrementalTestIntegrationTest.executesTestsWhenTestFrameworkChanges
@@ -108,16 +109,21 @@ class JUnitPlatformTestRewriter {
                 text = text.replace('useJUnit()', 'useJUnitPlatform()')
             } else if (text.contains('test {')) {
                 text = text.replace('test {', '''
-                    test {
-                    useJUnitPlatform()
-                    ''')
+test {
+    useJUnitPlatform()
+''')
             } else {
                 text += '''
-                    test {
-                        useJUnitPlatform()
-                    }
+test {
+    useJUnitPlatform()
+}
                 '''
             }
+        }
+        if (text.contains("--add-modules")) {
+            // This is a bit aggressive but it works for now
+            text = text.replace('"junit"', '"org.junit.jupiter.api"')
+            text = text.replace('=junit"', '=org.junit.jupiter.api"')
         }
         buildFile.text = text
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurer.java
@@ -42,7 +42,9 @@ public class Slf4jLoggingConfigurer implements LoggingConfigurer {
 
         ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
         if (!(loggerFactory instanceof OutputEventListenerBackedLoggerContext)) {
-            System.out.println("Gradle cannot configure Slf4j logger of type '" + loggerFactory.getClass().getSimpleName() + "'.");
+            // Cannot configure Slf4j logger. This will happen if:
+            // - Tests are executed with a custom classloader (e.g using `java.system.class.loader`)
+            // - Tests are run with `--module-path`, effectively hiding Gradle classes
             return;
         }
         OutputEventListenerBackedLoggerContext context = (OutputEventListenerBackedLoggerContext) loggerFactory;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurer.java
@@ -42,8 +42,7 @@ public class Slf4jLoggingConfigurer implements LoggingConfigurer {
 
         ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
         if (!(loggerFactory instanceof OutputEventListenerBackedLoggerContext)) {
-            System.out.println("Gradle cannot configure Slf4j logger of type '" + loggerFactory.getClass().getSimpleName()
-                + "'. This is expected when executing tests with a custom `java.system.class.loader` set.");
+            System.out.println("Gradle cannot configure Slf4j logger of type '" + loggerFactory.getClass().getSimpleName() + "'.");
             return;
         }
         OutputEventListenerBackedLoggerContext context = (OutputEventListenerBackedLoggerContext) loggerFactory;

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/Slf4jLoggingConfigurer.java
@@ -19,6 +19,7 @@ package org.gradle.internal.logging.slf4j;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.internal.logging.config.LoggingConfigurer;
 import org.gradle.internal.logging.events.OutputEventListener;
+import org.slf4j.ILoggerFactory;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -39,7 +40,13 @@ public class Slf4jLoggingConfigurer implements LoggingConfigurer {
             return;
         }
 
-        OutputEventListenerBackedLoggerContext context = (OutputEventListenerBackedLoggerContext) LoggerFactory.getILoggerFactory();
+        ILoggerFactory loggerFactory = LoggerFactory.getILoggerFactory();
+        if (!(loggerFactory instanceof OutputEventListenerBackedLoggerContext)) {
+            System.out.println("Gradle cannot configure Slf4j logger of type '" + loggerFactory.getClass().getSimpleName()
+                + "'. This is expected when executing tests with a custom `java.system.class.loader` set.");
+            return;
+        }
+        OutputEventListenerBackedLoggerContext context = (OutputEventListenerBackedLoggerContext) loggerFactory;
 
         if (currentLevel == null) {
             context.setOutputEventListener(outputEventListener);

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEnvironmentIntegrationTest.groovy
@@ -47,7 +47,6 @@ class TestEnvironmentIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         run 'test'
 
         then:
-        outputContains("Gradle cannot configure Slf4j logger of type 'SimpleLoggerFactory'.")
         def testResults = new DefaultTestExecutionResult(testDirectory)
         testResults.assertTestClassesExecuted('org.gradle.TestUsingSlf4j')
         with(testResults.testClass('org.gradle.TestUsingSlf4j')) {
@@ -64,7 +63,6 @@ class TestEnvironmentIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         run 'test'
 
         then:
-        outputContains("Gradle cannot configure Slf4j logger of type 'SimpleLoggerFactory'.")
         def testResults = new DefaultTestExecutionResult(testDirectory)
         testResults.assertTestClassesExecuted('org.gradle.example.TestUsingSlf4j')
         with(testResults.testClass('org.gradle.example.TestUsingSlf4j')) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEnvironmentIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/TestEnvironmentIntegrationTest.groovy
@@ -47,11 +47,28 @@ class TestEnvironmentIntegrationTest extends JUnitMultiVersionIntegrationSpec {
         run 'test'
 
         then:
-        outputContains("Gradle cannot configure Slf4j logger of type 'SimpleLoggerFactory'. This is expected when executing tests with a custom `java.system.class.loader` set.")
+        outputContains("Gradle cannot configure Slf4j logger of type 'SimpleLoggerFactory'.")
         def testResults = new DefaultTestExecutionResult(testDirectory)
         testResults.assertTestClassesExecuted('org.gradle.TestUsingSlf4j')
         with(testResults.testClass('org.gradle.TestUsingSlf4j')) {
             assertTestPassed('mySystemClassLoaderIsUsed')
+            assertStderr(Matchers.containsText("ERROR via slf4j"))
+            assertStderr(Matchers.containsText("WARN via slf4j"))
+            assertStderr(Matchers.containsText("INFO via slf4j"))
+        }
+    }
+
+    @Requires(TestPrecondition.JDK9_OR_LATER)
+    def canRunTestsReferencingSlf4jWithModularJava() {
+        when:
+        run 'test'
+
+        then:
+        outputContains("Gradle cannot configure Slf4j logger of type 'SimpleLoggerFactory'.")
+        def testResults = new DefaultTestExecutionResult(testDirectory)
+        testResults.assertTestClassesExecuted('org.gradle.example.TestUsingSlf4j')
+        with(testResults.testClass('org.gradle.example.TestUsingSlf4j')) {
+            assertTestPassed('testModular')
             assertStderr(Matchers.containsText("ERROR via slf4j"))
             assertStderr(Matchers.containsText("WARN via slf4j"))
             assertStderr(Matchers.containsText("INFO via slf4j"))

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithCustomSystemClassLoader/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithCustomSystemClassLoader/build.gradle
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'java'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.slf4j:slf4j-api:1.7.25'
+    testCompile 'junit:junit:4.12'
+    testRuntime 'org.slf4j:slf4j-simple:1.7.25'
+}
+
+test {
+    systemProperties 'java.system.class.loader':'org.gradle.MySystemClassLoader'
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithCustomSystemClassLoader/src/test/java/org/gradle/MySystemClassLoader.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithCustomSystemClassLoader/src/test/java/org/gradle/MySystemClassLoader.java
@@ -1,0 +1,14 @@
+package org.gradle;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class MySystemClassLoader extends URLClassLoader {
+    public MySystemClassLoader(ClassLoader parent) {
+        super(new URL[0], parent);
+        // Should be constructed with the default system ClassLoader as root
+        if (!getClass().getClassLoader().equals(parent)) {
+            throw new AssertionError();
+        }
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithCustomSystemClassLoader/src/test/java/org/gradle/TestUsingSlf4j.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithCustomSystemClassLoader/src/test/java/org/gradle/TestUsingSlf4j.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static junit.framework.Assert.*;
+
+public class TestUsingSlf4j {
+    @Test
+    public void mySystemClassLoaderIsUsed() throws ClassNotFoundException {
+        assertTrue(ClassLoader.getSystemClassLoader() instanceof MySystemClassLoader);
+        assertEquals(getClass().getClassLoader(), ClassLoader.getSystemClassLoader().getParent());
+
+        Logger logger = LoggerFactory.getLogger(TestUsingSlf4j.class);
+        logger.info("INFO via slf4j");
+        logger.warn("WARN via slf4j");
+        logger.error("ERROR via slf4j");
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java-library'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.slf4j:slf4j-api:1.7.25'
+    implementation 'org.slf4j:slf4j-simple:1.7.25'
+
+    testImplementation 'junit:junit:4.12'
+}
+
+
+compileTestJava {
+    def args = ["--module-path", compileTestJava.classpath.asPath,
+                "--add-modules", "junit",
+                "--add-reads", "org.gradle.example=junit"]
+    options.compilerArgs = args
+    classpath = files()
+}
+
+test {
+    def args = ["--module-path", test.classpath.asPath,
+                "--add-modules", "ALL-MODULE-PATH",
+                "--add-reads", "org.gradle.example=junit",
+                "--add-reads", "org.gradle.example=slf4j.api"]
+    jvmArgs = args
+    classpath = files()
+
+    // Required because modular tests are not properly supported
+    scanForTestClasses = false
+    include "**/TestUsingSlf4j.class"
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/settings.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'modular'

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/src/test/java/module-info.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/src/test/java/module-info.java
@@ -1,0 +1,3 @@
+module org.gradle.example {
+    exports org.gradle.example; 
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/src/test/java/org/gradle/example/TestUsingSlf4j.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/TestEnvironmentIntegrationTest/canRunTestsReferencingSlf4jWithModularJava/src/test/java/org/gradle/example/TestUsingSlf4j.java
@@ -1,0 +1,14 @@
+package org.gradle.example;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestUsingSlf4j {
+    @Test public void testModular() {
+        Logger logger = LoggerFactory.getLogger(org.gradle.example.TestUsingSlf4j.class);
+        logger.info("INFO via slf4j");
+        logger.warn("WARN via slf4j");
+        logger.error("ERROR via slf4j");
+    }
+}


### PR DESCRIPTION
The core `Slf4jLoggingConfigurer` assumes that the Gradle implementation
of `org.slf4j.ILoggerFactory` is being used. This is not the case when
tests are run using a custom system classloader (by setting the
`java.system.class.loader` system property), or when the tests are executed with modular java.

Previously, this would result in a `ClassCastException` when attempting
to configure the logger. This change makes `Slf4jLoggingConfigurer` lenient
in this case, opting not to configure the underlying logger rather than
fail.

Fixes #2657
