### PR TITLE
Allow lenient locks after deprecation warning is thrown

### DIFF
--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/GradleVersionsPluginSmokeTest.groovy
@@ -16,11 +16,8 @@
 
 package org.gradle.smoketests
 
-import spock.lang.Ignore
-
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-@Ignore("Until this plugin is updated to be compliant with 5.x (causes deadlocks)")
 class GradleVersionsPluginSmokeTest extends AbstractSmokeTest {
     def 'can check for updated versions'() {
         given:


### PR DESCRIPTION
This prevents deadlocks in user-managed threads when a configuration is resolved unsafely.