### PR TITLE
Added to fix MD5 error when .gradle project cache is part of the root source code directory

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -165,7 +165,11 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     }
 
     FileSystemSnapshotter createFileSystemSnapshotter(FileHasher hasher, StringInterner stringInterner, FileSystem fileSystem, FileSystemMirror fileSystemMirror) {
-        return new DefaultFileSystemSnapshotter(hasher, stringInterner, fileSystem, fileSystemMirror, DirectoryScanner.getDefaultExcludes());
+        // added to fix  MD5 error when .gradle project cache is part of the root source code dirs (typically in native builds)
+        // issue: https://github.com/gradle/gradle/issues/5941
+        DirectoryScanner.addDefaultExclude("**/.gradle/**"); // should never include the .gradle directory in a snapshot
+        FileSystemSnapshotter retval = new DefaultFileSystemSnapshotter(hasher, stringInterner, fileSystem, fileSystemMirror, DirectoryScanner.getDefaultExcludes());
+        return retval;
     }
 
     AbsolutePathFileCollectionFingerprinter createAbsolutePathFileCollectionFingerprinter(StringInterner stringInterner, FileSystemSnapshotter fileSystemSnapshotter) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -140,12 +140,6 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     ProjectCacheDir createCacheLayout(StartParameter startParameter, BuildLayoutFactory buildLayoutFactory, ProgressLoggerFactory progressLoggerFactory) {
         BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
         File cacheDir = startParameter.getProjectCacheDir() != null ? startParameter.getProjectCacheDir() : new File(buildLayout.getRootDirectory(), ".gradle");
-        /*
-         * add cacheDir to default exclusions because not doing so causes and MD5 error
-         * when .gradle project cache is part of the root source code directory
-         * (typically in native builds) issue:
-         * https://github.com/gradle/gradle/issues/5941
-         */
         DirectoryScanner.addDefaultExclude(cacheDir.getPath());
         return new ProjectCacheDir(cacheDir, progressLoggerFactory);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -140,7 +140,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
     ProjectCacheDir createCacheLayout(StartParameter startParameter, BuildLayoutFactory buildLayoutFactory, ProgressLoggerFactory progressLoggerFactory) {
         BuildLayout buildLayout = buildLayoutFactory.getLayoutFor(new BuildLayoutConfiguration(startParameter));
         File cacheDir = startParameter.getProjectCacheDir() != null ? startParameter.getProjectCacheDir() : new File(buildLayout.getRootDirectory(), ".gradle");
-        DirectoryScanner.addDefaultExclude(cacheDir.getPath());
+        String exludeCacheDirName = "**/"+ cacheDir.getName();
+        DirectoryScanner.addDefaultExclude(exludeCacheDirName);
         return new ProjectCacheDir(cacheDir, progressLoggerFactory);
     }
 

--- a/subprojects/docs/src/docs/userguide/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_files.adoc
@@ -418,7 +418,7 @@ include::sample[dir="userguide/files/fileTrees/kotlin",files="build.gradle.kts[t
 
 You can see more examples of supported patterns in the API docs for link:{javadocPath}/org/gradle/api/tasks/util/PatternFilterable.html[PatternFilterable]. Also, see the API documentation for `fileTree()` to see what types you can pass as the base directory.
 
-By default, `fileTree()` returns a `FileTree` instance that applies some default exclusion patterns for convenience — the same defaults as Ant in fact. For the complete default exclusion list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
+By default, `fileTree()` returns a `FileTree` instance that applies some default exclusion patterns for convenience — the same defaults as Ant.  In addition, the project cache directory is also excluded. For the complete default exclusion list, see http://ant.apache.org/manual/dirtasks.html#defaultexcludes[the Ant manual].
 
 If those default exclusions prove problematic, you can workaround the issue by using the {antManual}/Tasks/defaultexcludes.html[`defaultexcludes` Ant task], as demonstrated in this example:
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppMD5ErrorPreventionIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppMD5ErrorPreventionIntegrationTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.cpp
+
+import org.gradle.integtests.fixtures.CompilationOutputsFixture
+import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.test.fixtures.file.TestFile
+
+import groovy.ui.SystemOutputInterceptor
+
+class CppMD5ErrorPreventionIntegrationTest extends AbstractInstalledToolChainIntegrationSpec  implements CppTaskNames {
+	
+	private static final String APP = 'md5'
+
+    TestFile mainSourceFile
+    TestFile mainHeaderFile
+	String sourceType = "cpp"
+	
+	def out = installation("build/install/main/debug")
+	def projectTasks = tasks(APP)
+ 
+	def setup() {
+		buildFile << """
+			plugins {
+			    id 'cpp-application'
+			}
+			
+			application {
+			    source.from project.fileTree(dir: '.', include: '**/*.cpp')
+			    privateHeaders.from project.file('.')
+			}
+			
+			tasks.withType(CppCompile) {
+			    macros.put('EXTERNAL_HEADER', '<list/main.h>')
+			}
+		"""
+		settingsFile << """
+            rootProject.name = 'test'
+            include 'library', 'app'
+        """
+
+		mainSourceFile = file("list/main.cpp") << """
+			#include EXTERNAL_HEADER
+			#include <iostream>
+			
+			int main() {
+				std::cout << SAY_SOMETHING << std::endl;
+				return 0;
+			}
+			
+        """
+
+		mainHeaderFile = file("list/main.h") << """
+			#pragma once
+			#define SAY_SOMETHING "Hello World!!"
+        """
+	}
+
+	
+    def "can prevent md5 error when snapshotshotting source dir includes root dir"() {
+	
+		for(String s: projectTasks) {
+			System.out.println ("########  TASKS  #################")
+			System.out.println (s)
+		}
+
+		given:
+		run 'build'
+
+		expect:
+		for(String s: result.getExecutedTasks()) {
+			System.out.println ("###########  EXECUTED TASKS  ##################")
+			System.out.println (s)
+		}
+		for (TestFile tf :out.getLibraryFiles() ) {
+			System.out.println ("###########  LIBRARY FILES  ##################")
+			System.out.println(tf.md5())
+		}
+
+    }
+}


### PR DESCRIPTION
Issue #5972
added to fix  MD5 error when .gradle project cache is part of the root source code dirs (typically in native builds)

Signed-off-by: Kent Fletcher <kfletcher@sumglobal.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
