### PR TITLE
Prevent Groovy illegal access warnings

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -186,6 +186,14 @@ fun Project.applyGroovyProjectConventions() {
         inputs.property("javaInstallation", "$vendor ${JavaVersion.current()}")
     }
 
+    tasks.withType<Test>().configureEach {
+        //allow embedded executer to modify environment variables
+        jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
+        //allow embedded executer to inject legacy types into the system classloader
+        jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
+        jvmArgs("--illegal-access=deny")
+    }
+
     val compileGroovy: TaskProvider<GroovyCompile> = tasks.withType(GroovyCompile::class.java).named("compileGroovy")
 
     configurations {

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -198,6 +198,8 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
             if (javaInstallationForTest.javaVersion.isJava9Compatible) {
                 //allow embedded executer to modify environment variables
                 jvmArgs("--add-opens", "java.base/java.util=ALL-UNNAMED")
+                //allow embedded executer to inject legacy types into the system classloader
+                jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
             }
             // Includes JVM vendor and major version
             inputs.property("javaInstallation", Callable { javaInstallationForTest.vendorAndMajorVersion })

--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/VisitableURLClassLoader.java
@@ -54,6 +54,11 @@ public class VisitableURLClassLoader extends URLClassLoader implements ClassLoad
     }
 
     @Override
