### PR TITLE
Feature/6923 spawned exec tasks

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/AbstractExecTask.java
@@ -362,4 +362,21 @@ public abstract class AbstractExecTask<T extends AbstractExecTask> extends Conve
     public ExecResult getExecResult() {
         return execResult;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Internal
+    @Override
+    public boolean isSpawn() {
+        return execAction.isSpawn();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSpawn(boolean spawn) {
+        execAction.setSpawn(spawn);
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/JavaExec.java
@@ -551,6 +551,23 @@ public class JavaExec extends ConventionTask implements JavaExecSpec {
      * {@inheritDoc}
      */
     @Override
+    @Internal
+    public boolean isSpawn() {
+        return javaExecHandleBuilder.isSpawn();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setSpawn(boolean spawn) {
+        javaExecHandleBuilder.setSpawn(spawn);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<CommandLineArgumentProvider> getJvmArgumentProviders() {
         return javaExecHandleBuilder.getJvmArgumentProviders();
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/AbstractExecHandleBuilder.java
@@ -21,8 +21,8 @@ import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.BaseExecSpec;
 import org.gradle.process.internal.streams.EmptyStdInStreamsHandler;
 import org.gradle.process.internal.streams.ForwardStdinStreamsHandler;
-import org.gradle.process.internal.streams.SafeStreams;
 import org.gradle.process.internal.streams.OutputStreamsForwarder;
+import org.gradle.process.internal.streams.SafeStreams;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -45,6 +45,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
     private int timeoutMillis = Integer.MAX_VALUE;
     protected boolean daemon;
     private Executor executor;
+    private boolean spawn = false;
 
     AbstractExecHandleBuilder(PathToFileResolver fileResolver, Executor executor, BuildCancellationToken buildCancellationToken) {
         super(fileResolver);
@@ -133,7 +134,7 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
 
         StreamsHandler effectiveOutputHandler = getEffectiveStreamsHandler();
         return new DefaultExecHandle(getDisplayName(), getWorkingDir(), executable, getAllArguments(), getActualEnvironment(),
-                effectiveOutputHandler, inputHandler, listeners, redirectErrorStream, timeoutMillis, daemon, executor, buildCancellationToken);
+            effectiveOutputHandler, inputHandler, listeners, redirectErrorStream, timeoutMillis, daemon, executor, buildCancellationToken, spawn);
     }
 
     private StreamsHandler getEffectiveStreamsHandler() {
@@ -163,5 +164,15 @@ public abstract class AbstractExecHandleBuilder extends DefaultProcessForkOption
     public AbstractExecHandleBuilder setTimeout(int timeoutMillis) {
         this.timeoutMillis = timeoutMillis;
         return this;
+    }
+
+    @Override
+    public boolean isSpawn() {
+        return spawn;
+    }
+
+    @Override
+    public void setSpawn(boolean spawn) {
+        this.spawn = spawn;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
@@ -71,6 +71,13 @@ public class ExecHandleRunner implements Runnable {
 
             execHandle.started();
 
+            if (execHandle.isSpawn()) {
+                LOGGER.debug("Process successfully spawned");
+                streamsHandler.disconnect();
+                spawned();
+                return;
+            }
+
             LOGGER.debug("waiting until streams are handled...");
             streamsHandler.start();
 
@@ -112,5 +119,9 @@ public class ExecHandleRunner implements Runnable {
 
     private void detached() {
         execHandle.detached();
+    }
+
+    private void spawned() {
+        execHandle.spawned();
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
@@ -56,7 +56,7 @@ class ExecTest extends AbstractTaskTest {
         execTask.execResult.exitValue == 1
     }
 
-    def "spawns when configured"() {
+    def "spawn configuration is correctly passed to action"() {
         when:
         execTask.setExecutable("ls")
         execTask.setSpawn(true)

--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/ExecTest.groovy
@@ -56,6 +56,19 @@ class ExecTest extends AbstractTaskTest {
         execTask.execResult.exitValue == 1
     }
 
+    def "spawns when configured"() {
+        when:
+        execTask.setExecutable("ls")
+        execTask.setSpawn(true)
+        execute(execTask)
+
+        then:
+        1 * execAction.setExecutable("ls")
+        1 * execAction.setSpawn(true)
+        1 * execAction.execute() >> new ExpectedExecResult(0)
+        execTask.execResult.exitValue == 0
+    }
+
     private class ExpectedExecResult implements ExecResult {
         int exitValue
 

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleBuilderTest.groovy
@@ -17,11 +17,13 @@
 package org.gradle.process.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.api.tasks.ExecTest
 import org.gradle.process.internal.streams.EmptyStdInStreamsHandler
 import org.gradle.process.internal.streams.ForwardStdinStreamsHandler
 import org.gradle.util.UsesNativeServices
 import spock.lang.Specification
 
+import java.nio.file.Files
 import java.util.concurrent.Executor
 
 @UsesNativeServices
@@ -61,5 +63,27 @@ class DefaultExecHandleBuilderTest extends Specification {
         then:
         builder.args == ['1', '2', '3']
         builder.allArguments == ['1', '2', '3']
+    }
+
+    def "build and assert spawn flag"() {
+        builder.executable('ls')
+        File workingDir = Files.createTempDirectory(ExecTest.getSimpleName()).toFile()
+        workingDir.deleteOnExit()
+        builder.workingDir(workingDir)
+        if(inputSpawn != null) {
+            builder.setSpawn(inputSpawn)
+        }
+
+        when:
+        boolean isSpawn = ((DefaultExecHandle) builder.build()).isSpawn()
+
+        then:
+        isSpawn == expectedSpawn
+
+        where:
+        inputSpawn  | expectedSpawn
+        null        | false
+        true        | true
+        false       | false
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -50,6 +50,7 @@ class JavaExecHandleBuilderTest extends Specification {
         builder.minHeapSize = "64m"
         builder.maxHeapSize = "1g"
         builder.defaultCharacterEncoding = inputEncoding
+        builder.spawn = true
 
         when:
         List jvmArgs = builder.getAllJvmArgs()
@@ -63,6 +64,12 @@ class JavaExecHandleBuilderTest extends Specification {
         then:
         String executable = Jvm.current().getJavaExecutable().getAbsolutePath()
         commandLine == [executable,  '-Dprop=value', 'jvm1', 'jvm2', '-Xms64m', '-Xmx1g', fileEncodingProperty(expectedEncoding), *localeProperties(), '-cp', "$jar1$File.pathSeparator$jar2", 'mainClass', 'arg1', 'arg2']
+
+        when:
+        boolean isSpawn = builder.isSpawn()
+
+        then:
+        isSpawn
 
         where:
         inputEncoding | expectedEncoding

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.JavaExec.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.JavaExec.xml
@@ -88,6 +88,10 @@
                 <td>commandLine</td>
                 <td/>
             </tr>
+            <tr>
+                <td>spawn</td>
+                <td><literal>false</literal></td>
+            </tr>
         </table>
     </section>
     <section>
@@ -124,6 +128,9 @@
             </tr>
             <tr>
                 <td>environment</td>
+            </tr>
+            <tr>
+                <td>spawn</td>
             </tr>
         </table>
     </section>

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/JavaExecIntegrationTest.groovy
@@ -234,6 +234,25 @@ class JavaExecIntegrationTest extends AbstractIntegrationSpec {
         outputFile.text == "different"
     }
 
+    def "spawned process" () {
+        buildFile.text = """
+            apply plugin: "java"
+
+            task run(type: JavaExec) {
+                classpath = project.layout.files(compileJava)
+                main "driver.Driver"
+                args "1"
+                spawn true
+            }
+        """
+
+        when:
+        run "run"
+
+        then:
+        succeeds (":run")
+    }
+
     private void assertOutputFileIs(String text) {
         assert file("out.txt").text == text
     }

--- a/subprojects/process-services/src/main/java/org/gradle/process/BaseExecSpec.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/BaseExecSpec.java
@@ -95,4 +95,17 @@ public interface BaseExecSpec extends ProcessForkOptions {
      * @return The full command line, including the executable plus its arguments
      */
     List<String> getCommandLine();
+
+    /**
+     * Returns a boolean representing whether or not this exec will spawn in a new process.
+     *
+     * @return A boolean representing whether or not this exec will spawn in a new process.
+     */
+    boolean isSpawn();
+
+    /**
+     * Configures the exec to spawn in a new process which will not be tracked by the Gradle container
+     * @param spawn Whether or not to spawn a new process
+     */
+    void setSpawn(boolean spawn);
 }

--- a/subprojects/process-services/src/main/java/org/gradle/process/internal/ExecHandleState.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/internal/ExecHandleState.java
@@ -23,7 +23,8 @@ public enum ExecHandleState {
     ABORTED(true),
     FAILED(true),
     DETACHED(true),
-    SUCCEEDED(true);
+    SUCCEEDED(true),
+    SPAWNED(true);
 
     private final boolean terminal;
 


### PR DESCRIPTION
### Context
This functionality will permit Gradle to 'spawn' new processes. This will give users flexibility in designing their build/launch scripts to manage the subsequent process lifecycle outside of Gradle.
See #6923 and #1367

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
