### PR TITLE
Apply 2.0-rc2 build scan plugin from snapshot repo

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -10,7 +10,7 @@ apply<PrecompiledScriptPlugins>()
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.7")
     implementation("org.jsoup:jsoup:1.11.3")
-    implementation("com.gradle:build-scan-plugin:2.0-rc-1-20181004085302-release")
+    implementation("com.gradle:build-scan-plugin:2.0-rc-2-20181012132135-release")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
 }


### PR DESCRIPTION
### Context

Follow up to https://github.com/gradle/gradle/pull/7023

We've released a RC-2 for the 2.0 plugin, and this PR updates the performance buildSrc project to use it.