### PR TITLE
Add daily trigger to release nightly job.

### DIFF
--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_ReleaseSnapshotFromQuickFeedback.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_ReleaseSnapshotFromQuickFeedback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="eeff4410-1e7d-4db6-b7b8-34c1f2754477" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
-  <name>Release - Snapshot (from Quick Feedback)</name>
-  <description>Deploys the latest successful change on 'release' as a new snapshot</description>
+  <name>Release - Release Nightly (from Quick Feedback)</name>
+  <description>Deploys the latest successful change on 'release' as a new release nightly</description>
   <settings>
     <options>
       <option name="artifactRules" value="incoming-build-receipt/build-receipt.properties =&gt; incoming-build-receipt&#xA;**/build/git-checkout/build/build-receipt.properties&#xA;**/build/distributions/*.zip =&gt; promote-build-distributions&#xA;**/build/website-checkout/data/releases.xml&#xA;**/build/git-checkout/build/reports/integTest/** =&gt; distribution-tests&#xA;**/smoke-tests/build/reports/tests/** =&gt; post-smoke-tests" />
@@ -17,7 +17,7 @@
           <param name="teamcity.coverage.idea.includePatterns" value="*" />
           <param name="teamcity.step.mode" value="default" />
           <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PuseBuildReceipt &quot;-PgitUserName=Gradleware Git Bot&quot; &quot;-PgitUserEmail=gradlewaregitbot@gradleware.com&quot; -Igradle/buildScanInit.gradle -Djava7Home=%linux.jdk.for.gradle.compile% -Djava9Home=%linux.java9.oracle.64bit%" />
-          <param name="ui.gradleRunner.gradle.tasks.names" value="promoteReleaseSnapshot" />
+          <param name="ui.gradleRunner.gradle.tasks.names" value="promoteReleaseNightly" />
           <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true" />
         </parameters>
       </runner>

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_ReleaseSnapshotFromQuickFeedback.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_ReleaseSnapshotFromQuickFeedback.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="eeff4410-1e7d-4db6-b7b8-34c1f2754477" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
-  <name>Release - Release Nightly (from Quick Feedback)</name>
-  <description>Deploys the latest successful change on 'release' as a new release nightly</description>
+  <name>Release - Release Nightly Snapshot (from Quick Feedback)</name>
+  <description>Deploys the latest successful change on 'release' as a new release nightly snapshot</description>
   <settings>
     <options>
       <option name="artifactRules" value="incoming-build-receipt/build-receipt.properties =&gt; incoming-build-receipt&#xA;**/build/git-checkout/build/build-receipt.properties&#xA;**/build/distributions/*.zip =&gt; promote-build-distributions&#xA;**/build/website-checkout/data/releases.xml&#xA;**/build/git-checkout/build/reports/integTest/** =&gt; distribution-tests&#xA;**/smoke-tests/build/reports/tests/** =&gt; post-smoke-tests" />

--- a/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
@@ -28,24 +28,7 @@
     <requirements>
       <contains id="RQ_29" name="teamcity.agent.jvm.os.name" value="Linux" />
     </requirements>
-    <build-triggers>
-      <build-trigger id="TRIGGER_12" type="schedulingTrigger">
-        <parameters>
-          <param name="cronExpression_dm" value="*" />
-          <param name="cronExpression_dw" value="?" />
-          <param name="cronExpression_hour" value="*" />
-          <param name="cronExpression_min" value="0" />
-          <param name="cronExpression_month" value="*" />
-          <param name="cronExpression_sec" value="0" />
-          <param name="cronExpression_year" value="*" />
-          <param name="dayOfWeek" value="Sunday" />
-          <param name="enableQueueOptimization" value="true" />
-          <param name="hour" value="0" />
-          <param name="minute" value="0" />
-          <param name="schedulingPolicy" value="daily" />
-        </parameters>
-      </build-trigger>
-    </build-triggers>
+    <build-triggers />
     <artifact-dependencies>
       <dependency id="ARTIFACT_DEPENDENCY_46" sourceBuildTypeId="Gradle_Check_Stage_ReadyforNightly_Trigger" cleanDestination="true">
         <revisionRule name="lastSuccessful" revision="latest.lastSuccessful" branch="release" />

