### PR TITLE
Allow failed worker daemon processes to be cleaned up immediately

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/worker/MultiRequestWorkerProcessBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/worker/MultiRequestWorkerProcessBuilder.java
@@ -16,6 +16,8 @@
 
 package org.gradle.process.internal.worker;
 
+import org.gradle.api.Action;
+
 /**
  * Configures and builds multi-request workers. A multi-request worker runs zero or more requests in a forked worker process.
  *
@@ -32,4 +34,9 @@ public interface MultiRequestWorkerProcessBuilder<T> extends WorkerProcessSettin
      * <p>The worker process is not started until {@link WorkerControl#start()} is called on the returned object.</p>
      */
     T build();
+
+    /**
+     * Registers a callback to invoke if a failure in an underlying process is detected.
+     */
+    void onProcessFailure(Action<WorkerProcess> action);
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -165,6 +165,35 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
         assertDifferentDaemonsWereUsed("runInWorker1", "runInWorker2")
     }
 
+    def "worker daemons are not reused when they fail unexpectedly"() {
+        buildFile << """
+            $runnableThatCanFailUnexpectedly
+
+            task runInWorker1(type: WorkerTask) {
+                isolationMode = IsolationMode.PROCESS
+            }
+            
+            task runInWorker2(type: WorkerTask) {
+                // This will cause the worker process to fail with exit code 127
+                list = runInWorker1.list + ["4"]
+
+                isolationMode = IsolationMode.PROCESS
+            }
+        """
+
+        when:
+        succeeds "runInWorker1"
+
+        and:
+        fails "runInWorker2"
+
+        then:
+        assertSameDaemonWasUsed("runInWorker1", "runInWorker2")
+
+        then:
+        succeeds "runInWorker1"
+    }
+
     def "only compiler daemons are stopped with the build session"() {
         withRunnableClassInBuildScript()
         file('src/main/java').createDir()
@@ -204,5 +233,40 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
 
     String sinceSnapshot() {
         return daemons.daemon.log - logSnapshot
+    }
+
+    String getRunnableThatCanFailUnexpectedly() {
+        return """
+            import java.io.File;
+            import java.util.List;
+            import org.gradle.other.Foo;
+            import org.gradle.test.FileHelper;
+            import java.util.UUID;
+            import javax.inject.Inject;
+
+            public class TestRunnable implements Runnable {
+                private final List<String> files;
+                protected final File outputDir;
+                private final Foo foo;
+                private static final String id = UUID.randomUUID().toString();
+
+                @Inject
+                public TestRunnable(List<String> files, File outputDir, Foo foo) {
+                    this.files = files;
+                    this.outputDir = outputDir;
+                    this.foo = foo;
+                }
+
+                public void run() {
+                    for (String name : files) {
+                        File outputFile = new File(outputDir, name);
+                        FileHelper.write(id, outputFile);
+                    }
+                    if (files.contains("4")) {
+                        System.exit(127);
+                    }
+                }
+            }
+        """
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -28,6 +28,7 @@ class WorkerDaemonClient implements Worker, Stoppable {
     private final WorkerProcess workerProcess;
     private final LogLevel logLevel;
     private int uses;
+    private boolean failed;
 
     public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess workerDaemonProcess, WorkerProcess workerProcess, LogLevel logLevel) {
         this.forkOptions = forkOptions;
@@ -74,5 +75,17 @@ class WorkerDaemonClient implements Worker, Stoppable {
 
     public LogLevel getLogLevel() {
         return logLevel;
+    }
+
+    public boolean isProcess(WorkerProcess workerProcess) {
+        return this.workerProcess.equals(workerProcess);
+    }
+
+    public boolean isFailed() {
+        return failed;
+    }
+
+    public void setFailed(boolean failed) {
+        this.failed = failed;
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonStarter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal;
 
+import org.gradle.api.Action;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.LoggingManager;
@@ -36,7 +37,7 @@ public class WorkerDaemonStarter {
         this.loggingManager = loggingManager;
     }
 
-    public WorkerDaemonClient startDaemon(Class<? extends WorkerProtocol> workerProtocolImplementationClass, DaemonForkOptions forkOptions) {
+    public WorkerDaemonClient startDaemon(Class<? extends WorkerProtocol> workerProtocolImplementationClass, DaemonForkOptions forkOptions, Action<WorkerProcess> cleanupAction) {
         LOG.debug("Starting Gradle worker daemon with fork options {}.", forkOptions);
         Timer clock = Time.startTimer();
         MultiRequestWorkerProcessBuilder<WorkerDaemonProcess> builder = workerDaemonProcessFactory.multiRequestWorker(WorkerDaemonProcess.class, WorkerProtocol.class, workerProtocolImplementationClass);
@@ -44,6 +45,7 @@ public class WorkerDaemonStarter {
         builder.setLogLevel(loggingManager.getLevel()); // NOTE: might make sense to respect per-compile-task log level
         builder.applicationClasspath(forkOptions.getClasspath());
         builder.sharedPackages(forkOptions.getSharedPackages());
+        builder.onProcessFailure(cleanupAction);
         JavaExecHandleBuilder javaCommand = builder.getJavaCommand();
         forkOptions.getJavaForkOptions().copyTo(javaCommand);
         WorkerDaemonProcess workerDaemonProcess = builder.build();

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonExpirationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.api.Action
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.jvm.Jvm
@@ -27,6 +28,7 @@ import org.gradle.process.internal.health.memory.MBeanOsMemoryInfo
 import org.gradle.process.internal.health.memory.MaximumHeapHelper
 import org.gradle.process.internal.health.memory.MemoryAmount
 import org.gradle.process.internal.health.memory.MemoryManager
+import org.gradle.process.internal.worker.WorkerProcess
 import spock.lang.Specification
 
 import static org.gradle.api.internal.file.TestFiles.systemSpecificAbsolutePath
@@ -41,7 +43,7 @@ class WorkerDaemonExpirationTest extends Specification {
     def threeGbOptions = daemonForkOptions('3g', '3g', ['three-gb-options'])
     def reportsMemoryUsage = true
     def daemonStarter = Mock(WorkerDaemonStarter) {
-        startDaemon(_, _) >> { Class<? extends WorkerProtocol> impl, DaemonForkOptions forkOptions ->
+        startDaemon(_, _, _) >> { Class<? extends WorkerProtocol> impl, DaemonForkOptions forkOptions, Action<WorkerProcess> cleanupAction ->
             Mock(WorkerDaemonClient) {
                 getForkOptions() >> forkOptions
                 isCompatibleWith(_) >> { DaemonForkOptions otherForkOptions ->


### PR DESCRIPTION
This causes a failed worker daemon client to immediately be marked as failed and pulled out of service.  It also fixes an issue where a failed client could persist across invocations to the daemon.