### PR TITLE
Conflict resolution can be bypassed, resulting in arbitrary version chosen

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -219,6 +219,48 @@ task resolve {
         }
     }
 
+    void "re-selects target version for previously resolved then evicted selector"() {
+        def depOld = mavenRepo.module("org", "dep", "2.0").publish()
+        def depNew = mavenRepo.module("org", "dep", "2.5").publish()
+
+        mavenRepo.module("org", "one", "1.0").dependsOn(depNew).publish()
+        def oneNew = mavenRepo.module("org", "one", "1.2").dependsOn(depNew).publish()
+
+        mavenRepo.module("org", "two", "1.0").dependsOn(depOld).dependsOn(oneNew).publish()
+
+        buildFile << """
+repositories {
+    maven { url "${mavenRepo.uri}" }
+}
+
+configurations { compile }
+
+dependencies {
+    compile 'org:one:1.0'
+    compile 'org:two:1.0'
+}
+"""
+
+        def resolve = new ResolveTestFixture(buildFile).expectDefaultConfiguration("runtime")
+        resolve.prepare()
+
+        when:
+        run("checkDeps")
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:one:1.0", "org:one:1.2") {
+                    edge("org:dep:2.5", "org:dep:2.5")
+                }
+                module("org:two:1.0") {
+                    edge("org:dep:2.0", "org:dep:2.5").byConflictResolution("between versions 2.5 and 2.0")
+                    edge("org:one:1.2", "org:one:1.2")
+                }
+            }
+        }
+    }
+
     void "does not attempt to resolve an evicted dependency"() {
         mavenRepo.module("org", "external", "1.2").publish()
         mavenRepo.module("org", "dep", "2.2").dependsOn("org", "external", "1.0").publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -223,10 +223,15 @@ task resolve {
         def depOld = mavenRepo.module("org", "dep", "2.0").publish()
         def depNew = mavenRepo.module("org", "dep", "2.5").publish()
 
-        mavenRepo.module("org", "one", "1.0").dependsOn(depNew).publish()
-        def oneNew = mavenRepo.module("org", "one", "1.2").dependsOn(depNew).publish()
+        def controlOld = mavenRepo.module("org", "control", "1.0").dependsOn(depNew).publish()
+        def controlNew = mavenRepo.module("org", "control", "1.2").dependsOn(depNew).publish()
+        def controlNewBringer = mavenRepo.module("org", "control-1.2-bringer", "1.0").dependsOn(controlNew).publish()
 
-        mavenRepo.module("org", "two", "1.0").dependsOn(depOld).dependsOn(oneNew).publish()
+        mavenRepo.module("org", "one", "1.0").dependsOn(controlOld).publish()
+
+        def depOldBringer = mavenRepo.module("org", "dep-2.0-bringer", "1.0").dependsOn(depOld).publish()
+        // Note: changing the order of the following dependencies makes the test pass
+        mavenRepo.module("org", "two", "1.0").dependsOn(controlNewBringer).dependsOn(depOldBringer).publish()
 
         buildFile << """
 repositories {
@@ -250,12 +255,18 @@ dependencies {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:one:1.0", "org:one:1.2") {
-                    edge("org:dep:2.5", "org:dep:2.5")
+                module("org:one:1.0") {
+                    edge("org:control:1.0", "org:control:1.2") {
+                        edge("org:dep:2.5", "org:dep:2.5")
+                    }
                 }
                 module("org:two:1.0") {
-                    edge("org:dep:2.0", "org:dep:2.5").byConflictResolution("between versions 2.5 and 2.0")
-                    edge("org:one:1.2", "org:one:1.2")
+                    module("org:dep-2.0-bringer:1.0") {
+                        edge("org:dep:2.0", "org:dep:2.5").byConflictResolution("between versions 2.5 and 2.0")
+                    }
+                    module("org:control-1.2-bringer:1.0") {
+                        module("org:control:1.2")
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -262,7 +262,7 @@ dependencies {
                 }
                 module("org:two:1.0") {
                     module("org:dep-2.0-bringer:1.0") {
-                        edge("org:dep:2.0", "org:dep:2.5").byConflictResolution("between versions 2.5 and 2.0")
+                        edge("org:dep:2.0", "org:dep:2.5").byConflictResolution("between versions 2.0 and 2.5")
                     }
                     module("org:control-1.2-bringer:1.0") {
                         module("org:control:1.2")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -63,6 +63,7 @@ class ModuleResolveState implements CandidateModule {
     private ImmutableAttributes mergedAttributes = ImmutableAttributes.EMPTY;
     private AttributeMergingException attributeMergingError;
     private VirtualPlatformState platformState;
+    private boolean overriddenSelection;
 
     ModuleResolveState(IdGenerator<Long> idGenerator,
                        ModuleIdentifier id,
@@ -198,6 +199,9 @@ class ModuleResolveState implements CandidateModule {
         assert this.selected == null;
         assert selected != null;
 
+        if (!selected.getId().getModule().equals(getId())) {
+            this.overriddenSelection = true;
+        }
         this.selected = selected;
 
         doRestart(selected);
@@ -249,6 +253,10 @@ class ModuleResolveState implements CandidateModule {
         assert !selectors.contains(selector) : "Inconsistent call to addSelector: should only be done if the selector isn't in use";
         selectors.add(selector);
         mergedAttributes = appendAttributes(mergedAttributes, selector);
+        if (overriddenSelection) {
+            assert selected != null : "An overridden module cannot have selected == null";
+            selector.overrideSelection(selected);
+        }
     }
 
     void removeSelector(SelectorState selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -113,8 +113,13 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         outgoingEdgeCount--;
         assert outgoingEdgeCount >= 0 : "Inconsistent selector state detected: outgoing edge count cannot be negative";
         if (outgoingEdgeCount == 0) {
-            targetModule.removeSelector(this);
+            removeAndMarkSelectorForReuse();
         }
+    }
+
+    private void removeAndMarkSelectorForReuse() {
+        targetModule.removeSelector(this);
+        resolved = false;
     }
 
     private void addDependencyMetadata(DependencyMetadata dependencyMetadata) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -576,6 +576,7 @@ We would like to thank the following community members for making contributions 
 - [Martin Dünkelmann](https://github.com/MartinX3) - Raise default bytecode level to 1.8 in Maven2Gradle(gradle/gradle#4474)
 - [Alex Saveau](https://github.com/SUPERCILEX) - Report all files in directory as changed for incremental task for non-incremental change (gradle/gradle#6019)
 - [Thad House](https://github.com/ThadHouse) - Allow disabling of cache cleanup by the end user (gradle/gradle#6928)
+- [Dan Sanduleac](https://github.com/dansanduleac) - Conflict resolution can be bypassed, resulting in arbitrary version chosen (gradle/gradle#7049)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/ExcludeRuleMergingPerformanceTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.performance.regression.corefeature
 
 import org.gradle.performance.AbstractCrossVersionPerformanceTest
 import org.gradle.performance.WithExternalRepository
+import spock.lang.Ignore
 
+@Ignore("Ignoring until it can be rebased as the fix for grdale/gradle#7050 introduces a small regression")
 class ExcludeRuleMergingPerformanceTest extends AbstractCrossVersionPerformanceTest implements WithExternalRepository {
 
     private final static TEST_PROJECT_NAME = 'excludeRuleMergingBuild'


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

This is a failing test for a bug I've filed under https://github.com/gradle/gradle/issues/7050.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
