### PR TITLE
Apply the tag build plugin to the root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,7 @@ plugins {
     // We have to apply it here at the moment, so that when the build scan plugin is auto-applied via --scan can detect that
     // the plugin has been already applied. For that the plugin has to be applied with the new plugin DSL syntax.
     id("com.gradle.build-scan")
+    id("org.gradle.ci.tag-single-build")
 }
 
 defaultTasks("assemble")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -171,7 +171,7 @@ pluginManagement {
         eachPlugin {
             when (requested.id.id) {
                 // FIXME: Publish plugin marker artifacts for the ci tagging plugin
-                "org.gradle.ci.tag-single-build" -> useModule("org.gradle.ci.health:gradle-build-tag-plugin:0.44")
+                "org.gradle.ci.tag-single-build" -> useModule("org.gradle.ci.health:gradle-build-tag-plugin:0.43")
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -161,3 +161,19 @@ for (project in rootProject.children) {
         throw IllegalArgumentException("Build file ${project.buildFile} for project ${project.name} does not exist.")
     }
 }
+
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        maven { url = uri("https://repo.gradle.org/gradle/libs-releases") }
+    }
+    resolutionStrategy {
+        eachPlugin {
+            when (requested.id.id) {
+                // FIXME: Publish plugin marker artifacts for the ci tagging plugin
+                "org.gradle.ci.tag-single-build" -> useModule("org.gradle.ci.health:gradle-build-tag-plugin:0.44")
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
So we do not need to use `-b` to run a separate .gradle file and can
re-use the daemon.

Another try, since #7346 didn't work.