### PR TITLE
Use lazy API in application plugin

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -86,7 +86,6 @@ abstract class WellBehavedPluginTest extends AbstractPluginIntegrationTest {
             'xcode',
 
             'play-application',
-            'application',
         ])
 
         applyPlugin()

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/WellBehavedPluginTest.groovy
@@ -86,6 +86,7 @@ abstract class WellBehavedPluginTest extends AbstractPluginIntegrationTest {
             'xcode',
 
             'play-application',
+            'application',
         ])
 
         applyPlugin()

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/ApplicationPluginIntegrationTest.groovy
@@ -15,7 +15,8 @@
  */
 package org.gradle.api.plugins
 
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+
+import org.gradle.integtests.fixtures.WellBehavedPluginTest
 import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
@@ -24,7 +25,12 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
 
-class ApplicationPluginIntegrationTest extends AbstractIntegrationSpec {
+class ApplicationPluginIntegrationTest extends WellBehavedPluginTest {
+    @Override
+    String getMainTask() {
+        return "startScripts"
+    }
+
     def setup() {
         createSampleProjectSetup()
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/ApplicationPlugin.java
@@ -32,6 +32,7 @@ import org.gradle.api.plugins.internal.DefaultJavaApplication;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.Sync;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.application.CreateStartScripts;
 
 import java.io.File;
@@ -74,32 +75,37 @@ public class ApplicationPlugin implements Plugin<Project> {
             }
         });
         configureDistSpec(distribution.getContents());
-        configureInstallTask(project.getTasks().getAt(TASK_INSTALL_NAME));
+        configureInstallTask(project.getTasks().named(TASK_INSTALL_NAME));
     }
 
-    private void configureInstallTask(Task installTask) {
-        installTask.doFirst(new Action<Task>() {
+    private void configureInstallTask(TaskProvider<Task> installTask) {
+        installTask.configure(new Action<Task>() {
             @Override
             public void execute(Task task) {
-                Sync sync = (Sync) task;
-                File destinationDir = sync.getDestinationDir();
-                if (destinationDir.isDirectory()) {
-                    String[] children = destinationDir.list();
-                    if (children == null) {
-                        throw new UncheckedIOException("Could not list directory " + destinationDir);
-                    }
-                    if (children.length > 0) {
-                        if (!new File(destinationDir, "lib").isDirectory() || !new File(destinationDir, pluginConvention.getExecutableDir()).isDirectory()) {
-                            throw new GradleException("The specified installation directory \'"
-                                + destinationDir
-                                + "\' is neither empty nor does it contain an installation for \'"
-                                + pluginConvention.getApplicationName()
-                                + "\'.\n"
-                                + "If you really want to install to this directory, delete it and run the install task again.\n"
-                                + "Alternatively, choose a different installation directory.");
+                task.doFirst(new Action<Task>() {
+                    @Override
+                    public void execute(Task task) {
+                        Sync sync = (Sync) task;
+                        File destinationDir = sync.getDestinationDir();
+                        if (destinationDir.isDirectory()) {
+                            String[] children = destinationDir.list();
+                            if (children == null) {
+                                throw new UncheckedIOException("Could not list directory " + destinationDir);
+                            }
+                            if (children.length > 0) {
+                                if (!new File(destinationDir, "lib").isDirectory() || !new File(destinationDir, pluginConvention.getExecutableDir()).isDirectory()) {
+                                    throw new GradleException("The specified installation directory \'"
+                                        + destinationDir
+                                        + "\' is neither empty nor does it contain an installation for \'"
+                                        + pluginConvention.getApplicationName()
+                                        + "\'.\n"
+                                        + "If you really want to install to this directory, delete it and run the install task again.\n"
+                                        + "Alternatively, choose a different installation directory.");
+                                }
+                            }
                         }
                     }
-                }
+                });
             }
         });
     }
@@ -112,76 +118,84 @@ public class ApplicationPlugin implements Plugin<Project> {
     }
 
     private void addRunTask() {
-        JavaExec run = project.getTasks().create(TASK_RUN_NAME, JavaExec.class);
-        run.setDescription("Runs this project as a JVM application");
-        run.setGroup(APPLICATION_GROUP);
+        project.getTasks().register(TASK_RUN_NAME, JavaExec.class, new Action<JavaExec>() {
+            @Override
+            public void execute(JavaExec run) {
+                run.setDescription("Runs this project as a JVM application");
+                run.setGroup(APPLICATION_GROUP);
 
-        JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
-        run.setClasspath(javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath());
-        run.getConventionMapping().map("main", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return pluginConvention.getMainClassName();
-            }
-        });
-        run.getConventionMapping().map("jvmArgs", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return pluginConvention.getApplicationDefaultJvmArgs();
+                JavaPluginConvention javaPluginConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+                run.setClasspath(javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getRuntimeClasspath());
+                run.getConventionMapping().map("main", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return pluginConvention.getMainClassName();
+                    }
+                });
+                run.getConventionMapping().map("jvmArgs", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return pluginConvention.getApplicationDefaultJvmArgs();
+                    }
+                });
             }
         });
     }
 
     // @Todo: refactor this task configuration to extend a copy task and use replace tokens
     private void addCreateScriptsTask() {
-        CreateStartScripts startScripts = project.getTasks().create(TASK_START_SCRIPTS_NAME, CreateStartScripts.class);
-        startScripts.setDescription("Creates OS specific scripts to run the project as a JVM application.");
-        startScripts.setClasspath(project.getTasks().getAt(JavaPlugin.JAR_TASK_NAME).getOutputs().getFiles().plus(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
-
-        startScripts.getConventionMapping().map("mainClassName", new Callable<Object>() {
+        project.getTasks().register(TASK_START_SCRIPTS_NAME, CreateStartScripts.class, new Action<CreateStartScripts>() {
             @Override
-            public Object call() throws Exception {
-                return pluginConvention.getMainClassName();
-            }
-        });
+            public void execute(CreateStartScripts startScripts) {
+                startScripts.setDescription("Creates OS specific scripts to run the project as a JVM application.");
+                startScripts.setClasspath(project.getTasks().getAt(JavaPlugin.JAR_TASK_NAME).getOutputs().getFiles().plus(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)));
 
-        startScripts.getConventionMapping().map("applicationName", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return pluginConvention.getApplicationName();
-            }
-        });
+                startScripts.getConventionMapping().map("mainClassName", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return pluginConvention.getMainClassName();
+                    }
+                });
 
-        startScripts.getConventionMapping().map("outputDir", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return new File(project.getBuildDir(), "scripts");
-            }
-        });
+                startScripts.getConventionMapping().map("applicationName", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return pluginConvention.getApplicationName();
+                    }
+                });
 
