### PR TITLE
Make performance project templates cacheable

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
@@ -26,6 +26,8 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.testing.performance.generator.DependencyGraph
 import org.gradle.testing.performance.generator.MavenJarCreator
 import org.gradle.testing.performance.generator.MavenRepository
@@ -85,6 +87,7 @@ abstract class AbstractProjectGeneratorTask extends TemplateProjectGeneratorTask
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     FileTree getTemplateDirectories() {
         def allTemplates = rootProjectTemplates + subProjectTemplates
         if (buildSrcTemplate) {

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/JvmProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/JvmProjectGeneratorTask.groovy
@@ -19,8 +19,12 @@ package org.gradle.testing.performance.generator.tasks
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.testing.performance.generator.*
 
+@CacheableTask
 class JvmProjectGeneratorTask extends AbstractProjectGeneratorTask {
 
     @Internal
@@ -40,6 +44,7 @@ class JvmProjectGeneratorTask extends AbstractProjectGeneratorTask {
     private final Closure<List<Map<String, String>>> createExtraFields = { testProject, prefix, fileNumber -> [] }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     FileCollection testDependencies
 
     Map getTaskArgs() {

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/TemplateProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/TemplateProjectGeneratorTask.groovy
@@ -19,16 +19,22 @@ package org.gradle.testing.performance.generator.tasks
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 
 abstract class TemplateProjectGeneratorTask extends ProjectGeneratorTask {
+
     @OutputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     File destDir
 
     @InputDirectory
+    @PathSensitive(PathSensitivity.RELATIVE)
     File templateDirectory
 
     @InputDirectory
     @Optional
+    @PathSensitive(PathSensitivity.RELATIVE)
     File sharedTemplateDirectory
 
     TemplateProjectGeneratorTask() {


### PR DESCRIPTION
### Context
When testing locally this cut down template generation in half at least.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status