### PR TITLE
Move the project registration earlier in the Gradle execution

### DIFF
--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultNestedBuild.java
@@ -16,12 +16,12 @@
 
 package org.gradle.composite.internal;
 
-import org.gradle.api.Project;
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.component.BuildIdentifier;
+import org.gradle.api.initialization.Settings;
 import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.InternalAction;
 import org.gradle.api.internal.SettingsInternal;
 import org.gradle.initialization.GradleLauncher;
 import org.gradle.initialization.NestedBuildFactory;
@@ -77,10 +77,10 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
         try {
             gradleLauncher.getGradle().setIdentityPath(getCurrentPrefixForProjectsInChildBuilds());
             final GradleInternal gradle = buildController.getGradle();
-            gradle.rootProject(new InternalAction<Project>() {
+            gradle.settingsEvaluated(new Action<Settings>() {
                 @Override
-                public void execute(Project rootProject) {
-                    settings = gradle.getSettings();
+                public void execute(Settings settings) {
+                    DefaultNestedBuild.this.settings = (SettingsInternal)settings;
                     buildStateListener.projectsKnown(DefaultNestedBuild.this);
                 }
             });
@@ -110,6 +110,6 @@ class DefaultNestedBuild extends AbstractBuildState implements StandAloneNestedB
 
     @Override
     public Path getIdentityPathForProject(Path projectPath) {
-        return getLoadedSettings().getGradle().getRootProject().getProjectRegistry().getProject(projectPath.getPath()).getIdentityPath();
+        return getLoadedSettings().getGradle().getIdentityPath();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildOperationCrossProjectConfigurator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/BuildOperationCrossProjectConfigurator.java
@@ -46,30 +46,25 @@ public class BuildOperationCrossProjectConfigurator implements CrossProjectConfi
 
     @Override
     public void subprojects(Iterable<Project> projects, Action<? super Project> configureAction) {
-        runBlockConfigureAction(BlockConfigureBuildOperation.SUBPROJECTS_DETAILS, projects, configureAction, true);
+        runBlockConfigureAction(BlockConfigureBuildOperation.SUBPROJECTS_DETAILS, projects, configureAction);
     }
 
     @Override
     public void allprojects(Iterable<Project> projects, Action<? super Project> configureAction) {
-        runBlockConfigureAction(BlockConfigureBuildOperation.ALLPROJECTS_DETAILS, projects, configureAction, true);
+        runBlockConfigureAction(BlockConfigureBuildOperation.ALLPROJECTS_DETAILS, projects, configureAction);
     }
 
     @Override
     public Project rootProject(Project project, Action<Project> buildOperationExecutor) {
-        // TODO We don't fire rootProject blocks with the project mutation lock because they fire in projectsLoaded which is too early for the project to be registerd in ProjectRegistry
-        runBlockConfigureAction(BlockConfigureBuildOperation.ROOT_PROJECT_DETAILS, Collections.singleton(project), buildOperationExecutor, false);
+        runBlockConfigureAction(BlockConfigureBuildOperation.ROOT_PROJECT_DETAILS, Collections.singleton(project), buildOperationExecutor);
         return project;
     }
 
-    private void runBlockConfigureAction(final BuildOperationDescriptor.Builder details, final Iterable<Project> projects, final Action<? super Project> configureAction, final boolean withMutationLock) {
+    private void runBlockConfigureAction(final BuildOperationDescriptor.Builder details, final Iterable<Project> projects, final Action<? super Project> configureAction) {
         buildOperationExecutor.run(new BlockConfigureBuildOperation(details, projects) {
             @Override
             protected void doRunProjectConfigure(Project project) {
-                if (withMutationLock) {
-                    runProjectConfigureActionWithMutationLock(project, configureAction);
-                } else {
-                    runProjectConfigureAction(project, configureAction);
-                }
+                runProjectConfigureActionWithMutationLock(project, configureAction);
             }
         });
     }


### PR DESCRIPTION
Previously, the project registration was depending on the initialization
of the root project in order to get the identity path. The identity path
is now queried from the settings object.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native/issues/858

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fcore%2Fmove-project-registration-earlier)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
