### PR TITLE
Let gradlePluginPortal() fetch metadata from maven poms only

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationRepositoriesBuildOperationIntegrationTest.groovy
@@ -590,7 +590,7 @@ class ResolveConfigurationRepositoriesBuildOperationIntegrationTest extends Abst
                 ARTIFACT_URLS: [],
                 AUTHENTICATED: false,
                 AUTHENTICATION_SCHEMES: [],
-                METADATA_SOURCES: ['mavenPom', 'artifact'],
+                METADATA_SOURCES: ['mavenPom'],
                 URL: 'https://plugins.gradle.org/m2',
             ]
         ]

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -98,7 +98,7 @@ plugins {
 }
 """
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0'])
+        lockFile.createLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.0', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
 
         when:
         succeeds 'buildEnvironment'
@@ -149,7 +149,7 @@ plugins {
 
         then:
         def lockFile = new LockfileFixture(testDirectory: testDirectory)
-        lockFile.verifyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1', 'org.bar:bar-plugin:1.0'])
+        lockFile.verifyLockfile('buildscript-classpath', ['org.foo:foo-plugin:1.1', 'org.bar:bar-plugin:1.0', 'bar.plugin:bar.plugin.gradle.plugin:1.0'])
     }
 
     def 'fails to resolve if lock state present but no dependencies remain'() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories;
 
+import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
@@ -121,6 +122,12 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     public ArtifactRepository createGradlePluginPortal() {
         MavenArtifactRepository mavenRepository = createMavenRepository(new NamedMavenRepositoryDescriber(PLUGIN_PORTAL_DEFAULT_URL));
         mavenRepository.setUrl(System.getProperty(PLUGIN_PORTAL_OVERRIDE_URL_PROPERTY, PLUGIN_PORTAL_DEFAULT_URL));
+        mavenRepository.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+            @Override
+            public void execute(MavenArtifactRepository.MetadataSources metadataSources) {
+                metadataSources.mavenPom();
+            }
+        });
         return mavenRepository;
     }
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/AuthenticatedPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/AuthenticatedPluginRepositorySpec.groovy
@@ -92,6 +92,7 @@ class AuthenticatedPluginRepositorySpec extends AbstractHttpDependencyResolution
 
         expect:
         markerModule.ivy.expectGet(USERNAME, PASSWORD)
+        markerModule.jar.expectGet(USERNAME, PASSWORD)
         pluginModule.ivy.expectGet(USERNAME, PASSWORD)
         pluginModule.jar.expectGet(USERNAME, PASSWORD)
         succeeds("pluginTask")
@@ -127,6 +128,7 @@ class AuthenticatedPluginRepositorySpec extends AbstractHttpDependencyResolution
 
         expect:
         markerModule.pom.expectGet(USERNAME, PASSWORD)
+        markerModule.artifact.expectGet(USERNAME, PASSWORD)
         pluginModule.pom.expectGet(USERNAME, PASSWORD)
         pluginModule.artifact.expectGet(USERNAME, PASSWORD)
         succeeds("pluginTask")

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/RepositoryOrderingIntegrationSpec.groovy
@@ -57,7 +57,6 @@ class RepositoryOrderingIntegrationSpec extends AbstractIntegrationSpec {
               - $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.pom
               - $buildscriptRepoUri/my/plugin/1.0/plugin-1.0.jar
               - $pluginPortalUri/my/plugin/1.0/plugin-1.0.pom
-              - $pluginPortalUri/my/plugin/1.0/plugin-1.0.jar
         """.stripIndent().trim()
 
         when:

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromMultipleCustomPluginRepositorySpec.groovy
@@ -172,7 +172,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
             Plugin [id: 'org.example.foo', version: '1.1'] was not found in any of the following sources:
             
             - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            - Plugin Repositories (could not resolve plugin marker 'org.example.foo:org.example.foo.gradle.plugin:1.1')
+            - Plugin Repositories (could not resolve plugin artifact 'org.example.foo:org.example.foo.gradle.plugin:1.1')
               Searched in the following repositories:
                 ${repoType}(${repoA.uri})
                 ${repoType}2(${repoB.uri})
