### PR TITLE
Build scan plugin 2.0 simplifications

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListener.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListener.java
@@ -33,12 +33,14 @@ import org.gradle.internal.scan.UsedByScanPlugin;
  * Implementations must not error from either signal.
  * Callers should ignore any exceptions thrown by these methods.
  *
- * @since 4.0
+ * @since 4.4
  */
-@UsedByScanPlugin("implemented by the scan plugin - 1.8 - 1.10")
+@UsedByScanPlugin("implemented by the scan plugin - 1.11+")
 public interface BuildOperationNotificationListener {
 
     void started(BuildOperationStartedNotification notification);
+
+    void progress(BuildOperationProgressNotification notification);
 
     void finished(BuildOperationFinishedNotification notification);
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListener2.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListener2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListenerRegistrar.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationListenerRegistrar.java
@@ -31,24 +31,13 @@ import org.gradle.internal.scan.UsedByScanPlugin;
 public interface BuildOperationNotificationListenerRegistrar {
 
     /**
-     * This method is inaccurately named.
-     * The term “build” here is actually what we name “build tree”.
-     * The listener expects to be automatically de-registered.
-     *
-     * The registered listener will receive notification for all build operations for the
-     * current build execution, _NOT_ including those those operations that started before the
-     * listener was registered.
-     */
-    void registerBuildScopeListener(BuildOperationNotificationListener listener);
-
-    /**
      * The registered listener will receive notification for all build operations for the
      * current build execution, including those those operations that started before the
      * listener was registered.
      *
-     * @since 4.2
+     * @since 4.4
      */
-    void registerBuildScopeListenerAndReceiveStoredOperations(BuildOperationNotificationListener listener);
+    void register(BuildOperationNotificationListener listener);
 
     /**
      * The registered listener will receive notification for all build operations for the

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationContinuousBuildIntegrationTest.groovy
@@ -26,7 +26,7 @@ class BuildOperationNotificationContinuousBuildIntegrationTest extends AbstractC
     def "obtains notifications about init scripts"() {
         when:
         buildScript """
-           ${notifications.registerListenerWithDrainRecordings()}
+           ${notifications.registerListener()}
             apply plugin: "java"
         """
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationFixture.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationFixture.groovy
@@ -101,13 +101,7 @@ class BuildOperationNotificationFixture {
 
     String registerListener() {
         listenerClass() + """
-        registrar.registerBuildScopeListener(listener)
-        """
-    }
-
-    String registerListenerWithDrainRecordings() {
-        listenerClass() + """
-        registrar.registerBuildScopeListenerAndReceiveStoredOperations(listener)
+        registrar.register(listener)
         """
     }
 
@@ -132,6 +126,11 @@ class BuildOperationNotificationFixture {
                             detailsType: startedNotification.notificationOperationDetails.getClass().getInterfaces()[0].getName(),
                             details: details, 
                             started: startedNotification.notificationOperationStartedTimestamp))
+                }
+                
+                @Override
+                void progress(${BuildOperationProgressNotification.name} progressNotification){
+                    // Do nothing
                 }
             
                 @Override

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.operations.notify
 
-
 import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType
 import org.gradle.configuration.ApplyScriptPluginBuildOperationType
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType
@@ -46,7 +45,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
             println "init script"
         """
         buildScript """
-           ${notifications.registerListenerWithDrainRecordings()}
+           ${notifications.registerListener()}
             task t
         """
 
@@ -62,7 +61,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
     def "can emit notifications from start of build"() {
         when:
         buildScript """
-           ${notifications.registerListenerWithDrainRecordings()}
+           ${notifications.registerListener()}
             task t
         """
 
@@ -95,30 +94,6 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         notifications.finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
     }
 
-    def "can emit notifications from point of registration"() {
-        when:
-        buildScript """
-           ${notifications.registerListener()}
-            task t
-        """
-
-        succeeds "t", "-S"
-
-        then:
-        // Operations that started before the listener registration are not included (even if they finish _after_ listener registration)
-        notifications.notIncluded(EvaluateSettingsBuildOperationType.Details)
-        notifications.notIncluded(LoadProjectsBuildOperationType.Details)
-        notifications.notIncluded(NotifyProjectsLoadedBuildOperationType.Details)
-        notifications.notIncluded(ApplyPluginBuildOperationType.Details)
-        notifications.notIncluded(ConfigureProjectBuildOperationType.Details)
-
-        notifications.started(NotifyProjectsEvaluatedBuildOperationType.Details, [buildPath: ':'])
-        notifications.started(CalculateTaskGraphBuildOperationType.Details, [buildPath: ':'])
-        notifications.finished(CalculateTaskGraphBuildOperationType.Result, [excludedTaskPaths: [], requestedTaskPaths: [":t"]])
-        notifications.started(ExecuteTaskBuildOperationType.Details, [taskPath: ":t", buildPath: ":", taskClass: "org.gradle.api.DefaultTask"])
-        notifications.finished(ExecuteTaskBuildOperationType.Result, [actionable: false, originExecutionTime: null, cachingDisabledReasonMessage: "Cacheability was not determined", upToDateMessages: null, cachingDisabledReasonCategory: "UNKNOWN", skipMessage: "UP-TO-DATE", originBuildInvocationId: null])
-    }
-
     def "can emit notifications for nested builds"() {
         when:
         file("buildSrc/build.gradle") << ""
@@ -127,7 +102,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         file("a/settings.gradle") << ""
         file("settings.gradle") << "includeBuild 'a'"
         buildScript """
-           ${notifications.registerListenerWithDrainRecordings()}
+           ${notifications.registerListener()}
             task t {
                 dependsOn gradle.includedBuild("a").task(":t")
             }
@@ -280,7 +255,7 @@ class BuildOperationNotificationIntegrationTest extends AbstractIntegrationSpec 
         given:
         file("buildSrc/build.gradle") << ""
         file("build.gradle") << """
-            ${notifications.registerListenerWithDrainRecordings()}
+            ${notifications.registerListener()}
             task t
         """
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
@@ -42,15 +42,6 @@ public enum TaskOutputCachingDisabledReasonCategory {
     NO_OUTPUTS_DECLARED,
 
     /**
-     * Task has outputs declared via {@literal @}{@link org.gradle.api.tasks.OutputFiles} or {@literal @}{@link org.gradle.api.tasks.OutputDirectories}.
-     *
-     * @deprecated Simply having plural outputs is not a reason anymore to disable caching since Gradle 5.0
-     * The enum cannot be removed as build scan plugin depends on it.
-     */
-    @Deprecated
-    PLURAL_OUTPUTS,
-
-    /**
      * Task has a {@link org.gradle.api.file.FileTree} or {@link org.gradle.api.internal.file.collections.DirectoryFileTree} as an output.
      *
      * @since 5.0

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/notify/BuildOperationNotificationBridge.java
@@ -22,13 +22,7 @@ import org.gradle.api.internal.InternalAction;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.internal.InternalBuildAdapter;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.operations.BuildOperationDescriptor;
-import org.gradle.internal.operations.BuildOperationListener;
-import org.gradle.internal.operations.BuildOperationListenerManager;
-import org.gradle.internal.operations.OperationFinishEvent;
-import org.gradle.internal.operations.OperationIdentifier;
-import org.gradle.internal.operations.OperationProgressEvent;
-import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.internal.operations.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,9 +45,9 @@ public class BuildOperationNotificationBridge {
     private class State {
         private ReplayAndAttachListener replayAndAttachListener = new ReplayAndAttachListener();
         private BuildOperationListener buildOperationListener = new Adapter(replayAndAttachListener);
-        private BuildOperationNotificationListener2 notificationListener;
+        private BuildOperationNotificationListener notificationListener;
 
-        private void assignSingleListener(BuildOperationNotificationListener2 notificationListener) {
+        private void assignSingleListener(BuildOperationNotificationListener notificationListener) {
             if (this.notificationListener != null) {
                 throw new IllegalStateException("listener is already registered (implementation class " + this.notificationListener.getClass().getName() + ")");
             }
@@ -114,32 +108,20 @@ public class BuildOperationNotificationBridge {
     };
 
     private final BuildOperationNotificationListenerRegistrar registrar = new BuildOperationNotificationListenerRegistrar() {
+
         @Override
-        public void registerBuildScopeListener(BuildOperationNotificationListener notificationListener) {
+        public void register(BuildOperationNotificationListener listener) {
             State state = requireState();
-            BuildOperationNotificationListener2 adapted = adapt(notificationListener);
-            state.assignSingleListener(adapted);
-
-            // Remove the old adapter and start again.
-            // We explicitly do not want to receive finish notifications
-            // for any operations currently in flight,
-            // and we want to throw away the recorded notifications.
-            buildOperationListenerManager.removeListener(state.buildOperationListener);
-            state.buildOperationListener = new Adapter(adapted);
-            buildOperationListenerManager.addListener(state.buildOperationListener);
-            state.replayAndAttachListener = null;
-        }
-
-        @Override
-        public void registerBuildScopeListenerAndReceiveStoredOperations(BuildOperationNotificationListener notificationListener) {
-            register(adapt(notificationListener));
+            state.assignSingleListener(listener);
+            state.replayAndAttachListener.attach(listener);
         }
 
         @Override
         public void register(BuildOperationNotificationListener2 listener) {
             State state = requireState();
-            state.assignSingleListener(listener);
-            state.replayAndAttachListener.attach(listener);
+            BuildOperationNotificationListener adapted = adapt(listener);
+            state.assignSingleListener(adapted);
+            state.replayAndAttachListener.attach(adapted);
         }
 
         private State requireState() {
@@ -175,12 +157,12 @@ public class BuildOperationNotificationBridge {
      */
     private static class Adapter implements BuildOperationListener {
 
-        private final BuildOperationNotificationListener2 notificationListener;
+        private final BuildOperationNotificationListener notificationListener;
 
         private final Map<Object, Object> parents = new ConcurrentHashMap<Object, Object>();
         private final Map<Object, Object> active = new ConcurrentHashMap<Object, Object>();
 
-        private Adapter(BuildOperationNotificationListener2 notificationListener) {
+        private Adapter(BuildOperationNotificationListener notificationListener) {
             this.notificationListener = notificationListener;
         }
 
@@ -265,7 +247,7 @@ public class BuildOperationNotificationBridge {
 
     }
 
-    private static class RecordingListener implements BuildOperationNotificationListener2 {
+    private static class RecordingListener implements BuildOperationNotificationListener {
 
         private final Queue<Object> storedEvents = new ConcurrentLinkedQueue<Object>();
 
@@ -286,16 +268,16 @@ public class BuildOperationNotificationBridge {
 
     }
 
-    private static class ReplayAndAttachListener implements BuildOperationNotificationListener2 {
+    private static class ReplayAndAttachListener implements BuildOperationNotificationListener {
 
         private RecordingListener recordingListener = new RecordingListener();
 
-        private volatile BuildOperationNotificationListener2 listener = recordingListener;
+        private volatile BuildOperationNotificationListener listener = recordingListener;
 
         private final AtomicBoolean needLock = new AtomicBoolean(true);
         private final Lock lock = new ReentrantLock();
 
-        private synchronized void attach(BuildOperationNotificationListener2 realListener) {
+        private synchronized void attach(BuildOperationNotificationListener realListener) {
             lock.lock();
             try {
                 for (Object storedEvent : recordingListener.storedEvents) {
@@ -418,7 +400,7 @@ public class BuildOperationNotificationBridge {
         private final long timestamp;
         private final Object details;
 
-        public Progress(Object id, long timestamp, Object details) {
+        Progress(Object id, long timestamp, Object details) {
             this.id = id;
             this.timestamp = timestamp;
             this.details = details;
@@ -504,8 +486,9 @@ public class BuildOperationNotificationBridge {
         }
     }
 
-    private static BuildOperationNotificationListener2 adapt(final BuildOperationNotificationListener listener) {
-        return new BuildOperationNotificationListener2() {
+
+    private static BuildOperationNotificationListener adapt(final BuildOperationNotificationListener2 listener) {
+        return new BuildOperationNotificationListener() {
             @Override
             public void started(BuildOperationStartedNotification notification) {
                 listener.started(notification);
@@ -513,7 +496,7 @@ public class BuildOperationNotificationBridge {
 
             @Override
             public void progress(BuildOperationProgressNotification notification) {
-
+                listener.progress(notification);
             }
 
             @Override
@@ -522,4 +505,5 @@ public class BuildOperationNotificationBridge {
             }
         };
     }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/notify/BuildOperationNotificationBridgeTest.groovy
@@ -18,13 +18,7 @@ package org.gradle.internal.operations.notify
 
 import org.gradle.api.internal.GradleInternal
 import org.gradle.internal.event.DefaultListenerManager
-import org.gradle.internal.operations.BuildOperationDescriptor
-import org.gradle.internal.operations.BuildOperationListenerManager
-import org.gradle.internal.operations.DefaultBuildOperationListenerManager
-import org.gradle.internal.operations.OperationFinishEvent
-import org.gradle.internal.operations.OperationIdentifier
-import org.gradle.internal.operations.OperationProgressEvent
-import org.gradle.internal.operations.OperationStartEvent
+import org.gradle.internal.operations.*
 import org.gradle.testing.internal.util.Specification
 
 class BuildOperationNotificationBridgeTest extends Specification {
@@ -33,7 +27,6 @@ class BuildOperationNotificationBridgeTest extends Specification {
     def buildOperationListenerManager = new DefaultBuildOperationListenerManager()
     def broadcast = buildOperationListenerManager.broadcaster
     def listener = Mock(BuildOperationNotificationListener)
-    def listener2 = Mock(BuildOperationNotificationListener2)
     def gradle = Mock(GradleInternal)
 
     BuildOperationNotificationBridge bridgeInstance
@@ -61,145 +54,6 @@ class BuildOperationNotificationBridgeTest extends Specification {
         }
     }
 
-    def "does not allow duplicate registration"() {
-        when:
-        def bridge = bridge()
-        bridge.valve.start()
-        bridge.registrar.registerBuildScopeListener(listener)
-        bridge.registrar.registerBuildScopeListener(listener)
-
-        then:
-        thrown IllegalStateException
-    }
-
-    def "can register again after resetting valve"() {
-        when:
-        def bridge = bridge()
-        bridge.valve.start()
-        bridge.registrar.registerBuildScopeListener(listener)
-        bridge.valve.stop()
-        bridge.valve.start()
-        bridge.registrar.registerBuildScopeListener(listener)
-
-        then:
-        noExceptionThrown()
-    }
-
-    def "cannot register when valve is closed"() {
-        when:
-        register(listener)
-
-        then:
-        thrown IllegalStateException
-    }
-
-    def "passes recorded events to listeners registering"() {
-        def d1 = d(1, null, 1)
-        def bridge = bridge()
-        bridge.valve.start()
-
-        when:
-        broadcast.started(d1, new OperationStartEvent(0))
-        broadcast.finished(d1, new OperationFinishEvent(0, 1, null, ""))
-
-        and:
-        bridge.registrar.registerBuildScopeListenerAndReceiveStoredOperations(listener)
-
-        then:
-        1 * listener.started(_)
-        1 * listener.finished(_)
-    }
-
-    def "forwards operations with details"() {
-        given:
-        def d1 = d(1, null, 1)
-        def d2 = d(2, null, null)
-        def d3 = d(3, null, 3)
-        def e1 = new Exception()
-        bridge().valve.start()
-        register(listener)
-
-        // operation with details and non null result
-        when:
-        broadcast.started(d1, new OperationStartEvent(0))
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == new OperationIdentifier(1)
-            assert n.notificationOperationDetails.is(d1.details)
-            assert n.notificationOperationStartedTimestamp == 0
-        }
-
-        when:
-        broadcast.finished(d1, new OperationFinishEvent(0, 10, null, 10))
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d1.id
-            assert n.notificationOperationResult == 10
-            assert n.notificationOperationFailure == null
-            assert n.notificationOperationDetails.is(d1.details)
-            assert n.notificationOperationFinishedTimestamp == 10
-        }
-
-        // operation with no details
-        when:
-        broadcast.started(d2, new OperationStartEvent(20))
-
-        then:
-        0 * listener.started(_)
-
-        when:
-        broadcast.finished(d2, new OperationFinishEvent(20, 30, null, 10))
-
-        then:
-        0 * listener.finished(_)
-
-        // operation with details and null result
-        when:
-        broadcast.started(d3, new OperationStartEvent(40))
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d3.id
-            assert n.notificationOperationDetails.is(d3.details)
-            assert n.notificationOperationStartedTimestamp == 40
-        }
-
-        when:
-        broadcast.finished(d3, new OperationFinishEvent(40, 50, null, null))
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d3.id
-            assert n.notificationOperationResult == null
-            assert n.notificationOperationFailure == null
-            assert n.notificationOperationDetails.is(d3.details)
-            assert n.notificationOperationFinishedTimestamp == 50
-        }
-
-        // operation with details and failure
-        when:
-        broadcast.started(d3, new OperationStartEvent(60))
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d3.id
-            assert n.notificationOperationDetails.is(d3.details)
-        }
-
-        when:
-        broadcast.finished(d3, new OperationFinishEvent(60, 70, e1, null))
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d3.id
-            assert n.notificationOperationResult == null
-            assert n.notificationOperationFailure == e1
-            assert n.notificationOperationDetails.is(d3.details)
-        }
-    }
-
     BuildOperationDescriptor d(Long id, Long parentId, Long details) {
         BuildOperationDescriptor.displayName(id.toString()).details(details).build(
             new OperationIdentifier(id),
@@ -207,97 +61,10 @@ class BuildOperationNotificationBridgeTest extends Specification {
         )
     }
 
-    def "parentId is of last parent that a notification was sent for"() {
-        given:
-        bridge().valve.start()
-        register(listener)
-        def d1 = d(1, null, 1)
-        def d2 = d(2, 1, null)
-        def d3 = d(3, 2, 3)
-        def d4 = d(4, 2, 4)
-        def d5 = d(5, 4, 5)
-        def d6 = d(6, 5, null)
-        def d7 = d(7, 6, 7)
-
-        when:
-        broadcast.started(d1, new OperationStartEvent(0))
-        broadcast.started(d2, null)
-
-        broadcast.started(d3, new OperationStartEvent(0))
-        broadcast.finished(d3, new OperationFinishEvent(-1, -1, null, null))
-
-        broadcast.started(d4, new OperationStartEvent(0))
-        broadcast.started(d5, new OperationStartEvent(0))
-        broadcast.started(d6, new OperationStartEvent(0))
-        broadcast.started(d7, new OperationStartEvent(0))
-
-        broadcast.finished(d7, new OperationFinishEvent(-1, -1, null, null))
-        broadcast.finished(d6, new OperationFinishEvent(-1, -1, null, null))
-        broadcast.finished(d5, new OperationFinishEvent(-1, -1, null, null))
-        broadcast.finished(d4, new OperationFinishEvent(-1, -1, null, null))
-
-        broadcast.finished(d2, new OperationFinishEvent(-1, -1, null, null))
-        broadcast.finished(d1, new OperationFinishEvent(-1, -1, null, null))
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d1.id
-        }
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d3.id
-            assert n.notificationOperationParentId == d1.id
-        }
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d3.id
-        }
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d4.id
-            assert n.notificationOperationParentId == d1.id
-        }
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d5.id
-            assert n.notificationOperationParentId == d4.id
-        }
-
-        then:
-        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
-            assert n.notificationOperationId == d7.id
-            assert n.notificationOperationParentId == d5.id
-        }
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d7.id
-        }
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d5.id
-        }
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d4.id
-        }
-
-        then:
-        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
-            assert n.notificationOperationId == d1.id
-        }
-    }
-
     def "emits progress events"() {
         given:
         bridge().valve.start()
-        register(listener2)
+        register(listener)
         def d1 = d(1, null, 1)
         def d2 = d(2, 1, null)
         def d3 = d(3, 2, 3)
@@ -319,50 +86,46 @@ class BuildOperationNotificationBridgeTest extends Specification {
         broadcast.finished(d1, new OperationFinishEvent(-1, -1, null, null))
 
         then:
-        1 * listener2.started(_) >> { BuildOperationStartedNotification n ->
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
             assert n.notificationOperationId == d1.id
         }
 
         then:
-        1 * listener2.progress(_) >> { BuildOperationProgressNotification n ->
+        1 * listener.progress(_) >> { BuildOperationProgressNotification n ->
             assert n.notificationOperationId == d1.id
             assert n.notificationOperationProgressDetails == 1
         }
 
         then:
-        1 * listener2.progress(_) >> { BuildOperationProgressNotification n ->
+        1 * listener.progress(_) >> { BuildOperationProgressNotification n ->
             assert n.notificationOperationId == d1.id
             assert n.notificationOperationProgressDetails == 2
         }
 
         then:
-        1 * listener2.started(_) >> { BuildOperationStartedNotification n ->
+        1 * listener.started(_) >> { BuildOperationStartedNotification n ->
             assert n.notificationOperationId == d3.id
             assert n.notificationOperationParentId == d1.id
         }
 
         then:
-        1 * listener2.progress(_) >> { BuildOperationProgressNotification n ->
+        1 * listener.progress(_) >> { BuildOperationProgressNotification n ->
             assert n.notificationOperationId == d3.id
             assert n.notificationOperationProgressDetails == 1
         }
 
         then:
-        1 * listener2.finished(_) >> { BuildOperationFinishedNotification n ->
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
             assert n.notificationOperationId == d3.id
         }
 
         then:
-        1 * listener2.finished(_) >> { BuildOperationFinishedNotification n ->
+        1 * listener.finished(_) >> { BuildOperationFinishedNotification n ->
             assert n.notificationOperationId == d1.id
         }
     }
 
     void register(BuildOperationNotificationListener listener) {
-        bridge().registrar.registerBuildScopeListener(listener)
-    }
-
-    void register(BuildOperationNotificationListener2 listener) {
         bridge().registrar.register(listener)
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixture.groovy
@@ -18,7 +18,7 @@ package org.gradle.integtests.fixtures
 
 import org.gradle.integtests.fixtures.executer.GradleExecuter
 import org.gradle.internal.operations.notify.BuildOperationFinishedNotification
-import org.gradle.internal.operations.notify.BuildOperationNotificationListener2
+import org.gradle.internal.operations.notify.BuildOperationNotificationListener
 import org.gradle.internal.operations.notify.BuildOperationNotificationListenerRegistrar
 import org.gradle.internal.operations.notify.BuildOperationProgressNotification
 import org.gradle.internal.operations.notify.BuildOperationStartedNotification
@@ -64,7 +64,7 @@ class BuildOperationNotificationsFixture {
     }
 
     public static final String EVALUATION_LISTENER_SOURCE = """
-        class BuildOperationNotificationsEvaluationListener implements $BuildOperationNotificationListener2.name {
+        class BuildOperationNotificationsEvaluationListener implements $BuildOperationNotificationListener.name {
                 @Override
                 void started($BuildOperationStartedNotification.name notification) {
                     verify(notification.getNotificationOperationDetails(), 'Details')

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixtureTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/integtests/fixtures/BuildOperationNotificationsFixtureTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.integtests.fixtures
 
 import org.gradle.api.GradleException
 import org.gradle.internal.operations.notify.BuildOperationFinishedNotification
-import org.gradle.internal.operations.notify.BuildOperationNotificationListener2
+import org.gradle.internal.operations.notify.BuildOperationNotificationListener
 import org.gradle.internal.operations.notify.BuildOperationProgressNotification
 import org.gradle.internal.operations.notify.BuildOperationStartedNotification
 import org.gradle.internal.reflect.JavaReflectionUtil
@@ -79,10 +79,10 @@ class BuildOperationNotificationsFixtureTest extends Specification {
         e.cause.message == "!"
     }
 
-    BuildOperationNotificationListener2 listener() {
+    BuildOperationNotificationListener listener() {
         GroovyClassLoader groovyClassLoader = new GroovyClassLoader(BuildOperationNotificationsFixture.getClassLoader())
         Class theParsedClass = groovyClassLoader.parseClass(BuildOperationNotificationsFixture.EVALUATION_LISTENER_SOURCE)
-        return JavaReflectionUtil.newInstance(theParsedClass) as BuildOperationNotificationListener2
+        return JavaReflectionUtil.newInstance(theParsedClass) as BuildOperationNotificationListener
     }
 
     def progressNotification(Class<SimpleProgress> progressClazz = null) {


### PR DESCRIPTION
### Context
Some simplifications to prepare for the GBT 5.0 <=> build scan plugin 2.0 requirements

- Backporting `BuildOperationNotificationListener2` to `BuildOperationNotificationListener`
- Keep `BuildOperationNotificationListener2` around to allow build scan plugin 1.16 to still work with this GBT version

A build scan plugin 2.0 RC will be produced, that is built from this GBT version, and that does not need `BuildOperationNotificationListener2`.
This RC will then be made available for the GBT team to use, and we'll remove the then-unneeded `BuildOperationNotificationListener2` interface.
