### PR TITLE
Bugfixes to cached rules

### DIFF
--- a/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/artifactreuse/CacheReuseCrossVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/artifactreuse/CacheReuseCrossVersionIntegrationTest.groovy
@@ -18,9 +18,7 @@ package org.gradle.integtests.resolve.artifactreuse
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCacheMetadata
 import org.gradle.integtests.fixtures.IgnoreVersions
 import org.gradle.test.fixtures.file.LeaksFileHandles
-import spock.lang.Ignore
 
-@Ignore("broken by 5.0 milestone release")
 @IgnoreVersions({ it.artifactCacheLayoutVersion == DefaultArtifactCacheMetadata.CACHE_LAYOUT_VERSION })
 @LeaksFileHandles
 class CacheReuseCrossVersionIntegrationTest extends AbstractCacheReuseCrossVersionIntegrationTest {

--- a/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/caching/ConcurrentBuildsCachingCrossVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/caching/ConcurrentBuildsCachingCrossVersionIntegrationTest.groovy
@@ -22,9 +22,7 @@ import org.gradle.integtests.resolve.artifactreuse.AbstractCacheReuseCrossVersio
 import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.gradle.util.GradleVersion
 import org.junit.Rule
-import spock.lang.Ignore
 
-@Ignore("broken by 5.0 milestone release")
 @IgnoreVersions({ it.artifactCacheLayoutVersion == DefaultArtifactCacheMetadata.CACHE_LAYOUT_VERSION })
 class ConcurrentBuildsCachingCrossVersionIntegrationTest extends AbstractCacheReuseCrossVersionIntegrationTest {
     @Rule BlockingHttpServer blockingServer = new BlockingHttpServer()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -541,11 +541,11 @@ include 'other'
         ].permutations()*.join("\n")
     }
 
-    @Unroll
     @RequiredFeatures([
         @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),
         @RequiredFeature(feature = GradleMetadataResolveRunner.EXPERIMENTAL_RESOLVE_BEHAVIOR, value = "true")
     ])
+    @Unroll("can force a published platform version by forcing the platform itself via a constraint")
     def "can force a published platform version by forcing the platform itself via a constraint"() {
         repository {
             ['2.7.9', '2.9.4', '2.9.4.1'].each { v ->

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -117,7 +117,8 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         }
         try {
             ModuleComponentResolveMetadata forceRead = serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(bytes)));
-            assert metadata.equals(forceRead);
+            // TODO: CC cannot enable this assertion because moduleSource is not serialized, so doesn't appear in the deserialized form
+            //assert metadata.equals(forceRead);
             metadata = forceRead;
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -116,7 +116,9 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
             }
         }
         try {
-            metadata = serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(bytes)));
+            ModuleComponentResolveMetadata forceRead = serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(bytes)));
+            assert metadata.equals(forceRead);
+            metadata = forceRead;
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
+import com.google.common.base.Objects;
 import org.gradle.api.Action;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
@@ -24,6 +25,7 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.internal.ReusableAction;
+import org.gradle.internal.component.external.model.ComponentVariant;
 
 import java.util.Set;
 
@@ -50,6 +52,10 @@ public abstract class PlatformSupport {
                 attributeContainer.attribute(COMPONENT_CATEGORY, type);
             }
         });
