### PR TITLE
Validate repositories also when requesting a RepositoryDescriptor

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -196,6 +196,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
 
     @Override
     protected RepositoryDescriptor createDescriptor() {
+        validate();
         return new MavenRepositoryDescriptor.Builder(getName(), getUrl())
             .setAuthenticated(getConfiguredCredentials() != null)
             .setAuthenticationSchemes(getAuthenticationSchemes())
@@ -204,13 +205,16 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
             .create();
     }
 
-    protected MavenResolver createRealResolver() {
+    private void validate() {
         URI rootUri = getUrl();
         if (rootUri == null) {
             throw new InvalidUserDataException("You must specify a URL for a Maven repository.");
         }
+    }
 
-        MavenResolver resolver = createResolver(rootUri);
+    protected MavenResolver createRealResolver() {
+        validate();
+        MavenResolver resolver = createResolver(getUrl());
 
         for (URI repoUrl : getArtifactUrls()) {
             resolver.addArtifactLocation(repoUrl);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/UrlRepositoryDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/descriptor/UrlRepositoryDescriptor.java
@@ -54,7 +54,9 @@ abstract class UrlRepositoryDescriptor extends RepositoryDescriptor {
 
     @Override
     protected void addProperties(ImmutableSortedMap.Builder<String, Object> builder) {
-        builder.put(Property.URL.name(), url);
+        if (url != null) {
+            builder.put(Property.URL.name(), url);
+        }
         builder.put(Property.METADATA_SOURCES.name(), metadataSources);
         builder.put(Property.AUTHENTICATED.name(), authenticated);
         builder.put(Property.AUTHENTICATION_SCHEMES.name(), authenticationSchemes);


### PR DESCRIPTION
### Context
The build scan plugin captures information about repositories via a RepositoryDescriptor, generated from the repo properties.
Those properties were not validated (like when creating a resolver for a given repo)
This PR makes the same validation that occurs when requesting a resolver also happen when requesting a RepositoryDescriptor.