### PR TITLE
Update left nav to link to new publishing chapter

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -184,7 +184,7 @@
                 </ul>
             </li>
             <li><p></p></li>
-            <li><a href="/userguide/artifact_management.html">Publishing Artifacts</a></li>
+            <li><a href="/userguide/publishing_overview.html">Artifact Publishing</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#cpp-projects" aria-expanded="false" aria-controls="cpp-projects">C++ Projects</a>
                 <ul id="cpp-projects">
                     <li><a href="/userguide/native_software.html">Building Native Software</a></li>


### PR DESCRIPTION
We shouldn't be linking so prominently to the Legacy Publishing chapter instead of the new one.