### PR TITLE
Avoid locking the target project of project dependencies during task execution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
+import org.gradle.internal.ImmutableActionSet;
 
 import java.util.Set;
 
@@ -29,6 +30,7 @@ import java.util.Set;
  */
 public class LocalTaskNode extends TaskNode {
     private final TaskInternal task;
+    private ImmutableActionSet<Task> postAction = ImmutableActionSet.empty();
 
     public LocalTaskNode(TaskInternal task) {
         this.task = task;
@@ -36,6 +38,16 @@ public class LocalTaskNode extends TaskNode {
 
     public TaskInternal getTask() {
         return task;
+    }
+
+    @Override
+    public Action<? super Task> getPostAction() {
+        return postAction;
+    }
+
+    @Override
+    public void appendPostAction(Action<? super Task> action) {
+        postAction = postAction.add(action);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNodeExecutor.java
@@ -29,17 +29,19 @@ public class LocalTaskNodeExecutor implements NodeExecutor {
     @Override
     public boolean execute(Node node, ProjectExecutionServiceRegistry services) {
         if (node instanceof LocalTaskNode) {
-            TaskInternal task = ((LocalTaskNode) node).getTask();
+            LocalTaskNode localTaskNode = (LocalTaskNode) node;
+            TaskInternal task = localTaskNode.getTask();
             TaskStateInternal state = task.getState();
             if (state.getExecuted()) {
                 // Task has already been run. This can happen when the owning build is used both at configuration time and execution time
-                // This should move earlier in task scheduling, so that a worker thread does not even bother trying run this task
+                // This should move earlier in task scheduling, so that a worker thread does not even bother trying to run this task
                 return true;
             }
             TaskExecutionContext ctx = new DefaultTaskExecutionContext();
             TaskExecuter taskExecuter = services.getProjectService((ProjectInternal) task.getProject(), TaskExecuter.class);
             assert taskExecuter != null;
             taskExecuter.execute(task, state, ctx);
+            localTaskNode.getPostAction().execute(task);
             return true;
         } else {
             return false;

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -18,6 +18,8 @@ package org.gradle.execution.plan;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 
 import java.util.NavigableSet;
 import java.util.Set;
@@ -111,4 +113,15 @@ public abstract class TaskNode extends Node {
         return getMustSuccessors().contains(successor)
             || getFinalizingSuccessors().contains(successor);
     }
+
+    /**
+     * Attach an action to execute immediately after the <em>successful</em> completion of this task.
+     *
+     * <p>This is used to ensure that dependency resolution metadata for a particular artifact is calculated immediately after that artifact is produced and cached, to avoid consuming tasks having to lock the producing project in order to calculate this metadata.</p>
+     *
+     * <p>This action should really be modelled as a real node in the graph. This 'post action' concept is intended to be a step in this direction.</p>
+     */
+    public abstract void appendPostAction(Action<? super Task> action);
+
+    public abstract Action<? super Task> getPostAction();
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeDependencyResolver.java
@@ -40,4 +40,11 @@ public class TaskNodeDependencyResolver implements DependencyResolver {
             }
         });
     }
+
+    @Override
+    public boolean attachActionTo(Task task, Action<? super Task> action) {
+        TaskNode node = taskNodeFactory.getOrCreateNode(task);
+        node.appendPostAction(action);
+        return true;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -26,6 +26,7 @@ import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.composite.internal.IncludedBuildTaskGraph;
 import org.gradle.composite.internal.IncludedBuildTaskResource.State;
+import org.gradle.internal.Actions;
 import org.gradle.internal.build.BuildState;
 
 import java.util.HashMap;
@@ -94,6 +95,18 @@ public class TaskNodeFactory {
         @Override
         public void rethrowNodeFailure() {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void appendPostAction(Action<? super Task> action) {
+            // Ignore. Currently the actions don't need to run, it's just better if they do
+            // By the time this node is notified that the task in the other build has completed, it's too late to run the action
+            // Instead, the action should be attached to the task in the other build rather than here
+        }
+
+        @Override
+        public Action<? super Task> getPostAction() {
+            return Actions.doNothing();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -24,6 +24,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.ArtifactCollection;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
@@ -120,9 +121,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED;
-import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.GRAPH_RESOLVED;
-import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.UNRESOLVED;
+import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.*;
 import static org.gradle.util.ConfigureUtil.configure;
 
 public class DefaultConfiguration extends AbstractFileCollection implements ConfigurationInternal, MutationValidator {
@@ -1599,6 +1598,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 @Override
                 public void visitFailure(Throwable failure) {
                     failures.add(failure);
+                }
+
+                @Override
+                public void attachFinalizerTo(Task task, Action<? super Task> action) {
+                    context.attachFinalizerTo(task, action);
                 }
 
                 @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -31,7 +31,6 @@ import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
 import org.gradle.api.internal.project.ProjectStateRegistry;
-import org.gradle.internal.Factory;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
@@ -134,13 +133,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     @Override
     public ArtifactSet resolveArtifacts(final ComponentResolveMetadata component, final ConfigurationMetadata configuration, final ArtifactTypeRegistry artifactTypeRegistry, final ModuleExclusion exclusions, final ImmutableAttributes overriddenAttributes) {
         if (isProjectModule(component.getId())) {
-            ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) component.getId();
-            return projectStateRegistry.stateFor(projectId).withMutableState(new Factory<ArtifactSet>() {
-                @Override
-                public ArtifactSet create() {
-                    return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes);
-                }
-            });
+            return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes);
         } else {
             return null;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -16,13 +16,11 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.Buildable;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.DownloadArtifactBuildOperationType;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet.AsyncArtifactListener;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -117,17 +115,12 @@ class ArtifactBackedResolvedVariant implements ResolvedVariant {
 
         @Override
         public void collectBuildDependencies(BuildDependenciesVisitor visitor) {
-            visitor.visitDependency(getBuildDependencies());
+            artifact.collectBuildDependencies(visitor);
         }
 
         @Override
         public ComponentArtifactIdentifier getArtifactId() {
             return artifact.getId();
-        }
-
-        @Override
-        public TaskDependency getBuildDependencies() {
-            return ((Buildable) artifact).getBuildDependencies();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildDependenciesVisitor.java
@@ -16,8 +16,18 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+
 public interface BuildDependenciesVisitor {
     void visitDependency(Object dep);
+
+    /**
+     * Attach an action to run as soon as the given task completes, to perform some work before the outputs of the task are consumed by other tasks.
+     *
+     * <p>This should evolve into some mechanism to add a real node to the graph with similar behaviour, but as a first step this is simply bolted on.
+     */
+    void attachFinalizerTo(Task task, Action<? super Task> action);
 
     void visitFailure(Throwable failure);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildableSingleResolvedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/BuildableSingleResolvedArtifactSet.java
@@ -16,9 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
-import org.gradle.api.Buildable;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 
-public interface BuildableSingleResolvedArtifactSet extends ResolvedArtifactSet, Buildable {
+public interface BuildableSingleResolvedArtifactSet extends ResolvedArtifactSet {
     ComponentArtifactIdentifier getArtifactId();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.EmptySchema;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
@@ -159,7 +158,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
 
         @Override
         public void collectBuildDependencies(BuildDependenciesVisitor visitor) {
-            visitor.visitDependency(getBuildDependencies());
+            visitor.visitDependency(dependencyMetadata.getFiles().getBuildDependencies());
         }
 
         @Override
@@ -170,11 +169,6 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public ComponentArtifactIdentifier getArtifactId() {
             return artifactIdentifier;
-        }
-
-        @Override
-        public TaskDependency getBuildDependencies() {
-            return dependencyMetadata.getFiles().getBuildDependencies();
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvableArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvableArtifact.java
@@ -38,4 +38,6 @@ public interface ResolvableArtifact {
     File getFile();
 
     ResolvedArtifact toPublicView();
+
+    void collectBuildDependencies(BuildDependenciesVisitor visitor);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformingVisitor.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.Buildable;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
@@ -24,7 +23,6 @@ import org.gradle.api.internal.artifacts.DefaultResolvedArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier;
 import org.gradle.internal.component.model.DefaultIvyArtifactName;
@@ -58,12 +56,11 @@ class ArtifactTransformingVisitor implements ArtifactVisitor {
         ResolvedArtifact sourceArtifact = artifact.toPublicView();
         List<File> transformedFiles = operation.getResult();
         assert transformedFiles != null;
-        TaskDependency buildDependencies = ((Buildable) artifact).getBuildDependencies();
 
         for (File output : transformedFiles) {
             IvyArtifactName artifactName = DefaultIvyArtifactName.forFile(output, sourceArtifact.getClassifier());
             ComponentArtifactIdentifier newId = new ComponentFileArtifactIdentifier(sourceArtifact.getId().getComponentIdentifier(), artifactName);
-            DefaultResolvedArtifact resolvedArtifact = new DefaultResolvedArtifact(sourceArtifact.getModuleVersion().getId(), artifactName, newId, buildDependencies, output);
+            DefaultResolvedArtifact resolvedArtifact = new DefaultResolvedArtifact(sourceArtifact.getModuleVersion().getId(), artifactName, newId, artifact, output);
             visitor.visitArtifact(variantName, target, resolvedArtifact);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformNodeDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformNodeDependencyResolver.java
@@ -45,4 +45,9 @@ public class TransformNodeDependencyResolver implements DependencyResolver {
         }
         return false;
     }
+
+    @Override
+    public boolean attachActionTo(Task task, Action<? super Task> action) {
+        return false;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/PublishArtifactLocalArtifactMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/PublishArtifactLocalArtifactMetadata.java
@@ -29,10 +29,12 @@ import java.io.File;
 public class PublishArtifactLocalArtifactMetadata implements LocalComponentArtifactMetadata, ComponentArtifactIdentifier, DisplayName {
     private final ComponentIdentifier componentIdentifier;
     private final PublishArtifact publishArtifact;
+    private final DefaultIvyArtifactName ivyArtifactName;
 
     public PublishArtifactLocalArtifactMetadata(ComponentIdentifier componentIdentifier, PublishArtifact publishArtifact) {
         this.componentIdentifier = componentIdentifier;
         this.publishArtifact = publishArtifact;
+        ivyArtifactName = DefaultIvyArtifactName.forPublishArtifact(publishArtifact);
     }
 
     public String getDisplayName() {
@@ -75,7 +77,7 @@ public class PublishArtifactLocalArtifactMetadata implements LocalComponentArtif
 
     @Override
     public IvyArtifactName getName() {
-        return DefaultIvyArtifactName.forPublishArtifact(publishArtifact);
+        return ivyArtifactName;
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/TestArtifactSet.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/TestArtifactSet.java
@@ -80,6 +80,10 @@ public class TestArtifactSet implements ResolvedArtifactSet {
         }
 
         @Override
+        public void collectBuildDependencies(BuildDependenciesVisitor visitor) {
+        }
+
+        @Override
         public ComponentArtifactIdentifier getId() {
             return artifact.getId();
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariantTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact
 import org.gradle.api.Buildable
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.internal.attributes.AttributeContainerInternal
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.internal.Describables
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import spock.lang.Specification
@@ -123,28 +122,22 @@ class ArtifactBackedResolvedVariantTest extends Specification {
 
     def "collects build dependencies"() {
         def visitor = Mock(BuildDependenciesVisitor)
-        def deps1 = Stub(TaskDependency)
-        def deps2 = Stub(TaskDependency)
         def set1 = of([artifact1, artifact2])
         def set2 = of([artifact1])
-
-        given:
-        artifact1.buildDependencies >> deps1
-        artifact2.buildDependencies >> deps2
 
         when:
         set1.artifacts.collectBuildDependencies(visitor)
 
         then:
-        1 * visitor.visitDependency(deps1)
-        1 * visitor.visitDependency(deps2)
+        1 * artifact1.collectBuildDependencies(visitor)
+        1 * artifact2.collectBuildDependencies(visitor)
         0 * visitor._
 
         when:
         set2.artifacts.collectBuildDependencies(visitor)
 
         then:
-        1 * visitor.visitDependency(deps1)
+        1 * artifact1.collectBuildDependencies(visitor)
         0 * visitor._
     }
 

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.file.collections;
 
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.AbstractTaskDependencyResolveContext;
@@ -70,6 +71,11 @@ public class BuildDependenciesOnlyFileCollectionResolveContext implements FileCo
                     } else {
                         BuildDependenciesOnlyFileCollectionResolveContext.this.add(dependency);
                     }
+                }
+
+                @Override
+                public void attachFinalizerTo(Task task, Action<? super Task> action) {
+                    taskContext.attachFinalizerTo(task, action);
                 }
 
                 @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/AbstractTaskDependency.java
@@ -33,6 +33,11 @@ public abstract class AbstractTaskDependency implements TaskDependencyInternal {
             // Ignore artifact transforms
             return node instanceof ArtifactTransformDependency;
         }
+
+        @Override
+        public boolean attachActionTo(Task task, Action<? super Task> action) {
+            return false;
+        }
     };
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskDependency.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import groovy.lang.Closure;
+import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Task;
@@ -92,6 +93,11 @@ public class DefaultTaskDependency extends AbstractTaskDependency {
                     @Override
                     public void add(Object dependency) {
                         queue.addFirst(dependency);
+                    }
+
+                    @Override
+                    public void attachFinalizerTo(Task task, Action<? super Task> action) {
+                        context.attachFinalizerTo(task, action);
                     }
 
                     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/TaskDependencyResolveContext.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks;
 
+import org.gradle.api.Action;
 import org.gradle.api.Task;
 
 public interface TaskDependencyResolveContext {
@@ -38,6 +39,13 @@ public interface TaskDependencyResolveContext {
      * Adds an object that <em>may</em> be able to contribute tasks to the result.
      */
     void maybeAdd(Object dependency);
+
+    /**
+     * Attach an action to run as soon as the given task completes, to perform some work before the outputs of the task are consumed by other tasks.
+     *
+     * <p>This should evolve into some mechanism to add a real node to the graph with similar behaviour, but as a first step this is simply bolted on.
+     */
+    void attachFinalizerTo(Task task, Action<? super Task> action);
 
     /**
      * Returns the task whose dependencies are being resolved.

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/WorkDependencyResolver.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/tasks/WorkDependencyResolver.java
@@ -28,6 +28,8 @@ public interface WorkDependencyResolver<T> {
      */
     boolean resolve(Task task, Object node, Action<? super T> resolveAction);
 
+    boolean attachActionTo(Task task, Action<? super Task> action);
+
     /**
      * Resolves dependencies to {@link Task} objects.
      */
@@ -45,6 +47,11 @@ public interface WorkDependencyResolver<T> {
                 return false;
             }
             return true;
+        }
+
+        @Override
+        public boolean attachActionTo(Task task, Action<? super Task> action) {
+            return false;
         }
     };
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DependencyResolvingClasspath.java
@@ -16,6 +16,8 @@
 
 package org.gradle.jvm.internal;
 
+import org.gradle.api.Action;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.ResolutionStrategy;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.component.BuildIdentifier;
@@ -149,6 +151,10 @@ public class DependencyResolvingClasspath extends AbstractFileCollection {
             @Override
             public void visitDependency(Object dep) {
                 taskDependencies.add(dep);
+            }
+
+            @Override
+            public void attachFinalizerTo(Task task, Action<? super Task> action) {
             }
 
             @Override

--- a/subprojects/tooling-native/src/main/java/org/gradle/language/cpp/internal/tooling/CppModelBuilder.java
+++ b/subprojects/tooling-native/src/main/java/org/gradle/language/cpp/internal/tooling/CppModelBuilder.java
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp.internal.tooling;
 
 import com.google.common.collect.ImmutableList;
+import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.RegularFile;
@@ -165,6 +166,11 @@ public class CppModelBuilder implements ToolingModelBuilder {
             } else {
                 task = (Task) dependency;
             }
+        }
+
+        @Override
+        public void attachFinalizerTo(Task task, Action<? super Task> action) {
+            // Ignore
         }
 
         @Override


### PR DESCRIPTION

### Context

This PR is a rough solution to avoid locking the target of a project dependency during task execution. The implementation calculates dependency resolution metadata for an artifact immediately after the producing task completes, so that consuming tasks do not need to do this calculation and can avoid locking the target project.

The implementation adds a bunch of complexity in the interests of getting a solution out. A follow up PR will simplify the implementation.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
