### PR TITLE
Use quiet when unzipping

### DIFF
--- a/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/test/fixtures/file/TestFileHelper.groovy
@@ -63,7 +63,7 @@ class TestFileHelper {
         }
 
         if (nativeTools && isUnix()) {
-            def process = ['unzip', '-o', file.absolutePath, '-d', target.absolutePath].execute()
+            def process = ['unzip', '-q', '-o', file.absolutePath, '-d', target.absolutePath].execute()
             process.consumeProcessOutput(System.out, System.err)
             assertThat(process.waitFor(), equalTo(0))
             return


### PR DESCRIPTION
There is no use for printing out all the files we unzip in the logs.
