### PR TITLE
Use G1 GC for performance tests

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/PerformanceTest.java
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/PerformanceTest.java
@@ -16,26 +16,24 @@
 
 package org.gradle.testing;
 
-import org.gradle.api.tasks.options.Option;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.gradlebuild.test.integrationtests.DistributionTest;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.Task;
-
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.options.Option;
+import org.gradle.gradlebuild.test.integrationtests.DistributionTest;
+import org.gradle.process.CommandLineArgumentProvider;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.HashMap;
 import java.util.Map.Entry;
-
-import org.gradle.process.CommandLineArgumentProvider;
 
 /**
  * A test that checks execution time and memory consumption.
@@ -222,5 +220,10 @@ public class PerformanceTest extends DistributionTest {
                 result.add("-D" + propertyName + "=" + propertyValue.toString());
             }
         }
+    }
+
+    @Input
+    public long getPoisonPill() {
+        return System.currentTimeMillis();
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -345,6 +345,7 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                     params.arguments += profiler.getAdditionalGradleArgs(spec)
 
                     params.jvmArguments = params.jvmArguments = params.jvmArguments ?: []
+                    params.jvmArguments += "-XX:+UseG1GC"
                     params.jvmArguments += profiler.getAdditionalJvmOpts(spec)
                 }
                 try {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/PerformanceTestJvmOptions.groovy
@@ -32,6 +32,7 @@ class PerformanceTestJvmOptions {
         if (!JavaVersion.current().isJava8Compatible() && jvmOptions.count { it.startsWith('-XX:MaxPermSize=') } == 0) {
             jvmOptions << '-XX:MaxPermSize=256m'
         }
+        jvmOptions << '-XX:+UseG1GC'
 
         return jvmOptions
     }


### PR DESCRIPTION
So we may reduce flakyness due to Garbage collection.