+    }
+
+    public static boolean hasForcedDependencies(ComponentVariant variant) {
+        return Objects.equal(variant.getAttributes().getAttribute(COMPONENT_CATEGORY), ENFORCED_PLATFORM);
     }
 
     public static class ComponentCategoryDisambiguationRule implements AttributeDisambiguationRule<String>, ReusableAction {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -51,7 +51,9 @@ public enum CacheLayout {
         .changedTo(56, "4.7-rc-1")
         .changedTo(58, "4.8-rc-1")
         .changedTo(63, "4.10-rc-1")
-        .changedTo(68, "5.0-rc-1")),
+        .changedTo(68, "5.0-milestone-1")
+        .changedTo(69, "5.0-rc-1")
+    ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
+import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 
 import java.io.IOException;
@@ -44,7 +45,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static com.google.gson.stream.JsonToken.*;
+import static com.google.gson.stream.JsonToken.BOOLEAN;
+import static com.google.gson.stream.JsonToken.END_ARRAY;
+import static com.google.gson.stream.JsonToken.END_OBJECT;
 
 public class ModuleMetadataParser {
     public static final String FORMAT_VERSION = "0.4";
@@ -80,6 +83,7 @@ public class ModuleMetadataParser {
                         throw new RuntimeException(String.format("Unsupported format version '%s' specified in module metadata. This version of Gradle supports format version %s only.", version, FORMAT_VERSION));
                     }
                     consumeTopLevelElements(reader, metadata);
+                    metadata.setContentHash(HashUtil.createHash(resource.getFile(), "MD5"));
                     return null;
                 } catch (Exception e) {
                     throw new MetaDataParseException("module metadata", resource, e);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -69,7 +69,7 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
 
     @Override
     public void write(Encoder encoder, ModuleComponentResolveMetadata value) throws Exception {
-        AbstractRealisedModuleComponentResolveMetadata transformed = transformToRealisedForSerialization(value);
+        AbstractRealisedModuleComponentResolveMetadata transformed = assertRealized(value);
         delegate.write(encoder, transformed);
         if (transformed instanceof RealisedIvyModuleResolveMetadata) {
             ivySerializationHelper.writeRealisedVariantsData(encoder, transformed);
@@ -82,13 +82,9 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
         }
     }
 
-    private AbstractRealisedModuleComponentResolveMetadata transformToRealisedForSerialization(ModuleComponentResolveMetadata metadata) {
+    private AbstractRealisedModuleComponentResolveMetadata assertRealized(ModuleComponentResolveMetadata metadata) {
         if (metadata instanceof AbstractRealisedModuleComponentResolveMetadata) {
             return (AbstractRealisedModuleComponentResolveMetadata) metadata;
-        } else if (metadata instanceof DefaultIvyModuleResolveMetadata) {
-            return RealisedIvyModuleResolveMetadata.transform((DefaultIvyModuleResolveMetadata) metadata);
-        } else if (metadata instanceof DefaultMavenModuleResolveMetadata) {
-            return RealisedMavenModuleResolveMetadata.transform((DefaultMavenModuleResolveMetadata) metadata);
         }
         throw new IllegalStateException("The type of metadata received is not supported - " + metadata.getClass().getName());
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -16,14 +16,23 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.internal.component.external.model.AbstractLazyModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.DefaultVirtualModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
 import org.gradle.internal.component.external.model.ivy.DefaultIvyModuleResolveMetadata;
+import org.gradle.internal.component.external.model.ivy.RealisedIvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.RealisedIvyModuleResolveMetadataSerializationHelper;
 import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
-import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
-import org.gradle.internal.component.external.model.ivy.RealisedIvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.RealisedMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.RealisedMavenModuleResolveMetadataSerializationHelper;
 import org.gradle.internal.resolve.caching.DesugaringAttributeContainerSerializer;
@@ -32,6 +41,7 @@ import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 
 import java.io.EOFException;
+import java.io.IOException;
 
 /**
  * Serializer for {@link ModuleComponentResolveMetadata}.
@@ -56,7 +66,9 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
     @Override
     public ModuleComponentResolveMetadata read(Decoder decoder) throws EOFException, Exception {
 
-        AbstractLazyModuleComponentResolveMetadata resolveMetadata = (AbstractLazyModuleComponentResolveMetadata) delegate.read(decoder, moduleIdentifierFactory).asImmutable();
+        MutableModuleComponentResolveMetadata mutable = delegate.read(decoder, moduleIdentifierFactory);
+        readPlatformOwners(decoder, mutable);
+        AbstractLazyModuleComponentResolveMetadata resolveMetadata = (AbstractLazyModuleComponentResolveMetadata) mutable.asImmutable();
 
         if (resolveMetadata instanceof DefaultIvyModuleResolveMetadata) {
             return ivySerializationHelper.readMetadata(decoder, (DefaultIvyModuleResolveMetadata) resolveMetadata);
@@ -67,10 +79,30 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
         }
     }
 
+    private void readPlatformOwners(Decoder decoder, MutableModuleComponentResolveMetadata mutable) throws IOException {
+        int len = decoder.readSmallInt();
+        if (len>0) {
+            for (int i=0; i<len; i++) {
+                ComponentIdentifier moduleComponentIdentifier = readModuleIdentifier(decoder);
+                mutable.belongsTo(moduleComponentIdentifier);
+            }
+        }
+    }
+
+    private ModuleComponentIdentifier readModuleIdentifier(Decoder decoder) throws IOException {
+        boolean virtual = decoder.readBoolean();
+        String group = decoder.readString();
+        String module = decoder.readString();
+        String version = decoder.readString();
+        ModuleIdentifier moduleIdentifier = DefaultModuleIdentifier.newId(group, module);
+        return virtual ? new DefaultVirtualModuleComponentIdentifier(moduleIdentifier, version) : DefaultModuleComponentIdentifier.newId(moduleIdentifier, version);
+    }
+
     @Override
     public void write(Encoder encoder, ModuleComponentResolveMetadata value) throws Exception {
         AbstractRealisedModuleComponentResolveMetadata transformed = assertRealized(value);
         delegate.write(encoder, transformed);
+        writeOwners(encoder, value.getPlatformOwners());
         if (transformed instanceof RealisedIvyModuleResolveMetadata) {
             ivySerializationHelper.writeRealisedVariantsData(encoder, transformed);
             ivySerializationHelper.writeRealisedConfigurationsData(encoder, transformed);
@@ -80,6 +112,20 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
         } else {
             throw new IllegalStateException("Unexpected realised module component resolve metadata type: " + transformed.getClass());
         }
+    }
+
+    private void writeOwners(Encoder encoder, ImmutableList<? extends ComponentIdentifier> platformOwners) throws IOException {
+        encoder.writeSmallInt(platformOwners.size());
+        for (ComponentIdentifier platformOwner : platformOwners) {
+            writeComponentIdentifier(encoder, (ModuleComponentIdentifier)platformOwner);
+        }
+    }
+
+    private void writeComponentIdentifier(Encoder encoder, ModuleComponentIdentifier platformOwner) throws IOException {
+        encoder.writeBoolean(platformOwner instanceof VirtualComponentIdentifier);
+        encoder.writeString(platformOwner.getGroup());
+        encoder.writeString(platformOwner.getModule());
+        encoder.writeString(platformOwner.getVersion());
     }
 
     private AbstractRealisedModuleComponentResolveMetadata assertRealized(ModuleComponentResolveMetadata metadata) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -117,8 +117,9 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         ModuleComponentSelector selector = componentSelectorSerializer.read(decoder);
         List<ExcludeMetadata> excludes = readMavenExcludes(decoder);
         boolean constraint = decoder.readBoolean();
+        boolean force = decoder.readBoolean();
         String reason = decoder.readNullableString();
-        return new GradleDependencyMetadata(selector, excludes, constraint, reason, false);
+        return new GradleDependencyMetadata(selector, excludes, constraint, reason, force);
     }
 
     protected List<ExcludeMetadata> readMavenExcludes(Decoder decoder) throws IOException {
@@ -157,6 +158,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         List<ExcludeMetadata> excludes = dependencyMetadata.getExcludes();
         writeMavenExcludeRules(encoder, excludes);
         encoder.writeBoolean(dependencyMetadata.isConstraint());
+        encoder.writeBoolean(dependencyMetadata.isForce());
         encoder.writeNullableString(dependencyMetadata.getReason());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -16,13 +16,12 @@
 
 package org.gradle.internal.component.external.model;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
@@ -53,7 +52,7 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
         // Forced dependencies are only supported for enforced platforms, so it is currently hardcoded.
         // Should we want to add this as a first class concept to Gradle metadata, then it should be available on the component variant
         // metadata as well.
-        boolean forcedDependencies = Objects.equal(variant.getAttributes().getAttribute(PlatformSupport.COMPONENT_CATEGORY), PlatformSupport.ENFORCED_PLATFORM);
+        boolean forcedDependencies = PlatformSupport.hasForcedDependencies(variant);
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes());
             List<ExcludeMetadata> excludes = dependency.getExcludes();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -131,4 +131,25 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     public ForcingDependencyMetadata forced() {
         return new GradleDependencyMetadata(selector, excludes, constraint, reason, true);
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        GradleDependencyMetadata that = (GradleDependencyMetadata) o;
+        return constraint == that.constraint &&
+            force == that.force &&
+            Objects.equal(selector, that.selector) &&
+            Objects.equal(excludes, that.excludes) &&
+            Objects.equal(reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(selector, excludes, constraint, reason, force);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.descriptor.Configuration;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -48,7 +49,8 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         for (ComponentVariant variant : variants) {
             ImmutableAttributes attributes = variantMetadataRules.applyVariantAttributeRules(variant, variant.getAttributes());
             CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, variant.getCapabilities());
-            List<GradleDependencyMetadata> dependencies = variantMetadataRules.applyDependencyMetadataRules(variant, convertDependencies(variant.getDependencies(), variant.getDependencyConstraints()));
+            boolean force = PlatformSupport.hasForcedDependencies(variant);
+            List<GradleDependencyMetadata> dependencies = variantMetadataRules.applyDependencyMetadataRules(variant, convertDependencies(variant.getDependencies(), variant.getDependencyConstraints(), force));
             realisedVariants.add(new AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl(mutableMetadata.getId(), variant.getName(), attributes,
                 variant.getDependencies(), variant.getDependencyConstraints(), variant.getFiles(),
                 ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()), dependencies));
@@ -56,12 +58,12 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
         return ImmutableList.copyOf(realisedVariants);
     }
 
-    private static List<GradleDependencyMetadata> convertDependencies(List<? extends ComponentVariant.Dependency> dependencies, List<? extends ComponentVariant.DependencyConstraint> dependencyConstraints) {
+    private static List<GradleDependencyMetadata> convertDependencies(List<? extends ComponentVariant.Dependency> dependencies, List<? extends ComponentVariant.DependencyConstraint> dependencyConstraints, boolean force) {
         List<GradleDependencyMetadata> result = new ArrayList<GradleDependencyMetadata>(dependencies.size());
         for (ComponentVariant.Dependency dependency : dependencies) {
             ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
-            result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), false));
+            result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), force));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : dependencyConstraints) {
             result.add(new GradleDependencyMetadata(
@@ -69,7 +71,7 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
                 dependencyConstraint.getReason(),
-                false
+                force
             ));
         }
         return result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -45,6 +45,9 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
      * @return a list of realised variants
      */
     public static ImmutableList<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> realiseVariants(ModuleComponentResolveMetadata mutableMetadata, VariantMetadataRules variantMetadataRules, ImmutableList<? extends ComponentVariant> variants) {
+        if (variants.isEmpty()) {
+            return ImmutableList.of();
+        }
         List<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> realisedVariants = Lists.newArrayListWithExpectedSize(variants.size());
         for (ComponentVariant variant : variants) {
             ImmutableAttributes attributes = variantMetadataRules.applyVariantAttributeRules(variant, variant.getAttributes());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -91,21 +91,21 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
                     builder.add(derivedVariantMetadata);
                 }
                 derivedVariants = builder.build();
-            }
+            } else {
+                for (String configurationName : metadata.getConfigurationNames()) {
+                    ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
+                    Configuration configuration = configurationDefinitions.get(configurationName);
 
-            for (String configurationName : metadata.getConfigurationNames()) {
-                ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
-                Configuration configuration = configurationDefinitions.get(configurationName);
+                    NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
+                    ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
+                    CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
 
-                NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
-                ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
-                CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
+                    RealisedConfigurationMetadata realisedConfiguration = createConfiguration(variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
+                        LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions), metadata.getDependencies(),
+                        variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()));
+                    configurations.put(configurationName, realisedConfiguration);
 
-                RealisedConfigurationMetadata realisedConfiguration = createConfiguration(variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
-                    LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions), metadata.getDependencies(),
-                    variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()));
-                configurations.put(configurationName, realisedConfiguration);
-
+                }
             }
         }
         RealisedMavenModuleResolveMetadata realisedMavenModuleResolveMetadata = new RealisedMavenModuleResolveMetadata(metadata, variants, derivedVariants, configurations);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -91,22 +91,20 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
                     builder.add(derivedVariantMetadata);
                 }
                 derivedVariants = builder.build();
