### PR TITLE
Add a new `MultiValueJavadocOptionFileOption` class

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/javadoc/JavadocIntegrationTest.groovy
@@ -235,6 +235,11 @@ Joe!""")
                         "b",
                         "c"
                     ])
+                    addMultiValueOption("addMultiValueOption").setValue([
+                        "a",
+                        "b",
+                        "c"
+                    ])
                     addMultilineMultiValueOption("addMultilineMultiValueOption").setValue([
                         [ "a" ],
                         [ "b", "c" ]
@@ -253,10 +258,10 @@ Joe!""")
 
         file("build/tmp/javadoc/javadoc.options").assertContents(containsNormalizedString("""-addStringsOption 'a b c'"""))
 
-        file("build/tmp/javadoc/javadoc.options").assertContents(containsNormalizedString("""-addMultilineMultiValueOption 
-'a' 
--addMultilineMultiValueOption 
-'b' 'c' """))
+        file("build/tmp/javadoc/javadoc.options").assertContents(containsNormalizedString("""-addMultiValueOption 'a' 'b' 'c'"""))
+
+        file("build/tmp/javadoc/javadoc.options").assertContents(containsNormalizedString("""-addMultilineMultiValueOption 'a'
+-addMultilineMultiValueOption 'b' 'c'"""))
     }
 
     @Issue("https://github.com/gradle/gradle/issues/1502")

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/CoreJavadocOptions.java
@@ -648,6 +648,22 @@ public abstract class CoreJavadocOptions implements MinimalJavadocOptions {
         return optionFile.addMultilineStringsOption(option);
     }
 
