### PR TITLE
Fix realization of Maven module dependencies

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencyMetadataRulesIntegrationTest.groovy
@@ -708,6 +708,10 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                     withModule('org.test:moduleA', ModifyRule)
                 }
             }
+
+            configurations.all {
+                incoming.beforeResolve { println "Resolving \$name" }
+            }
         """
         repositoryInteractions {
             'org.test:moduleA:1.0' {


### PR DESCRIPTION
### Context

We need to use the actual dependencies, not the dependencies of the whole Maven configuration.

In practice this _should_ require bumping the metadata file format. However, this is just about realization of component metadata, which is only used when caching metadata rules, which nobody is using today because of bugs, so this is a safe change.

Fixes gradle/gradle-private#1590

