### PR TITLE
Sum Global PR.

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -165,7 +165,11 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     }
 
     FileSystemSnapshotter createFileSystemSnapshotter(FileHasher hasher, StringInterner stringInterner, FileSystem fileSystem, FileSystemMirror fileSystemMirror) {
-        return new DefaultFileSystemSnapshotter(hasher, stringInterner, fileSystem, fileSystemMirror, DirectoryScanner.getDefaultExcludes());
+        // added to fix  MD5 error when .gradle project cache is part of the root source code dirs (typically in native builds)
+        // issue: https://github.com/gradle/gradle/issues/5941
+        DirectoryScanner.addDefaultExclude("**/.gradle/**"); // should never include the .gradle directory in a snapshot
+        FileSystemSnapshotter retval = new DefaultFileSystemSnapshotter(hasher, stringInterner, fileSystem, fileSystemMirror, DirectoryScanner.getDefaultExcludes());
+        return retval;
     }
 
     AbsolutePathFileCollectionFingerprinter createAbsolutePathFileCollectionFingerprinter(StringInterner stringInterner, FileSystemSnapshotter fileSystemSnapshotter) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractNativeCompileSpec.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/AbstractNativeCompileSpec.java
@@ -39,12 +39,15 @@ public abstract class AbstractNativeCompileSpec extends AbstractBinaryToolSpec i
     private File objectFileDir;
     private boolean positionIndependentCode;
     private boolean debuggable;
+    private String debugInfoFormat;
     private boolean optimized;
+    private String optimizationLevel;
     private BuildOperationLogger oplogger;
     private File prefixHeaderFile;
     private File preCompiledHeaderObjectFile;
     private List<File> sourceFilesForPch = new ArrayList<File>();
     private String preCompiledHeader;
