### PR TITLE
Updated WindowsResourceComple to use provider api

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/plugins/internal/WindowsResourcesCompileTaskConfig.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/plugins/internal/WindowsResourcesCompileTaskConfig.java
@@ -87,7 +87,7 @@ public class WindowsResourcesCompileTaskConfig implements SourceTransformTaskCon
 
         PreprocessingTool rcCompiler = (PreprocessingTool) binary.getToolByName("rcCompiler");
         task.setMacros(rcCompiler.getMacros());
-        task.setCompilerArgs(rcCompiler.getArgs());
+        task.getCompilerArgs().set(rcCompiler.getArgs());
 
         FileTree resourceOutputs = task.getOutputs().getFiles().getAsFileTree().matching(new PatternSet().include("**/*.res"));
         binary.binaryInputs(resourceOutputs);

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -211,9 +211,6 @@ public class WindowsResourceCompile extends DefaultTask {
         return compilerArgs;
     }
 
-    public void setCompilerArgs(List<String> compilerArgs) {
-        this.compilerArgs.addAll(compilerArgs);
-    }
 
     /**
      * The set of dependent headers. This is used for up-to-date checks only.

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -51,7 +51,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -21,6 +21,7 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.provider.Providers;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
@@ -49,7 +50,6 @@ import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,13 +67,14 @@ public class WindowsResourceCompile extends DefaultTask {
     private ConfigurableFileCollection includes;
     private ConfigurableFileCollection source;
     private Map<String, String> macros = new LinkedHashMap<String, String>();
-    private List<String> compilerArgs = new ArrayList<String>();
+    private final ListProperty<String> compilerArgs;
     private final IncrementalCompilerBuilder.IncrementalCompiler incrementalCompiler;
 
     public WindowsResourceCompile() {
         ObjectFactory objectFactory = getProject().getObjects();
         includes = getProject().files();
         source = getProject().files();
+        this.compilerArgs = getProject().getObjects().listProperty(String.class).empty();
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
         incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes, macros, Providers.FALSE);
@@ -107,7 +108,7 @@ public class WindowsResourceCompile extends DefaultTask {
         spec.include(getIncludes());
         spec.source(getSource());
         spec.setMacros(getMacros());
-        spec.args(getCompilerArgs());
+        spec.args(getCompilerArgs().get());
         spec.setIncrementalCompile(inputs.isIncremental());
         spec.setOperationLogger(operationLogger);
 
@@ -201,15 +202,17 @@ public class WindowsResourceCompile extends DefaultTask {
     }
 
     /**
-     * Additional arguments to provide to the compiler.
+     * <em>Additional</em> arguments to provide to the compiler.
+     *
+     * @since 5.1
      */
     @Input
-    public List<String> getCompilerArgs() {
+    public ListProperty<String> getCompilerArgs() {
         return compilerArgs;
     }
 
     public void setCompilerArgs(List<String> compilerArgs) {
-        this.compilerArgs = compilerArgs;
+        this.compilerArgs.addAll(compilerArgs);
     }
 
     /**


### PR DESCRIPTION
Issue [#173](https://github.com/gradle/gradle-native/issues/173) Windows Resource Support
Updated this class to use ListProperty<String> instead of List<String> for the compilerArgs, consistent with other tasks within 'cpp-application'

Signed-off-by: Kent Fletcher <kfletcher@sumglobal.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
