### PR TITLE
Remove deprecation warning in `generateGradleApiPackageList` task configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,6 +246,26 @@ val testRuntime by configurations.creating {
     extendsFrom(gradlePlugins)
 }
 
+val gradleApiElementsConfigurationAction : Configuration.() -> Unit = {
+    isVisible = false
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    description = "Configuration for runtime API info."
+    usage(Usage.JAVA_RUNTIME)
+    attributes.attribute(Attribute.of("org.gradle.api", String::class.java), "yes")
+}
+
+val gradleApiElements by configurations.creating(gradleApiElementsConfigurationAction)
+gradleApiElements.extendsFrom(gradlePlugins)
+gradleApiElements.extendsFrom(externalModules)
+
+subprojects {
+    pluginManager.withPlugin("java") {
+        val gradleApiElements by configurations.creating(gradleApiElementsConfigurationAction)
+        gradleApiElements.extendsFrom(configurations.getByName("runtimeClasspath"))
+    }
+}
+
 configurations {
     all {
         usage(Usage.JAVA_RUNTIME)

--- a/subprojects/runtime-api-info/runtime-api-info.gradle.kts
+++ b/subprojects/runtime-api-info/runtime-api-info.gradle.kts
@@ -26,13 +26,22 @@ gradlebuildJava {
     moduleType = ModuleType.INTERNAL
 }
 
+val gradleApi by configurations.creating {
+    isVisible = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.JAVA_RUNTIME))
+    attributes.attribute(Attribute.of("org.gradle.api", String::class.java), "yes")
+}
+
+dependencies {
+    listOf(":", ":core", ":dependencyManagement", ":pluginUse", ":toolingApi").forEach {
+        add(gradleApi.name, project(it))
+    }
+}
+
 val generateGradleApiPackageList = tasks.register<PackageListGenerator>("generateGradleApiPackageList") {
-    classpath = files(
-        rootProject.configurations["externalModules"],
-        listOf(":core", ":dependencyManagement", ":pluginUse", ":toolingApi").map {
-            project(it).configurations.runtimeClasspath
-        },
-        project(":").configurations["gradlePlugins"])
+    classpath = gradleApi
     outputFile = file("$runtimeShadedPath/api-relocated.txt")
 }
 


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native/issues/890

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2Fgradle-api-deprecation)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