-            } else {
-                for (String configurationName : metadata.getConfigurationNames()) {
-                    ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
-                    Configuration configuration = configurationDefinitions.get(configurationName);
-
-                    NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
-                    ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
-                    CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
-
-                    RealisedConfigurationMetadata realisedConfiguration = createConfiguration(variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
-                        LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions), metadata.getDependencies(),
-                        variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()));
-                    configurations.put(configurationName, realisedConfiguration);
-
-                }
             }
+        }
+        for (String configurationName : metadata.getConfigurationNames()) {
+            ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
+            Configuration configuration = configurationDefinitions.get(configurationName);
+
+            NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
+            ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
+            CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
+
+            RealisedConfigurationMetadata realisedConfiguration = createConfiguration(variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
+                LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions), metadata.getDependencies(),
+                variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()));
+            configurations.put(configurationName, realisedConfiguration);
         }
         RealisedMavenModuleResolveMetadata realisedMavenModuleResolveMetadata = new RealisedMavenModuleResolveMetadata(metadata, variants, derivedVariants, configurations);
         return realisedMavenModuleResolveMetadata;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadata.java
@@ -69,43 +69,47 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         VariantMetadataRules variantMetadataRules = metadata.getVariantMetadataRules();
         ImmutableList<? extends ComponentVariant> variants = LazyToRealisedModuleComponentResolveMetadataHelper.realiseVariants(metadata, variantMetadataRules, metadata.getVariants());
         Map<String, ConfigurationMetadata> configurations = Maps.newHashMapWithExpectedSize(metadata.getConfigurationNames().size());