--- a/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="1f5ca7f8-b0f5-41f9-9ba7-6d518b2822f0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
-  <name>Release - Snapshot</name>
-  <description>Deploys the latest successful change on 'release' as a new snapshot</description>
+  <name>Release - Release Nightly</name>
+  <description>Deploys the latest successful change on 'release' as a new release nightly</description>
   <settings>
     <options>
       <option name="artifactRules" value="incoming-build-receipt/build-receipt.properties =&gt; incoming-build-receipt&#xA;**/build/git-checkout/build/build-receipt.properties&#xA;**/build/distributions/*.zip =&gt; promote-build-distributions&#xA;**/build/website-checkout/data/releases.xml&#xA;**/build/git-checkout/build/reports/integTest/** =&gt; distribution-tests&#xA;**/smoke-tests/build/reports/tests/** =&gt; post-smoke-tests" />
@@ -17,7 +17,7 @@
           <param name="teamcity.coverage.idea.includePatterns" value="*" />
           <param name="teamcity.step.mode" value="default" />
           <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PuseBuildReceipt &quot;-PgitUserName=Gradleware Git Bot&quot; &quot;-PgitUserEmail=gradlewaregitbot@gradleware.com&quot; -Igradle/buildScanInit.gradle -Djava7Home=%linux.jdk.for.gradle.compile% -Djava9Home=%linux.java9.oracle.64bit%" />
-          <param name="ui.gradleRunner.gradle.tasks.names" value="promoteReleaseSnapshot" />
+          <param name="ui.gradleRunner.gradle.tasks.names" value="promoteReleaseNightly" />
           <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true" />
         </parameters>
       </runner>
@@ -28,7 +28,24 @@
     <requirements>
       <contains id="RQ_29" name="teamcity.agent.jvm.os.name" value="Linux" />
     </requirements>
-    <build-triggers />
+    <build-triggers>
+      <build-trigger id="TRIGGER_12" type="schedulingTrigger">
+        <parameters>
+          <param name="cronExpression_dm" value="*" />
+          <param name="cronExpression_dw" value="?" />
+          <param name="cronExpression_hour" value="*" />
+          <param name="cronExpression_min" value="0" />
+          <param name="cronExpression_month" value="*" />
+          <param name="cronExpression_sec" value="0" />
+          <param name="cronExpression_year" value="*" />
+          <param name="dayOfWeek" value="Sunday" />
+          <param name="enableQueueOptimization" value="true" />
+          <param name="hour" value="0" />
+          <param name="minute" value="0" />
+          <param name="schedulingPolicy" value="daily" />
+        </parameters>
+      </build-trigger>
+    </build-triggers>
     <artifact-dependencies>
       <dependency id="ARTIFACT_DEPENDENCY_46" sourceBuildTypeId="Gradle_Check_Stage_ReadyforNightly_Trigger" cleanDestination="true">
         <revisionRule name="lastSuccessful" revision="latest.lastSuccessful" branch="release" />

--- a/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="1f5ca7f8-b0f5-41f9-9ba7-6d518b2822f0" xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
-  <name>Release - Release Nightly</name>
-  <description>Deploys the latest successful change on 'release' as a new release nightly</description>
+  <name>Release - Release Nightly Snapshot</name>
+  <description>Deploys the latest successful change on 'release' as a new release nightly snapshot</description>
   <settings>
     <options>
       <option name="artifactRules" value="incoming-build-receipt/build-receipt.properties =&gt; incoming-build-receipt&#xA;**/build/git-checkout/build/build-receipt.properties&#xA;**/build/distributions/*.zip =&gt; promote-build-distributions&#xA;**/build/website-checkout/data/releases.xml&#xA;**/build/git-checkout/build/reports/integTest/** =&gt; distribution-tests&#xA;**/smoke-tests/build/reports/tests/** =&gt; post-smoke-tests" />


### PR DESCRIPTION
So we can automatically publish its related metadata into `services.gradle.org` to be consumed by GE testing automation.