### PR TITLE
Do not use snapshot Groovy versions in tests

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/RepoScriptBlockUtil.groovy
@@ -21,11 +21,11 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.test.fixtures.dsl.GradleDsl
 
-import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
-import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 import static org.gradle.api.artifacts.ArtifactRepositoryContainer.GOOGLE_URL
 import static org.gradle.api.artifacts.ArtifactRepositoryContainer.MAVEN_CENTRAL_URL
 import static org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler.BINTRAY_JCENTER_URL
+import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
+import static org.gradle.test.fixtures.dsl.GradleDsl.KOTLIN
 
 @CompileStatic
 class RepoScriptBlockUtil {
@@ -64,8 +64,7 @@ class RepoScriptBlockUtil {
         GRADLE_LIB_SNAPSHOTS('https://repo.gradle.org/gradle/libs-snapshots', System.getProperty('org.gradle.integtest.mirrors.gradle'), 'maven'),
         GRADLE_JAVASCRIPT('https://repo.gradle.org/gradle/javascript-public', System.getProperty('org.gradle.integtest.mirrors.gradlejavascript'), 'maven'),
         KOTLIN_EAP('https://dl.bintray.com/kotlin/kotlin-eap/', System.getProperty('org.gradle.integtest.mirrors.kotlineap'), 'maven'),
-        KOTLIN_DEV('https://dl.bintray.com/kotlin/kotlin-dev/', System.getProperty('org.gradle.integtest.mirrors.kotlindev'), 'maven'),
-        GROOVY_SNAPSHOTS('https://oss.jfrog.org/artifactory/oss-snapshot-local', System.getProperty('org.gradle.integtest.mirrors.groovy-snapshots'), 'maven')
+        KOTLIN_DEV('https://dl.bintray.com/kotlin/kotlin-dev/', System.getProperty('org.gradle.integtest.mirrors.kotlindev'), 'maven')
 
         String originalUrl
         String mirrorUrl
@@ -169,10 +168,6 @@ class RepoScriptBlockUtil {
 
     static String gradlePluginRepositoryDefinition(GradleDsl dsl = GROOVY) {
         MirroredRepository.GRADLE_PLUGIN.getRepositoryDefinition(dsl)
-    }
-
-    static String groovySnapshotsRepositoryDefinition(GradleDsl dsl = GROOVY) {
-        MirroredRepository.GROOVY_SNAPSHOTS.getRepositoryDefinition(dsl)
     }
 
     static File createMirrorInitScript() {

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocIntegrationTest.groovy
@@ -23,8 +23,6 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.testing.fixture.GroovyCoverage
 import spock.lang.Issue
 
-import static org.gradle.testing.fixture.GroovyCoverage.groovySnapshotRepository
-
 @TargetCoverage({GroovyCoverage.SUPPORTS_GROOVYDOC})
 class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
 
@@ -33,7 +31,6 @@ class GroovyDocIntegrationTest extends MultiVersionIntegrationSpec {
             apply plugin: "groovy"
 
             ${mavenCentralRepository()}
-            ${groovySnapshotRepository(version)}
 
             dependencies {
                 compile "org.codehaus.groovy:groovy:${version}"

--- a/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocStampsIntegrationTest.groovy
+++ b/subprojects/language-groovy/src/integTest/groovy/org/gradle/groovy/GroovyDocStampsIntegrationTest.groovy
@@ -20,8 +20,6 @@ import org.gradle.integtests.fixtures.MultiVersionIntegrationSpec
 import org.gradle.integtests.fixtures.TargetCoverage
 import org.gradle.testing.fixture.GroovyCoverage
 
-import static org.gradle.testing.fixture.GroovyCoverage.groovySnapshotRepository
-
 @TargetCoverage({GroovyCoverage.SUPPORTS_TIMESTAMP})
 class GroovyDocStampsIntegrationTest extends MultiVersionIntegrationSpec {
 
@@ -31,7 +29,6 @@ class GroovyDocStampsIntegrationTest extends MultiVersionIntegrationSpec {
             apply plugin: "groovy"
 
             ${mavenCentralRepository()}
-            ${groovySnapshotRepository(version)}
 
             dependencies {
                 compile "org.codehaus.groovy:groovy:${version}"

--- a/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
+++ b/subprojects/language-groovy/src/testFixtures/groovy/org/gradle/testing/fixture/GroovyCoverage.groovy
@@ -16,42 +16,33 @@
 
 package org.gradle.testing.fixture
 
-import org.gradle.integtests.fixtures.RepoScriptBlockUtil
-import org.gradle.test.fixtures.dsl.GradleDsl
+
 import org.gradle.util.VersionNumber
 
-import static org.gradle.test.fixtures.dsl.GradleDsl.GROOVY
-
 class GroovyCoverage {
-    final static String NEWEST = GroovySystem.version
+    private static final String[] PREVIOUS = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15']
+    static final String[] ALL
 
-    final static String[] ALL = ['1.5.8', '1.6.9', '1.7.11', '1.8.8', '2.0.5', '2.1.9', '2.2.2', '2.3.10', '2.4.15', NEWEST]
+    private static final MINIMUM_WITH_GROOVYDOC_SUPPORT = VersionNumber.parse("1.6.9")
+    static final String[] SUPPORTS_GROOVYDOC
 
-    private final static List<VersionNumber> ALL_VERSIONS = ALL.collect { VersionNumber.parse(it) }
+    private static final MINIMUM_WITH_TIMESTAMP_SUPPORT = VersionNumber.parse("2.4.6")
+    static final String[] SUPPORTS_TIMESTAMP
 
-    final static String[] SUPPORTS_GROOVYDOC = ALL_VERSIONS.findAll {
-        it >= VersionNumber.parse("1.6.9")
-    }.collect {
-        it.toString()
-    }
+    static {
+        def allVersions = [*PREVIOUS]
 
-    final static String[] SUPPORTS_TIMESTAMP = ALL_VERSIONS.findAll {
-        it >= VersionNumber.parse("2.4.6")
-    }.collect {
-        it.toString()
-    }
-
-    /**
-     * Returns configuration DSL to set up the Groovy snapshot if a snapshot version is requested.
-     */
-    static String groovySnapshotRepository(GradleDsl dsl = GROOVY, def version) {
-        if (!version.toString().endsWith("-SNAPSHOT")) {
-            return ""
+        // Only test current Groovy version if it isn't a SNAPSHOT
+        if (!GroovySystem.version.endsWith("-SNAPSHOT")) {
+            allVersions += GroovySystem.version
         }
-        return """
-            repositories {
-                ${RepoScriptBlockUtil.groovySnapshotsRepositoryDefinition(dsl)}
-            }
-        """
+
+        ALL = allVersions
+        SUPPORTS_GROOVYDOC = allVersions.findAll {
+            VersionNumber.parse(it) >= MINIMUM_WITH_GROOVYDOC_SUPPORT
+        }
+        SUPPORTS_TIMESTAMP = allVersions.findAll {
+            VersionNumber.parse(it) >= MINIMUM_WITH_TIMESTAMP_SUPPORT
+        }
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -30,8 +30,6 @@ import org.junit.Rule
 import spock.lang.Ignore
 import spock.lang.Issue
 
-import static org.gradle.testing.fixture.GroovyCoverage.groovySnapshotRepository
-
 @TargetCoverage({GroovyCoverage.ALL})
 abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegrationSpec {
     @Rule
@@ -47,7 +45,6 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         // necessary for picking up some of the output/errorOutput when forked executer is used
         executer.withArgument("-i")
         executer.withRepositoryMirrors()
-        buildFile << groovySnapshotRepository(version)
     }
 
     def "compileGoodCode"() {
@@ -401,7 +398,6 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         buildScript """
             apply plugin: 'groovy'
             ${mavenCentralRepository()}
-            ${groovySnapshotRepository(version)}
         """
 
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/DaemonGroovyCompilerIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/DaemonGroovyCompilerIntegrationTest.groovy
@@ -19,7 +19,6 @@ import org.gradle.integtests.fixtures.AvailableJavaHomes
 import org.gradle.internal.jvm.Jvm
 import org.junit.Assume
 
-import static org.gradle.testing.fixture.GroovyCoverage.groovySnapshotRepository
 import static org.gradle.util.TextUtil.normaliseFileSeparators
 
 class DaemonGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSpec {
@@ -38,7 +37,6 @@ class DaemonGroovyCompilerIntegrationTest extends ApiGroovyCompilerIntegrationSp
 
             apply plugin: "groovy"
             ${mavenCentralRepository()}
-            ${groovySnapshotRepository(version)}
             tasks.withType(GroovyCompile) {
                 options.forkOptions.executable = "${differentJavacExecutablePath}"
                 options.forkOptions.memoryInitialSize = "128m"


### PR DESCRIPTION
When we depend on a SNAPSHOT version of Groovy, we shouldn't run tests that need to download Groovy versions with that SNAPSHOT version. This is to prevent us from bumping into problems with how Groovy snapshots are published.
