### PR TITLE
Add incubation reports tab

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -75,6 +75,7 @@ fun applyDefaultSettings(buildType: BuildType, os: OS = OS.linux, timeout: Int =
         buildSrc/build/report-* => .
         subprojects/*/build/tmp/test files/** => test-files
         build/errorLogs/** => errorLogs
+        build/reports/incubation/** => incubation-reports
     """.trimIndent()
 
     buildType.vcs {

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -23,6 +23,7 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
     features {
         if (stage.specificBuilds.contains(SpecificBuild.SanityCheck)) {
             buildReportTab("API Compatibility Report", "report-distributions-binary-compatibility-report.html")
+            buildReportTab("Incubating APIs Report", "incubation-reports/all-incubating.html")
         }
         if (!stage.performanceTests.isEmpty()) {
             buildReportTab("Performance", "report-performance-performance-tests.zip!report/index.html")


### PR DESCRIPTION
### Context

This can be merged after #7001 is. It should add a report tab to the sanity check builds.
