### PR TITLE
Make AbstractArchiveTask.destinationDir mandatory

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -94,10 +94,12 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 bar.attributes { attribute(buildType, 'release'); attribute(flavor, 'free') }
             }
             task fooJar(type: Jar) {
-               baseName = 'c-foo'
+                baseName = 'c-foo'
+                destinationDir = projectDir
             }
             task barJar(type: Jar) {
-               baseName = 'c-bar'
+                baseName = 'c-bar'
+                destinationDir = projectDir
             }
             artifacts {
                 foo fooJar
@@ -196,10 +198,12 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 bar.attributes { attribute(buildType, 'release'); attribute(flavor, 'free') }
             }
             task fooJar(type: Jar) {
-               baseName = 'c-foo'
+                baseName = 'c-foo'
+                destinationDir = projectDir
             }
             task barJar(type: Jar) {
-               baseName = 'c-bar'
+                baseName = 'c-bar'
+                destinationDir = projectDir
             }
             artifacts {
                 foo fooJar
@@ -298,10 +302,12 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 bar.attributes { attribute(buildType, 'release'); attribute(flavor, 'free') }
             }
             task fooJar(type: Jar) {
-               baseName = 'c-foo'
+                baseName = 'c-foo'
+                destinationDir = projectDir
             }
             task barJar(type: Jar) {
-               baseName = 'c-bar'
+                baseName = 'c-bar'
+                destinationDir = projectDir
             }
             artifacts {
                 foo fooJar
@@ -401,9 +407,11 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
             }
             task fooJar(type: Jar) {
                baseName = 'c-foo'
+               destinationDir = projectDir
             }
             task barJar(type: Jar) {
                baseName = 'c-bar'
+               destinationDir = projectDir
             }
             artifacts {
                 foo fooJar
@@ -524,9 +532,11 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
             }
             task fooJar(type: Jar) {
                baseName = 'c-foo'
+               destinationDir = projectDir
             }
             task barJar(type: Jar) {
                baseName = 'c-bar'
+               destinationDir = projectDir
             }
             artifacts {
                 foo fooJar
@@ -626,10 +636,12 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
                 bar.attributes { attribute(flavor, objects.named(Thing, 'blue')) }
             }
             task fooJar(type: Jar) {
-               baseName = 'c-foo'
+                baseName = 'c-foo'
+                destinationDir = projectDir
             }
             task barJar(type: Jar) {
-               baseName = 'c-bar'
+                baseName = 'c-bar'
+                destinationDir = projectDir
             }
             artifacts {
                 foo fooJar
@@ -740,10 +752,12 @@ All of them match the consumer attributes:
                 bar.attributes { attribute(buildType, release); attribute(flavor, free) }
             }
             task fooJar(type: Jar) {
-               baseName = 'c-foo'
+                baseName = 'c-foo'
+                destinationDir = projectDir
             }
             task barJar(type: Jar) {
-               baseName = 'c-bar'
+                baseName = 'c-bar'
+                destinationDir = projectDir
             }
             artifacts {
                 foo fooJar

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/resource/BrokenTextResourceIntegrationTest.groovy
@@ -69,9 +69,11 @@ task text(type: TextTask)
     def "reports read of missing archive entry"() {
         given:
         buildFile << """
-            task jar(type: Jar)
+            task jar(type: Jar) {
+                destinationDir = buildDir
+            }
             text.text = resources.text.fromArchiveEntry(jar, 'config.txt')
-"""
+        """
 
         expect:
         fails("text")

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveIntegrationTest.groovy
@@ -225,6 +225,8 @@ class ArchiveIntegrationTest extends AbstractIntegrationSpec {
         given:
         buildFile << '''
             task myTar(type: Tar) {
+                destinationDir = buildDir
+
                 assert compression == Compression.NONE
 
                 compression = Compression.GZIP

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveTaskPermissionsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ArchiveTaskPermissionsIntegrationTest.groovy
@@ -43,6 +43,7 @@ class ArchiveTaskPermissionsIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
             task pack(type: $taskName) {
                 archiveName = "$archName"
+                destinationDir = projectDir
                 from 'parent'
             }
             """
@@ -74,6 +75,7 @@ class ArchiveTaskPermissionsIntegrationTest extends AbstractIntegrationSpec {
         buildFile << """
                 task pack(type: $taskName) {
                     archiveName = "$archName"
+                    destinationDir = projectDir
                     fileMode = 0774
                     dirMode = 0756
                     from 'parent'

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/DeferredTaskDefinitionIntegrationTest.groovy
@@ -838,6 +838,7 @@ class DeferredTaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
             }
             def zipTaskRealizedCount = 0
             tasks.register("aZipTask", Zip) {
+                destinationDir = buildDir
                 zipTaskRealizedCount++
             }
 

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -28,7 +28,6 @@ import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.GUtil;
 
-import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -91,6 +90,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     @OutputFile
     public File getArchivePath() {
         File destinationDir = getDestinationDir();
+        //noinspection ConstantConditions
         if (destinationDir == null) {
             throw new InvalidUserDataException("The destinationDir property must be set. Please apply the base plugin or set it explicitly.");
         }
@@ -103,7 +103,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @return the directory
      */
     @Internal("Represented as part of archivePath")
-    @Nullable
     public File getDestinationDir() {
         return destinationDir;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -17,6 +17,7 @@ package org.gradle.api.tasks.bundling;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.internal.file.copy.CopyActionExecuter;
 import org.gradle.api.tasks.AbstractCopyTask;
@@ -27,6 +28,7 @@ import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.GUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 
 /**
@@ -88,7 +90,11 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      */
     @OutputFile
     public File getArchivePath() {
-        return new File(getDestinationDir(), getArchiveName());
+        File destinationDir = getDestinationDir();
+        if (destinationDir == null) {
+            throw new InvalidUserDataException("The destinationDir property must be set. Please apply the base plugin or set it explicitly.");
+        }
+        return new File(destinationDir, getArchiveName());
     }
 
     /**
@@ -97,6 +103,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @return the directory
      */
     @Internal("Represented as part of archivePath")
+    @Nullable
     public File getDestinationDir() {
         return destinationDir;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifactTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/publish/ArchivePublishArtifactTest.groovy
@@ -22,14 +22,14 @@ import org.gradle.util.TestUtil
 import org.junit.Rule
 import spock.lang.Specification
 
-public class ArchivePublishArtifactTest extends Specification {
+class ArchivePublishArtifactTest extends Specification {
     @Rule
     public TestNameTestDirectoryProvider temporaryFolder = TestNameTestDirectoryProvider.newInstance()
 
-    def TestUtil testUtil = TestUtil.create(temporaryFolder)
+    def testUtil = TestUtil.create(temporaryFolder)
 
     def "provides sensible default values for quite empty archive tasks"() {
-        def quiteEmptyJar = testUtil.task(DummyJar)
+        def quiteEmptyJar = testUtil.task(DummyJar, [destinationDir: temporaryFolder.testDirectory])
 
         when:
         def a = new ArchivePublishArtifact(quiteEmptyJar)

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/bundling/AbstractArchiveTaskTest.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/tasks/bundling/AbstractArchiveTaskTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.bundling
 
+import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.AbstractCopyTaskContractTest
 
 abstract class AbstractArchiveTaskTest extends AbstractCopyTaskContractTest {
@@ -131,5 +132,17 @@ abstract class AbstractArchiveTaskTest extends AbstractCopyTaskContractTest {
     def "correct archive path"() {
         expect:
         archiveTask.archivePath == new File(archiveTask.destinationDir, archiveTask.archiveName)
+    }
+
+    def "does not accept unset destinationDir"() {
+        given:
+        archiveTask.destinationDir = null
+
+        when:
+        archiveTask.archivePath
+
+        then:
+        def e = thrown(InvalidUserDataException)
+        e.message == "The destinationDir property must be set. Please apply the base plugin or set it explicitly."
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/api/artifacts/transform/ArtifactTransformBuildScanIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/api/artifacts/transform/ArtifactTransformBuildScanIntegrationTest.groovy
@@ -67,6 +67,7 @@ class ArtifactTransformBuildScanIntegrationTest extends AbstractIntegrationSpec 
             }
             
             project(':lib') {
+                apply plugin: 'base'
                 task jar1(type: Jar) {
                     archiveName = 'lib1.jar'
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -84,6 +84,7 @@ abstract class AbstractConfigurationAttributesResolveIntegrationTest extends Abs
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -149,6 +150,7 @@ include 'a', 'b'
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -236,6 +238,7 @@ include 'a', 'b'
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -307,6 +310,7 @@ include 'a', 'b'
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     freeDebug fooJar
                     freeRelease fooJar
@@ -366,6 +370,7 @@ include 'a', 'b'
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -427,6 +432,7 @@ include 'a', 'b'
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -482,6 +488,7 @@ Variant 'bar':
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -529,6 +536,7 @@ Variant 'bar':
                 }
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
+                   destinationDir = buildDir
                 }
                 artifacts {
                     'default' barJar
@@ -579,6 +587,7 @@ Variant 'bar':
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -634,6 +643,7 @@ Variant 'bar':
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -741,6 +751,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -791,6 +802,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -854,6 +866,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     'default' defaultJar
                     foo fooJar
@@ -912,6 +925,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     'default' defaultJar
                     foo fooJar
@@ -976,6 +990,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1025,6 +1040,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1084,6 +1100,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1162,6 +1179,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     debug fooJar
                     compile barJar
@@ -1236,6 +1254,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1329,6 +1348,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'c-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1412,6 +1432,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'c-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1480,6 +1501,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1504,6 +1526,7 @@ All of them match the consumer attributes:
                 task bar2Jar(type: Jar) {
                    baseName = 'c-bar2'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar, foo2Jar
                     bar barJar, bar2Jar
@@ -1612,6 +1635,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'c-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1682,6 +1706,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     _compileFreeDebug fooJar
                     _compileFreeRelease barJar
@@ -1740,6 +1765,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1792,6 +1818,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1853,6 +1880,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1873,6 +1901,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'c-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1930,6 +1959,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     'default' defaultJar
                     foo fooJar

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1406,6 +1406,7 @@ Required by:
                 if (project.version != 'unspecified') {
                     archiveName = "\${project.name}-\${project.version}.jar"
                 }
+                destinationDir = buildDir
             }
             artifacts { conf jar }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -52,7 +52,10 @@ project(":a") {
         api "org.other:externalA:1.2"
         'default' "org.other:externalB:2.1"
     }
-    task jar(type: Jar) { baseName = 'a' }
+    task jar(type: Jar) {
+        baseName = 'a'
+        destinationDir = buildDir
+    }
     artifacts { api jar }
 }
 project(":b") {
@@ -135,6 +138,7 @@ allprojects {
     repositories { maven { url '$mavenRepo.uri' } }
 }
 project(":a") {
+    apply plugin: 'base'
     configurations {
         api
         runtime { extendsFrom api }
@@ -198,6 +202,7 @@ project(":b") {
         and:
         buildFile << """
 project(':a') {
+    apply plugin: 'base'
     configurations {
         configA1
         configA2

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedArtifactsApiIntegrationTest.groovy
@@ -222,6 +222,7 @@ project(':a') {
     dependencies.attributesSchema.attribute(flavor).compatibilityRules.add(OneRule)
     task oneJar(type: Jar) { baseName = 'a1' }
     task twoJar(type: Jar) { baseName = 'a2' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations {
         compile {
             attributes.attribute(buildType, 'debug')
@@ -247,6 +248,7 @@ project(':b') {
     dependencies.attributesSchema.attribute(flavor).compatibilityRules.add(TwoRule)
     task oneJar(type: Jar) { baseName = 'b1' }
     task twoJar(type: Jar) { baseName = 'b2' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations {
         compile {
             outgoing {
@@ -322,6 +324,7 @@ project(':a') {
     dependencies.attributesSchema.attribute(flavor).disambiguationRules.add(OneRule)
     task oneJar(type: Jar) { baseName = 'a1' }
     task twoJar(type: Jar) { baseName = 'a2' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations {
         compile {
             attributes.attribute(buildType, 'debug')
@@ -347,6 +350,7 @@ project(':b') {
     dependencies.attributesSchema.attribute(flavor).disambiguationRules.add(TwoRule)
     task oneJar(type: Jar) { baseName = 'b1' }
     task twoJar(type: Jar) { baseName = 'b2' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations {
         compile {
             outgoing {
@@ -894,7 +898,10 @@ Searched in the following locations:
         buildFile << """
 allprojects {
     repositories { maven { url '$mavenHttpRepo.uri' } }
-    tasks.withType(Jar) { archiveName = project.name + '-' + name + ".jar" }
+    tasks.withType(Jar) {
+        archiveName = project.name + '-' + name + ".jar"
+        destinationDir = buildDir
+    }
 }
 dependencies {
     compile 'org:missing-module:1.0'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolvedFilesApiIntegrationTest.groovy
@@ -166,6 +166,7 @@ project(':a') {
     }
     task freeJar(type: Jar) { archiveName = 'a-free.jar' }
     task paidJar(type: Jar) { archiveName = 'a-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -185,6 +186,7 @@ project(':b') {
     }    
     task freeJar(type: Jar) { archiveName = 'b-free.jar' }
     task paidJar(type: Jar) { archiveName = 'b-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -251,6 +253,7 @@ project(':a') {
     }
     task freeJar(type: Jar) { archiveName = 'a-free.jar' }
     task paidJar(type: Jar) { archiveName = 'a-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -270,6 +273,7 @@ project(':b') {
     }    
     task freeJar(type: Jar) { archiveName = 'b-free.jar' }
     task paidJar(type: Jar) { archiveName = 'b-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -323,6 +327,7 @@ project(':a') {
     }
     task freeJar(type: Jar) { archiveName = 'a-free.jar' }
     task paidJar(type: Jar) { archiveName = 'a-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -340,6 +345,7 @@ project(':b') {
     }    
     task freeJar(type: Jar) { archiveName = 'b-free.jar' }
     task paidJar(type: Jar) { archiveName = 'b-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -418,6 +424,7 @@ project(':a') {
     }
     task freeJar(type: Jar) { archiveName = 'a-free.jar' }
     task paidJar(type: Jar) { archiveName = 'a-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')
@@ -432,6 +439,7 @@ project(':a') {
 project(':b') {
     task freeJar(type: Jar) { archiveName = 'b-free.jar' }
     task paidJar(type: Jar) { archiveName = 'b-paid.jar' }
+    tasks.withType(Jar) { destinationDir = buildDir }
     configurations.compile.outgoing.variants {
         free {
             attributes.attribute(flavor, 'free')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -214,6 +214,7 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     foo2 foo2Jar
@@ -288,6 +289,7 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     foo2 foo2Jar
@@ -489,6 +491,7 @@ All of them match the consumer attributes:
                 task bar2Jar(type: Jar) {
                    baseName = 'b-bar2'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     foo2 foo2Jar
@@ -571,6 +574,7 @@ All of them match the consumer attributes:
                 task foo2Jar(type: Jar) {
                    baseName = 'b-foo2'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     foo2 foo2Jar
@@ -650,6 +654,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -722,6 +727,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -779,6 +785,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -834,6 +841,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -890,6 +898,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -964,6 +973,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -980,6 +990,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'c-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts {
                     foo fooJar
                     bar barJar
@@ -1063,6 +1074,7 @@ All of them match the consumer attributes:
                 task barJar(type: Jar) {
                    baseName = 'b-bar'
                 }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 configurations {
                     c1 { attributes { attribute(flavor, objects.named(Flavor, 'preview')); $debug } }
                     c2 { attributes { attribute(flavor, objects.named(Flavor, 'preview')); $release } }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1031,6 +1031,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
             project(':lib') {
                 task jar1(type: Jar) {
                     archiveName = 'util1.jar'
+                    destinationDir = buildDir
                 }
                 artifacts {
                     compile jar1

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1141,6 +1141,7 @@ Found the following transforms:
             project(':lib') {
                 task jar1(type: Jar) { archiveName = 'jar1.jar' }
                 task jar2(type: Jar) { archiveName = 'jar2.jar' }
+                tasks.withType(Jar) { destinationDir = buildDir }
                 artifacts { compile jar1, jar2 }
             }
 
@@ -1638,7 +1639,9 @@ Found the following transforms:
                 def file1 = file('lib1.size')
                 file1.text = 'some text'
 
-                task lib1(type: Jar) {}
+                task lib1(type: Jar) {
+                    destinationDir = buildDir
+                }
     
                 dependencies {
                     compile files(lib1)

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/artifact/IvyArtifactNotationParserFactoryTest.groovy
@@ -126,6 +126,7 @@ public class IvyArtifactNotationParserFactoryTest extends AbstractProjectBuilder
         def archive = rootProject.task('foo', type: Jar, {})
         archive.setBaseName("base-name")
         archive.setExtension('extension')
+        archive.setDestinationDir(rootProject.buildDir)
 
         IvyArtifact ivyArtifact = parser.parseNotation(archive)
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppCustomHeaderDependencyIntegrationTest.groovy
@@ -127,6 +127,7 @@ class CppCustomHeaderDependencyIntegrationTest extends AbstractInstalledToolChai
 
     def producerBuildScript(String repoType) {
         return """
+            apply plugin: "base"
             apply plugin: "${repoType}-publish"
             
             configurations {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -338,6 +338,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractIntegrati
             }
 
             project(':lib') {
+                apply plugin: 'base'
                 task jar(type: Jar) {
                     destinationDir = buildDir
                     archiveName = 'lib.jar'

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/artifact/MavenArtifactNotationParserFactoryTest.groovy
@@ -121,6 +121,7 @@ public class MavenArtifactNotationParserFactoryTest extends AbstractProjectBuild
         def rootProject = TestUtil.createRootProject(temporaryFolder.testDirectory)
         def archive = rootProject.task('foo', type: Jar, {})
         archive.setBaseName("baseName")
+        archive.setDestinationDir(temporaryFolder.testDirectory)
         archive.setExtension(archiveExtension)
         archive.setClassifier(archiveClassifier)
 

--- a/subprojects/performance/src/templates/archivePerformanceProject/build.gradle
+++ b/subprojects/performance/src/templates/archivePerformanceProject/build.gradle
@@ -60,3 +60,7 @@ task visitTarGz(dependsOn: tarGz) {
         }
     }
 }
+
+tasks.withType(AbstractArchiveTask) {
+    destinationDir = projectDir
+}

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/PackageListGeneratorIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/impldeps/PackageListGeneratorIntegrationTest.groovy
@@ -127,6 +127,7 @@ class PackageListGeneratorIntegrationTest extends AbstractIntegrationSpec {
         buildFile << '''
             task jar(type: Jar) {
                 archiveName = 'mylib.jar'
+                destinationDir = buildDir
                 from file('build/classes')
             }
         '''

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -662,6 +662,21 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         skippedTasks.contains ":jar"
     }
 
+    def "cannot create a JAR without destination dir"() {
+        given:
+        buildFile << """
+            task jar(type: Jar) {
+                archiveName = 'some.jar'
+            }
+        """
+
+        when:
+        fails('jar')
+
+        then:
+        failureCauseContains('The destinationDir property must be set')
+    }
+
     private static String customJarManifestTask() {
         return '''
             class CustomJarManifest extends org.gradle.jvm.tasks.Jar {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/JarIntegrationTest.groovy
@@ -270,13 +270,13 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         buildFile << '''
         task jar(type: Jar) {
             archiveName = 'test.jar'
+            destinationDir = projectDir
             from 'dir1'
             from 'dir2'
             eachFile {
                 it.duplicatesStrategy = it.relativePath.toString().startsWith('META-INF/services/') ? 'include' : 'exclude'
             }
         }
-
         '''
 
         when:
@@ -293,6 +293,7 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
         buildFile << '''
         task jar(type: Jar) {
             archiveName = 'test.jar'
+            destinationDir = projectDir
             from 'dir1'
             from 'dir2'
             duplicatesStrategy = 'exclude'
@@ -300,7 +301,6 @@ class JarIntegrationTest extends AbstractIntegrationSpec {
                 duplicatesStrategy = 'include'
             }
         }
-
         '''
 
         when:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/WarTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/tasks/bundling/WarTaskIntegrationTest.groovy
@@ -299,6 +299,7 @@ task assertUnresolved {
 task war(type: War) {
     dependsOn assertUnresolved
     classpath = configurations.conf
+    destinationDir = buildDir
 }
 """
 

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -60,6 +60,7 @@ class GitVersionSelectionIntegrationTest extends AbstractIntegrationSpec {
                 version = '1.0'
                 def jar = tasks.create("jar_$version", Jar) {
                     baseName = "test"
+                    destinationDir = buildDir
                     version = project.version
                 }
                 configurations['default'].outgoing.artifact(jar)

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/RemoteSourceDependencyIntegrationTest.groovy
@@ -69,6 +69,7 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                 def jar = tasks.create("jar", Jar) {
                     dependsOn c
                     baseName = "test"
+                    destinationDir = buildDir
                     version = project.version
                 }
                 d.outgoing.artifact(jar)
@@ -97,6 +98,7 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                 def jar = tasks.create("jar", Jar) {
                     dependsOn c
                     baseName = "test"
+                    destinationDir = buildDir
                     version = project.version
                 }
                 d.outgoing.artifact(jar)
@@ -118,6 +120,7 @@ class RemoteSourceDependencyIntegrationTest extends AbstractIntegrationSpec {
                 version = '1.2'
                 def jar = tasks.create("jar", Jar) {
                     baseName = "test"
+                    destinationDir = buildDir
                     version = project.version
                 }
                 d.outgoing.artifact(jar)


### PR DESCRIPTION
Prior to this commit the current working directory was used when the
`destinationDir` was not set. Since this behavior does not play nice
with reproducible builds, it will now fail instead. However, it should
rarely happen because the `base` plugin provides a convention.