### PR TITLE
Deprecate ProjectBuilder constructor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.testfixtures;
 
+import org.gradle.util.SingleMessageLogger;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.internal.ProjectBuilderImpl;
 

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -56,6 +56,7 @@ public class ProjectBuilder {
      *
      * An instance should only be created via the {@link #builder()}.
      */
+    @Deprecated
     public ProjectBuilder() {
         SingleMessageLogger.nagUserOfDeprecated("The ProjectBuilder() constructor", "Please use ProjectBuilder.builder() instead.");
     }

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -51,6 +51,15 @@ public class ProjectBuilder {
     private ProjectBuilderImpl impl = new ProjectBuilderImpl();
 
     /**
+     * Don't use this constructor anymore.
+     *
+     * An instance should only be created via the {@link #builder()}.
+     */
+    public ProjectBuilder() {
+        SingleMessageLogger.nagUserOfDeprecated("The ProjectBuilder() constructor", "Please use ProjectBuilder.builder() instead.");
+    }
+
+    /**
      * Creates a project builder.
      *
      * @return The builder
@@ -73,6 +82,7 @@ public class ProjectBuilder {
     /**
      * Specifies the Gradle user home for the builder. If not set, an empty directory under the project directory
      * will be used.
+     *
      * @return The builder
      */
     public ProjectBuilder withGradleUserHomeDir(File dir) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -46,6 +46,10 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
+### `ProjectBuilder` constructor
+Now the constructor of the `ProjectBuilder` is deprecated.
+You should always grab an instance of it via the `ProjectBuilder#builder()` method.
+
 ### Breaking changes
 
 <!-- summary and links -->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -47,8 +47,9 @@ The following are the newly deprecated items in this Gradle release. If you have
 -->
 
 ### `ProjectBuilder` constructor
-Now the constructor of the `ProjectBuilder` is deprecated.
-You should always grab an instance of it via the `ProjectBuilder#builder()` method.
+
+The default constructor of `ProjectBuilder` is now deprecated.
+You should always use `ProjectBuilder#builder()` to create instances.
 
 ### Breaking changes
 
@@ -63,6 +64,8 @@ We would like to thank the following community members for making contributions 
 <!--
  - [Some person](https://github.com/some-person) - fixed some issue (gradle/gradle#1234)
 -->
+
+ - [Stefan M.](https://github.com/StefMa) - Deprecate ProjectBuilder constructor (gradle/gradle#7444)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 


### PR DESCRIPTION
### Context
I've created a test for one of my plugins for the first time with the `ProjectBuilder`.
I found out that I can create an instance via the constructor meanwhile the whole thing should be a... well a builder 🙃 
It should only be allowed to create an instance of it via `ProjectBuilder#build`.

TBH - I don't know if you want to maintain these class in the future. But since its a public class and some projects uses it it should get at least **some** care units 🙃 
See also this #5396 

Beside of that.
I thought that I do these changes for the 5.0 release (because it is a breaking change probably)
But the notes.md is empty 😕 
So maybe the `master` branch is already on 5.1(?) 🤔 🤷‍♂️ 
Maybe this commit should be cherry-picked in some other branch?!

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [ ] ~Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [ ] ~Ensure that tests pass locally: `./gradlew <changed-subproject>:check`~

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
