### PR TITLE
Avoid holding lock when changing log level

### DIFF
--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClientsManager.java
@@ -53,7 +53,7 @@ public class WorkerDaemonClientsManager implements Stoppable {
     private final OutputEventListener logLevelChangeEventListener;
     private final WorkerDaemonExpiration workerDaemonExpiration;
     private final MemoryManager memoryManager;
-    private LogLevel currentLogLevel;
+    private volatile LogLevel currentLogLevel;
 
     public WorkerDaemonClientsManager(WorkerDaemonStarter workerDaemonStarter, ListenerManager listenerManager, LoggingManagerInternal loggingManager, MemoryManager memoryManager) {
         this.workerDaemonStarter = workerDaemonStarter;
@@ -183,9 +183,7 @@ public class WorkerDaemonClientsManager implements Stoppable {
         public void onOutput(OutputEvent event) {
             if (event instanceof LogLevelChangeEvent) {
                 LogLevelChangeEvent logLevelChangeEvent = (LogLevelChangeEvent) event;
-                synchronized (lock) {
-                    currentLogLevel = logLevelChangeEvent.getNewLogLevel();
-                }
+                currentLogLevel = logLevelChangeEvent.getNewLogLevel();
             }
         }
     }


### PR DESCRIPTION
See https://github.com/gradle/gradle-private/issues/1581 and discussion in https://github.com/gradle/gradle/pull/7062

Previously, holding the lock while changing `currentLogLevel` might cause deadlock
in daemon process. This commit uses volatile instead of synchronized block.
