### PR TITLE
Implement retries with exponential backoff

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/Transformer.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/Transformer.java
@@ -15,8 +15,6 @@
  */
 package org.gradle.api;
 
-import javax.annotation.Nullable;
-
 /**
  * <p>A {@code Transformer} transforms objects of type.</p>
  *
@@ -32,5 +30,5 @@ public interface Transformer<OUT, IN> {
      * @param in The object to transform.
      * @return The transformed object.
      */
-    OUT transform(@Nullable IN in);
+    OUT transform(IN in);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklister.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ConnectionFailureRepositoryBlacklister.java
@@ -17,12 +17,15 @@
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
 import com.google.common.collect.Sets;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 
 import java.util.Set;
 
 import static org.gradle.internal.resolve.ResolveExceptionAnalyzer.isCriticalFailure;
 
 public class ConnectionFailureRepositoryBlacklister implements RepositoryBlacklister {
+    private static final Logger LOGGER = Logging.getLogger(ConnectionFailureRepositoryBlacklister.class);
 
     private final Set<String> blacklistedRepositories = Sets.newConcurrentHashSet();
 
@@ -40,6 +43,7 @@ public class ConnectionFailureRepositoryBlacklister implements RepositoryBlackli
         }
 
         if (isCriticalFailure(throwable)) {
+            LOGGER.debug("Repository {} has been blacklisted for this build due to connectivity issues", repositoryId);
             blacklistedRepositories.add(repositoryId);
             return true;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -23,12 +24,15 @@ import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.repositories.resolver.MetadataFetchingCost;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
 import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.resolve.ArtifactNotFoundException;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.resolve.result.BuildableArtifactResolveResult;
@@ -36,8 +40,10 @@ import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult;
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
+import org.gradle.internal.resolve.result.ErroringResolveResult;
 
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 /**
  * A ModuleComponentRepository that catches any exception and applies it to the result object.
@@ -94,15 +100,30 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
     }
 
     private static final class ErrorHandlingModuleComponentRepositoryAccess implements ModuleComponentRepositoryAccess {
+        private static final Logger LOGGER = Logging.getLogger(ErrorHandlingModuleComponentRepositoryAccess.class);
+        private final static String MAX_RETRIES_BEFORE_BLACKLISTING = "org.gradle.internal.repository.max.retries";
+        private final static String INITIAL_BACKOFF_MS = "org.gradle.internal.repository.initial.backoff";
+
         private final static String BLACKLISTED_REPOSITORY_ERROR_MESSAGE = "Skipped due to earlier error";
+
         private final ModuleComponentRepositoryAccess delegate;
         private final String repositoryId;
         private final RepositoryBlacklister repositoryBlacklister;
+        private final int maxRetriesCount;
+        private final int initialBackOff;
 
         private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate, String repositoryId, RepositoryBlacklister repositoryBlacklister) {
+            this(delegate, repositoryId, repositoryBlacklister, Integer.getInteger(MAX_RETRIES_BEFORE_BLACKLISTING, 3), Integer.getInteger(INITIAL_BACKOFF_MS, 125));
+        }
+
+        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate, String repositoryId, RepositoryBlacklister repositoryBlacklister, int maxRetriesCount, int initialBackoff) {
+            assert maxRetriesCount > 0 : "Max retries must be > 0";
+            assert initialBackoff >= 0 : "Initial backoff must be >= 0";
             this.delegate = delegate;
             this.repositoryId = repositoryId;
             this.repositoryBlacklister = repositoryBlacklister;
+            this.maxRetriesCount = maxRetriesCount;
+            this.initialBackOff = initialBackoff;
         }
 
         @Override
@@ -112,78 +133,125 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
 
         @Override
         public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
-            if (repositoryBlacklister.isBlacklisted(repositoryId)) {
-                result.failed(new ModuleVersionResolveException(dependency.getSelector(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE));
-                return;
-            }
-
-            try {
-                delegate.listModuleVersions(dependency, result);
-            } catch (Throwable throwable) {
-                repositoryBlacklister.blacklistRepository(repositoryId, throwable);
+            performOperationWithRetries(result, () -> delegate.listModuleVersions(dependency, result), throwable -> {
+                if (throwable == null) {
+                    return new ModuleVersionResolveException(dependency.getSelector(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE);
+                }
                 ModuleComponentSelector selector = dependency.getSelector();
                 String message = "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".";
-                result.failed(new ModuleVersionResolveException(selector, message, throwable));
-            }
+                return new ModuleVersionResolveException(selector, message, throwable);
+            });
         }
 
         @Override
         public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
-            if (repositoryBlacklister.isBlacklisted(repositoryId)) {
-                result.failed(new ModuleVersionResolveException(moduleComponentIdentifier, BLACKLISTED_REPOSITORY_ERROR_MESSAGE));
-                return;
-            }
-
-            try {
-                delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result);
-            } catch (Throwable throwable) {
-                repositoryBlacklister.blacklistRepository(repositoryId, throwable);
-                result.failed(new ModuleVersionResolveException(moduleComponentIdentifier, throwable));
-            }
+            performOperationWithRetries(result, () -> delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result), throwable -> {
+                if (throwable == null) {
+                    return new ModuleVersionResolveException(moduleComponentIdentifier, BLACKLISTED_REPOSITORY_ERROR_MESSAGE);
+                }
+                return new ModuleVersionResolveException(moduleComponentIdentifier, throwable);
+            });
         }
 
         @Override
         public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
-            if (repositoryBlacklister.isBlacklisted(repositoryId)) {
-                result.failed(new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE));
-                return;
-            }
-
-            try {
-                delegate.resolveArtifactsWithType(component, artifactType, result);
-            } catch (Throwable throwable) {
-                repositoryBlacklister.blacklistRepository(repositoryId, throwable);
-                result.failed(new ArtifactResolveException(component.getId(), throwable));
-            }
+            performOperationWithRetries(result, () -> delegate.resolveArtifactsWithType(component, artifactType, result), throwable -> {
+                if (throwable == null) {
+                    return new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE);
+                }
+                return new ArtifactResolveException(component.getId(), throwable);
+            });
         }
 
         @Override
         public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
-            if (repositoryBlacklister.isBlacklisted(repositoryId)) {
-                result.failed(new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE));
-                return;
-            }
-
-            try {
-                delegate.resolveArtifacts(component, result);
-            } catch (Throwable throwable) {
-                repositoryBlacklister.blacklistRepository(repositoryId, throwable);
-                result.failed(new ArtifactResolveException(component.getId(), throwable));
-            }
+            performOperationWithRetries(result, () -> delegate.resolveArtifacts(component, result), throwable -> {
+                if (throwable == null) {
+                    return new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE);
+                }
+                return new ArtifactResolveException(component.getId(), throwable);
+            });
         }
 
         @Override
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
+            performOperationWithRetries(result, () -> {
+                delegate.resolveArtifact(artifact, moduleSource, result);
+                if (result.hasResult()) {
+                    ArtifactResolveException failure = result.getFailure();
+                    if (!(failure instanceof ArtifactNotFoundException)) {
+                        return failure;
+                    }
+                }
+                return null;
+            }, throwable -> {
+                if (throwable == null) {
+                    return new ArtifactResolveException(artifact.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE);
+                }
+                return new ArtifactResolveException(artifact.getId(), throwable);
+            });
+        }
+
+        private <E extends Throwable, R extends ErroringResolveResult<E>> void performOperationWithRetries(R result, Callable<E> operation, Transformer<E, Throwable> onError) {
             if (repositoryBlacklister.isBlacklisted(repositoryId)) {
-                result.failed(new ArtifactResolveException(artifact.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE));
+                result.failed(onError.transform(null));
                 return;
             }
 
-            try {
-                delegate.resolveArtifact(artifact, moduleSource, result);
-            } catch (Throwable throwable) {
-                repositoryBlacklister.blacklistRepository(repositoryId, throwable);
-                result.failed(new ArtifactResolveException(artifact.getId(), throwable));
+            tryResolveAndMaybeBlacklist(result, operation, onError);
+        }
+
+        private <E extends Throwable, R extends ErroringResolveResult<E>> void performOperationWithRetries(R result, Runnable operation, Transformer<E, Throwable> onError) {
+            if (repositoryBlacklister.isBlacklisted(repositoryId)) {
+                result.failed(onError.transform(null));
+                return;
+            }
+
+            tryResolveAndMaybeBlacklist(result, operation, onError);
+        }
+
+        private <E extends Throwable, R extends ErroringResolveResult<E>> void tryResolveAndMaybeBlacklist(R result, Runnable operation, Transformer<E, Throwable> onError) {
+            tryResolveAndMaybeBlacklist(result, () -> {
+                operation.run();
+                return null;
+            }, onError);
+        }
+
+        private <E extends Throwable, R extends ErroringResolveResult<E>> void tryResolveAndMaybeBlacklist(R result, Callable<E> operation, Transformer<E, Throwable> onError) {
+            int retries = 0;
+            int backoff = initialBackOff;
+
+            while (retries < maxRetriesCount) {
+                retries++;
+                E failure;
+                Throwable unexpectedFailure = null;
+                try {
+                    failure = operation.call();
+                    if (failure == null) {
+                        if (retries > 1) {
+                            LOGGER.debug("Successfully fetched external resource after {} retries", retries - 1);
+                        }
+                        return;
+                    }
+                } catch (Throwable throwable) {
+                    unexpectedFailure = throwable;
+                    failure = onError.transform(throwable);
+                }
+                if (retries == maxRetriesCount) {
+                    if (unexpectedFailure != null) {
+                        repositoryBlacklister.blacklistRepository(repositoryId, unexpectedFailure);
+                    }
+                    result.failed(failure);
+                    break;
+                } else {
+                    LOGGER.debug("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", repositoryId, backoff, maxRetriesCount - retries);
+                    try {
+                        Thread.sleep(backoff);
+                        backoff *= 2;
+                    } catch (InterruptedException e) {
+                        break;
+                    }
+                }
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 /**
  * The result of attempting to resolve a component id to the meta-data for the component.
  */
-public interface BuildableModuleComponentMetaDataResolveResult extends ResourceAwareResolveResult, ResolveResult {
+public interface BuildableModuleComponentMetaDataResolveResult extends ResourceAwareResolveResult, ErroringResolveResult<ModuleVersionResolveException> {
     enum State {
         Resolved, Missing, Failed, Unknown
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleVersionListingResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleVersionListingResolveResult.java
@@ -25,7 +25,7 @@ import java.util.Set;
 /**
  * The result of attempting to resolve the list of versions for a particular module.
  */
-public interface BuildableModuleVersionListingResolveResult extends ResourceAwareResolveResult, ResolveResult {
+public interface BuildableModuleVersionListingResolveResult extends ResourceAwareResolveResult, ErroringResolveResult<ModuleVersionResolveException> {
 
     enum State {
         /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableTypedResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableTypedResolveResult.java
@@ -16,9 +16,7 @@
 
 package org.gradle.internal.resolve.result;
 
-import javax.annotation.Nullable;
-
-public interface BuildableTypedResolveResult<T, E extends Throwable> extends ResolveResult {
+public interface BuildableTypedResolveResult<T, E extends Throwable> extends ErroringResolveResult<E> {
     /**
      * Returns the result.
      *
@@ -27,19 +25,8 @@ public interface BuildableTypedResolveResult<T, E extends Throwable> extends Res
     T getResult() throws E;
 
     /**
-     * {@inheritDoc}
-     */
-    @Nullable
-    @Override
-    E getFailure();
-
-    /**
      * Marks the resolution as completed with the given value.
      */
     void resolved(T result);
 
-    /**
-     * Marks the resolution as failed with the given failure.
-     */
-    void failed(E failure);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultResourceAwareResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultResourceAwareResolveResult.java
@@ -16,16 +16,18 @@
 
 package org.gradle.internal.resolve.result;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import org.gradle.internal.resource.ExternalResourceName;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public class DefaultResourceAwareResolveResult implements ResourceAwareResolveResult {
-    private final List<String> attempted = new ArrayList<String>();
+    private final Set<String> attempted = Sets.newLinkedHashSet();
 
     public List<String> getAttempted() {
-        return attempted;
+        return ImmutableList.copyOf(attempted);
     }
 
     public void attempted(String locationDescription) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ErroringResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/ErroringResolveResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2008 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,24 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api;
+package org.gradle.internal.resolve.result;
 
 import javax.annotation.Nullable;
 
-/**
- * <p>A {@code Transformer} transforms objects of type.</p>
- *
- * <p>Implementations are free to return new objects or mutate the incoming value.</p>
- *
- * @param <OUT> The type the value is transformed to.
- * @param <IN> The type of the value to be transformed.
- */
-public interface Transformer<OUT, IN> {
+public interface ErroringResolveResult<E extends Throwable> extends ResolveResult {
     /**
-     * Transforms the given object, and returns the transformed value.
-     *
-     * @param in The object to transform.
-     * @return The transformed object.
+     * Marks the resolution as failed with the given failure.
      */
-    OUT transform(@Nullable IN in);
+    void failed(E error);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Nullable
+    @Override
+    E getFailure();
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -77,8 +77,13 @@ class AbstractIntegrationSpec extends Specification {
     private MavenFileRepository mavenRepo
     private IvyFileRepository ivyRepo
 
+    protected int maxHttpRetries = 1
+
     def setup() {
         m2.isolateMavenLocalRepo(executer)
+        executer.beforeExecute {
+            executer.withArgument("-Dorg.gradle.internal.repository.max.retries=$maxHttpRetries")
+        }
     }
 
     def cleanup() {
@@ -295,6 +300,11 @@ class AbstractIntegrationSpec extends Specification {
                 return new GradleBackedArtifactBuilder(executer, dir)
             }
         }
+    }
+
+    AbstractIntegrationSpec withMaxHttpRetryCount(int count) {
+        maxHttpRetries = count
+        this
     }
 
     def jarWithClasses(Map<String, String> javaSourceFiles, TestFile jarFile) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -82,7 +82,7 @@ class AbstractIntegrationSpec extends Specification {
     def setup() {
         m2.isolateMavenLocalRepo(executer)
         executer.beforeExecute {
-            executer.withArgument("-Dorg.gradle.internal.repository.max.retries=$maxHttpRetries")
+            executer.withArgument("-Dorg.gradle.internal.repository.max.tentatives=$maxHttpRetries")
         }
     }
 


### PR DESCRIPTION
This commit reworks the strategy used to blacklist repositories. In the case
an error occurs when trying to access a remote resource, if the error is not
a missing resource, we're going to retry twice before actually blacklisting.

Between each try, we're going to wait, and the wait is increasing between
each trial exponentially. There are two internal parameters which allow
tweaking the behavior:

- `org.gradle.internal.repository.max.tentavies` (default 3) is the number
of retries (initial included)
- `org.gradle.internal.repository.initial.backoff` is the initial time
before retrying, in milliseconds (default 125)

Fixes #4629