-        Optional<ImmutableList<? extends ConfigurationMetadata>> maybeDeriveVariants = metadata.maybeDeriveVariants();
         List<ConfigurationMetadata> derivedVariants = ImmutableList.of();
-        if (maybeDeriveVariants.isPresent()) {
-            ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<>();
-            for (ConfigurationMetadata derivedVariant : maybeDeriveVariants.get()) {
-                ImmutableList<ModuleDependencyMetadata> dependencies = Cast.uncheckedCast(derivedVariant.getDependencies());
-                RealisedConfigurationMetadata derivedVariantMetadata = new RealisedConfigurationMetadata(
-                    metadata.getId(),
-                    derivedVariant.getName(),
-                    derivedVariant.isTransitive(),
-                    derivedVariant.isVisible(),
-                    derivedVariant.getHierarchy(),
-                    Cast.<ImmutableList<? extends ModuleComponentArtifactMetadata>>uncheckedCast(derivedVariant.getArtifacts()),
-                    derivedVariant.getExcludes(),
-                    derivedVariant.getAttributes(),
-                    (ImmutableCapabilities) derivedVariant.getCapabilities(),
-                    dependencies
-                );
-                builder.add(derivedVariantMetadata);
+        if (variants.isEmpty()) {
+            Optional<ImmutableList<? extends ConfigurationMetadata>> maybeDeriveVariants = metadata.maybeDeriveVariants();
+            if (maybeDeriveVariants.isPresent()) {
+                ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<>();
+                for (ConfigurationMetadata derivedVariant : maybeDeriveVariants.get()) {
+                    ImmutableList<ModuleDependencyMetadata> dependencies = Cast.uncheckedCast(derivedVariant.getDependencies());
+                    RealisedConfigurationMetadata derivedVariantMetadata = new RealisedConfigurationMetadata(
+                        metadata.getId(),
+                        derivedVariant.getName(),
+                        derivedVariant.isTransitive(),
+                        derivedVariant.isVisible(),
+                        derivedVariant.getHierarchy(),
+                        Cast.<ImmutableList<? extends ModuleComponentArtifactMetadata>>uncheckedCast(derivedVariant.getArtifacts()),
+                        derivedVariant.getExcludes(),
+                        derivedVariant.getAttributes(),
+                        (ImmutableCapabilities) derivedVariant.getCapabilities(),
+                        dependencies
+                    );
+                    builder.add(derivedVariantMetadata);
+                }
+                derivedVariants = builder.build();
             }
-            derivedVariants = builder.build();
+
+            for (String configurationName : metadata.getConfigurationNames()) {
+                ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
+                Configuration configuration = configurationDefinitions.get(configurationName);
+
+                NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
+                ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
+                CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
+
+                RealisedConfigurationMetadata realisedConfiguration = createConfiguration(variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
+                    LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions), metadata.getDependencies(),
+                    variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()));
+                configurations.put(configurationName, realisedConfiguration);
+
+            }
         }
