### PR TITLE
Restore daily trigger to release nightly job. 

### DIFF
--- a/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/bt61.xml
@@ -28,7 +28,24 @@
     <requirements>
       <contains id="RQ_29" name="teamcity.agent.jvm.os.name" value="Linux" />
     </requirements>
-    <build-triggers />
+    <build-triggers>
+      <build-trigger id="TRIGGER_12" type="schedulingTrigger">
+        <parameters>
+          <param name="cronExpression_dm" value="*" />
+          <param name="cronExpression_dw" value="?" />
+          <param name="cronExpression_hour" value="*" />
+          <param name="cronExpression_min" value="0" />
+          <param name="cronExpression_month" value="*" />
+          <param name="cronExpression_sec" value="0" />
+          <param name="cronExpression_year" value="*" />
+          <param name="dayOfWeek" value="Sunday" />
+          <param name="enableQueueOptimization" value="true" />
+          <param name="hour" value="0" />
+          <param name="minute" value="0" />
+          <param name="schedulingPolicy" value="daily" />
+        </parameters>
+      </build-trigger>
+    </build-triggers>
     <artifact-dependencies>
       <dependency id="ARTIFACT_DEPENDENCY_46" sourceBuildTypeId="Gradle_Check_Stage_ReadyforNightly_Trigger" cleanDestination="true">
         <revisionRule name="lastSuccessful" revision="latest.lastSuccessful" branch="release" />


### PR DESCRIPTION
Now that this has been manually E2E tested and we're sure that works as expected, let's add a daily trigger.