### PR TITLE
Update project_report_plugin.adoc

### DIFF
--- a/subprojects/docs/src/docs/userguide/project_report_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/project_report_plugin.adoc
@@ -39,7 +39,7 @@ The project report plugin defines the following tasks:
 `dependencyReport` — link:{groovyDslPath}/org.gradle.api.tasks.diagnostics.DependencyReportTask.html[DependencyReportTask]::
 Generates the project dependency report.
 
-`dependencyReport` — link:{groovyDslPath}/org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.html[HtmlDependencyReportTask]::
+`htmlDependencyReport` — link:{groovyDslPath}/org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.html[HtmlDependencyReportTask]::
 Generates an HTML dependency and dependency insight report for the project or a set of projects.
 
 `propertyReport` — link:{groovyDslPath}/org.gradle.api.tasks.diagnostics.PropertyReportTask.html[PropertyReportTask]::


### PR DESCRIPTION
There is a typo in project_report_plugin.adoc under the Tasks subsection.

Before Change:
dependencyReport — HtmlDependencyReportTask

After Change:
htmlDependencyReport — HtmlDependencyReportTask

### Context
<!--- Why do you believe many users will benefit from this change? -->
Correcting the typo will ensure that the doc does not seem confusing to the users.
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
