### PR TITLE
Bundle JAXB into Gradle distribution and use it on Java 9 and above

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -64,6 +64,7 @@ libraries.jackson_annotations = [coordinates: 'com.fasterxml.jackson.core:jackso
 libraries.jackson_databind =    [coordinates: 'com.fasterxml.jackson.core:jackson-databind', version: libraries.jackson_core.version]
 libraries.jansi =               [coordinates: 'org.fusesource.jansi:jansi', version: '1.17.1']
 libraries.jatl =                [coordinates: 'com.googlecode.jatl:jatl', version: '0.2.3']
+libraries.jaxb =                [coordinates: 'com.sun.xml.bind:jaxb-impl', version: '2.3.1']
 libraries.jcifs =               [coordinates: 'org.samba.jcifs:jcifs', version: '1.3.17']
 libraries.jcip =                [coordinates: 'net.jcip:jcip-annotations', version: '1.0']
 libraries.jgit =                [coordinates: 'org.eclipse.jgit:org.eclipse.jgit', version: '5.0.3.201809091024-r']

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/ClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/ClassPath.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.classpath;
 
+import org.gradle.api.specs.Spec;
+
 import java.io.File;
 import java.net.URI;
 import java.net.URL;
@@ -42,4 +44,6 @@ public interface ClassPath {
     ClassPath plus(Collection<File> classPath);
 
     ClassPath plus(ClassPath classPath);
+
+    ClassPath removeIf(Spec<? super File> filter);
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classpath/DefaultClassPath.java
@@ -16,7 +16,10 @@
 
 package org.gradle.internal.classpath;
 
+import org.gradle.api.specs.NotSpec;
+import org.gradle.api.specs.Spec;
 import org.gradle.internal.UncheckedException;
+import org.gradle.util.CollectionUtils;
 
 import java.io.File;
 import java.io.Serializable;
@@ -93,10 +96,12 @@ public class DefaultClassPath implements ClassPath, Serializable {
         return files.toString();
     }
 
+    @Override
     public boolean isEmpty() {
         return files.isEmpty();
     }
 
+    @Override
     public List<URI> getAsURIs() {
         List<URI> urls = new ArrayList<URI>();
         for (File file : files) {
@@ -105,15 +110,18 @@ public class DefaultClassPath implements ClassPath, Serializable {
         return urls;
     }
 
+    @Override
     public List<File> getAsFiles() {
         return files;
     }
 
+    @Override
     public URL[] getAsURLArray() {
         Collection<URL> result = getAsURLs();
         return result.toArray(new URL[0]);
     }
 
+    @Override
     public List<URL> getAsURLs() {
         List<URL> urls = new ArrayList<URL>();
         for (File file : files) {
@@ -126,6 +134,7 @@ public class DefaultClassPath implements ClassPath, Serializable {
         return urls;
     }
 
+    @Override
     public ClassPath plus(ClassPath other) {
         if (files.isEmpty()) {
             return other;
@@ -136,11 +145,21 @@ public class DefaultClassPath implements ClassPath, Serializable {
         return new DefaultClassPath(concat(files, other.getAsFiles()));
     }
 
+    @Override
     public ClassPath plus(Collection<File> other) {
         if (other.isEmpty()) {
             return this;
         }
         return new DefaultClassPath(concat(files, other));
+    }
+
+    @Override
+    public ClassPath removeIf(Spec<? super File> filter) {
+        List<File> remainingFiles = CollectionUtils.filter(files, new NotSpec<File>(filter));
+        if (remainingFiles.size() == files.size()) {
+            return this;
+        }
+        return DefaultClassPath.of(remainingFiles);
     }
 
     private ImmutableUniqueList<File> concat(Collection<File> files1, Collection<File> files2) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classpath/DefaultClassPathTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classpath/DefaultClassPathTest.groovy
@@ -79,6 +79,36 @@ class DefaultClassPathTest extends Specification {
         (cp + []).is(cp)
     }
 
+    def "removes files based on predicate"() {
+        given:
+        def a1 = new File("a1.jar")
+        def b = new File("b.jar")
+        def a2 = new File("a2.jar")
+        def c = new File("c.jar")
+
+        when:
+        def originalClasspath = DefaultClassPath.of(a1, b, a2, c)
+        def newClasspath = originalClasspath.removeIf { it.name.startsWith("a") }
+
+        then:
+        originalClasspath.asFiles == [a1, b, a2, c]
+        newClasspath.asFiles == [b, c]
+    }
+
+    def "returns same classpath when predicate to remove does not match"() {
+        given:
+        def a = new File("a.jar")
+        def b = new File("b.jar")
+
+        when:
+        def originalClasspath = DefaultClassPath.of(a, b)
+        def newClasspath = originalClasspath.removeIf { it.name.startsWith("c") }
+
+        then:
+        originalClasspath.asFiles == [a, b]
+        newClasspath.is(originalClasspath)
+    }
+
     def "classpaths are equal when the contain the same sequence of files"() {
         def file1 = new File("a.jar")
         def file2 = new File("b.jar")

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -51,7 +51,7 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
      * Change this if you added or removed dependencies.
      */
     int getThirdPartyLibJarsCount() {
-        179
+        180
     }
 
     int getLibJarsCount() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -369,6 +369,12 @@ Several libraries that are used by Gradle have been upgraded:
 - The Maven Wagon libraries used to access Maven repositories have been upgraded from 2.4 to 3.0.0.
 - SLF4J has been upgraded from 1.7.16 to 1.7.25.
 
+### Gradle now bundles JAXB for Java 9 and above
+
+In order to use S3 backed artifact repositories, it was previously required to add `--add-modules java.xml.bind` to `org.gradle.jvmargs` when running on Java 9 and above.
+Since Java 11 no longer contains the `java.xml.bind` module, Gradle now bundles JAXB 2.3.1 (`com.sun.xml.bind:jaxb-impl`) and uses it on Java 9 and above.
+Please remove the `--add-modules java.xml.bind` option from `org.gradle.jvmargs`, if set.
+
 ### `CopySpec.duplicatesStrategy` is no longer nullable
 
 For better compatibility with the Kotlin DSL, the property setter no longer accepts `null` as a way

--- a/subprojects/resources-s3/resources-s3.gradle
+++ b/subprojects/resources-s3/resources-s3.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':resourcesHttp')
     implementation libraries.slf4j_api.coordinates
     implementation libraries.guava.coordinates
-    implementation libraries.awsS3_core.coordinates, libraries.awsS3_s3.coordinates, libraries.awsS3_kms.coordinates
+    implementation libraries.awsS3_core.coordinates, libraries.awsS3_s3.coordinates, libraries.awsS3_kms.coordinates, libraries.jaxb.coordinates
     implementation libraries.jackson_core.coordinates, libraries.jackson_annotations.coordinates, libraries.jackson_databind.coordinates
     implementation libraries.commons_httpclient.coordinates, libraries.joda.coordinates
     implementation libraries.commons_lang.coordinates
@@ -27,13 +27,6 @@ testFixtures {
 
 gradlebuildJava {
     moduleType = ModuleType.CORE
-}
-
-tasks.withType(Test).configureEach {
-    def javaVersion = rootProject.availableJavaInstallations.javaInstallationForTest.javaVersion
-    if (javaVersion.java9Compatible) {
-        jvmArgs '--add-modules', 'java.xml.bind'
-    }
 }
 
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/S3ClientIntegrationTest.groovy
@@ -34,9 +34,10 @@ import org.gradle.internal.resource.transport.aws.s3.S3Client
 import org.gradle.internal.resource.transport.aws.s3.S3ConnectionProperties
 import org.gradle.internal.resource.transport.aws.s3.S3RegionalResource
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Ignore
-import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -63,7 +64,7 @@ class S3ClientIntegrationTest extends Specification {
     }
 
     @Unroll
-    @Issue("Currently the 'javax.xml.bind' jigsaw module is not automatically required on the Gradle Jvm")
+    @Requires(TestPrecondition.JDK9_OR_LATER)
     def "should perform #authenticationType put get and list on an S3 bucket"() {
         setup:
         def fileContents = 'This is only a test'

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/S3IntegrationTestPrecondition.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/fixtures/S3IntegrationTestPrecondition.groovy
@@ -16,18 +16,14 @@
 
 package org.gradle.integtests.resource.s3.fixtures
 
-import groovy.transform.CompileStatic
-import groovy.transform.SelfType
-import org.gradle.api.JavaVersion
-import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
-@CompileStatic
-@SelfType(AbstractIntegrationSpec)
-trait AddJavaXmBindModulesTrait {
-    def addJavaXmlBindModuleIfNecessary() {
-        if (!GradleContextualExecuter.embedded && JavaVersion.current().isJava9Compatible()) {
-            executer.withBuildJvmOpts('--add-modules', 'java.xml.bind')
-        }
+import static org.gradle.util.TestPrecondition.JDK9_OR_LATER
+
+class S3IntegrationTestPrecondition {
+
+    static boolean isFulfilled() {
+        JDK9_OR_LATER.fulfilled || !GradleContextualExecuter.embedded
     }
+
 }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyPublishS3IntegrationTest.groovy
@@ -17,16 +17,17 @@
 package org.gradle.integtests.resource.s3.ivy
 
 import org.gradle.api.publish.ivy.AbstractIvyPublishIntegTest
-import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
+import org.gradle.integtests.resource.s3.fixtures.S3IntegrationTestPrecondition
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.junit.Rule
+import spock.lang.Requires
 
-class IvyPublishS3IntegrationTest extends AbstractIvyPublishIntegTest implements AddJavaXmBindModulesTrait{
+@Requires({ S3IntegrationTestPrecondition.fulfilled })
+class IvyPublishS3IntegrationTest extends AbstractIvyPublishIntegTest {
     @Rule
     public S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
-        addJavaXmlBindModuleIfNecessary()
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.getUri()}")
     }
 

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3UploadArchivesIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/ivy/IvyS3UploadArchivesIntegrationTest.groovy
@@ -17,12 +17,14 @@
 package org.gradle.integtests.resource.s3.ivy
 
 import org.gradle.api.publish.ivy.AbstractIvyRemoteLegacyPublishIntegrationTest
-import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
+import org.gradle.integtests.resource.s3.fixtures.S3IntegrationTestPrecondition
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.gradle.test.fixtures.server.RepositoryServer
 import org.junit.Rule
+import spock.lang.Requires
 
-class IvyS3UploadArchivesIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest implements AddJavaXmBindModulesTrait{
+@Requires({ S3IntegrationTestPrecondition.fulfilled })
+class IvyS3UploadArchivesIntegrationTest extends AbstractIvyRemoteLegacyPublishIntegrationTest {
     @Rule
     public S3Server server = new S3Server(temporaryFolder)
 
@@ -32,7 +34,6 @@ class IvyS3UploadArchivesIntegrationTest extends AbstractIvyRemoteLegacyPublishI
     }
 
     def setup() {
-        addJavaXmlBindModuleIfNecessary()
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.uri}")
     }
 }

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3ErrorsIntegrationTest.groovy
@@ -18,12 +18,11 @@
 package org.gradle.integtests.resource.s3.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
-import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
 import org.gradle.integtests.resource.s3.fixtures.MavenS3Repository
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.junit.Rule
 
-class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest implements AddJavaXmBindModulesTrait {
+class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest {
 
     String mavenVersion = "1.45"
     String projectName = "publishS3Test"
@@ -34,7 +33,6 @@ class MavenPublishS3ErrorsIntegrationTest extends AbstractMavenPublishIntegTest 
     public final S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
-        addJavaXmlBindModuleIfNecessary()
         disableModuleMetadataPublishing()
         executer.withArgument('-i')
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.uri}")

--- a/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3IntegrationTest.groovy
+++ b/subprojects/resources-s3/src/integTest/groovy/org/gradle/integtests/resource/s3/maven/MavenPublishS3IntegrationTest.groovy
@@ -17,18 +17,19 @@
 package org.gradle.integtests.resource.s3.maven
 
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
-import org.gradle.integtests.resource.s3.fixtures.AddJavaXmBindModulesTrait
 import org.gradle.integtests.resource.s3.fixtures.MavenS3Repository
 import org.gradle.integtests.resource.s3.fixtures.S3Artifact
+import org.gradle.integtests.resource.s3.fixtures.S3IntegrationTestPrecondition
 import org.gradle.integtests.resource.s3.fixtures.S3Server
 import org.junit.Rule
+import spock.lang.Requires
 
-class MavenPublishS3IntegrationTest extends AbstractMavenPublishIntegTest implements AddJavaXmBindModulesTrait {
+@Requires({ S3IntegrationTestPrecondition.fulfilled })
+class MavenPublishS3IntegrationTest extends AbstractMavenPublishIntegTest {
     @Rule
     public S3Server server = new S3Server(temporaryFolder)
 
     def setup() {
-        addJavaXmlBindModuleIfNecessary()
         executer.withArgument("-Dorg.gradle.s3.endpoint=${server.getUri()}")
         .withArgument("-Daws.accessKeyId=someKey")
         .withArgument("-Daws.secretKey=someSecret");

--- a/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
+++ b/subprojects/resources-s3/src/main/java/org/gradle/internal/resource/transport/aws/s3/S3Client.java
@@ -38,9 +38,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
-import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
-import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.repositories.PasswordCredentials;
 import org.gradle.api.credentials.AwsCredentials;
 import org.gradle.internal.resource.ResourceExceptions;
@@ -96,17 +94,6 @@ public class S3Client {
         amazonS3Client.setS3ClientOptions(clientOptionsBuilder.build());
     }
 
-    private void checkRequiredJigsawModuleIsOnPath() {
-        if (JavaVersion.current().isJava9Compatible()) {
-            try {
-                Class.forName("javax.xml.bind.DatatypeConverter");
-            } catch (ClassNotFoundException e) {
-                throw new GradleException("Cannot publish to S3 since the module 'java.xml.bind' is not available. "
-                    + "Please add \"--add-modules java.xml.bind '-Dorg.gradle.jvmargs=--add-modules java.xml.bind'\" to your GRADLE_OPTS.");
-            }
-        }
-    }
-
     private ClientConfiguration createConnectionProperties() {
         ClientConfiguration clientConfiguration = new ClientConfiguration();
         Optional<HttpProxySettings.HttpProxy> proxyOptional = s3ConnectionProperties.getProxy();
@@ -128,7 +115,6 @@ public class S3Client {
     }
 
     public void put(InputStream inputStream, Long contentLength, URI destination) {
-        checkRequiredJigsawModuleIsOnPath();
         try {
             S3RegionalResource s3RegionalResource = new S3RegionalResource(destination);
             String bucketName = s3RegionalResource.getBucketName();


### PR DESCRIPTION
In order to use S3 backed artifact repositories, it was previously
required to configure `--add-modules java.xml.bind` and
`'-Dorg.gradle.jvmargs=--add-modules java.xml.bind'` in `GRADLE_OPTS`
when running on Java 9 and above. Since Java 11 no longer contains the
`java.xml.bind` module, Gradle now bundles JAXB 2.3.1
(`com.sun.xml.bind:jaxb-impl`) and uses it on Java 9 and above.