### PR TITLE
Adjust debug code's order in DefaultExecHandle

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -178,11 +178,11 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
     private void setState(ExecHandleState state) {
         lock.lock();
         try {
-            LOGGER.debug("Changing state to: {}", state);
             this.state = state;
             this.stateChanged.signalAll();
         } finally {
             lock.unlock();
+            LOGGER.debug("Changed state to: {}", state);
         }
     }
 


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/1581

Previously, logger debug code at the beginning of DefaultExecHandle.setState()
method might cause whole Gradle daemon deadlock and stuck. This commit move
the debug code at the end and out of the lock.