-        startScripts.getConventionMapping().map("executableDir", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return pluginConvention.getExecutableDir();
-            }
-        });
+                startScripts.getConventionMapping().map("outputDir", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return new File(project.getBuildDir(), "scripts");
+                    }
+                });
 
-        startScripts.getConventionMapping().map("defaultJvmOpts", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                return pluginConvention.getApplicationDefaultJvmArgs();
+                startScripts.getConventionMapping().map("executableDir", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return pluginConvention.getExecutableDir();
+                    }
+                });
+
+                startScripts.getConventionMapping().map("defaultJvmOpts", new Callable<Object>() {
+                    @Override
+                    public Object call() throws Exception {
+                        return pluginConvention.getApplicationDefaultJvmArgs();
+                    }
+                });
             }
         });
     }
 
     private CopySpec configureDistSpec(CopySpec distSpec) {
-        Task jar = project.getTasks().getAt(JavaPlugin.JAR_TASK_NAME);
-        Task startScripts = project.getTasks().getAt(TASK_START_SCRIPTS_NAME);
+        TaskProvider<Task> jar = project.getTasks().named(JavaPlugin.JAR_TASK_NAME);
+        TaskProvider<Task> startScripts = project.getTasks().named(TASK_START_SCRIPTS_NAME);
 
         CopySpec libChildSpec = project.copySpec();
         libChildSpec.into("lib");
         libChildSpec.from(jar);
-        libChildSpec.from(project.getConfigurations().getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
+        libChildSpec.from(project.getConfigurations().named(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME));
 
         CopySpec binChildSpec = project.copySpec();
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Lazily creates the application plugin's `run` and `startScripts` tasks, and makes the plugin lazily reference other tasks, like `jar` and `installDist`, during configuration time.

Given a build script containing:

```gradle
plugins {
    id 'application'
}
```

The task stats for running `help` are:

![image](https://user-images.githubusercontent.com/2957142/46389892-cbbd9100-c6a2-11e8-83df-24909b1f71e3.png)

With this patch, the task stats for running `help` with the same build script are:

![image](https://user-images.githubusercontent.com/2957142/46389919-f1e33100-c6a2-11e8-80c7-2dc0a66b1cb1.png)

/cc @big-guy 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