-        for (String configurationName : metadata.getConfigurationNames()) {
-            ImmutableMap<String, Configuration> configurationDefinitions = metadata.getConfigurationDefinitions();
-            Configuration configuration = configurationDefinitions.get(configurationName);
-
-            NameOnlyVariantResolveMetadata variant = new NameOnlyVariantResolveMetadata(configurationName);
-            ImmutableAttributes variantAttributes = variantMetadataRules.applyVariantAttributeRules(variant, metadata.getAttributes());
-            CapabilitiesMetadata capabilitiesMetadata = variantMetadataRules.applyCapabilitiesRules(variant, ImmutableCapabilities.EMPTY);
-
-            RealisedConfigurationMetadata realisedConfiguration = createConfiguration(variantMetadataRules, metadata.getId(), configurationName, configuration.isTransitive(), configuration.isVisible(),
-                LazyToRealisedModuleComponentResolveMetadataHelper.constructHierarchy(configuration, configurationDefinitions), metadata.getDependencies(),
-                variantAttributes, ImmutableCapabilities.of(capabilitiesMetadata.getCapabilities()));
-            configurations.put(configurationName, realisedConfiguration);
-
-        }
-        return new RealisedMavenModuleResolveMetadata(metadata, variants, derivedVariants, configurations);
+        RealisedMavenModuleResolveMetadata realisedMavenModuleResolveMetadata = new RealisedMavenModuleResolveMetadata(metadata, variants, derivedVariants, configurations);
+        return realisedMavenModuleResolveMetadata;
     }
 
     private static RealisedConfigurationMetadata createConfiguration(VariantMetadataRules variantMetadataRules, ModuleComponentIdentifier componentId, String name, boolean transitive, boolean visible, ImmutableSet<String> hierarchy, ImmutableList<MavenDependencyDescriptor> dependencies, ImmutableAttributes attributes, ImmutableCapabilities capabilities) {
@@ -166,7 +170,6 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
     private final NamedObjectInstantiator objectInstantiator;
 
     private final ImmutableList<MavenDependencyDescriptor> dependencies;
-    private final DefaultMavenModuleResolveMetadata metadata;
     private final String packaging;
     private final boolean relocated;
     private final String snapshotTimestamp;
@@ -181,7 +184,6 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         relocated = metadata.isRelocated();
         snapshotTimestamp = metadata.getSnapshotTimestamp();
         dependencies = metadata.getDependencies();
-        this.metadata = metadata;
         this.derivedVariants = ImmutableList.copyOf(derivedVariants);
     }
 
