### PR TITLE
Introduce an incubating APIs report

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -312,7 +312,7 @@ tasks.register<Install>("installAll") {
 }
 
 val allIncubationReports = tasks.register<IncubatingApiAggregateReportTask>("allIncubationReports") {
-    val allReports = subprojects.flatMap { it.tasks.withType(IncubatingApiReportTask::class) }
+    val allReports = collectAllIncubationReports()
     dependsOn(allReports)
     reports = allReports.associateBy({ it.title.get()}) { it.textReportFile.asFile.get() }
 }
@@ -320,6 +320,7 @@ tasks.register<Zip>("allIncubationReportsZip") {
     destinationDir = file("$buildDir/reports/incubation")
     baseName = "incubating-apis"
     from(allIncubationReports.get().htmlReportFile)
+    from(collectAllIncubationReports().map { it.htmlReportFile })
 }
 
 fun distributionImage(named: String) =
@@ -327,3 +328,5 @@ fun distributionImage(named: String) =
 
 fun Configuration.usage(named: String) =
     attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(named))
+
+fun Project.collectAllIncubationReports() = subprojects.flatMap { it.tasks.withType(IncubatingApiReportTask::class) }

--- a/buildSrc/subprojects/buildquality/buildquality.gradle.kts
+++ b/buildSrc/subprojects/buildquality/buildquality.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.codenarc:CodeNarc:1.0") {
         exclude(group = "org.codehaus.groovy")
     }
+    implementation("com.github.javaparser:javaparser-symbol-solver-core:3.6.11")
 }
 
 gradlePlugin {
@@ -44,6 +45,10 @@ gradlePlugin {
         register("taskPropertyValidation") {
             id = "gradlebuild.task-properties-validation"
             implementationClass = "org.gradle.gradlebuild.buildquality.TaskPropertyValidationPlugin"
+        }
+        register("incubationReport") {
+            id = "gradlebuild.incubation-report"
+            implementationClass = "org.gradle.gradlebuild.buildquality.incubation.IncubationReportPlugin"
         }
     }
 }

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiAggregateReportTask.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiAggregateReportTask.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.buildquality.incubation
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.workers.IsolationMode
+import org.gradle.workers.WorkerExecutor
+import java.io.File
+import javax.inject.Inject
+
+
+@CacheableTask
+open class IncubatingApiAggregateReportTask @Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
+
+    @Input
+    var reports: Map<String, File>? = null
+
+    @OutputFile
+    val htmlReportFile = project.objects.fileProperty().also {
+        it.set(project.layout.buildDirectory.file("reports/incubation/all-incubating.html"))
+    }
+
+    @TaskAction
+    fun generateReport() {
+        workerExecutor.submit(GenerateReport::class.java) {
+            isolationMode = IsolationMode.CLASSLOADER
+            params(reports, htmlReportFile.asFile.get())
+        }
+    }
+}
+
+
+typealias ReportNameToProblems = MutableMap<String, MutableSet<String>>
+
+
+open class GenerateReport @Inject constructor(private val reports: Map<String, File>, private val outputFile: File) : Runnable {
+    override
+    fun run() {
+        val byVersion = mutableMapOf<String, ReportNameToProblems>()
+        reports.forEach { name, file ->
+            file.forEachLine(Charsets.UTF_8) {
+                val (version, _, problem) = it.split(';')
+                byVersion.getOrPut(version) {
+                    mutableMapOf()
+                }.getOrPut(name) {
+                    mutableSetOf()
+                }.add(problem)
+            }
+        }
+        generateReport(byVersion)
+    }
+
+    private
+    fun generateReport(data: Map<String, ReportNameToProblems>) {
+        outputFile.parentFile.mkdirs()
+        outputFile.printWriter(Charsets.UTF_8).use { writer ->
+            writer.println("""<html lang="en">
+    <head>
+       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+       <title>Incubating APIs</title>
+       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
+       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
+       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
+
+    </head>
+    <body>
+       <h1>Incubating APIs</h1>
+       <h2>Index</h2>
+       <ul>
+    """)
+
+            data.toSortedMap().forEach { version, _ ->
+                writer.println("<li><a href=\"#$version\">Incubating since $version</a><br></li>")
+            }
+            writer.println("</ul>")
+            data.toSortedMap().forEach { version, problems ->
+                writer.println("<a name=\"$version\"></a>")
+                writer.println("<h2>Incubating since $version</h2>")
+                problems.forEach { name, issues ->
+                    writer.println("<h3>In $name</h3>")
+                    writer.println("<ul>")
+                    issues.forEach {
+                        writer.println("   <li>${it.escape()}</li>")
+                    }
+                    writer.println("</ul>")
+                }
+            }
+            writer.println("</body></html>")
+        }
+    }
+
+    private
+    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
+}

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiAggregateReportTask.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiAggregateReportTask.kt
@@ -28,7 +28,8 @@ import javax.inject.Inject
 
 
 @CacheableTask
