### PR TITLE
Disable gradle 1.x TAPI tests

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/ReleasedVersionsFromVersionControl.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/ReleasedVersionsFromVersionControl.groovy
@@ -24,7 +24,7 @@ import org.gradle.util.VersionNumber
 class ReleasedVersionsFromVersionControl implements ReleasedVersions {
     private static final List<String> BANNED_VERSIONS = []
     private lowestInterestingVersion = GradleVersion.version("0.8")
-    private lowestTestedVersion = GradleVersion.version("1.0")
+    private lowestTestedVersion = GradleVersion.version("2.0")
 
     ReleasedVersion mostRecentRelease
     List<ReleasedVersion> allVersions


### PR DESCRIPTION
We still test Gradle 1.x in cross version TAPI tests, which timeouts frequently recently.
Now we disable them for now. We should work out a new plan for cross version tests as the number of distributions keep increasing.

See https://github.com/gradle/gradle-private/issues/1542