@@ -198,7 +198,7 @@ class ResolvingFromMultipleCustomPluginRepositorySpec extends AbstractDependency
 
         then:
         failure.assertThatDescription(containsNormalizedString("""
-            - Plugin Repositories (could not resolve plugin marker 'org.gradle.hello-world:org.gradle.hello-world.gradle.plugin:0.2')
+            - Plugin Repositories (could not resolve plugin artifact 'org.gradle.hello-world:org.gradle.hello-world.gradle.plugin:0.2')
               Searched in the following repositories:
                 ${repoType}(${repoA.uri})
                 ${repoType}2(${repoB.uri})

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingFromSingleCustomPluginRepositorySpec.groovy
@@ -189,7 +189,7 @@ class ResolvingFromSingleCustomPluginRepositorySpec extends AbstractDependencyRe
             Plugin [id: 'org.example.foo', version: '1.1'] was not found in any of the following sources:
             
             - Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
-            - Plugin Repositories (could not resolve plugin marker 'org.example.foo:org.example.foo.gradle.plugin:1.1')
+            - Plugin Repositories (could not resolve plugin artifact 'org.example.foo:org.example.foo.gradle.plugin:1.1')
               Searched in the following repositories:
                 ${repoType}($repoUrl)
         """.stripIndent().trim())

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/repository/ResolvingWithPluginManagementSpec.groovy
@@ -328,7 +328,7 @@ class ResolvingWithPluginManagementSpec extends AbstractDependencyResolutionTest
         fails("helloWorld")
 
         then:
-        failureDescriptionContains("could not resolve plugin module 'foo:bar:1.0'")
+        failureDescriptionContains("could not resolve plugin artifact 'foo:bar:1.0'")
     }
 
     def "succeeds build for resolvable custom artifact"() {

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/DeployedPortalIntegrationSpec.groovy
@@ -107,7 +107,7 @@ class DeployedPortalIntegrationSpec extends AbstractPluginIntegrationTest {
         and:
         failureDescriptionStartsWith("Plugin [id: 'org.gradle.non-existing', version: '1.0'] was not found in any of the following sources:")
         failureDescriptionContains("""
-            - Plugin Repositories (could not resolve plugin marker 'org.gradle.non-existing:org.gradle.non-existing.gradle.plugin:1.0')
+            - Plugin Repositories (could not resolve plugin artifact 'org.gradle.non-existing:org.gradle.non-existing.gradle.plugin:1.0')
               Searched in the following repositories:
                 Gradle Central Plugin Repository
         """.stripIndent().trim())

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
@@ -238,7 +238,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractIntegrationSpec {
         and:
         failure.assertThatDescription(startsWith("Plugin [id: 'org.myplugin', version: '1.0'] was not found in any of the following sources"))
         failure.assertThatDescription(containsString("""
-            - Plugin Repositories (could not resolve plugin marker 'org.myplugin:org.myplugin.gradle.plugin:1.0')
+            - Plugin Repositories (could not resolve plugin artifact 'org.myplugin:org.myplugin.gradle.plugin:1.0')
               Searched in the following repositories:
                 Gradle Central Plugin Repository(${pluginRepo.uri})
         """.stripIndent().trim()))

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -17,16 +17,13 @@ package org.gradle.plugin.use.resolve.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
-
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleDependency;
-import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
-import org.gradle.api.artifacts.result.DependencyResult;
-import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
@@ -36,12 +33,9 @@ import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.use.PluginId;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.util.Iterator;
-import java.util.Set;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.collect.Iterables.getOnlyElement;
 
 public class ArtifactRepositoriesPluginResolver implements PluginResolver {
 
@@ -61,60 +55,33 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
     private final DependencyResolutionServices resolution;
     private final VersionSelectorScheme versionSelectorScheme;
 
-    private ArtifactRepositoriesPluginResolver(DependencyResolutionServices dependencyResolutionServices, VersionSelectorScheme versionSelectorScheme) {
+    public ArtifactRepositoriesPluginResolver(DependencyResolutionServices dependencyResolutionServices, VersionSelectorScheme versionSelectorScheme) {
         this.resolution = dependencyResolutionServices;
         this.versionSelectorScheme = versionSelectorScheme;
     }
 
     @Override
     public void resolve(PluginRequestInternal pluginRequest, PluginResolutionResult result) throws InvalidPluginRequestException {
-        ModuleVersionSelector moduleSelector = pluginRequest.getModule();
-        if (validateVersion(moduleSelector != null ? moduleSelector.getVersion() : pluginRequest.getVersion(), result)) {
-            if (moduleSelector == null) {
-                resolveFromPluginMarker(pluginRequest, result);
-            } else {
-                resolveFromModule(pluginRequest, moduleSelector, result);
-            }
-        }
-    }
-
-    private boolean validateVersion(@Nullable String version, PluginResolutionResult result) {
-        return validateVersion(versionSelectorScheme, version, result);
-    }
-
-    @VisibleForTesting
-    static boolean validateVersion(VersionSelectorScheme scheme, @Nullable String version, PluginResolutionResult result) {
-        if (isNullOrEmpty(version)) {
+        ModuleDependency markerDependency = getMarkerDependency(pluginRequest);
+        String markerVersion = markerDependency.getVersion();
+        if (isNullOrEmpty(markerVersion)) {
             result.notFound(SOURCE_NAME, "plugin dependency must include a version number for this source");
-            return false;
+            return;
         }
-        if (scheme.parseSelector(version).isDynamic()) {
+
+        if (versionSelectorScheme.parseSelector(markerVersion).isDynamic()) {
             result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported");
-            return false;
+            return;
         }
-        return true;
-    }
 
-    private void resolveFromPluginMarker(PluginRequestInternal pluginRequest, PluginResolutionResult result) {
-        ModuleDependency markerDependency = pluginMarkerDependencyFor(pluginRequest);
-        PluginFromMarkerResult pluginResult = resolvePluginDependencyFrom(markerDependency);
-        if (pluginResult.pluginDependency != null) {
-            handleFound(pluginRequest, pluginResult.pluginDependency, result);
+        if (exists(markerDependency)) {
+            handleFound(result, pluginRequest, markerDependency);
         } else {
-            handleNotFound(pluginResult.notFound, markerDependency, result);
+            handleNotFound(result, "could not resolve plugin artifact '" + getNotation(markerDependency) + "'");
         }
     }
 
-    private void resolveFromModule(PluginRequestInternal pluginRequest, ModuleVersionSelector moduleSelector, PluginResolutionResult result) {
-        ModuleDependency moduleDependency = moduleDependencyFor(moduleSelector);
-        if (moduleDependencyExists(moduleDependency)) {
-            handleFound(pluginRequest, moduleDependency, result);
-        } else {
-            handleNotFound("module", moduleDependency, result);
-        }
-    }
-
-    private void handleFound(final PluginRequestInternal pluginRequest, final Dependency pluginDependency, PluginResolutionResult result) {
+    private void handleFound(PluginResolutionResult result, final PluginRequestInternal pluginRequest, final Dependency markerDependency) {
         result.found("Plugin Repositories", new PluginResolution() {
             @Override
             public PluginId getPluginId() {
@@ -122,72 +89,12 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
             }
 
             public void execute(@Nonnull PluginResolveContext context) {
-                context.addLegacy(pluginRequest.getId(), pluginDependency);
+                context.addLegacy(pluginRequest.getId(), markerDependency);
             }
         });
     }
 
-    private void handleNotFound(String description, ModuleDependency dependency, PluginResolutionResult result) {
-        String message = "could not resolve plugin " + description + " '" + getNotation(dependency) + "'";
-        result.notFound(SOURCE_NAME, message, buildNotFoundDetailMessage());
-    }
-
-    private PluginFromMarkerResult resolvePluginDependencyFrom(ModuleDependency markerDependency) {
-        ResolutionResult resolutionResult = resolution
-            .getConfigurationContainer()
-            .detachedConfiguration(markerDependency)
-            .getIncoming()
-            .getResolutionResult();
-        DependencyResult markerResult = getOnlyElement(resolutionResult.getRoot().getDependencies());
-        if (!(markerResult instanceof ResolvedDependencyResult)) {
-            return PluginFromMarkerResult.MARKER;
-        }
-        ResolvedDependencyResult resolvedMarker = (ResolvedDependencyResult) markerResult;
-        Set<? extends DependencyResult> markerDependencies = resolvedMarker.getSelected().getDependencies();
-        if (markerDependencies.size() != 1) {
-            return PluginFromMarkerResult.MODULE_DEPENDENCY;
-        }
-        DependencyResult pluginResult = getOnlyElement(markerDependencies);
-        if (!(pluginResult instanceof ResolvedDependencyResult)) {
-            return PluginFromMarkerResult.MODULE_DEPENDENCY;
-        }
-        ResolvedDependencyResult resolvedPlugin = (ResolvedDependencyResult) pluginResult;
-        ModuleVersionIdentifier resolvedPluginVersion = resolvedPlugin.getSelected().getModuleVersion();
-        if (resolvedPluginVersion == null) {
-            return PluginFromMarkerResult.MODULE_DEPENDENCY;
-        }
-        return new PluginFromMarkerResult(moduleDependencyFor(resolvedPluginVersion));
-    }
-
-    private boolean moduleDependencyExists(ModuleDependency moduleDependency) {
-        ResolutionResult resolutionResult = resolution
-            .getConfigurationContainer()
-            .detachedConfiguration(moduleDependency)
-            .setTransitive(false)
-            .getIncoming()
-            .getResolutionResult();
-        DependencyResult moduleResult = getOnlyElement(resolutionResult.getRoot().getDependencies());
-        return moduleResult instanceof ResolvedDependencyResult;
-    }
-
-    private ModuleDependency pluginMarkerDependencyFor(PluginRequestInternal pluginRequest) {
-        String id = pluginRequest.getId().getId();
-        return new DefaultExternalModuleDependency(id, id + PLUGIN_MARKER_SUFFIX, pluginRequest.getVersion());
-    }
-
-    private ModuleDependency moduleDependencyFor(ModuleVersionIdentifier moduleIdentifier) {
-        return new DefaultExternalModuleDependency(moduleIdentifier.getGroup(), moduleIdentifier.getName(), moduleIdentifier.getVersion());
-    }
-
-    private ModuleDependency moduleDependencyFor(ModuleVersionSelector moduleSelector) {
-        return new DefaultExternalModuleDependency(moduleSelector.getGroup(), moduleSelector.getName(), moduleSelector.getVersion());
-    }
-
-    private String getNotation(Dependency dependency) {
-        return Joiner.on(':').join(dependency.getGroup(), dependency.getName(), dependency.getVersion());
-    }
-
-    private String buildNotFoundDetailMessage() {
+    private void handleNotFound(PluginResolutionResult result, String message) {
         StringBuilder detail = new StringBuilder("Searched in the following repositories:\n");
         for (Iterator<ArtifactRepository> it = resolution.getResolveRepositoryHandler().iterator(); it.hasNext();) {
             detail.append("  ").append(((ArtifactRepositoryInternal) it.next()).getDisplayName());
@@ -195,28 +102,30 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
                 detail.append("\n");
             }
         }
-        return detail.toString();
+        result.notFound(SOURCE_NAME, message, detail.toString());
     }
 
-    private static class PluginFromMarkerResult {
+    /*
+     * Checks whether the plugin marker artifact exists in the backing artifacts repositories.
+     */
+    private boolean exists(ModuleDependency dependency) {
+        ConfigurationContainer configurations = resolution.getConfigurationContainer();
+        Configuration configuration = configurations.detachedConfiguration(dependency);
+        configuration.setTransitive(false);
+        return !configuration.getResolvedConfiguration().hasError();
+    }
 
-        static final PluginFromMarkerResult MARKER = new PluginFromMarkerResult("marker");
-        static final PluginFromMarkerResult MODULE_DEPENDENCY = new PluginFromMarkerResult("module from found marker");
-
-        @Nullable
-        final ModuleDependency pluginDependency;
-
-        @Nullable
-        final String notFound;
-
-        PluginFromMarkerResult(ModuleDependency pluginDependency) {
-            this.pluginDependency = pluginDependency;
-            this.notFound = null;
+    private ModuleDependency getMarkerDependency(PluginRequestInternal pluginRequest) {
+        ModuleVersionSelector selector = pluginRequest.getModule();
+        if (selector == null) {
+            String id = pluginRequest.getId().getId();
+            return new DefaultExternalModuleDependency(id, id + PLUGIN_MARKER_SUFFIX, pluginRequest.getVersion());
+        } else {
+            return new DefaultExternalModuleDependency(selector.getGroup(), selector.getName(), selector.getVersion());
         }
+    }
 
-        private PluginFromMarkerResult(String notFound) {
-            this.pluginDependency = null;
-            this.notFound = notFound;
-        }
+    private String getNotation(Dependency dependency) {
+        return Joiner.on(':').join(dependency.getGroup(), dependency.getName(), dependency.getVersion());
     }
 }

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -16,38 +16,74 @@
 
 package org.gradle.plugin.use.resolve.internal
 
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
+import org.gradle.api.artifacts.ResolvedConfiguration
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
+import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal
+import org.gradle.groovy.scripts.StringScriptSource
+import org.gradle.plugin.management.internal.DefaultPluginRequest
+import org.gradle.plugin.management.internal.PluginRequestInternal
+import org.gradle.plugin.use.internal.DefaultPluginId
 import spock.lang.Specification
 
 import static org.gradle.plugin.use.resolve.internal.ArtifactRepositoriesPluginResolver.SOURCE_NAME
 
 class ArtifactRepositoriesPluginResolverTest extends Specification {
-
     def versionSelectorScheme = new MavenVersionSelectorScheme(new DefaultVersionSelectorScheme(new DefaultVersionComparator(), new VersionParser()))
+    def repository = Mock(ArtifactRepositoryInternal) {
+        getDisplayName() >> "maven(url)"
+    }
+    def repositories = Mock(RepositoryHandler) {
+        iterator() >> [repository].iterator()
+    }
+    def resolvedConfiguration = Mock(ResolvedConfiguration) {
+        hasError() >> false
+    }
+    def configuration = Mock(Configuration) {
+        getResolvedConfiguration() >> resolvedConfiguration
+        setTransitive(false) >> {}
+    }
+    def configurations = Mock(ConfigurationContainer) {
+        detachedConfiguration(_) >> configuration
+    }
+
+    def resolution = Mock(DependencyResolutionServices) {
+        getResolveRepositoryHandler() >> repositories
+        getConfigurationContainer() >> configurations
+    }
     def result = Mock(PluginResolutionResult)
 
-    def "validation of pluginRequests without version fails"() {
+    def resolver = new ArtifactRepositoriesPluginResolver(resolution, versionSelectorScheme)
+
+    PluginRequestInternal request(String id, String version = null) {
+        new DefaultPluginRequest(DefaultPluginId.of(id), version, true, 1, new StringScriptSource("test", "test"))
+    }
+
+    def "fail pluginRequests without versions"() {
         when:
-        ArtifactRepositoriesPluginResolver.validateVersion(versionSelectorScheme, null, result)
+        resolver.resolve(request("plugin"), result)
 
         then:
         1 * result.notFound(SOURCE_NAME, "plugin dependency must include a version number for this source")
     }
 
-    def "validation of pluginRequests with SNAPSHOT versions succeeds"() {
+    def "succeed pluginRequests with SNAPSHOT versions"() {
         when:
-        ArtifactRepositoriesPluginResolver.validateVersion(versionSelectorScheme, "1.1-SNAPSHOT", result)
+        resolver.resolve(request("plugin", "1.1-SNAPSHOT"), result)
 
         then:
-        0 * result.notFound(SOURCE_NAME, _)
+        1 * result.found(SOURCE_NAME, _)
     }
 
-    def "validation of pluginRequests with dynamic versions fails"() {
+    def "fail pluginRequests with dynamic versions"() {
         when:
-        ArtifactRepositoriesPluginResolver.validateVersion(versionSelectorScheme, "latest.revision", result)
+        resolver.resolve(request("plugin", "latest.revision"), result)
 
         then:
         1 * result.notFound(SOURCE_NAME, "dynamic plugin versions are not supported")


### PR DESCRIPTION
First commit in this PR reverts #6774.

Second commit let `gradlePluginPortal()` repository only consider maven poms as a metadata source, skipping artifacts.
