### PR TITLE
Document minimum JDK in user guide and announce Java 11 support in release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Contributors must follow the Code of Conduct outlined at [https://gradle.org/con
 In order to make changes to Gradle, you'll need:
 
 * A text editor or IDE. We use and recommend [IntelliJ IDEA CE](http://www.jetbrains.com/idea/).
-* A [Java Development Kit](http://www.oracle.com/technetwork/java/javase/downloads/index.html) (JDK) version 9 or 10.
+* A [Java Development Kit](http://jdk.java.net/) (JDK) version 9 or 10.
 * [git](https://git-scm.com/) and a [GitHub account](https://github.com/join).
 
 Gradle uses pull requests for contributions. Fork [gradle/gradle](https://github.com/gradle/gradle) and clone your fork. Configure your Git username and email with

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -253,7 +253,7 @@ def userguideSinglePage = tasks.register("userguideSinglePage", AsciidoctorTask)
         'source-highlighter': 'coderay'
 }
 
-def javaApiUrl = "https://docs.oracle.com/javase/7/docs/api"
+def javaApiUrl = "https://docs.oracle.com/javase/8/docs/api"
 def groovyApiUrl = "http://docs.groovy-lang.org/docs/groovy-${groovyVersion}/html/gapi"
 def mavenApiUrl = "http://maven.apache.org/ref/${libraries.maven3.version}/maven-model/apidocs"
 
@@ -324,7 +324,10 @@ tasks.withType(AsciidoctorTask).configureEach {
         encoding            : 'utf-8',
         idprefix            : '',
         website             : 'https://gradle.org',
-        javaApi             : 'https://docs.oracle.com/javase/7/docs/api',
+        javaApi             : javaApiUrl,
+        jdkDownloadUrl      : 'http://jdk.java.net/',
+        javadocReferenceUrl : 'http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html',
+        minJdkVersion       : '8',
         antManual           : 'https://ant.apache.org/manual',
         docsUrl             : 'https://docs.gradle.org',
         guidesUrl           : 'https://guides.gradle.org',

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -13,6 +13,8 @@ Authoring your build logic using Kotlin provides significant additional editing 
 Please follow our [migrating build logic from Groovy to Kotlin guide](https://guides.gradle.org/migrating-build-logic-from-groovy-to-kotlin/) if you're interested.
 If you prefer the flexibility and dynamic nature of Groovy, that's totally okay — the Groovy DSL will _never_ be deprecated.
 
+Java enthusiasts will be happy to read that this release **supports running Gradle builds with JDK 11**.
+
 You can now specify a timeout duration for a task, after which it will be interrupted.
 Read more [about task timeouts](userguide/more_about_tasks.html#sec:task_timeouts) in the docs.
 

--- a/subprojects/docs/src/docs/userguide/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/building_java_projects.adoc
@@ -386,7 +386,7 @@ include::sample[dir="userguide/tutorial/manifest/kotlin",files="build.gradle.kts
 [[sec:generating_javadocs]]
 == Generating API documentation
 
-The Java Plugin provides a `javadoc` task of type link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Javadoc.html[Javadoc], that will generate standard Javadocs for all your production code, i.e. whatever source is in the `main` source set. The task supports the core Javadoc and standard doclet options described in the http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html#options[Javadoc reference documentation]. See link:{javadocPath}/org/gradle/external/javadoc/CoreJavadocOptions.html[CoreJavadocOptions] and link:{javadocPath}/org/gradle/external/javadoc/StandardJavadocDocletOptions.html[StandardJavadocDocletOptions] for a complete list of those options.
+The Java Plugin provides a `javadoc` task of type link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Javadoc.html[Javadoc], that will generate standard Javadocs for all your production code, i.e. whatever source is in the `main` source set. The task supports the core Javadoc and standard doclet options described in the link:{javadocReferenceUrl}#options[Javadoc reference documentation]. See link:{javadocPath}/org/gradle/external/javadoc/CoreJavadocOptions.html[CoreJavadocOptions] and link:{javadocPath}/org/gradle/external/javadoc/StandardJavadocDocletOptions.html[StandardJavadocDocletOptions] for a complete list of those options.
 
 As an example of what you can do, imagine you want to use Asciidoc syntax in your Javadoc comments. To do this, you need to add Asciidoclet to Javadoc's doclet path. Here's an example that does just that:
 

--- a/subprojects/docs/src/docs/userguide/eclipse_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/eclipse_plugin.adoc
@@ -228,7 +228,7 @@ link:{groovyDslPath}/org.gradle.plugins.ide.eclipse.model.EclipseWtpFacet.html[E
 link:{groovyDslPath}/org.gradle.plugins.ide.eclipse.model.EclipseJdt.html[EclipseJdt]::
   * `beforeMerged { link:{javadocPath}/org/gradle/plugins/ide/eclipse/model/Jdt.html[Jdt] arg -&gt; ... }`
   * `whenMerged { link:{javadocPath}/org/gradle/plugins/ide/eclipse/model/Jdt.html[Jdt] arg -&gt; ... }`
-  * `withProperties { arg -&gt; }` argument type => http://docs.oracle.com/javase/7/docs/api/java/util/Properties.html[`java.util.Properties`]
+  * `withProperties { arg -&gt; }` argument type => link:{javaApi}/java/util/Properties.html[`java.util.Properties`]
 
 
 [[sec:partial-overwrite]]

--- a/subprojects/docs/src/docs/userguide/installation.adoc
+++ b/subprojects/docs/src/docs/userguide/installation.adoc
@@ -24,7 +24,7 @@ You can find all releases and their checksums on the link:{website}/releases[rel
 
 [[sec:prerequisites]]
 == Prerequisites
-Gradle runs on all major operating systems and requires only a link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java JDK] version 7 or higher to run. To check, run `java -version`. You should see something like this:
+Gradle runs on all major operating systems and requires only a link:{jdkDownloadUrl}[Java Development Kit] version {minJdkVersion} or higher to run. To check, run `java -version`. You should see something like this:
 
 ----
 ❯ java -version

--- a/subprojects/docs/src/docs/userguide/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_plugin.adoc
@@ -465,7 +465,7 @@ These properties are provided by convention objects of type link:{javadocPath}/o
 [[sec:javadoc]]
 == Javadoc
 
-The `javadoc` task is an instance of link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Javadoc.html[Javadoc]. It supports the core Javadoc options and the options of the standard doclet described in the http://docs.oracle.com/javase/7/docs/technotes/tools/windows/javadoc.html[reference documentation] of the Javadoc executable. For a complete list of supported Javadoc options consult the API documentation of the following classes: link:{javadocPath}/org/gradle/external/javadoc/CoreJavadocOptions.html[CoreJavadocOptions] and link:{javadocPath}/org/gradle/external/javadoc/StandardJavadocDocletOptions.html[StandardJavadocDocletOptions].
+The `javadoc` task is an instance of link:{groovyDslPath}/org.gradle.api.tasks.javadoc.Javadoc.html[Javadoc]. It supports the core Javadoc options and the options of the standard doclet described in the link:{javadocReferenceUrl}[reference documentation] of the Javadoc executable. For a complete list of supported Javadoc options consult the API documentation of the following classes: link:{javadocPath}/org/gradle/external/javadoc/CoreJavadocOptions.html[CoreJavadocOptions] and link:{javadocPath}/org/gradle/external/javadoc/StandardJavadocDocletOptions.html[StandardJavadocDocletOptions].
 
 === Javadoc properties
 
@@ -583,7 +583,7 @@ include::{samplesPath}/java/incrementalAnnotationProcessing/processor/src/main/r
 
 
 If your processor can only decide at runtime whether it is incremental or not, you can declare it as "dynamic" in the META-INF descriptor
-and return its true type at runtime using the https://docs.oracle.com/javase/10/docs/api/javax/annotation/processing/Processor.html#getSupportedOptions()[Processor#getSupportedOptions()] method.
+and return its true type at runtime using the link:{javaApi}/javax/annotation/processing/Processor.html#getSupportedOptions--[Processor#getSupportedOptions()] method.
 
 === Example: Registering incremental annotation processors dynamically
 
@@ -595,13 +595,13 @@ include::{samplesPath}/java/incrementalAnnotationProcessing/processor/src/main/j
 
 Both categories have the following limitations:
 
-* They must generate their files using the https://docs.oracle.com/javase/10/docs/api/javax/annotation/processing/Filer.html[Filer API].
+* They must generate their files using the link:{javaApi}/javax/annotation/processing/Filer.html[Filer API].
     Writing files any other way will result in silent failures later on, as these files won't be cleaned up correctly.
     If your processor does this, it cannot be incremental.
-* They must not depend on compiler-specific APIs like https://docs.oracle.com/javase/8/docs/jdk/api/javac/tree/com/sun/source/util/Trees.html[com.sun.source.util.Trees].
+* They must not depend on compiler-specific APIs like `com.sun.source.util.Trees`.
     Gradle wraps the processing APIs, so attempts to cast to compiler-specific types will fail.
     If your processor does this, it cannot be incremental, unless you have some fallback mechanism.
-* If they use link:https://docs.oracle.com/javase/10/docs/api/javax/annotation/processing/Filer.html#createResource(javax.tools.JavaFileManager.Location,java.lang.CharSequence,java.lang.CharSequence,javax.lang.model.element.Element++...++)[Filer#createResource], Gradle will recompile all source files.
+* If they use link:{javaApi}/javax/annotation/processing/Filer.html#createResource(javax.tools.JavaFileManager.Location,java.lang.CharSequence,java.lang.CharSequence,javax.lang.model.element.Element++...++)[Filer#createResource], Gradle will recompile all source files.
     See https://github.com/gradle/gradle/issues/4702[gradle/issues/4702]
 
 ==== "Isolating" annotation processors

--- a/subprojects/docs/src/docs/userguide/lazy_configuration.adoc
+++ b/subprojects/docs/src/docs/userguide/lazy_configuration.adoc
@@ -132,7 +132,7 @@ In <<working_with_files.adoc#working_with_files,Working with Files>>, we introdu
 
 All of these types are also considered lazy types.
 
-In this section, we are going to introduce more strongly typed models types to represent elements of the file system: link:{javadocPath}/org/gradle/api/file/Directory.html[Directory] and link:{javadocPath}/org/gradle/api/file/RegularFile.html[RegularFile]. These types shouldn't be confused with the standard Java https://docs.oracle.com/javase/7/docs/api/java/io/File.html[File] type as they are used to tell Gradle, and other people, that you expect more specific values (a directory or a non-directory, regular file).
+In this section, we are going to introduce more strongly typed models types to represent elements of the file system: link:{javadocPath}/org/gradle/api/file/Directory.html[Directory] and link:{javadocPath}/org/gradle/api/file/RegularFile.html[RegularFile]. These types shouldn't be confused with the standard Java link:{javaApi}/java/io/File.html[File] type as they are used to tell Gradle, and other people, that you expect more specific values (a directory or a non-directory, regular file).
 
 Gradle provides two specialized `Property` subtypes for dealing with values of these types: link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty] and link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]. link:{javadocPath}/org/gradle/api/model/ObjectFactory.html[ObjectFactory] has methods to create these: link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#fileProperty--[ObjectFactory.fileProperty()] and link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#directoryProperty--[ObjectFactory.directoryProperty()].
 

--- a/subprojects/docs/src/docs/userguide/troubleshooting.adoc
+++ b/subprojects/docs/src/docs/userguide/troubleshooting.adoc
@@ -58,7 +58,7 @@ ERROR: JAVA_HOME is set to an invalid directory
 Please set the JAVA_HOME variable in your environment to match the location of your Java installation.
 ----
 
-You’ll need to ensure that a link:http://www.oracle.com/technetwork/java/javase/downloads/index.html[Java Development Kit] version 7 or higher is link:https://www.java.com/en/download/help/index_installing.xml[properly installed], the `JAVA_HOME` environment variable is set, and link:https://www.java.com/en/download/help/path.xml[Java is added to your `PATH`].
+You’ll need to ensure that a link:{jdkDownloadUrl}[Java Development Kit] version {minJdkVersion} or higher is link:https://www.java.com/en/download/help/index_installing.xml[properly installed], the `JAVA_HOME` environment variable is set, and link:https://www.java.com/en/download/help/path.xml[Java is added to your `PATH`].
 
 === Permission denied
 


### PR DESCRIPTION
 - Change minimum required JDK version to 8
 - Link to Java 8 Javadoc
 - Link to OpenJDK builds instead of Oracle JDK