@@ -193,7 +195,6 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
         snapshotTimestamp = metadata.snapshotTimestamp;
         dependencies = metadata.dependencies;
         this.derivedVariants = metadata.derivedVariants;
-        this.metadata = metadata.metadata.withSource(source);
     }
 
     @Override
@@ -212,7 +213,7 @@ public class RealisedMavenModuleResolveMetadata extends AbstractRealisedModuleCo
 
     @Override
     public MutableMavenModuleResolveMetadata asMutable() {
-        return metadata.asMutable();
+        return new DefaultMutableMavenModuleResolveMetadata(this, objectInstantiator);
     }
 
     public String getPackaging() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadataRules.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.model;
 
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyConstraintMetadata;
@@ -82,10 +83,10 @@ public class DependencyMetadataRules {
     }
 
     public <T extends ModuleDependencyMetadata> List<T> execute(VariantResolveMetadata variant, List<T> dependencies) {
-        List<T> calculatedDependencies = new ArrayList<T>();
+        ImmutableList.Builder<T> calculatedDependencies = new ImmutableList.Builder<>();
         calculatedDependencies.addAll(executeDependencyRules(variant, dependencies));
         calculatedDependencies.addAll(executeDependencyConstraintRules(variant, dependencies));
-        return calculatedDependencies;
+        return calculatedDependencies.build();
     }
 
     private <T extends ModuleDependencyMetadata> List<T> executeDependencyRules(VariantResolveMetadata variant, List<T> dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,10 +54,10 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.68'
-        cacheLayout.version == CacheVersion.parse("2.68")
-        cacheLayout.version.toString() == '2.68'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.68')
+        cacheLayout.key == 'metadata-2.69'
+        cacheLayout.version == CacheVersion.parse("2.69")
+        cacheLayout.version.toString() == '2.69'
+        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.69')
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -27,12 +27,17 @@ import org.gradle.internal.component.external.model.MutableComponentVariant
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata
 import org.gradle.internal.component.model.Exclude
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.TestUtil
+import org.junit.Rule
 import spock.lang.Specification
 
 import static org.gradle.util.TestUtil.attributes
 
 class ModuleMetadataParserTest extends Specification {
+    @Rule
+    final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
+
     def identifierFactory = new DefaultImmutableModuleIdentifierFactory()
     def parser = new ModuleMetadataParser(TestUtil.attributesFactory(), identifierFactory, NamedObjectInstantiator.INSTANCE)
 
@@ -78,6 +83,7 @@ class ModuleMetadataParserTest extends Specification {
         parser.parse(resource('{ "formatVersion": "0.4" }'), metadata)
 
         then:
+        1 * metadata.setContentHash(_)
         0 * metadata._
     }
 
@@ -94,6 +100,7 @@ class ModuleMetadataParserTest extends Specification {
 '''), metadata)
 
         then:
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -111,6 +118,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.setAttributes(attributes(foo: 'bar', 'org.gradle.status': 'release'))
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -137,6 +145,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant
         1 * variant.addFile("a.zip", "a.zop")
         1 * variant.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -165,6 +174,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -205,6 +215,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addFile("api.zip", "api.zop")
         1 * variant2.addFile("runtime.zip", "runtime.zop")
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -261,6 +272,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * variant2.addDependency("g4", "m4", strictly("v5"), [], null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependency("g6", "m6", strictly("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY)
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -311,6 +323,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * variant2.addDependencyConstraint("g4", "m4", prefersAndRejects("v4", ["v5"]), null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependencyConstraint("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), null, ImmutableAttributes.EMPTY)
         1 * variant2.addDependencyConstraint("g6", "m6", prefers("v6"), "v5 is buggy", ImmutableAttributes.EMPTY)
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -351,6 +364,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependencyConstraint("g1", "m1", prefers("v1"), null, attributes(custom: 'foo'))
         1 * variant2.addDependencyConstraint("g2", "m2", requires("v2"), null, attributes(custom: 'foo', other: 'bar'))
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -391,6 +405,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addCapability("g3", "m3", "3")
         1 * variant2.addCapability("g4", "m4", "4")
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -414,6 +429,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile", debuggable: true, testable: false)) >> variant
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -443,6 +459,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes([:])) >> variant1
         1 * metadata.addVariant("runtime", attributes([:])) >> variant2
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -485,6 +502,7 @@ class ModuleMetadataParserTest extends Specification {
         1 * variant1.addDependency("g1", "m1", version("v1"), [], null, ImmutableAttributes.EMPTY)
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependency("g2", "m2", version("v2"), [], null, ImmutableAttributes.EMPTY)
+        1 * metadata.setContentHash(_)
         0 * _
     }
 
@@ -514,6 +532,7 @@ class ModuleMetadataParserTest extends Specification {
         }'''), metadata)
 
         then:
+        1 * metadata.setContentHash(_)
         0 * metadata._
     }
 
@@ -540,6 +559,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes([:]))
+        1 * metadata.setContentHash(_)
         0 * metadata._
     }
 
@@ -571,6 +591,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes([:])) >> variant
+        1 * metadata.setContentHash(_)
         0 * metadata._
     }
 
@@ -607,6 +628,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes([:])) >> variant
         1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY)
+        1 * metadata.setContentHash(_)
         0 * metadata._
     }
 
@@ -670,6 +692,11 @@ class ModuleMetadataParserTest extends Specification {
         def resource = Stub(LocallyAvailableExternalResource)
         _ * resource.displayName >> "<resource>"
         _ * resource.withContent(_) >> { Transformer transformer -> return transformer.transform(new ByteArrayInputStream(content.getBytes("utf-8"))) }
+        _ * resource.getFile() >> {
+            def file = temporaryFolder.createFile("module${UUID.randomUUID().toString()}.module")
+            file.write(content, "UTF-8")
+            file
+        }
         resource
     }
 }


### PR DESCRIPTION
### Context

This PR fixes several issues with component metadata rule caching, that were hidden by the fact we didn't have enough test coverage: the test suite that enables forced realization was missing a pretty common code path.
