### PR TITLE
Introduce Travis build for contributor PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk: oraclejdk9
+install: ./gradlew --version
+script: ./gradlew --continue --init-script gradle/init-scripts/build-scan.init.gradle.kts --scan --stacktrace sanityCheck
+if: pull_request AND head_repo != gradle/gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
 jdk: oraclejdk9
 install: ./gradlew --version
-script: ./gradlew --continue --init-script gradle/init-scripts/build-scan.init.gradle.kts --scan --stacktrace sanityCheck
+script: ./gradlew --continue --init-script gradle/init-scripts/public-build-scan.init.gradle.kts sanityCheck
 if: pull_request AND head_repo != gradle/gradle

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -111,10 +111,15 @@ open class BuildScanPlugin : Plugin<Project> {
         if (isCiServer) {
             buildScan {
                 tag("CI")
-                link("TeamCity Build", System.getenv("BUILD_URL"))
-                value("Build ID", System.getenv("BUILD_ID"))
-                setCommitId(System.getenv("BUILD_VCS_NUMBER"))
-
+                if (!System.getenv("TRAVIS").isNullOrEmpty()) {
+                    link("Travis Build", System.getenv("TRAVIS_BUILD_WEB_URL"))
+                    value("Build ID", System.getenv("TRAVIS_BUILD_ID"))
+                    setCommitId(System.getenv("TRAVIS_COMMIT"))
+                } else {
+                    link("TeamCity Build", System.getenv("BUILD_URL"))
+                    value("Build ID", System.getenv("BUILD_ID"))
+                    setCommitId(System.getenv("BUILD_VCS_NUMBER"))
+                }
                 whenEnvIsSet("BUILD_TYPE_ID") { buildType ->
                     value(ciBuildTypeName, buildType)
                     link("Build Type Scans", customValueSearchUrl(mapOf(ciBuildTypeName to buildType)))

--- a/gradle/init-scripts/public-build-scan.init.gradle.kts
+++ b/gradle/init-scripts/public-build-scan.init.gradle.kts
@@ -1,0 +1,9 @@
+rootProject {
+    pluginManager.withPlugin("com.gradle.build-scan") {
+        extensions["buildScan"].withGroovyBuilder {
+            "publishAlways"()
+            setProperty("termsOfServiceUrl", "https://gradle.com/terms-of-service")
+            setProperty("termsOfServiceAgree", "yes")
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a basic Travis config file that executes the `sanityCheck` task for PRs not from gradle/gradle and uploads a build scan.