### PR TITLE
fix the single page userguide to link to the new 5.0 upgrade guide location

### DIFF
--- a/subprojects/docs/src/docs/userguide/userguide_single.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide_single.adoc
@@ -35,8 +35,7 @@ include::installation.adoc[leveloffset=+2]
 
 include::kotlin_dsl.adoc[leveloffset=+2]
 
-include::upgrading_from_gradle4.adoc[leveloffset=+2]
-
+include::upgrading_version_4.adoc[leveloffset=+2]
 
 == Using Gradle Builds
 


### PR DESCRIPTION
The name of the .adoc file was changed previously, but the link was not updated until now.