+    /**
+     * Adds an option that will have multiple values separated by spaces.
+     *
+     * <p>
+     * {@code addMultiValueOption("foo").setValue(["a", "b", "c"])} will produce the command-line
+     * </p>
+     * <pre>
+     *     -foo 'a' 'b' 'c'
+     * </pre>
+     * @param option command-line option
+     *
+     * @since 4.10.3
+     */
+    public JavadocOptionFileOption<List<String>> addMultiValueOption(String option) {
+        return optionFile.addMultiValueOption(option);
+    }
 
     /**
      * Adds an option that will appear multiple times to the javadoc tool. Each line can have more than one value separated by spaces.

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFile.java
@@ -143,7 +143,11 @@ public class JavadocOptionFile {
         return Cast.uncheckedCast(foundOption);
     }
 
+    public JavadocOptionFileOption<List<String>> addMultiValueOption(String option) {
+        return addOption(new MultiValueJavadocOptionFileOption(option, Lists.<String>newArrayList()));
+    }
+
     public JavadocOptionFileOption<List<List<String>>> addMultilineMultiValueOption(String option) {
-        return addOption(new MultilineMultiValueJavadocOptionFileOption(option, Lists.<List<String>>newArrayList(), " "));
+        return addOption(new MultilineMultiValueJavadocOptionFileOption(option, Lists.<List<String>>newArrayList()));
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContext.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContext.java
@@ -95,6 +95,28 @@ public class JavadocOptionFileWriterContext {
         return this;
     }
 
+    public JavadocOptionFileWriterContext writeMultiValueOption(String option, Collection<String> values) throws IOException {
+        writeOptionHeader(option);
+
+        Iterator<String> valuesIt = values.iterator();
+        while (valuesIt.hasNext()) {
+            writeValue(valuesIt.next());
+            if (valuesIt.hasNext()) {
+                write(" ");
+            }
+        }
+
+        newLine();
+        return this;
+    }
+
+    public JavadocOptionFileWriterContext writeMultilineMultiValueOption(String option, Collection<? extends Collection<String>> values) throws IOException {
+        for (Collection<String> valuesInLine : values) {
+            writeMultiValueOption(option, valuesInLine);
+        }
+        return this;
+    }
+
     public JavadocOptionFileWriterContext writePathOption(String option, Collection<File> files, String joinValuesBy) throws IOException {
         StringBuilder builder = new StringBuilder();
         Iterator<File> filesIt = files.iterator();

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/MultiValueJavadocOptionFileOption.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/internal/MultiValueJavadocOptionFileOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,22 +21,19 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.List;
 
-public class MultilineMultiValueJavadocOptionFileOption extends AbstractListJavadocOptionFileOption<List<List<String>>> {
-    protected MultilineMultiValueJavadocOptionFileOption(String option, List<List<String>> value) {
+public class MultiValueJavadocOptionFileOption extends AbstractListJavadocOptionFileOption<List<String>> {
+    protected MultiValueJavadocOptionFileOption(String option, List<String> value) {
         super(option, value, null);
     }
 
     @Override
-    public JavadocOptionFileOptionInternal<List<List<String>>> duplicate() {
-        List<List<String>> copyValues = Lists.newArrayList();
-        for (List<String> occurrence : getValue()) {
-            copyValues.add(Lists.newArrayList(occurrence));
-        }
-        return new MultilineMultiValueJavadocOptionFileOption(option, copyValues);
+    public JavadocOptionFileOptionInternal<List<String>> duplicate() {
+        List<String> duplicateValue = Lists.newArrayList(value);
+        return new MultiValueJavadocOptionFileOption(option, duplicateValue);
     }
 
     @Override
     protected void writeCollectionValue(JavadocOptionFileWriterContext writerContext) throws IOException {
-        writerContext.writeMultilineMultiValueOption(option, getValue());
+        writerContext.writeMultiValueOption(option, value);
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContextTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/JavadocOptionFileWriterContextTest.groovy
@@ -54,4 +54,23 @@ public class JavadocOptionFileWriterContextTest extends Specification {
 
         then: writer.toString() == "-key 'Hey\\${SystemProperties.instance.getLineSeparator()}Joe!'${SystemProperties.instance.getLineSeparator()}"
     }
+
+    def "writes single line multiple values"() {
+        when:
+        context.writeMultiValueOption("key", WrapUtil.toList("a\\b", "c"))
+
+        then: writer.toString() == "-key 'a\\\\b' 'c'${SystemProperties.instance.getLineSeparator()}"
+    }
+
+    def "writes multiple line multiple values"() {
+        when:
+        context.writeMultilineMultiValueOption("key",
+            WrapUtil.toList(
+                WrapUtil.toList("a\\b", "c"),
+                WrapUtil.toList("d", "e\\f")
+            )
+        )
+
+        then: writer.toString() == "-key 'a\\\\b' 'c'${SystemProperties.instance.getLineSeparator()}-key 'd' 'e\\\\f'${SystemProperties.instance.getLineSeparator()}"
+    }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/MultiValueJavadocOptionFileOptionTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/MultiValueJavadocOptionFileOptionTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.external.javadoc.internal
+
+import com.google.common.collect.Lists
+import spock.lang.Specification
+
+class MultiValueJavadocOptionFileOptionTest extends Specification {
+    private JavadocOptionFileWriterContext writerContextMock = Mock()
+    private final String optionName = "testOption"
+
+    private MultiValueJavadocOptionFileOption multiValueOption = new MultiValueJavadocOptionFileOption(optionName, Lists.<String> newArrayList())
+
+    def testWriteNullValue() throws IOException {
+        when:
+        multiValueOption.write(writerContextMock)
+
+        then:
+        0 * writerContextMock._
+    }
+
+    def writeNoneNullValue() throws IOException {
+        final String valueOne = "valueOne"
+        final String valueTwo = "valueTwo"
+
+        multiValueOption.getValue().add(valueOne)
+        multiValueOption.getValue().add(valueTwo)
+
+        when:
+        multiValueOption.write(writerContextMock)
+
+        then:
+        1 * writerContextMock.writeMultiValueOption(optionName, multiValueOption.getValue())
+    }
+}

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/MultilineMultiValueJavadocOptionFileOptionTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/internal/MultilineMultiValueJavadocOptionFileOptionTest.groovy
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.external.javadoc.internal
+
+import com.google.common.collect.Lists
+import spock.lang.Specification
+
+class MultilineMultiValueJavadocOptionFileOptionTest extends Specification {
+    private JavadocOptionFileWriterContext writerContextMock = Mock()
+    private final String optionName = "testOption"
+
+    private MultilineMultiValueJavadocOptionFileOption multilineMultiValueOption = new MultilineMultiValueJavadocOptionFileOption(optionName, Lists.<List<String>> newArrayList())
+
+    def testWriteNullValue() throws IOException {
+        when:
+        multilineMultiValueOption.write(writerContextMock)
+
+        then:
+        0 * writerContextMock._
+    }
+
+    def writeNoneNullValue() throws IOException {
+        final List<String> valueListOne = Lists.asList "valueOne-One", "valueOne-Two"
+        final List<String> valueListTwo = Lists.asList "valueTwo-One", "valueTwo-Two"
+
+        multilineMultiValueOption.getValue().add(valueListOne)
+        multilineMultiValueOption.getValue().add(valueListTwo)
+
+        when:
+        multilineMultiValueOption.write(writerContextMock)
+
+        then:
+        1 * writerContextMock.writeMultilineMultiValueOption(optionName, multilineMultiValueOption.getValue())
+    }
+}


### PR DESCRIPTION
### Context
This fix issue #6991

The current existing `MultilineMultiValueJavadocOptionFileOption` class take a `List<List<String>>` as value, and output multiple lines.
It will be a little inconvenient if we only want 1 line.

So I think it will be helpful if we add a new `MultiValueJavadocOptionFileOption` class which take a `List<String>` as value, and output only 1 line.

And also, this PR fixes a minor bug in `MultilineMultiValueJavadocOptionFileOption`, which is described [here](https://github.com/gradle/gradle/issues/6991#issuecomment-427278068)

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [X] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [X] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [X] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
