### PR TITLE
Clear remaining edges when module is pending again

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -1678,8 +1678,8 @@ task checkDeps(dependsOn: configurations.compile) {
 
     }
 
-    @Unroll
-    def 'optional dependency marked as no longer pending reverts to pending if hard edge disappears (remover depends on optional #dependsOptional)'() {
+    @Unroll('optional dependency marked as no longer pending reverts to pending if hard edge disappears (remover has constraint: #dependsOptional, root has constraint: #constraintsOptional)')
+    def 'optional dependency marked as no longer pending reverts to pending if hard edge disappears (remover has constraint: #dependsOptional, root has constraint: #constraintsOptional)'() {
         given:
         def optional = mavenRepo.module('org', 'optional', '1.0').publish()
         def main = mavenRepo.module('org', 'main', '1.0').dependsOn(optional, optional: true).publish()
@@ -1708,6 +1708,9 @@ dependencies {
     implementation platform('org:bom:1.0')
     constraints {
         implementation 'org.a:root:1.0'
+        if ($constraintsOptional) {
+            implementation 'org:optional:1.0'
+        }
     }
 }
 """
@@ -1718,7 +1721,11 @@ dependencies {
         outputDoesNotContain('org:optional')
 
         where:
-        dependsOptional << [true, false]
+        dependsOptional | constraintsOptional
+        true            | true
+        true            | false
+        false           | true
+        false           | false
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -308,6 +308,15 @@ class ModuleResolveState implements CandidateModule {
 
     void decreaseHardEdgeCount() {
         pendingDependencies.decreaseHardEdgeCount();
+        if (pendingDependencies.isPending()) {
+            // Back to being a pending dependency
+            // Clear remaining incoming edges, as they must be all from constraints
+            if (selected != null) {
+                for (NodeState node : selected.getNodes()) {
+                    node.clearConstraintEdges(pendingDependencies);
+                }
+            }
+        }
     }
 
     boolean isPending() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -466,4 +466,19 @@ class NodeState implements DependencyGraphNode {
         return resolveState.getAttributesFactory();
     }
 
+    /**
+     * Invoked when this node is back to being a pending dependency.
+     * There may be some incoming edges left at that point, but they must all be coming from constraints.
+     * @param pendingDependencies
+     */
+    public void clearConstraintEdges(PendingDependencies pendingDependencies) {
+        for (EdgeState incomingEdge : incomingEdges) {
+            assert incomingEdge.getDependencyMetadata().isConstraint();
+            incomingEdge.getSelector().release();
+            NodeState from = incomingEdge.getFrom();
+            from.getOutgoingEdges().remove(incomingEdge);
+            pendingDependencies.addNode(from);
+        }
+        incomingEdges.clear();
+    }
 }


### PR DESCRIPTION
When a module moves back to pending - aka no hard edges left to it - we
were not removing the remaining constraint edges that could point to it.
We can simply clear these edges and not restart their origin as we know
the scope of the change is only about dropping constraints.