### PR TITLE
Use last redirect location for HTTP failures

### DIFF
--- a/subprojects/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/HttpResourceAccessorIntegrationTest.groovy
+++ b/subprojects/resources-http/src/integTest/groovy/org/gradle/internal/resource/transport/http/HttpResourceAccessorIntegrationTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.resource.transport.http
 
-import org.apache.http.client.methods.CloseableHttpResponse
 import org.gradle.util.ConcurrentSpecification
 import spock.lang.Issue
 
@@ -26,7 +25,7 @@ class HttpResourceAccessorIntegrationTest extends ConcurrentSpecification {
     @Issue("GRADLE-3574")
     def "should not generate any concurrent exception"() {
         def http = Mock(HttpClientHelper) {
-            performGet(uri.toString(), _) >> Mock(CloseableHttpResponse)
+            performGet(uri.toString(), _) >> Mock(HttpClientResponse)
         }
         def httpResourceAccessor = new HttpResourceAccessor(http)
 

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientHelper.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientHelper.java
@@ -16,19 +16,12 @@
 
 package org.gradle.internal.resource.transport.http;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderIterator;
-import org.apache.http.HttpEntity;
+import com.google.common.collect.Iterables;
 import org.apache.http.HttpHeaders;
-import org.apache.http.ProtocolVersion;
-import org.apache.http.StatusLine;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpHead;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.protocol.HttpClientContext;
-import org.apache.http.client.utils.HttpClientUtils;
-import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.protocol.BasicHttpContext;
@@ -38,8 +31,11 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Locale;
+import java.net.URI;
+import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
+
+import static org.apache.http.client.protocol.HttpClientContext.REDIRECT_LOCATIONS;
 
 /**
  * Provides some convenience and unified logging.
@@ -68,59 +64,46 @@ public class HttpClientHelper implements Closeable {
         }
     }
 
-    public CloseableHttpResponse performRawHead(String source, boolean revalidate) {
+    private HttpClientResponse performRawHead(String source, boolean revalidate) {
         return performRequest(new HttpHead(source), revalidate);
     }
 
-    public CloseableHttpResponse performHead(String source, boolean revalidate) {
-        return processResponse(source, "HEAD", performRawHead(source, revalidate));
+    public HttpClientResponse performHead(String source, boolean revalidate) {
+        return processResponse(performRawHead(source, revalidate));
     }
 
-    public CloseableHttpResponse performRawGet(String source, boolean revalidate) {
+    HttpClientResponse performRawGet(String source, boolean revalidate) {
         return performRequest(new HttpGet(source), revalidate);
     }
 
-    public CloseableHttpResponse performGet(String source, boolean revalidate) {
-        return processResponse(source, "GET", performRawGet(source, revalidate));
+    public HttpClientResponse performGet(String source, boolean revalidate) {
+        return processResponse(performRawGet(source, revalidate));
     }
 
-    public CloseableHttpResponse performRequest(HttpRequestBase request, boolean revalidate) {
+    public HttpClientResponse performRequest(HttpRequestBase request, boolean revalidate) {
         String method = request.getMethod();
         if (revalidate) {
             request.addHeader(HttpHeaders.CACHE_CONTROL, "max-age=0");
         }
-        CloseableHttpResponse response;
         try {
-            response = executeGetOrHead(request);
+            return executeGetOrHead(request);
+        } catch (FailureFromRedirectLocation e) {
+            throw new HttpRequestException(String.format("Could not %s '%s'.", method, e.getLastRedirectLocation()), e.getCause());
         } catch (IOException e) {
             throw new HttpRequestException(String.format("Could not %s '%s'.", method, request.getURI()), e);
         }
+    }
 
+    protected HttpClientResponse executeGetOrHead(HttpRequestBase method) throws IOException {
+        HttpClientResponse response = performHttpRequest(method);
+        // Consume content for non-successful, responses. This avoids the connection being left open.
+        if (!response.wasSuccessful()) {
+            response.close();
+        }
         return response;
     }
 
-    protected CloseableHttpResponse executeGetOrHead(HttpRequestBase method) throws IOException {
-        final CloseableHttpResponse httpResponse = performHttpRequest(method);
-        // Consume content for non-successful, responses. This avoids the connection being left open.
-        if (!wasSuccessful(httpResponse)) {
-            CloseableHttpResponse response = new AutoClosedHttpResponse(httpResponse);
-            HttpClientUtils.closeQuietly(httpResponse);
-            return response;
-        }
-        return httpResponse;
-    }
-
-    public boolean wasMissing(CloseableHttpResponse response) {
-        int statusCode = response.getStatusLine().getStatusCode();
-        return statusCode == 404;
-    }
-
-    public boolean wasSuccessful(CloseableHttpResponse response) {
-        int statusCode = response.getStatusLine().getStatusCode();
-        return statusCode >= 200 && statusCode < 400;
-    }
-
-    public CloseableHttpResponse performHttpRequest(HttpRequestBase request) throws IOException {
+    public HttpClientResponse performHttpRequest(HttpRequestBase request) throws IOException {
         if (sharedContext == null) {
             // There's no authentication involved, requests can be done concurrently
             return performHttpRequest(request, new BasicHttpContext());
@@ -141,21 +124,40 @@ public class HttpClientHelper implements Closeable {
         return context;
     }
 
-    private CloseableHttpResponse performHttpRequest(HttpRequestBase request, HttpContext httpContext) throws IOException {
+    private HttpClientResponse performHttpRequest(HttpRequestBase request, HttpContext httpContext) throws IOException {
         // Without this, HTTP Client prohibits multiple redirects to the same location within the same context
-        httpContext.removeAttribute(HttpClientContext.REDIRECT_LOCATIONS);
+        httpContext.removeAttribute(REDIRECT_LOCATIONS);
         LOGGER.debug("Performing HTTP {}: {}", request.getMethod(), request.getURI());
-        return getClient().execute(request, httpContext);
+        try {
+            CloseableHttpResponse response = getClient().execute(request, httpContext);
+            return toHttpClientResponse(request, httpContext, response);
+        } catch (IOException e) {
+            URI lastRedirectLocation = getLastRedirectLocation(httpContext);
+            throw (lastRedirectLocation == null) ? e : new FailureFromRedirectLocation(lastRedirectLocation, e);
+        }
     }
 
-    private CloseableHttpResponse processResponse(String source, String method, CloseableHttpResponse response) {
-        if (wasMissing(response)) {
-            LOGGER.info("Resource missing. [HTTP {}: {}]", method, source);
+    private HttpClientResponse toHttpClientResponse(HttpRequestBase request, HttpContext httpContext, CloseableHttpResponse response) {
+        URI lastRedirectLocation = getLastRedirectLocation(httpContext);
+        URI effectiveUri = lastRedirectLocation == null ? request.getURI() : lastRedirectLocation;
+        return new HttpClientResponse(request.getMethod(), effectiveUri, response);
+    }
+
+    @SuppressWarnings("unchecked")
+    private URI getLastRedirectLocation(HttpContext httpContext) {
+        List<URI> redirectLocations = (List<URI>) httpContext.getAttribute(REDIRECT_LOCATIONS);
+        return (redirectLocations == null || redirectLocations.isEmpty()) ? null : Iterables.getLast(redirectLocations);
+    }
+
+    private HttpClientResponse processResponse(HttpClientResponse response) {
+        if (response.wasMissing()) {
+            LOGGER.info("Resource missing. [HTTP {}: {}]", response.getMethod(), response.getEffectiveUri());
             return null;
         }
-        if (!wasSuccessful(response)) {
-            LOGGER.info("Failed to get resource: {}. [HTTP {}: {}]", method, response.getStatusLine(), source);
-            throw new HttpErrorStatusCodeException(method, source, response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
+        if (!response.wasSuccessful()) {
+            URI effectiveUri = response.getEffectiveUri();
+            LOGGER.info("Failed to get resource: {}. [HTTP {}: {})]", response.getMethod(), response.getStatusLine(), effectiveUri);
+            throw new HttpErrorStatusCodeException(response.getMethod(), effectiveUri.toString(), response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase());
         }
 
         return response;
@@ -180,155 +182,16 @@ public class HttpClientHelper implements Closeable {
         }
     }
 
-    private static class AutoClosedHttpResponse implements CloseableHttpResponse {
-        private final HttpEntity entity;
-        private final CloseableHttpResponse httpResponse;
+    private static class FailureFromRedirectLocation extends IOException {
+        private final URI lastRedirectLocation;
 
-        public AutoClosedHttpResponse(CloseableHttpResponse httpResponse) throws IOException {
-            this.httpResponse = httpResponse;
-            HttpEntity entity = httpResponse.getEntity();
-            this.entity = entity != null ? new BufferedHttpEntity(entity) : null;
+        private FailureFromRedirectLocation(URI lastRedirectLocation, Throwable cause) {
+            super(cause);
+            this.lastRedirectLocation = lastRedirectLocation;
         }
 
-        @Override
-        public void close() throws IOException {
-        }
-
-        @Override
-        public StatusLine getStatusLine() {
-            return httpResponse.getStatusLine();
-        }
-
-        @Override
-        public void setStatusLine(StatusLine statusline) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setStatusLine(ProtocolVersion ver, int code) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setStatusLine(ProtocolVersion ver, int code, String reason) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setStatusCode(int code) throws IllegalStateException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setReasonPhrase(String reason) throws IllegalStateException {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public HttpEntity getEntity() {
-            return entity;
-        }
-
-        @Override
-        public void setEntity(HttpEntity entity) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Locale getLocale() {
-            return httpResponse.getLocale();
-        }
-
-        @Override
-        public void setLocale(Locale loc) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ProtocolVersion getProtocolVersion() {
-            return httpResponse.getProtocolVersion();
-        }
-
-        @Override
-        public boolean containsHeader(String name) {
-            return httpResponse.containsHeader(name);
-        }
-
-        @Override
-        public Header[] getHeaders(String name) {
-            return httpResponse.getHeaders(name);
-        }
-
-        @Override
-        public Header getFirstHeader(String name) {
-            return httpResponse.getFirstHeader(name);
-        }
-
-        @Override
-        public Header getLastHeader(String name) {
-            return httpResponse.getLastHeader(name);
-        }
-
-        @Override
-        public Header[] getAllHeaders() {
-            return httpResponse.getAllHeaders();
-        }
-
-        @Override
-        public void addHeader(Header header) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void addHeader(String name, String value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setHeader(Header header) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setHeader(String name, String value) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setHeaders(Header[] headers) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void removeHeader(Header header) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void removeHeaders(String name) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public HeaderIterator headerIterator() {
-            return httpResponse.headerIterator();
-        }
-
-        @Override
-        public HeaderIterator headerIterator(String name) {
-            return httpResponse.headerIterator(name);
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public org.apache.http.params.HttpParams getParams() {
-            return httpResponse.getParams();
-        }
-
-        @Override
-        @SuppressWarnings("deprecation")
-        public void setParams(org.apache.http.params.HttpParams params) {
-            throw new UnsupportedOperationException();
+        private URI getLastRedirectLocation() {
+            return lastRedirectLocation;
         }
     }
 

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientResponse.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpClientResponse.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.resource.transport.http;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.utils.HttpClientUtils;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+
+public class HttpClientResponse implements Closeable {
+
+    private final String method;
+    private final URI effectiveUri;
+    private final CloseableHttpResponse httpResponse;
+    private boolean closed;
+
+    HttpClientResponse(String method, URI effectiveUri, CloseableHttpResponse httpResponse) {
+        this.method = method;
+        this.effectiveUri = effectiveUri;
+        this.httpResponse = httpResponse;
+    }
+
+    public String getHeader(String name) {
+        Header header = httpResponse.getFirstHeader(name);
+        return header == null ? null : header.getValue();
+    }
+
+    public InputStream getContent() throws IOException {
+        HttpEntity entity = httpResponse.getEntity();
+        if (entity == null) {
+            throw new IOException(String.format("Response %d: %s has no content!", getStatusLine().getStatusCode(), getStatusLine().getReasonPhrase()));
+        }
+        return entity.getContent();
+    }
+
+    public StatusLine getStatusLine() {
+        return httpResponse.getStatusLine();
+    }
+
+    @Override
+    public void close() {
+        if (!closed) {
+            closed = true;
+            HttpClientUtils.closeQuietly(httpResponse);
+        }
+    }
+
+    String getMethod() {
+        return method;
+    }
+
+    URI getEffectiveUri() {
+        return effectiveUri;
+    }
+
+    boolean wasSuccessful() {
+        int statusCode = getStatusLine().getStatusCode();
+        return statusCode >= 200 && statusCode < 400;
+    }
+
+    boolean wasMissing() {
+        int statusCode = getStatusLine().getStatusCode();
+        return statusCode == 404;
+    }
+}

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceAccessor.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceAccessor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.resource.transport.http;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.resource.metadata.ExternalResourceMetaData;
 import org.gradle.internal.resource.transfer.ExternalResourceAccessor;
@@ -40,7 +39,7 @@ public class HttpResourceAccessor implements ExternalResourceAccessor {
         String location = uri.toString();
         LOGGER.debug("Constructing external resource: {}", location);
 
-        CloseableHttpResponse response = http.performGet(location, revalidate);
+        HttpClientResponse response = http.performGet(location, revalidate);
         if (response != null) {
             return wrapResponse(uri, response);
         }
@@ -55,14 +54,14 @@ public class HttpResourceAccessor implements ExternalResourceAccessor {
     public HttpResponseResource getRawResource(final URI uri, boolean revalidate) {
         String location = uri.toString();
         LOGGER.debug("Constructing external resource: {}", location);
-        CloseableHttpResponse response = http.performRawGet(location, revalidate);
+        HttpClientResponse response = http.performRawGet(location, revalidate);
         return wrapResponse(uri, response);
     }
 
     public ExternalResourceMetaData getMetaData(URI uri, boolean revalidate) {
         String location = uri.toString();
         LOGGER.debug("Constructing external resource metadata: {}", location);
-        CloseableHttpResponse response = http.performHead(location, revalidate);
+        HttpClientResponse response = http.performHead(location, revalidate);
 
         ExternalResourceMetaData result = null;
         if (response != null) {
@@ -76,7 +75,7 @@ public class HttpResourceAccessor implements ExternalResourceAccessor {
         return result;
     }
 
-    private HttpResponseResource wrapResponse(URI uri, CloseableHttpResponse response) {
+    private HttpResponseResource wrapResponse(URI uri, HttpClientResponse response) {
         return new HttpResponseResource("GET", uri, response);
     }
 

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceUploader.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpResourceUploader.java
@@ -16,9 +16,7 @@
 
 package org.gradle.internal.resource.transport.http;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.utils.HttpClientUtils;
 import org.apache.http.entity.ContentType;
 import org.gradle.internal.resource.ReadableContent;
 import org.gradle.internal.resource.transfer.ExternalResourceUploader;
@@ -38,15 +36,11 @@ public class HttpResourceUploader implements ExternalResourceUploader {
         HttpPut method = new HttpPut(destination);
         final RepeatableInputStreamEntity entity = new RepeatableInputStreamEntity(resource, ContentType.APPLICATION_OCTET_STREAM);
         method.setEntity(entity);
-        CloseableHttpResponse response = null;
-        try {
-            response = http.performHttpRequest(method);
-            if (!http.wasSuccessful(response)) {
+        try (HttpClientResponse response = http.performHttpRequest(method)) {
+            if (!response.wasSuccessful()) {
                 throw new IOException(String.format("Could not PUT '%s'. Received status code %s from server: %s",
                     destination, response.getStatusLine().getStatusCode(), response.getStatusLine().getReasonPhrase()));
             }
-        } finally {
-            HttpClientUtils.closeQuietly(response);
         }
     }
 }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientHelperTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.resource.transport.http
 
-import org.apache.http.client.methods.CloseableHttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.client.methods.HttpRequestBase
 import org.apache.http.impl.client.CloseableHttpClient
@@ -30,7 +29,7 @@ class HttpClientHelperTest extends AbstractHttpClientTest {
     def "throws HttpRequestException if an IO error occurs during a request"() {
         def client = new HttpClientHelper(httpSettings) {
             @Override
-            protected CloseableHttpResponse executeGetOrHead(HttpRequestBase method) {
+            protected HttpClientResponse executeGetOrHead(HttpRequestBase method) {
                 throw new IOException("ouch")
             }
         }
@@ -62,7 +61,7 @@ class HttpClientHelperTest extends AbstractHttpClientTest {
     def "request with revalidate adds Cache-Control header"() {
         def client = new HttpClientHelper(httpSettings) {
             @Override
-            protected CloseableHttpResponse executeGetOrHead(HttpRequestBase method) {
+            protected HttpClientResponse executeGetOrHead(HttpRequestBase method) {
                 return null
             }
         }

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceAccessorTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceAccessorTest.groovy
@@ -19,13 +19,13 @@ package org.gradle.internal.resource.transport.http
 import org.apache.http.client.methods.CloseableHttpResponse
 import spock.lang.Specification
 
-class HttpResourceAccessorTest  extends Specification {
+class HttpResourceAccessorTest extends Specification {
     URI uri = new URI("http://somewhere")
 
     def "should call close() on ClosableHttpResource when getMetaData is called"() {
         def response = Mock(CloseableHttpResponse)
         def http = Mock(HttpClientHelper) {
-            performHead(uri.toString(), _) >> response
+            performHead(uri.toString(), _) >> new HttpClientResponse("GET", uri, response)
         }
 
         when:

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceUploaderTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceUploaderTest.groovy
@@ -25,13 +25,14 @@ class HttpResourceUploaderTest extends AbstractHttpClientTest {
         HttpClientHelper client = Mock()
         ReadableContent resource = Mock()
         MockedHttpResponse mockedHttpResponse = mockedHttpResponse()
+        def uri = new URI("http://somewhere.org/somehow")
 
         when:
-        new HttpResourceUploader(client).upload(resource, new URI("http://somewhere.org/somehow"))
+        new HttpResourceUploader(client).upload(resource, uri)
 
         then:
         interaction {
-            1 * client.performHttpRequest(_) >> mockedHttpResponse.response
+            1 * client.performHttpRequest(_) >> new HttpClientResponse("PUT", uri, mockedHttpResponse.response)
             assertIsClosedCorrectly(mockedHttpResponse)
         }
         IOException exception = thrown()

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResponseResourceTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResponseResourceTest.groovy
@@ -85,7 +85,7 @@ class HttpResponseResourceTest extends AbstractHttpClientTest {
     }
 
     HttpResponseResource resource() {
-        new HttpResponseResource(method, sourceUrl, response)
+        new HttpResponseResource(method, sourceUrl, new HttpClientResponse("GET", sourceUrl, response))
     }
 
     void addHeader(String name, String value) {


### PR DESCRIPTION
Instead of including the original HTTP request URI, the bottommost
exception for failed HTTP requests now includes the URI of the last
redirect location, if any.