### PR TITLE
Parameterize tooling api shaded jar install path

### DIFF
--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
@@ -123,10 +123,11 @@ open class ShadedJarPlugin : Plugin<Project> {
         val configurationToShade = shadedJarExtension.shadedConfiguration
         val baseVersion: String by rootProject.extra
         val jar: TaskProvider<Jar> = tasks.withType(Jar::class).named("jar")
+        val jarInstallPath = findProperty("${project.name}ShadedJarInstallPath") ?: "shaded-jar/${base.archivesBaseName}-shaded-$baseVersion.jar"
 
         return tasks.register("${project.name}ShadedJar", ShadedJar::class) {
             dependsOn(jar)
-            jarFile.set(layout.buildDirectory.file("shaded-jar/${base.archivesBaseName}-shaded-$baseVersion.jar"))
+            jarFile.set(layout.buildDirectory.file(jarInstallPath.toString()))
             classTreesConfiguration.from(configurationToShade.artifactViewForType(classTreesType))
             entryPointsConfiguration.from(configurationToShade.artifactViewForType(entryPointsType))
             relocatedClassesConfiguration.from(configurationToShade.artifactViewForType(relocatedClassesType))

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ShadedJarPlugin.kt
@@ -26,11 +26,14 @@ import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.attributes.Usage
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.gradlebuild.packaging.Attributes.artifactType
 import org.gradle.gradlebuild.packaging.Attributes.minified
 import org.gradle.kotlin.dsl.*
+import java.io.File
+import java.lang.IllegalArgumentException
 
 
 private
@@ -66,6 +69,8 @@ open class ShadedJarPlugin : Plugin<Project> {
         registerTransforms(shadedJarExtension)
 
         val shadedJarTask = addShadedJarTask(shadedJarExtension)
+
+        addInstallShadedJarTask(shadedJarTask)
 
         plugins.withId("gradlebuild.publish-public-libraries") {
             addShadedJarArtifact(shadedJarTask)
@@ -121,18 +126,36 @@ open class ShadedJarPlugin : Plugin<Project> {
     private
     fun Project.addShadedJarTask(shadedJarExtension: ShadedJarExtension): TaskProvider<ShadedJar> {
         val configurationToShade = shadedJarExtension.shadedConfiguration
-        val baseVersion: String by rootProject.extra
         val jar: TaskProvider<Jar> = tasks.withType(Jar::class).named("jar")
-        val jarInstallPath = findProperty("${project.name}ShadedJarInstallPath") ?: "shaded-jar/${base.archivesBaseName}-shaded-$baseVersion.jar"
 
         return tasks.register("${project.name}ShadedJar", ShadedJar::class) {
             dependsOn(jar)
-            jarFile.set(layout.buildDirectory.file(jarInstallPath.toString()))
+            jarFile.set(layout.buildDirectory.file("shaded-jar/${base.archivesBaseName}-shaded-${rootProject.extra["baseVersion"]}.jar"))
             classTreesConfiguration.from(configurationToShade.artifactViewForType(classTreesType))
             entryPointsConfiguration.from(configurationToShade.artifactViewForType(entryPointsType))
             relocatedClassesConfiguration.from(configurationToShade.artifactViewForType(relocatedClassesType))
             manifests.from(configurationToShade.artifactViewForType(manifestsType))
             buildReceiptFile.set(shadedJarExtension.buildReceiptFile)
+        }
+    }
+
+    private
+    fun Project.addInstallShadedJarTask(shadedJarTask: TaskProvider<ShadedJar>) {
+        val installPathProperty = "${project.name}ShadedJarInstallPath"
+        fun targetFile(): File {
+            val file = findProperty(installPathProperty)?.let { File(findProperty(installPathProperty) as String) }
+
+            if (true == file?.isAbsolute) {
+                return file
+            } else {
+                throw IllegalArgumentException("Property $installPathProperty is required and must be absolute!")
+            }
+        }
+        tasks.register<Copy>("install${project.name.capitalize()}ShadedJar") {
+            dependsOn(shadedJarTask)
+            from(shadedJarTask.map { it.jarFile })
+            into(deferred { targetFile().parentFile })
+            rename { targetFile().name }
         }
     }
 


### PR DESCRIPTION
During implementation of #7337, we need to customize tooling api shaded jar installation. This commit
adds a parameter `toolingApiShadedJarInstallPath`, which is similar to `gradle_installPath`.
