### PR TITLE
Fix extra attributes are ignored when selecting transforms chains from candidates

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -822,6 +822,155 @@ class FileSizer extends ArtifactTransform {
         output.count("Transforming") == 0
     }
 
+    def "transform with two attributes will not confuse"() {
+        given:
+        buildFile << """
+class AarRelease extends ArtifactTransform {
+    AarRelease() {
+        println "Creating AarRelease"
+    }
+    
+    List<File> transform(File input) {
+        assert outputDirectory.directory && outputDirectory.list().length == 0
+        def output = new File(outputDirectory, input.name.replace(".jar",".release.aar"))
+        println "Transforming \${input.name} to \${output.name}"
+        output.text = String.valueOf(input.length())
+        return [output]
+    }
+}
+
+class AarDebug extends ArtifactTransform {
+    AarDebug() {
+        println "Creating AarDebug"
+    }
+    
+    List<File> transform(File input) {
+        assert outputDirectory.directory && outputDirectory.list().length == 0
+        def output = new File(outputDirectory, input.name.replace(".jar",".debug.aar"))
+        println "Transforming \${input.name} to \${output.name}"
+        output.text = String.valueOf(input.length())
+        return [output]
+    }
+}
+
+class AarClasses extends ArtifactTransform {
+    AarClasses() {
+        println "Creating AarClasses"
+    }
+    
+    List<File> transform(File input) {
+        assert outputDirectory.directory && outputDirectory.list().length == 0
+        def output = new File(outputDirectory, input.name.replace(".aar",".classes"))
+        println "Transforming \${input.name} to \${output.name}"
+        output.text = String.valueOf(input.length())
+        return [output]
+    }
+} 
+
+
+def buildType = Attribute.of('buildType', String)
+projectDir.mkdirs()
+def jar1 = file('lib1.jar')
+jar1.text = 'some text'
+
+dependencies {
+    attributesSchema {
+        attribute(buildType)
+    }
+
+    compile files(jar1)
+
+    registerTransform {
+        from.attribute(artifactType, 'jar')
+        to.attribute(artifactType, 'aar')
+
+        from.attribute(buildType, 'default')
+        to.attribute(buildType, 'release')
+
+        artifactTransform(AarRelease)
+    }
+    
+    registerTransform {
+        from.attribute(artifactType, 'jar')
+        to.attribute(artifactType, 'aar')
+
+        from.attribute(buildType, 'default')
+        to.attribute(buildType, 'debug')
+
+        artifactTransform(AarDebug)
+    }
+    
+    registerTransform {
+        from.attribute(artifactType, 'aar')
+        to.attribute(artifactType, 'classes')
+
+        artifactTransform(AarClasses)
+    }
+}
+
+task resolveReleaseClasses {
+    def artifacts = configurations.compile.incoming.artifactView {
+        attributes { 
+            it.attribute(artifactType, 'classes') 
+            it.attribute(buildType, 'release') 
+        }
+    }.artifacts
+    inputs.files artifacts.artifactFiles
+    doLast {
+        println "files: " + artifacts.collect { it.file.name }
+        println "ids: " + artifacts.collect { it.id }
+        println "components: " + artifacts.collect { it.id.componentIdentifier }
+        println "variants: " + artifacts.collect { it.variant.attributes }
+        println "content: " + artifacts.collect { it.file.text }
+    }
+}
+
+
+task resolveTestClasses {
+    def artifacts = configurations.compile.incoming.artifactView {
+        attributes { 
+            it.attribute(artifactType, 'classes') 
+            it.attribute(buildType, 'test') 
+        }
+    }.artifacts
+    inputs.files artifacts.artifactFiles
+    doLast {
+        println "files: " + artifacts.collect { it.file.name }
+        println "ids: " + artifacts.collect { it.id }
+        println "components: " + artifacts.collect { it.id.componentIdentifier }
+        println "variants: " + artifacts.collect { it.variant.attributes }
+        println "content: " + artifacts.collect { it.file.text }
+    }
+}
+        """
+
+        when:
+        run "resolveReleaseClasses"
+
+        then:
+        outputContains("files: [lib1.release.classes]")
+        outputContains("ids: [lib1.release.classes (lib1.jar)]")
+        outputContains("components: [lib1.jar]")
+        outputContains("variants: [{artifactType=classes, buildType=release}]")
+        outputContains("content: [1]")
+
+        and:
+        output.count("Transforming") == 2
+
+        when:
+        run "resolveTestClasses"
+
+        then:
+        outputContains("files: []")
+        outputContains("ids: []")
+        outputContains("components: []")
+        outputContains("variants: []")
+        outputContains("content: []")
+
+        and:
+        output.count("Transforming") == 0
+    }
+
     def "user receives reasonable error message when multiple transforms are available to produce requested variant"() {
         given:
         buildFile << """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -78,7 +78,8 @@ public class ConsumerProvidedVariantFinder {
 
         for (final VariantTransformRegistry.Registration candidate : candidates) {
             ConsumerVariantMatchResult inputVariants = new ConsumerVariantMatchResult();
-            collectConsumerVariants(actual, candidate.getFrom(), inputVariants);
+            AttributeContainerInternal requestedPrevious = inverseTransformAttributes(requested, candidate);
+            collectConsumerVariants(actual, requestedPrevious, inputVariants);
             if (!inputVariants.hasMatches()) {
                 continue;
             }
@@ -88,6 +89,10 @@ public class ConsumerProvidedVariantFinder {
                 result.matched(variantAttributes, transformer, inputVariant.depth + 1);
             }
         }
+    }
+
+    private AttributeContainerInternal inverseTransformAttributes(AttributeContainerInternal result, VariantTransformRegistry.Registration transform) {
+        return attributesFactory.concat(result.asImmutable(), transform.getFrom().asImmutable()).asImmutable();
     }
 
     private AttributeSpecificCache getCache(AttributeContainer attributes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
@@ -26,7 +26,10 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.internal.component.model.AttributeMatcher
 import org.gradle.util.AttributeTestUtil
+import spock.lang.Issue
 import spock.lang.Specification
+
+import static org.spockframework.util.CollectionUtil.mapOf
 
 class ConsumerProvidedVariantFinderTest extends Specification {
     def matcher = Mock(AttributeMatcher)
@@ -46,6 +49,20 @@ class ConsumerProvidedVariantFinderTest extends Specification {
 
         List<File> transform(File input) {
             return transformer.transform(input)
+        }
+    }
+
+    /**
+     * Match all AttributeContainer that contains the same attributes.
+     *
+     * This method is for writing argument constraint in spock interaction. When search for
+     * chains, ConsumerProvidedVariantFinder may create a new instance of the AttributeContainer
+     * to call {@link AttributeMatcher#isMatching(AttributeContainerInternal, AttributeContainerInternal)}.
+     * So we cannot use the origin object instance to write method specification in spock interaction.
+     */
+    def attributesIs(AttributeContainer except, Map<Attribute<Object>, Object> vals) {
+        return except.keySet().size() == vals.size() && vals.every { entry ->
+            except.getAttribute(entry.key) == entry.value
         }
     }
 
@@ -175,10 +192,10 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         1 * matcher.isMatching(c2, requested) >> false
         1 * matcher.isMatching(c5, requested) >> true
         1 * matcher.isMatching(source, c4) >> false
-        1 * matcher.isMatching(c5, c4) >> false
-        1 * matcher.isMatching(c2, c4) >> true
-        1 * matcher.isMatching(c3, c4) >> false
+        1 * matcher.isMatching(c3, { attributesIs(it, mapOf(a1, "4")) }) >> false
+        1 * matcher.isMatching(c2, { attributesIs(it, mapOf(a1, "4")) }) >> true
         1 * matcher.isMatching(source, c1) >> true
+        1 * matcher.isMatching(c5, { attributesIs(it, mapOf(a1, "4")) }) >> false
         0 * matcher._
 
         when:
@@ -249,9 +266,9 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         1 * matcher.isMatching(c4, requested) >> false
         1 * matcher.isMatching(c5, requested) >> true
         1 * matcher.isMatching(source, c4) >> false
-        1 * matcher.isMatching(c4, c4) >> true
-        1 * matcher.isMatching(c3, c4) >> false
-        1 * matcher.isMatching(c5, c4) >> false
+        1 * matcher.isMatching(c4, { attributesIs(it, mapOf(a1, "4")) }) >> true
+        1 * matcher.isMatching(c3, { attributesIs(it, mapOf(a1, "4")) }) >> false
+        1 * matcher.isMatching(c5, { attributesIs(it, mapOf(a1, "4")) }) >> false
         1 * matcher.isMatching(source, c2) >> true
         1 * matcher.isMatching(source, c3) >> false
         0 * matcher._
@@ -264,6 +281,47 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         transform1.transform(new File("a")) >> [new File("b"), new File("c")]
         transform2.transform(new File("b")) >> [new File("d")]
         transform2.transform(new File("c")) >> [new File("e")]
+    }
+
+    @Issue("gradle/gradle#7061")
+    def "selects chain of transforms that only all the attributes are satisfied"() {
+        def c1 = attributes().attribute(a1, "1").attribute(a2, 1).asImmutable()
+        def c4 = attributes().attribute(a1, "2").attribute(a2, 2).asImmutable()
+        def c5 = attributes().attribute(a1, "2").attribute(a2, 3).asImmutable()
+        def c6 = attributes().attribute(a1, "2").asImmutable()
+        def c7 = attributes().attribute(a1, "3").asImmutable()
+        def requested = attributes().attribute(a1, "3").attribute(a2, 3).asImmutable()
+        def source = c1
+        def reg1 = registration(c1, c4, {})
+        def reg2 = registration(c1, c5, {})
+        def reg3 = registration(c6, c7, {})
+
+        given:
+        transformRegistrations.transforms >> [reg1, reg2, reg3]
+
+        when:
+        def result = new ConsumerVariantMatchResult()
+        matchingCache.collectConsumerVariants(source, requested, result)
+
+        then:
+        result.matches.size() == 1
+
+        and:
+        _ * schema.matcher() >> matcher
+        _ * matcher.ignoreAdditionalProducerAttributes() >> matcher
+        _ * matcher.ignoreAdditionalConsumerAttributes() >> matcher
+        1 * matcher.isMatching(c4, requested) >> false
+        1 * matcher.isMatching(c5, requested) >> false
+        1 * matcher.isMatching(c7, requested) >> true
+        1 * matcher.isMatching(source, c6) >> false
+        1 * matcher.isMatching(c4, { attributesIs(it, mapOf(a1, "2", a2, 3)) }) >> false // "2" 3 ; c5
+        1 * matcher.isMatching(c5, { attributesIs(it, mapOf(a1, "2", a2, 3)) }) >> true
+        1 * matcher.isMatching(source, c1) >> true
+        1 * matcher.isMatching(c7, { attributesIs(it, mapOf(a1, "2", a2, 3)) }) >> false
+        0 * matcher._
+
+        expect:
+        result.matches.size() == 1
     }
 
     def "returns empty list when no transforms are available to produce requested variant"() {


### PR DESCRIPTION
When selecting transforms chains from candidates, additional attributes
should not be ignored. If we just use the last transform's from to
search chains, we may get a wrong chain which cannot produce the requested
 artifact at all.

Fixes #7061

Signed-off-by: noproxy <toxzcp@gmail.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
