### PR TITLE
Remove deprecation warning for `javadocAll` task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.ProjectGroups.implementationPluginProjects
 import org.gradle.gradlebuild.ProjectGroups.javaProjects
 import org.gradle.gradlebuild.ProjectGroups.pluginProjects
+import org.gradle.gradlebuild.ProjectGroups.publicJavaProjects
 import org.gradle.gradlebuild.ProjectGroups.publishedProjects
 import org.gradle.util.GradleVersion
 import org.gradle.gradlebuild.buildquality.incubation.IncubatingApiAggregateReportTask
@@ -244,6 +245,21 @@ val gradlePlugins by configurations.creating {
 val testRuntime by configurations.creating {
     extendsFrom(runtime)
     extendsFrom(gradlePlugins)
+}
+
+publicJavaProjects.forEach {
+    it.configure {
+        val javadocClasspathElements by it.configurations.creating {
+            extendsFrom(it.configurations["compileClasspath"])
+            extendsFrom(it.configurations["runtimeClasspath"])
+            isVisible = false
+            isCanBeResolved = false
+            isCanBeConsumed = true
+            description = "Classpath for javadoc"
+            usage(Usage.JAVA_API_CLASSES)
+            attributes.attribute(Attribute.of("org.gradle.javadoc", String::class.java), "yes")
+        }
+    }
 }
 
 configurations {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -257,6 +257,20 @@ def javaApiUrl = "https://docs.oracle.com/javase/8/docs/api"
 def groovyApiUrl = "http://docs.groovy-lang.org/docs/groovy-${groovyVersion}/html/gapi"
 def mavenApiUrl = "http://maven.apache.org/ref/${libraries.maven3.version}/maven-model/apidocs"
 
+configurations.create("javadocClasspath") {
+    attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API_CLASSES))
+    attributes.attribute(Attribute.of("org.gradle.javadoc", String), "yes")
+    visible = false
+    canBeConsumed = false
+    canBeResolved = true
+    description = "Classpath for javadoc"
+}
+
+dependencies {
+    javadocClasspath ProjectGroups.INSTANCE.getPublicJavaProjects(project)
+}
+
+
 def javadocAll = tasks.register("javadocAll", Javadoc) {
     ext.stylesheetFile = file("src/docs/css/javadoc.css")
     inputs.file stylesheetFile withPropertyName "stylesheetFile" withPathSensitivity PathSensitivity.NAME_ONLY
@@ -271,7 +285,7 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
     options.addStringOption "stylesheetfile", stylesheetFile.absolutePath
     source ProjectGroups.INSTANCE.getPublicJavaProjects(project).collect { project -> project.sourceSets.main.allJava }
     destinationDir = new File(docsDir, 'javadoc')
-    classpath = files(ProjectGroups.INSTANCE.getPublicJavaProjects(project).collect {project -> [project.sourceSets.main.compileClasspath, project.sourceSets.main.output] })
+    classpath = configurations.javadocClasspath
     PublicApi.includes.each {
         include it
     }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native/issues/890

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2FjavadocAll-deperation-warning)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
