### PR TITLE
Performance regression test for "gradle help after buildSrc change"

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -105,6 +105,15 @@ dependencies {
     }
 }
 
+// Set gradlebuild.skipBuildSrcChecks Gradle property to "true" to disable all buildSrc verification tasks
+if(findProperty("gradlebuild.skipBuildSrcChecks") == "true") {
+    allprojects {
+        tasks.matching { it.group == LifecycleBasePlugin.VERIFICATION_GROUP }.configureEach {
+            enabled = false
+        }
+    }
+}
+
 // TODO Avoid duplication of what defines a CI Server with BuildEnvironment
 val isCiServer: Boolean by extra { "CI" in System.getenv() }
 if (!isCiServer || System.getProperty("enableCodeQuality")?.toLowerCase() == "true") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -106,7 +106,7 @@ dependencies {
 }
 
 // Set gradlebuild.skipBuildSrcChecks Gradle property to "true" to disable all buildSrc verification tasks
-if(findProperty("gradlebuild.skipBuildSrcChecks") == "true") {
+if (findProperty("gradlebuild.skipBuildSrcChecks") == "true") {
     allprojects {
         tasks.matching { it.group == LifecycleBasePlugin.VERIFICATION_GROUP }.configureEach {
             enabled = false

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -62,7 +62,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
 
     @Category(PerformanceExperiment)
     @Unroll
-    def "buildSrc change in #testProject comparing gradle"() {
+    def "buildSrc api change in #testProject comparing gradle"() {
         given:
         runner.testProject = testProject
         runner.tasksToRun = ['help']
@@ -82,7 +82,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
                     parentFile.mkdirs()
                     text = """
                         class ChangingClass {
-                            def value = "${invocationInfo.phase} ${invocationInfo.iterationNumber}"
+                            void changingMethod${invocationInfo.phase}${invocationInfo.iterationNumber}() {}
                         }
                     """.stripIndent()
                 }


### PR DESCRIPTION
To measure the feedback loop on
* a single project build (Groovy DSL only for now)
* a 500 projects build (Groovy and Kotlin DSLs)
* the `gradle/gradle` build (with `buildSrc` verification tasks disabled)

Added as an experiment for now