+    public void addURL(URL url) {
+        super.addURL(url);
+    }
+
+    @Override
     public String toString() {
         return VisitableURLClassLoader.class.getSimpleName() + "(" + name + ")";
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsWorkarounds.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/jvm/GroovyJpmsWorkarounds.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.jvm;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class GroovyJpmsWorkarounds {
+    /**
+     * These JVM arguments should be passed to any process that will be using Groovy on Java 9+ to avoid noisy illegal access warnings that the user can't do anything about.
+     */
+    public static final List<String> SUPPRESS_COMMON_GROOVY_WARNINGS = Collections.unmodifiableList(Arrays.asList(
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang.invoke=ALL-UNNAMED"
+    ));
+}

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/GroovyCompilerFactory.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetec
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.GroovyCompileOptions;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.compile.CompilerFactory;
 import org.gradle.process.internal.DefaultExecActionFactory;
@@ -40,13 +41,15 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
     private final IsolatedClassloaderWorkerFactory inProcessWorkerFactory;
     private final PathToFileResolver fileResolver;
     private AnnotationProcessorDetector processorDetector;
+    private final JvmVersionDetector jvmVersionDetector;
 
-    public GroovyCompilerFactory(ProjectInternal project, WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, PathToFileResolver fileResolver, AnnotationProcessorDetector processorDetector) {
+    public GroovyCompilerFactory(ProjectInternal project, WorkerDaemonFactory workerDaemonFactory, IsolatedClassloaderWorkerFactory inProcessWorkerFactory, PathToFileResolver fileResolver, AnnotationProcessorDetector processorDetector, JvmVersionDetector jvmVersionDetector) {
         this.project = project;
         this.workerDaemonFactory = workerDaemonFactory;
         this.inProcessWorkerFactory = inProcessWorkerFactory;
         this.fileResolver = fileResolver;
         this.processorDetector = processorDetector;
+        this.jvmVersionDetector = jvmVersionDetector;
     }
 
     @Override
@@ -58,7 +61,7 @@ public class GroovyCompilerFactory implements CompilerFactory<GroovyJavaJointCom
         } else {
             workerFactory = inProcessWorkerFactory;
         }
-        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(project.getServices().get(WorkerDirectoryProvider.class).getIdleWorkingDirectory(), new DaemonSideCompiler(), project.getServices().get(ClassPathRegistry.class), workerFactory, fileResolver);
+        Compiler<GroovyJavaJointCompileSpec> groovyCompiler = new DaemonGroovyCompiler(project.getServices().get(WorkerDirectoryProvider.class).getIdleWorkingDirectory(), new DaemonSideCompiler(), project.getServices().get(ClassPathRegistry.class), workerFactory, fileResolver, jvmVersionDetector);
         return new AnnotationProcessorDiscoveringCompiler<GroovyJavaJointCompileSpec>(new NormalizingGroovyCompiler(groovyCompiler), processorDetector);
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -43,6 +43,7 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.jvm.toolchain.JavaToolChain;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.GFileUtils;
@@ -84,7 +85,8 @@ public class GroovyCompile extends AbstractCompile {
             IsolatedClassloaderWorkerFactory inProcessWorkerFactory = getServices().get(IsolatedClassloaderWorkerFactory.class);
             PathToFileResolver fileResolver = getServices().get(PathToFileResolver.class);
             AnnotationProcessorDetector processorDetector = getServices().get(AnnotationProcessorDetector.class);
-            GroovyCompilerFactory groovyCompilerFactory = new GroovyCompilerFactory(projectInternal, workerDaemonFactory, inProcessWorkerFactory, fileResolver, processorDetector);
+            JvmVersionDetector jvmVersionDetector = getServices().get(JvmVersionDetector.class);
+            GroovyCompilerFactory groovyCompilerFactory = new GroovyCompilerFactory(projectInternal, workerDaemonFactory, inProcessWorkerFactory, fileResolver, processorDetector, jvmVersionDetector);
             Compiler<GroovyJavaJointCompileSpec> delegatingCompiler = groovyCompilerFactory.newCompiler(spec);
             compiler = new CleaningGroovyCompiler(delegatingCompiler, getOutputs());
         }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -19,6 +19,7 @@ import com.google.common.collect.ImmutableList;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.IdentityFileResolver;
 import org.gradle.initialization.BuildLayoutParameters;
+import org.gradle.internal.jvm.GroovyJpmsWorkarounds;
 import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.util.GUtil;
@@ -123,6 +124,7 @@ public class DaemonParameters {
     public void applyDefaultsFor(JavaVersion javaVersion) {
         if (javaVersion.compareTo(JavaVersion.VERSION_1_9) >= 0) {
             jvmOptions.jvmArgs(ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE);
+            jvmOptions.jvmArgs(GroovyJpmsWorkarounds.SUPPRESS_COMMON_GROOVY_WARNINGS);
         }
         if (hasJvmArgs) {
             return;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/DefaultPayloadClassLoaderRegistry.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/serialization/DefaultPayloadClassLoaderRegistry.java
@@ -24,13 +24,11 @@ import org.gradle.internal.classloader.ClassLoaderSpec;
 import org.gradle.internal.classloader.ClassLoaderVisitor;
 import org.gradle.internal.classloader.SystemClassLoaderSpec;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
-import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.util.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +99,7 @@ public class DefaultPayloadClassLoaderRegistry implements PayloadClassLoaderRegi
             Set<URL> currentClassPath = ImmutableSet.copyOf(urlClassLoader.getURLs());
             for (URL url : spec.getClasspath()) {
                 if (!currentClassPath.contains(url)) {
-                    JavaReflectionUtil.method(URLClassLoader.class, Void.class, "addURL", URL.class).invoke(urlClassLoader, url);
+                    urlClassLoader.addURL(url);
                 }
             }
         }

--- a/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/BootstrapSecurityManagerTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/process/internal/worker/child/BootstrapSecurityManagerTest.groovy
@@ -18,13 +18,16 @@ package org.gradle.process.internal.worker.child
 
 import org.gradle.process.internal.streams.EncodedStream
 import org.gradle.util.RedirectStdIn
+import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
+import org.gradle.util.TestPrecondition
 import org.junit.Rule
 import spock.lang.Specification
 
 import java.security.AllPermission
 import java.security.Permission
 
+@Requires(TestPrecondition.JDK8_OR_EARLIER)
 class BootstrapSecurityManagerTest extends Specification {
     @Rule SetSystemProperties systemProperties
     @Rule RedirectStdIn stdIn


### PR DESCRIPTION
Start all processes that are likely to use Groovy with the
necessary --add-opens arguments to avoid noisy warnings that
our users can't do anything about.

Fixes #6725