### PR TITLE
Fix `api-metadata` project to remove deprecation warning

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -246,6 +246,16 @@ val testRuntime by configurations.creating {
     extendsFrom(gradlePlugins)
 }
 
+val apiMetadataElements by configurations.creating {
+    extendsFrom(runtime)
+    extendsFrom(gradlePlugins)
+    isVisible = false
+    isCanBeConsumed = true
+    isCanBeResolved = false
+    description = "Classpath configuration for API metadata"
+    attributes.attribute(Attribute.of("org.gradle.api.metadata", String::class.java), "yes")
+}
+
 configurations {
     all {
         usage(Usage.JAVA_RUNTIME)

--- a/subprojects/api-metadata/api-metadata.gradle.kts
+++ b/subprojects/api-metadata/api-metadata.gradle.kts
@@ -10,14 +10,21 @@ gradlebuildJava {
     moduleType = ModuleType.INTERNAL
 }
 
+val apiMetadata by configurations.creating {
+    isVisible = false
+    isCanBeConsumed = false
+    isCanBeResolved = true
+    description = "Classpath configuration for API metadata"
+    attributes.attribute(Attribute.of("org.gradle.api.metadata", String::class.java), "yes")
+}
+
 apiMetadata {
     sources.from(provider {
         javaProjects.map { it.sourceSets["main"].allJava }
     })
     includes.addAll(provider { PublicApi.includes })
     excludes.addAll(provider { PublicApi.excludes })
-    classpath.from(rootProject.configurations.runtime)
-    classpath.from(rootProject.configurations["gradlePlugins"])
+    classpath.from(apiMetadata)
 }
 
 dependencies {


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-native/issues/890

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Flazy%2FapiMetadata-deprecation-warning)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