+
 
     @Override
     public List<File> getIncludeRoots() {
@@ -227,5 +230,25 @@ public abstract class AbstractNativeCompileSpec extends AbstractBinaryToolSpec i
     @Override
     public void setSourceFilesForPch(List<File> sourceFilesForPch) {
         this.sourceFilesForPch = sourceFilesForPch;
+    }
+
+    @Override
+    public String getDebugInfoFormat() {
+        return debugInfoFormat;
+    }
+
+    @Override
+    public void setDebugInfoFormat(String debugInfoFormat) {
+        this.debugInfoFormat = debugInfoFormat;
+    }
+
+    @Override
+    public String getOptimizationLevel() {
+        return optimizationLevel;
+    }
+
+    @Override
+    public void setOptimizationLevel(String optimizationLevel) {
+        this.optimizationLevel = optimizationLevel;
     }
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -49,7 +50,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,13 +67,14 @@ public class WindowsResourceCompile extends DefaultTask {
     private ConfigurableFileCollection includes;
     private ConfigurableFileCollection source;
     private Map<String, String> macros = new LinkedHashMap<String, String>();
-    private List<String> compilerArgs = new ArrayList<String>();
+    private final ListProperty<String> compilerArgs;
     private final IncrementalCompilerBuilder.IncrementalCompiler incrementalCompiler;
 
     public WindowsResourceCompile() {
         ObjectFactory objectFactory = getProject().getObjects();
         includes = getProject().files();
         source = getProject().files();
+        this.compilerArgs = getProject().getObjects().listProperty(String.class).empty();
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
         incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes, macros, Providers.FALSE);
@@ -107,7 +108,7 @@ public class WindowsResourceCompile extends DefaultTask {
         spec.include(getIncludes());
         spec.source(getSource());
         spec.setMacros(getMacros());
-        spec.args(getCompilerArgs());
+        spec.args(getCompilerArgs().get());
         spec.setIncrementalCompile(inputs.isIncremental());
         spec.setOperationLogger(operationLogger);
 
@@ -201,15 +202,17 @@ public class WindowsResourceCompile extends DefaultTask {
     }
 
     /**
-     * Additional arguments to provide to the compiler.
+     * <em>Additional</em> arguments to provide to the compiler.
+     *
+     * @since 5.1
      */
     @Input
-    public List<String> getCompilerArgs() {
+    public ListProperty<String> getCompilerArgs() {
         return compilerArgs;
     }
 
     public void setCompilerArgs(List<String> compilerArgs) {
-        this.compilerArgs = compilerArgs;
+        this.compilerArgs.addAll(compilerArgs);
     }
 
     /**

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompileSpec.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/NativeCompileSpec.java
@@ -92,4 +92,13 @@ public interface NativeCompileSpec extends BinaryToolSpec {
     List<File> getSourceFilesForPch();
 
     void setSourceFilesForPch(List<File> sourceFilesForPch);
+    
+    String getDebugInfoFormat();
+    
+    void setDebugInfoFormat(String debugInfoFormat);
+    
+    String getOptimizationLevel();
+    
+    void setOptimizationLevel(String optimizationLevel);
+    
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformer.java
@@ -48,10 +48,10 @@ abstract class GccCompilerArgsTransformer<T extends NativeCompileSpec> implement
             }
         }
         if (spec.isDebuggable()) {
-            args.add("-g");
+            args.add((spec.getDebugInfoFormat()!=null) ? spec.getDebugInfoFormat() : "-g");
         }
         if (spec.isOptimized()) {
-            args.add("-O3");
+            args.add((spec.getOptimizationLevel() !=null) ? spec.getOptimizationLevel() :"-O3");
         }
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -16,16 +16,17 @@
 
 package org.gradle.nativeplatform.toolchain.internal.msvcpp;
 
-import com.google.common.collect.Lists;
-import org.gradle.nativeplatform.toolchain.internal.ArgsTransformer;
-import org.gradle.nativeplatform.toolchain.internal.MacroArgsConverter;
-import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
+import static org.gradle.nativeplatform.toolchain.internal.msvcpp.EscapeUserArgs.escapeUserArg;
+import static org.gradle.nativeplatform.toolchain.internal.msvcpp.EscapeUserArgs.escapeUserArgs;
 
 import java.io.File;
 import java.util.List;
 
-import static org.gradle.nativeplatform.toolchain.internal.msvcpp.EscapeUserArgs.escapeUserArg;
-import static org.gradle.nativeplatform.toolchain.internal.msvcpp.EscapeUserArgs.escapeUserArgs;
+import org.gradle.nativeplatform.toolchain.internal.ArgsTransformer;
+import org.gradle.nativeplatform.toolchain.internal.MacroArgsConverter;
+import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
+
+import com.google.common.collect.Lists;
 
 abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> implements ArgsTransformer<T> {
     @Override
@@ -47,10 +48,10 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
         args.add("/nologo");
         args.add("/c");
         if (spec.isDebuggable()) {
-            args.add("/Zi");
+            args.add((spec.getDebugInfoFormat() != null) ? spec.getDebugInfoFormat() : "/Zi");
         }
         if (spec.isOptimized()) {
-            args.add("/O2");
+            args.add((spec.getOptimizationLevel() != null) ? spec.getOptimizationLevel() : "/O2");
         }
     }
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/swift/SwiftCompiler.java
@@ -139,11 +139,12 @@ class SwiftCompiler extends AbstractCompiler<SwiftCompileSpec> {
                     importRootArgs.add("-I");
                     importRootArgs.add(importRoot.getAbsolutePath());
                 }
+                
                 if (spec.isDebuggable()) {
-                    genericArgs.add("-g");
+                    genericArgs.add((spec.getDebugInfoFormat()!=null) ? spec.getDebugInfoFormat() : "-g");
                 }
                 if (spec.isOptimized()) {
-                    genericArgs.add("-O");
+                    genericArgs.add((spec.getOptimizationLevel() !=null) ? spec.getOptimizationLevel() :"-O");
                 }
 
                 genericArgs.addAll(CollectionUtils.collect(spec.getMacros().keySet(), new Transformer<String, String>() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/GccCompilerArgsTransformerTest.groovy
@@ -32,16 +32,22 @@ class GccCompilerArgsTransformerTest extends Specification {
         def spec = Stub(NativeCompileSpec)
         spec.debuggable >> debug
         spec.optimized >> optimize
+        spec.debugInfoFormat >> debugInfoFormat
+        spec.optimizationLevel >> optimizationLevel
 
         expect:
         def args = transformer.transform(spec)
         args.containsAll(expected)
 
+
         where:
-        debug | optimize | expected
-        true  | false    | ["-g"]
-        false | true     | ["-O3"]
-        true  | true     | ["-g", "-O3"]
+        debug | optimize | debugInfoFormat | optimizationLevel | expected
+        true  | false    | null            | null              | ["-g"]
+        true  | false    | "-g3"           | null              | ["-g3"]
+        false | true     | null            | null              | ["-O3"]
+        false | true     | null            | "-O0"             | ["-O0"]
+        true  | true     | null            | null              | ["-g", "-O3"]
+        true  | true     | "-g3"           | "-O0"             | ["-g3", "-O0"]
     }
 
     def "transforms system header and include args correctly"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformerTest.groovy
@@ -31,16 +31,21 @@ class VisualCppCompilerArgsTransformerTest extends Specification {
         def spec = Stub(NativeCompileSpec)
         spec.debuggable >> debug
         spec.optimized >> optimize
+        spec.debugInfoFormat >> debugInfoFormat
+        spec.optimizationLevel >> optimizationLevel
 
         expect:
         def args = transformer.transform(spec)
         args.containsAll(expected)
 
         where:
-        debug | optimize | expected
-        true  | false    | ["/Zi"]
-        false | true     | ["/O2"]
-        true  | true     | ["/Zi", "/O2"]
+        debug | optimize | debugInfoFormat | optimizationLevel | expected
+        true  | false    | null            | null              | ["/Zi"]
+        true  | false    | "/Z7"           | null              | ["/Z7"]
+        false | true     | null            | null              | ["/O2"]
+        false | true     | null            | "/Od"             | ["/Od"]
+        true  | true     | null            | null              | ["/Zi", "/O2"]
+        true  | true     | "/Z7"           | "/Od"             | ["/Z7", "/Od"]
     }
 
     def "transforms system header and include args correctly"() {


### PR DESCRIPTION
### Context
This  pull request contains 3 commits addressing three issues.

- Remove hardcoded debug/optimization '/Zi' & '/O2' compiler options and allow user DSL to override it.  Updated unit test to reflect new changes.  subprojects :  languageNative & platformNative  [Issue #884](https://github.com/gradle/gradle-native/issues/884) commit [9e74658](https://github.com/gradle/gradle/commit/9e74658fde1d7c00bfa2b92799ddfb8907d36cc0)  
-  Use provider api for the WindowsResourceCompile Task to support building DSL consistent with other tasks in the  `cpp-application` plugin.  subprojects:  languageNative.  [Issue #173](https://github.com/gradle/gradle-native/issues/173) commit [83c70d2 ](https://github.com/gradle/gradle/commit/83c70d2e16765070d15e8ce9899f9e53cf0de295)
- Added to fix MD5 error when .gradle project cache is part of the root source code directory.  subprojects:  core.  [Issue #5972](https://github.com/gradle/gradle/issues/5972) commit [be96b6c](https://github.com/gradle/gradle/commit/be96b6cdf03a6df171200088205c5b793ac72f5d)
 
### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective `Able to reuse existing integration tests`
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic `Modified existing test cases`
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes ```this needs work as all of gradle native documentation has fallen behind```
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`
```
E:\gradle>gradlew.bat :core:check :platformNative:check :languageNative:check
.
BUILD SUCCESSFUL in 8m 56s
1385 actionable tasks: 1384 executed, 1 up-to-date
```
### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
