### PR TITLE
Add missing methods and types to DSL reference

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.dsl.DependencyConstraintHandler.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.dsl.DependencyConstraintHandler.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright 2018 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr>
+                <td>add</td>
+            </tr>
+            <tr>
+                <td>create</td>
+            </tr>
+            <tr>
+                <td>platform</td>
+            </tr>
+            <tr>
+                <td>enforcedPlatform</td>
+            </tr>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.dsl.DependencyHandler.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.dsl.DependencyHandler.xml
@@ -8,6 +8,9 @@
                 </tr>
             </thead>
             <tr>
+                <td>constraints</td>
+            </tr>
+            <tr>
                 <td>components</td>
             </tr>
             <tr>
@@ -45,10 +48,19 @@
                 <td>localGroovy</td>
             </tr>
             <tr>
+                <td>constraints</td>
+            </tr>
+            <tr>
                 <td>components</td>
             </tr>
             <tr>
                 <td>modules</td>
+            </tr>
+            <tr>
+                <td>platform</td>
+            </tr>
+            <tr>
+                <td>enforcedPlatform</td>
             </tr>
             <tr>
                 <td>createArtifactResolutionQuery</td>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.dsl.RepositoryHandler.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.dsl.RepositoryHandler.xml
@@ -54,6 +54,9 @@
             <tr>
                 <td>flatDir</td>
             </tr>
+            <tr>
+                <td>gradlePluginPortal</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.repositories.IvyArtifactRepository.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.repositories.IvyArtifactRepository.xml
@@ -48,6 +48,12 @@
             <tr>
                 <td>layout</td>
             </tr>
+            <tr>
+                <td>patternLayout</td>
+            </tr>
+            <tr>
+                <td>metadataSources</td>
+            </tr>
         </table>
     </section>
 </section>

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.repositories.MavenArtifactRepository.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.artifacts.repositories.MavenArtifactRepository.xml
@@ -42,6 +42,9 @@
             <tr>
                 <td>artifactUrls</td>
             </tr>
+            <tr>
+                <td>metadataSources</td>
+            </tr>
         </table>
     </section>
 </section>


### PR DESCRIPTION
Adds a few missing methods and types to the DSL reference. I avoided adding methods that are likely to be only called by plugin authors, like `DependencyHandler.attributesSchema` and `MavenArtifactRepository.setMetadataSupplier`. Since these are unlikely to be used by build script authors via the DSL, I thought it OK to leave them out for now.