### PR TITLE
Publish inherited exclude rules

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -16,9 +16,12 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.internal.artifacts.ResolveContext;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.util.Path;
+
+import java.util.Set;
 
 public interface ConfigurationInternal extends ResolveContext, Configuration, DependencyMetaDataProvider {
     enum InternalState {UNRESOLVED, GRAPH_RESOLVED, ARTIFACTS_RESOLVED}
@@ -52,4 +55,10 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
     OutgoingVariant convertToOutgoingVariant();
 
     void preventFromFurtherMutation();
+
+    /**
+     * Gets the complete set of exclude rules including those contributed by
+     * superconfigurations.
+     */
+    Set<ExcludeRule> getAllExcludeRules();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/Configurations.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.configurations;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.capabilities.Capability;
 
@@ -26,7 +27,8 @@ public class Configurations {
     public static ImmutableSet<String> getNames(Collection<Configuration> configurations) {
         if (configurations.isEmpty()) {
             return ImmutableSet.of();
-        } else if (configurations.size()==1) {
+        }
+        if (configurations.size() == 1) {
             return ImmutableSet.of(configurations.iterator().next().getName());
         }
         ImmutableSet.Builder<String> names = new ImmutableSet.Builder<String>();
@@ -47,10 +49,6 @@ public class Configurations {
     }
 
     public static String uploadTaskName(String configurationName) {
-        return "upload".concat(getCapitalName(configurationName));
-    }
-
-    private static String getCapitalName(String configurationName) {
-        return configurationName.substring(0, 1).toUpperCase() + configurationName.substring(1);
+        return "upload" + StringUtils.capitalize(configurationName);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -751,6 +751,15 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         return Collections.unmodifiableSet(parsedExcludeRules);
     }
 
+    public Set<ExcludeRule> getAllExcludeRules() {
+        Set<ExcludeRule> result = Sets.newLinkedHashSet();
+        result.addAll(getExcludeRules());
+        for (Configuration config : extendsFrom) {
+            result.addAll(((ConfigurationInternal) config).getAllExcludeRules());
+        }
+        return result;
+    }
+
     /**
      * Synchronize read access to excludes. Mutation does not need to be thread-safe.
      */
@@ -866,16 +875,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         // todo An ExcludeRule is a value object but we don't enforce immutability for DefaultExcludeRule as strong as we
         // should (we expose the Map). We should provide a better API for ExcludeRule (I don't want to use unmodifiable Map).
         // As soon as DefaultExcludeRule is truly immutable, we don't need to create a new instance of DefaultExcludeRule.
-        Set<Configuration> excludeRuleSources = new LinkedHashSet<Configuration>();
-        excludeRuleSources.add(this);
-        if (recursive) {
-            excludeRuleSources.addAll(getHierarchy());
-        }
-
-        for (Configuration excludeRuleSource : excludeRuleSources) {
-            for (ExcludeRule excludeRule : excludeRuleSource.getExcludeRules()) {
-                copiedConfiguration.excludeRules.add(new DefaultExcludeRule(excludeRule.getGroup(), excludeRule.getModule()));
-            }
+        for (ExcludeRule excludeRule : getAllExcludeRules()) {
+            copiedConfiguration.excludeRules.add(new DefaultExcludeRule(excludeRule.getGroup(), excludeRule.getModule()));
         }
 
         DomainObjectSet<Dependency> copiedDependencies = copiedConfiguration.getDependencies();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/ConfigurationsTest.groovy
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.api.internal.artifacts.configurations;
+package org.gradle.api.internal.artifacts.configurations
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.gradle.testing.internal.util.Specification
 
-import static org.junit.Assert.assertThat;
+class ConfigurationsTest extends Specification {
 
-public class ConfigurationsTest {
-    private static final String TEST_CONF = "testConf";
-
-    @Test
-    public void testUploadTaskName() {
-        assertThat(Configurations.uploadTaskName(TEST_CONF), Matchers.equalTo("uploadTestConf"));
+    def "prefixes task name with 'upload'"() {
+        expect:
+        Configurations.uploadTaskName("testConf") == "uploadTestConf"
     }
+
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -23,6 +23,11 @@ The following are the features that have been promoted in this Gradle release.
 
 ## Fixed issues
 
+### Inherited configuration-wide dependency excludes are now published
+
+Previously, only exclude rules directly declared on published configurations (e.g. `apiElements` and `runtimeElements` for the `java` component defined by the [Java Library Plugin](userguide/java_library_plugin.html#sec:java_library_configurations_graph)) were published in the Ivy descriptor and POM when using the [Ivy Publish Plugin](userguide/publishing_ivy.html) or [Maven Publish Plugins](userguide/publishing_maven.html), respectively.
+Now, inherited exclude rules defined on extended configurations (e.g. `api` for Java libraries) are also taken into account.
+
 ## Deprecations
 
 Features that have become superseded or irrelevant due to the natural evolution of Gradle become *deprecated*, and scheduled to be removed

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -358,15 +358,18 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
     @Issue("https://github.com/gradle/gradle/issues/4356, https://github.com/gradle/gradle/issues/5035")
     void "generated ivy descriptor includes configuration exclusions"() {
         requiresExternalDependencies = true
+        def exclusion = { name -> "$name-group:$name-module" }
+        def exclusions = { conf -> javaLibrary.parsedIvy.exclusions.findAll { it.conf == conf }.collect { it.org + ":" + it.module } }
 
         given:
         createBuildScripts("""
-            configurations.apiElements {
-                exclude group: "foo", module: "bar"
-            }
-
-            configurations.runtimeElements {
-                exclude group: "baz", module: "qux"
+            configurations {
+                api.exclude(group: "api-group", module: "api-module")
+                apiElements.exclude(group: "apiElements-group", module: "apiElements-module")
+                runtime.exclude(group: "runtime-group", module: "runtime-module")
+                runtimeElements.exclude(group: "runtimeElements-group", module: "runtimeElements-module")
+                implementation.exclude(group: "implementation-group", module: "implementation-module")
+                runtimeOnly.exclude(group: "runtimeOnly-group", module: "runtimeOnly-module")
             }
 
             $dependencies
@@ -378,25 +381,32 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
                     }
                 }
             }
-""")
+        """)
 
         when:
         run "publish"
 
         then:
         javaLibrary.assertPublishedAsJavaModule()
-        javaLibrary.parsedIvy.exclusions.collect { it.org + ":" + it.module + "@" + it.conf} == ["foo:bar@compile", "baz:qux@runtime"]
+        exclusions('compile') == [exclusion("apiElements"), exclusion("runtime"), exclusion("api")]
+        exclusions('runtime') == [exclusion("runtimeElements"), exclusion("implementation"), exclusion("api"), exclusion("runtimeOnly"), exclusion("runtime")]
 
         and:
         javaLibrary.parsedModuleMetadata.variant('api') {
             dependency('commons-collections:commons-collections:3.2.2') {
-                hasExclude('foo', 'bar')
+                hasExclude('apiElements-group', 'apiElements-module')
+                hasExclude('runtime-group', 'runtime-module')
+                hasExclude('api-group', 'api-module')
                 noMoreExcludes()
             }
         }
         javaLibrary.parsedModuleMetadata.variant('runtime') {
             dependency('commons-io:commons-io:1.4') {
-                hasExclude('baz', 'qux')
+                hasExclude('runtimeElements-group', 'runtimeElements-module')
+                hasExclude('implementation-group', 'implementation-module')
+                hasExclude('api-group', 'api-module')
+                hasExclude('runtimeOnly-group', 'runtimeOnly-module')
+                hasExclude('runtime-group', 'runtime-module')
                 noMoreExcludes()
             }
         }

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
@@ -25,6 +25,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Collections;
@@ -60,7 +61,7 @@ public class DefaultUsageContext implements UsageContext, Named {
         if (configuration != null) {
             this.dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
             this.dependencyConstraints = configuration.getAllDependencyConstraints();
-            this.globalExcludes = configuration.getExcludeRules();
+            this.globalExcludes = ((ConfigurationInternal) configuration).getAllExcludeRules();
         } else {
             this.dependencies = null;
             this.dependencyConstraints = null;

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.Configurations;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -166,7 +167,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
         @Override
         public Set<ExcludeRule> getGlobalExcludes() {
             if (excludeRules == null) {
-                this.excludeRules = ImmutableSet.copyOf(getConfiguration().getExcludeRules());
+                this.excludeRules = ImmutableSet.copyOf(((ConfigurationInternal) getConfiguration()).getAllExcludeRules());
             }
             return excludeRules;
         }


### PR DESCRIPTION
Prior to this commit, only exclude rules directly declared on published
configurations (e.g. `apiElements` and `runtimeElements` for Java) were
published in the Ivy descriptor, POM, and Gradle metadata. Now, exclude
rules from superconfigurations (e.g. `api` for Java) are also taken into
account.

Fixes #6766.