### PR TITLE
Don't show artifact transformation headers

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationCategory.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/operations/BuildOperationCategory.java
@@ -25,49 +25,51 @@ public enum BuildOperationCategory {
     /**
      * Configure the root build. May also include nested {@link #CONFIGURE_BUILD} and {@link #RUN_WORK} operations.
      */
-    CONFIGURE_ROOT_BUILD(false, false),
+    CONFIGURE_ROOT_BUILD(false, false, false),
 
     /**
      * Configure a nested build or a buildSrc build.
      */
-    CONFIGURE_BUILD(false, false),
+    CONFIGURE_BUILD(false, false, false),
 
     /**
      * Configure a single project in any build.
      */
-    CONFIGURE_PROJECT(true, false),
+    CONFIGURE_PROJECT(true, false, false),
 
     /**
      * Execute all work in the root build. Might include work from nested builds.
      */
-    RUN_WORK_ROOT_BUILD(false, false),
+    RUN_WORK_ROOT_BUILD(false, false, false),
 
     /**
      * Execute all work in a nested build or a buildSrc build. Includes {@link #TASK} and Includes {@link #TRANSFORM} operations.
      */
-    RUN_WORK(false, false),
+    RUN_WORK(false, false, false),
 
     /**
      * Execute an individual task.
      */
-    TASK(true, true),
+    TASK(true, true, true),
 
     /**
      * Execute an individual transform.
      */
-    TRANSFORM(true, true),
+    TRANSFORM(true, true, false),
 
     /**
      * Operation doesn't belong to any category.
      */
-    UNCATEGORIZED(false, false);
+    UNCATEGORIZED(false, false, false);
 
     private final boolean grouped;
     private final boolean topLevelWorkItem;
+    private final boolean showHeader;
 
-    BuildOperationCategory(boolean grouped, boolean topLevelWorkItem) {
+    BuildOperationCategory(boolean grouped, boolean topLevelWorkItem, boolean showHeader) {
         this.grouped = grouped;
         this.topLevelWorkItem = topLevelWorkItem;
+        this.showHeader = showHeader;
     }
 
     public boolean isGrouped() {
@@ -76,5 +78,9 @@ public enum BuildOperationCategory {
 
     public boolean isTopLevelWorkItem() {
         return topLevelWorkItem;
+    }
+
+    public boolean isShowHeader() {
+        return showHeader;
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -70,7 +70,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("Transformed") == 0
     }
 
-    def "early-discovered transform is applied before consuming task is executed"() {
+    def "scheduled transformation is invoked before consuming task is executed"() {
         given:
         buildFile << declareAttributes() << multiProjectWithJarSizeTransform() << withJarTasks()
 
@@ -89,7 +89,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         transformationPosition2 < taskPosition
     }
 
-    def "early-discovered transform is only run once per transform"() {
+    def "scheduled transformation is only invoked once per subject"() {
         given:
         settingsFile << """
             include 'util2'
@@ -111,7 +111,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("> Transform artifact lib2.jar (project :lib) with FileSizer") == 1
     }
 
-    def "early discovered chained transform is only run once per transform"() {
+    def "scheduled chained transformation is only invoked once per subject"() {
         given:
         settingsFile << """
             include 'app1'
@@ -325,7 +325,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
 
     def "can use custom type that does not implement equals() for transform configuration"() {
         given:
-        buildFile << declareAttributes() <<withJarTasks() << """
+        buildFile << declareAttributes() << withJarTasks() << """
             class CustomType implements Serializable {
                 String value
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+
+import org.gradle.api.logging.configuration.ConsoleOutput
+import org.gradle.integtests.fixtures.console.AbstractConsoleGroupedTaskFunctionalTest
+import spock.lang.Unroll
+
+class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFunctionalTest {
+    ConsoleOutput consoleType
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include 'lib'
+            include 'util'
+            include 'app'
+        """
+
+        buildFile << """
+            def usage = Attribute.of('usage', String)
+            def artifactType = Attribute.of('artifactType', String)
+                
+            allprojects {
+                dependencies {
+                    attributesSchema {
+                        attribute(usage)
+                    }
+                    registerTransform {
+                        from.attribute(artifactType, "jar")
+                        to.attribute(artifactType, "size")
+                        artifactTransform(FileSizer)
+                    }                    
+                }
+                configurations {
+                    compile {
+                        attributes.attribute usage, 'api'
+                    }
+                }
+                task resolve {
+                    def size = configurations.compile.incoming.artifactView {
+                        attributes { it.attribute(artifactType, 'size') }
+                    }.artifacts
+
+                    inputs.files size.artifactFiles
+                }
+            }
+            
+            project(':lib') {
+                task jar1(type: Jar) {
+                    archiveName = 'lib1.jar'
+                }
+                task jar2(type: Jar) {
+                    archiveName = 'lib2.jar'
+                }
+                tasks.withType(Jar) {
+                    destinationDir = buildDir
+                }
+                artifacts {
+                    compile jar1
+                    compile jar2
+                }
+            }            
+    
+            project(':util') {
+                dependencies {
+                    compile project(':lib')
+                }
+            }
+    
+            project(':app') {
+                dependencies {
+                    compile project(':util')
+                }
+            }
+
+            class FileSizer extends ArtifactTransform {
+                private boolean showOutput = System.getProperty("showOutput") != null
+            
+                FileSizer() {
+                    if (showOutput) {
+                        println "Creating FileSizer"
+                    }
+                }
+                
+                List<File> transform(File input) {
+                    assert outputDirectory.directory && outputDirectory.list().length == 0
+                    def output = new File(outputDirectory, input.name + ".txt")
+                    if (showOutput) {
+                        println "Transforming \${input.name} to \${output.name}"
+                    }
+                    output.text = String.valueOf(input.length())
+                    return [output]
+                }
+            }
+        """
+    }
+
+//    @Unroll
+    def "does not show transformation headers when there is no output for #type console"() {
+        consoleType = ConsoleOutput.Plain
+
+        when:
+        succeeds(":util:resolve")
+        then:
+        result.groupedOutput.transformationCount == 0
+
+        where:
+        type << ConsoleOutput.values()
+    }
+
+    @Unroll
+    def "does show transformation headers when there is output for #type console"() {
+        consoleType = type
+
+        when:
+        succeeds(":util:resolve", "-DshowOutput")
+        then:
+        result.groupedOutput.transformationCount == 2
+
+        where:
+        type << [ConsoleOutput.Plain, ConsoleOutput.Rich, ConsoleOutput.Verbose]
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
@@ -144,7 +144,7 @@ class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFun
 
     @Unroll
     def "does not show transformation headers when there is no output for #type console"() {
-        consoleType = ConsoleOutput.Plain
+        consoleType = type
 
         when:
         succeeds(":util:resolveGreen")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/TransformationLoggingIntegrationTest.groovy
@@ -175,5 +175,8 @@ class TransformationLoggingIntegrationTest extends AbstractConsoleGroupedTaskFun
         succeeds(":util:resolveBlue", "-DshowOutput")
         then:
         result.groupedOutput.transformationCount == 4
+        def initialSubjects = ((1..2).collect { "lib${it}.jar (project :lib)".toString() }) as Set
+        result.groupedOutput.subjectsFor('GreenMultiplier') == initialSubjects
+        result.groupedOutput.subjectsFor('BlueMultiplier') == initialSubjects
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -140,10 +140,8 @@ public abstract class TransformationNode extends Node {
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                String displayName = "Transform artifact " + artifactSet.getArtifactId().getDisplayName() + " with " + transformationStep.getDisplayName();
-                return BuildOperationDescriptor.displayName(displayName)
-                    .progressDisplayName(displayName)
-                    .operationType(BuildOperationCategory.TRANSFORM);
+                String subject = "artifact " + artifactSet.getArtifactId().getDisplayName();
+                return buildOperationDescriptor(subject, transformationStep);
             }
 
             @Override
@@ -207,10 +205,7 @@ public abstract class TransformationNode extends Node {
 
             @Override
             public BuildOperationDescriptor.Builder description() {
-                String displayName = "Transform " + previousTransformationNode.getTransformedSubject().getDisplayName() + " with " + transformationStep.getDisplayName();
-                return BuildOperationDescriptor.displayName(displayName)
-                    .progressDisplayName(displayName)
-                    .operationType(BuildOperationCategory.TRANSFORM);
+                return buildOperationDescriptor(previousTransformationNode.getTransformedSubject().getDisplayName(), transformationStep);
             }
 
             public TransformationSubject getTransformedSubject() {
@@ -255,5 +250,12 @@ public abstract class TransformationNode extends Node {
         @Override
         public void fileAvailable(File file) {
         }
+    }
+
+    private static BuildOperationDescriptor.Builder buildOperationDescriptor(String subject, TransformationStep step) {
+        String basicName = subject + " with " + step.getDisplayName();
+        return BuildOperationDescriptor.displayName("Transform " + basicName)
+            .progressDisplayName("Transforming " + basicName)
+            .operationType(BuildOperationCategory.TRANSFORM);
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedOutputFixture.java
@@ -31,8 +31,8 @@ public class GroupedOutputFixture {
     /**
      * All tasks will start with > Task, captures everything starting with : and going until a control char
      */
-    private final static String TASK_HEADER = "> Task (artifact [^\\n]*|:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n?";
-    private final static String TRANSFORMATION_HEADER = "> Transform (artifact|file) ([^\\n]+) with ([^\\n]+)";
+    private final static String TASK_HEADER = "> Task (:[\\w:]*) ?(FAILED|FROM-CACHE|UP-TO-DATE|SKIPPED|NO-SOURCE)?\\n?";
+    private final static String TRANSFORMATION_HEADER = "> Transform (artifact|file) ([^\\n]+) with ([^\\n]+\\n?)";
 
     private final static String EMBEDDED_BUILD_START = "> :\\w* > [:\\w]+";
     private final static String BUILD_STATUS_FOOTER = "BUILD SUCCESSFUL";

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTransformationFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTransformationFixture.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging;
+
+import org.gradle.api.specs.Spec;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.gradle.util.CollectionUtils.filter;
+import static org.gradle.util.CollectionUtils.join;
+
+public class GroupedTransformationFixture {
+    private final String initialSubjectType;
+    private final String subject;
+    private final String transformer;
+    private final List<String> outputs = new ArrayList<String>(1);
+
+    public GroupedTransformationFixture(String initialSubjectType, String subject, String transformer) {
+        this.initialSubjectType = initialSubjectType;
+        this.subject = subject;
+        this.transformer = transformer;
+    }
+
+    public void addOutput(String transformationOutput) {
+        outputs.add(transformationOutput);
+    }
+
+    public String getInitialSubjectType() {
+        return initialSubjectType;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getTransformer() {
+        return transformer;
+    }
+
+    public String getOutput() {
+        List<String> nonEmptyOutputs = filter(outputs, new Spec<String>() {
+            @Override
+            public boolean isSatisfiedBy(String string) {
+                return !string.equals("");
+            }
+        });
+        return join("\n", nonEmptyOutputs);
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTransformationFixture.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/GroupedTransformationFixture.java
@@ -61,4 +61,13 @@ public class GroupedTransformationFixture {
         });
         return join("\n", nonEmptyOutputs);
     }
+
+    @Override
+    public String toString() {
+        return "GroupedTransformationFixture{" +
+                "initialSubjectType='" + initialSubjectType + '\'' +
+                ", subject='" + subject + '\'' +
+                ", transformer='" + transformer + '\'' +
+                '}';
+    }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/GroupingProgressLogEventGenerator.java
@@ -286,7 +286,7 @@ public class GroupingProgressLogEventGenerator implements OutputEventListener {
         }
 
         private boolean shouldForward() {
-            return !bufferedLogs.isEmpty() || (buildOperationCategory.isTopLevelWorkItem() && (shouldPrintHeader() || statusIsFailed()));
+            return !bufferedLogs.isEmpty() || (buildOperationCategory.isShowHeader() && (shouldPrintHeader() || statusIsFailed()));
         }
     }
 }


### PR DESCRIPTION
The headers for artifact transforms should not show up in the build
log if there is no output from the transformations.
That makes the console log much cleaner, especially for the plain and
verbose console.

The logging for artifact transformations still shows up in build scan
logs or if the transformation produced some output.