-open class IncubatingApiAggregateReportTask @Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
+open class IncubatingApiAggregateReportTask
+    @Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
 
     @Input
     var reports: Map<String, File>? = null

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiReportTask.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiReportTask.kt
@@ -1,0 +1,274 @@
+package org.gradle.gradlebuild.buildquality.incubation
+
+import com.github.javaparser.JavaParser
+import com.github.javaparser.ast.CompilationUnit
+import com.github.javaparser.ast.Node
+import com.github.javaparser.ast.body.AnnotationDeclaration
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration
+import com.github.javaparser.ast.body.EnumDeclaration
+import com.github.javaparser.ast.body.MethodDeclaration
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc
+import com.github.javaparser.ast.nodeTypes.NodeWithSimpleName
+import com.github.javaparser.javadoc.description.JavadocSnippet
+import com.github.javaparser.symbolsolver.JavaSymbolSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver
+import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.workers.IsolationMode
+import org.gradle.workers.WorkerExecutor
+import java.io.BufferedReader
+import java.io.File
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+
+@CacheableTask
+open class IncubatingApiReportTask @Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    val versionFile: RegularFileProperty = project.objects.fileProperty()
+
+    @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
+    val releasedVersionsFile: RegularFileProperty = project.objects.fileProperty()
+
+    @Input
+    val title: Property<String> = project.objects.property(String::class.java).also {
+        it.set(project.provider { project.name })
+    }
+
+    @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
+    val sources: Property<FileCollection> = project.objects.property(FileCollection::class.java).also {
+        it.set(project.provider {
+            project.convention
+                .getPlugin(JavaPluginConvention::class.java)
+                .sourceSets
+                .getByName("main")
+                .java
+                .sourceDirectories
+        })
+    }
+
+    @OutputFile
+    val htmlReportFile: RegularFileProperty = project.objects.fileProperty().also {
+        it.set(project.layout.buildDirectory.file("reports/incubating.html"))
+    }
+
+    @OutputFile
+    val textReportFile: RegularFileProperty = project.objects.fileProperty().also {
+        it.set(project.layout.buildDirectory.file("reports/incubating.txt"))
+    }
+
+    @TaskAction
+    fun analyze() = workerExecutor.submit(Analyzer::class.java) {
+        isolationMode = IsolationMode.CLASSLOADER
+        params(versionFile.asFile.get(), sources.get().files, htmlReportFile.asFile.get(), textReportFile.asFile.get(), title.get(), releasedVersionsFile.asFile.get())
+    }
+}
+
+
+open
+class Analyzer @Inject constructor(
+    private val versionFile: File,
+    private val srcDirs: Set<File>,
+    private val htmlReportFile: File,
+    private val textReportFile: File,
+    private val title: String,
+    private val releasedVersionsFile: File
+) : Runnable {
+
+    override
+    fun run() {
+        val versionToIncubating = mutableMapOf<String, MutableSet<String>>()
+        val hashToVersionCache = mutableMapOf<String, String>()
+        srcDirs.forEach { srcDir ->
+            if (srcDir.exists()) {
+                val solver = JavaSymbolSolver(CombinedTypeSolver(JavaParserTypeSolver(srcDir), ReflectionTypeSolver()))
+                srcDir.walkTopDown().forEach {
+                    if (it.name.endsWith(".java")) {
+                        try {
+                            parseJavaFile(srcDir, it, versionToIncubating, solver, hashToVersionCache)
+                        } catch (e: Exception) {
+                            println("Unable to parse $it: ${e.message}")
+                        }
+                    }
+                }
+            }
+        }
+        generateTextReport(versionToIncubating)
+        generateHtmlReport(versionToIncubating)
+    }
+
+    private
+    fun parseJavaFile(srcDir: File, file: File, versionToIncubating: MutableMap<String, MutableSet<String>>, solver: JavaSymbolSolver, hashToVersionCache: MutableMap<String, String>) =
+        JavaParser.parse(file).run {
+            solver.inject(this)
+            findAll(Node::class.java)
+                .filter {
+                    it is NodeWithAnnotations<*> &&
+                        it.annotations.any { it.nameAsString == "Incubating" }
+                }.map {
+                    val node = it as NodeWithAnnotations<*>
+                    val version = findVersionFromJavadoc(node)
+                        ?: speculateVersion(srcDir, file, hashToVersionCache)
+                    Pair(version, nodeName(it, this, file))
+                }.forEach {
+                    versionToIncubating.getOrPut(it.first) {
+                        mutableSetOf()
+                    }.add(it.second)
+                }
+        }
+
+
+    private
+    fun findVersionFromJavadoc(node: NodeWithAnnotations<*>): String? = if (node is NodeWithJavadoc<*>) {
+        node.javadoc.map {
+            it.blockTags.find {
+                it.tagName == "since"
+            }?.content?.elements?.find {
+                it is JavadocSnippet
+            }?.toText()
+        }.orElse(null)
+    } else {
+        null
+    }
+
+    private
+    fun nodeName(it: Node?, unit: CompilationUnit, file: File) = when (it) {
+        is EnumDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
+        is ClassOrInterfaceDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
+        is MethodDeclaration -> tryResolve({ it.resolve().qualifiedSignature }) { inferClassName(unit) }
+        is AnnotationDeclaration -> tryResolve({ it.resolve().qualifiedName }) { inferClassName(unit) }
+        is NodeWithSimpleName<*> -> it.nameAsString
+        else -> unit.primaryTypeName.orElse(file.name)
+    }
+
+    private
+    fun inferClassName(unit: CompilationUnit) = "${unit.packageDeclaration.map { it.nameAsString }.orElse("")}.${unit.primaryTypeName.orElse("")}"
+
+    private
+    inline fun tryResolve(resolver: () -> String, or: () -> String) = try {
+        resolver()
+    } catch (e: Throwable) {
+        or()
+    }
+
+    private
+    inline fun <T> File.cmd(vararg cmd: String, action: BufferedReader.() -> T): T = ProcessBuilder(cmd.asList())
+        .directory(this)
+        .redirectOutput(ProcessBuilder.Redirect.PIPE)
+        .redirectError(ProcessBuilder.Redirect.PIPE)
+        .start()
+        .run {
+            waitFor(5, TimeUnit.SECONDS)
+            action(inputStream.bufferedReader(Charsets.UTF_8))
+        }
+
+    private
+    fun speculateVersion(srcDir: File, f: File, hashToVersionCache: MutableMap<String, String>): String {
+        val hash = srcDir.cmd("git", "log", "--format=%H", "--diff-filter=A", "--", f.toRelativeString(srcDir)) {
+            readText().trim()
+        }
+        return speculateVersionFromHash(hash, hashToVersionCache)
+    }
+
+    private
+    fun speculateVersionFromHash(hash: String, hashToVersionCache: MutableMap<String, String>): String = if (hash.length == 40) {
+        hashToVersionCache.getOrPut(hash) {
+            val version = versionFile.parentFile.cmd("git", "show", hash + ":" + versionFile.name) {
+                readLine().trim()
+            }
+            return if (version.length == 0) {
+                "Not found"
+            } else {
+                version
+            }
+        }
+    } else {
+        "Not found"
+    }
+
+    private
+    fun generateHtmlReport(versionToIncubating: Map<String, Set<String>>) {
+        htmlReportFile.parentFile.mkdirs()
+        htmlReportFile.printWriter(Charsets.UTF_8).use { writer ->
+            writer.println("""<html lang="en">
+    <head>
+       <META http-equiv="Content-Type" content="text/html; charset=UTF-8">
+       <title>Incubating APIs for $title</title>
+       <link xmlns:xslthl="http://xslthl.sf.net" rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,400i,700">
+       <meta xmlns:xslthl="http://xslthl.sf.net" content="width=device-width, initial-scale=1" name="viewport">
+       <link xmlns:xslthl="http://xslthl.sf.net" type="text/css" rel="stylesheet" href="https://docs.gradle.org/current/userguide/base.css">
+
+    </head>
+    <body>
+       <h1>Incubating APIs for $title</h1>
+    """)
+            val versions = versionsDates()
+            versionToIncubating.toSortedMap().forEach {
+                writer.println("<a name=\"sec_${it.key}\"></a>")
+                writer.println("<h2>Incubating since ${it.key} (${versions.get(it.key)?.run { "released on $this" }
+                    ?: "unreleased"})</h2>")
+                writer.println("<ul>")
+                it.value.forEach {
+                    writer.println("   <li>${it.escape()}</li>")
+                }
+                writer.println("</ul>")
+            }
+            writer.println("</body></html>")
+        }
+    }
+
+    private
+    fun generateTextReport(versionToIncubating: Map<String, Set<String>>) {
+        textReportFile.parentFile.mkdirs()
+        textReportFile.printWriter(Charsets.UTF_8).use { writer ->
+            val versions = versionsDates()
+            versionToIncubating.toSortedMap().forEach {
+                val version = it.key
+                val releaseDate = versions.get(it.key) ?: "unreleased"
+                it.value.forEach {
+                    writer.println("$version;$releaseDate;$it")
+                }
+            }
+        }
+    }
+
+    private
+    fun versionsDates(): Map<String, String> {
+        val versions = mutableMapOf<String, String>()
+        var version: String? = null
+        releasedVersionsFile.forEachLine(Charsets.UTF_8) {
+            val line = it.trim()
+            if (line.startsWith("\"version\"")) {
+                version = line.substring(line.indexOf("\"", 11) + 1, line.lastIndexOf("\""))
+            }
+            if (line.startsWith("\"buildTime\"")) {
+                var date = line.substring(line.indexOf("\"", 12) + 1, line.lastIndexOf("\""))
+                date = date.substring(0, 4) + "-" + date.substring(4, 6) + "-" + date.substring(6, 8)
+                versions.put(version!!, date)
+            }
+        }
+        return versions
+    }
+
+
+    private
+    fun String.escape() = replace("<", "&lt;").replace(">", "&gt;")
+}

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiReportTask.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubatingApiReportTask.kt
@@ -37,7 +37,8 @@ import javax.inject.Inject
 
 
 @CacheableTask
