### PR TITLE
Do not use local `.m2` repository when running integration tests

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -77,6 +77,10 @@ class AbstractIntegrationSpec extends Specification {
     private MavenFileRepository mavenRepo
     private IvyFileRepository ivyRepo
 
+    def setup() {
+        m2.isolateMavenLocalRepo(executer)
+    }
+
     def cleanup() {
         executer.cleanup()
     }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/SamplesMavenPublishIntegrationTest.groovy
@@ -48,6 +48,8 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @UsesSample("maven-publish/quickstart")
     def quickstartPublishLocal() {
+        using m2
+        
         given:
         executer.beforeExecute m2
         def localModule = m2.mavenRepo().module("org.gradle.sample", "quickstart", "1.0")
@@ -119,6 +121,8 @@ class SamplesMavenPublishIntegrationTest extends AbstractSampleIntegrationTest {
 
     @UsesSample("maven-publish/conditional-publishing")
     def conditionalPublishing() {
+        using m2
+
         given:
         sample sampleProject
 


### PR DESCRIPTION
Some integration tests expect that metadata is missing from `.m2`.
In practice we have something to avoid that `.m2` leaks on CI, but
nothing for local development. It appears it's pretty simple to
break integration tests because of the accidental presence of a
component in your local .m2 repository. This commit makes sure
that we isolate by default on all integration tests.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
