### PR TITLE
Change path sensitivity of SourceTask.source to relative

### DIFF
--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/AntlrTask.java
@@ -31,8 +31,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
@@ -269,16 +267,5 @@ public class AntlrTask extends SourceTask {
         if (source instanceof SourceDirectorySet) {
             this.sourceDirectorySet = (SourceDirectorySet) source;
         }
-    }
-
-    /**
-     * Returns the source for this task, after the include and exclude patterns have been applied. Ignores source files which do not exist.
-     *
-     * @return The source.
-     */
-    @Override
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public FileTree getSource() {
-        return super.getSource();
     }
 }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Checkstyle.java
@@ -158,7 +158,6 @@ public class Checkstyle extends SourceTask implements VerificationTask, Reportin
      * executed.</p>
      */
     @Override
-    @PathSensitive(PathSensitivity.RELATIVE)
     public FileTree getSource() {
         return super.getSource();
     }

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarc.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarc.java
@@ -19,7 +19,6 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.quality.internal.CodeNarcInvoker;
@@ -31,8 +30,6 @@ import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.VerificationTask;
@@ -74,15 +71,6 @@ public class CodeNarc extends SourceTask implements VerificationTask, Reporting<
     @Internal
     public File getConfigFile() {
         return getConfig() == null ? null : getConfig().asFile();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugs.java
@@ -24,7 +24,6 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.quality.internal.FindBugsReportsImpl;
@@ -353,15 +352,6 @@ public class FindBugs extends SourceTask implements VerificationTask, Reporting<
     public FindBugs jvmArgs(String... arguments) {
         jvmArgs.addAll(Arrays.asList(arguments));
         return this;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/Pmd.java
@@ -20,7 +20,6 @@ import groovy.lang.DelegatesTo;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.quality.internal.PmdInvoker;
@@ -118,15 +117,6 @@ public class Pmd extends SourceTask implements VerificationTask, Reporting<PmdRe
         if (value > 5 || value < 1) {
             throw new InvalidUserDataException(String.format("Invalid rulePriority '%d'.  Valid range 1 (highest) to 5 (lowest).", value));
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @PathSensitive(PathSensitivity.RELATIVE)
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/SourceTask.java
@@ -52,9 +52,13 @@ public class SourceTask extends ConventionTask implements PatternFilterable {
     /**
      * Returns the source for this task, after the include and exclude patterns have been applied. Ignores source files which do not exist.
      *
-     * @return The source.
+     * <p>
+     * The path sensitivity of the source is {@link PathSensitivity#RELATIVE} by default.
+     * If your sources have a different path sensitivity, override this method and add the corresponding annotations.
+     * </p>
      */
     @InputFiles
+    @PathSensitive(PathSensitivity.RELATIVE)
     @SkipWhenEmpty
     public FileTree getSource() {
         ArrayList<Object> copy = new ArrayList<Object>(this.source);

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks.javadoc;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.internal.tasks.AntGroovydoc;
@@ -31,8 +30,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GFileUtils;
@@ -115,15 +112,6 @@ public class Groovydoc extends SourceTask {
         if (classpath.isEmpty()) {
             throw new InvalidUserDataException("You must assign a Groovy library to the groovy configuration!");
         }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @PathSensitive(PathSensitivity.RELATIVE)
-    @Override
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/Javadoc.java
@@ -19,7 +19,6 @@ package org.gradle.api.tasks.javadoc;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
@@ -27,8 +26,6 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.javadoc.internal.JavadocSpec;
@@ -156,15 +153,6 @@ public class Javadoc extends SourceTask {
 
         Compiler<JavadocSpec> generator = ((JavaToolChainInternal) getToolChain()).select(getPlatform()).newCompiler(JavadocSpec.class);
         generator.execute(spec);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @PathSensitive(PathSensitivity.RELATIVE)
-    @Override
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**

--- a/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/language/scala/tasks/AbstractScalaCompile.java
@@ -24,7 +24,6 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.tasks.compile.CompilerForkUtils;
 import org.gradle.api.internal.tasks.scala.CleaningScalaCompiler;
@@ -39,8 +38,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.LocalState;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
@@ -188,15 +185,6 @@ public abstract class AbstractScalaCompile extends AbstractCompile {
     public FileCollection getEffectiveAnnotationProcessorPath() {
         SingleMessageLogger.nagUserOfReplacedProperty("AbstractScalaCompile.effectiveAnnotationProcessorPath", "AbstractScalaCompile.options.annotationProcessorPath");
         return compileOptions.getAnnotationProcessorPath();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @PathSensitive(PathSensitivity.NAME_ONLY)
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**

--- a/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/tasks/scala/ScalaDoc.java
@@ -16,7 +16,6 @@
 package org.gradle.api.tasks.scala;
 
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.internal.tasks.scala.AntScalaDoc;
 import org.gradle.api.tasks.CacheableTask;
@@ -25,8 +24,6 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SourceTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.util.GUtil;
@@ -63,15 +60,6 @@ public class ScalaDoc extends SourceTask {
 
     public void setDestinationDir(File destinationDir) {
         this.destinationDir = destinationDir;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @PathSensitive(PathSensitivity.RELATIVE)
-    @Override
-    public FileTree getSource() {
-        return super.getSource();
     }
 
     /**


### PR DESCRIPTION
Most sources have relative path sensitivity, so changing the default
makes sense. This also makes it easier to write cacheable tasks
extending source tasks.