-open class IncubatingApiReportTask @Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
+open class IncubatingApiReportTask
+    @Inject constructor(private val workerExecutor: WorkerExecutor) : DefaultTask() {
 
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubationReportPlugin.kt
+++ b/buildSrc/subprojects/buildquality/src/main/kotlin/org/gradle/gradlebuild/buildquality/incubation/IncubationReportPlugin.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.gradlebuild.buildquality.incubation
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+import accessors.java
+
+import org.gradle.kotlin.dsl.*
+
+
+class IncubationReportPlugin : Plugin<Project> {
+    override fun apply(project: Project) = project.run {
+        val reportTask = tasks.register("incubationReport", IncubatingApiReportTask::class) {
+            val main by java.sourceSets
+            description = "Generates a report of incubating APIS"
+            title.set(project.name)
+            versionFile.set(rootProject.file("version.txt"))
+            releasedVersionsFile.set(rootProject.file("released-versions.json"))
+            sources.set(main.java.sourceDirectories)
+            htmlReportFile.set(file("$buildDir/reports/incubation/${project.name}.html"))
+            textReportFile.set(file("$buildDir/reports/incubation/${project.name}.txt"))
+        }
+        tasks.named("check").configure { dependsOn(reportTask) }
+    }
+}

--- a/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-projects.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/src/main/kotlin/gradlebuild/java-projects.gradle.kts
@@ -19,6 +19,7 @@ apply(plugin = "gradlebuild.unittest-and-compile")
 apply(plugin = "gradlebuild.test-fixtures")
 apply(plugin = "gradlebuild.distribution-testing")
 apply(plugin = "gradlebuild.int-test-image")
+apply(plugin = "gradlebuild.incubation-report")
 
 if (file("src/integTest").isDirectory) {
     apply(plugin = "gradlebuild.integration-tests")


### PR DESCRIPTION
### Context

This commit adds an incubating APIs report to all Java projects. One
can get a report of the incubating APIs by running the `incubationReport`
task.

An aggregate task, bound to `sanityCheck`, is also available:
  - `allIncubationReportsZip` will generate a report aggregating all projects incubating APIs
  - `allIncubationReports` will do the same but without a zip. This tasks is not bound to `sanityCheck`.

