### PR TITLE
 Recognise substitution as a force

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -84,6 +84,116 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
         }
     }
 
+    def "can force a virtual platform version by forcing one of its leaves through resolutionStrategy.force"() {
+        repository {
+            ['2.7.9', '2.9.4', '2.9.4.1'].each {
+                path "databind:$it -> core:$it"
+                path "databind:$it -> annotations:$it"
+                path "kotlin:$it -> core:$it"
+                path "kotlin:$it -> annotations:$it"
+            }
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf("org:core:2.9.4")
+                conf("org:databind:2.7.9")
+                conf("org:kotlin:2.9.4.1")        
+            }
+            
+            configurations {
+                conf.resolutionStrategy.force("org:databind:2.7.9")
+            }
+        """
+
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        expectAlignment {
+            module('core') tries('2.9.4', '2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('databind') alignsTo('2.7.9') byVirtualPlatform()
+            module('kotlin') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('annotations') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:core:2.9.4", "org:core:2.7.9") {
+                    forced()
+                }
+                module("org:databind:2.7.9") {
+                    module('org:annotations:2.7.9')
+                    module('org:core:2.7.9')
+                }
+                edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
+                    forced()
+                    module('org:core:2.7.9')
+                    module('org:annotations:2.7.9')
+                }
+            }
+        }
+    }
+
+    def "can force a virtual platform version by forcing one of its leaves through resolutionStrategy.substitution"() {
+        repository {
+            ['2.7.9', '2.9.4', '2.9.4.1'].each {
+                path "databind:$it -> core:$it"
+                path "databind:$it -> annotations:$it"
+                path "kotlin:$it -> core:$it"
+                path "kotlin:$it -> annotations:$it"
+            }
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                conf("org:core:2.9.4")
+                conf("org:databind:2.7.9")
+                conf("org:kotlin:2.9.4.1")        
+            }
+            
+            configurations {
+                conf.resolutionStrategy.dependencySubstitution {
+                    substitute module("org:databind") with module("org:databind:2.7.9")
+                }
+            }
+        """
+
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        expectAlignment {
+            module('core') tries('2.9.4', '2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('databind') alignsTo('2.7.9') byVirtualPlatform()
+            module('kotlin') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+            module('annotations') tries('2.9.4.1') alignsTo('2.7.9') byVirtualPlatform()
+        }
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:core:2.9.4", "org:core:2.7.9") {
+                    forced()
+                }
+                module("org:databind:2.7.9") {
+                    module('org:annotations:2.7.9')
+                    module('org:core:2.7.9')
+                }
+                edge("org:kotlin:2.9.4.1", "org:kotlin:2.7.9") {
+                    forced()
+                    module('org:core:2.7.9')
+                    module('org:annotations:2.7.9')
+                }
+            }
+        }
+    }
+
     @Unroll
     def "fails if forcing a virtual platform version by forcing multiple leaves with different versions"() {
         repository {
@@ -141,6 +251,43 @@ class ForcingPlatformAlignmentTest extends AbstractAlignmentSpec {
                 conf.resolutionStrategy {
                     force('org:core:2.9.4')
                     force('org:databind:2.7.9')
+                }
+            }
+            dependencies {
+                conf("org:core:2.9.4.1")
+                conf("org:kotlin:2.9.4.1")
+
+                conf("org:databind:2.9.4.1")
+            }
+        """
+
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        allowAllRepositoryInteractions()
+        fails ':checkDeps'
+
+        then:
+        failureCauseContains("Multiple forces on different versions for virtual platform org:platform")
+    }
+
+    def "fails if forcing a virtual platform version by forcing multiple leaves with different versions through resolutionStrategy.dependencySubstitution"() {
+        repository {
+            ['2.7.9', '2.9.4', '2.9.4.1'].each {
+                path "databind:$it -> core:$it"
+                path "databind:$it -> annotations:$it"
+                path "kotlin:$it -> core:$it"
+                path "kotlin:$it -> annotations:$it"
+            }
+        }
+
+        given:
+        buildFile << """
+            configurations {
+                conf.resolutionStrategy.dependencySubstitution {
+                    substitute module('org:core') with module('org:core:2.9.4')
+                    substitute module('org:databind') with module('org:databind:2.7.9')
                 }
             }
             dependencies {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -148,6 +148,12 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
 
                 if (substituted instanceof UnversionedModuleComponentSelector) {
                     final ModuleIdentifier moduleId = ((UnversionedModuleComponentSelector) substituted).getModuleIdentifier();
+                    if (substitute instanceof ModuleComponentSelector) {
+                        if (((ModuleComponentSelector) substitute).getModuleIdentifier().equals(moduleId)) {
+                            // This substitution is effectively a force
+                            substitutionReason = substitutionReason.markAsEquivalentToForce();
+                        }
+                    }
                     all(new ModuleMatchDependencySubstitutionAction(substitutionReason, moduleId, substitute));
                 } else {
                     all(new ExactMatchDependencySubstitutionAction(substitutionReason, substituted, substitute));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -21,7 +21,6 @@ import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultResolvedVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
@@ -303,7 +302,7 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
     }
 
     private static boolean isForced(DependencyState dependencyState) {
-        if (dependencyState.getRuleDescriptor() != null && dependencyState.getRuleDescriptor().getCause() == ComponentSelectionCause.FORCED) {
+        if (dependencyState.getRuleDescriptor() != null && dependencyState.getRuleDescriptor().isEquivalentToForce()) {
             return true;
         }
         DependencyMetadata dependencyMetadata = dependencyState.getDependency();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorInternal.java
@@ -36,6 +36,20 @@ public interface ComponentSelectionDescriptorInternal extends ComponentSelection
      */
     boolean hasCustomDescription();
 
+    /**
+     * Updates this component selection descriptor to indicate it is equivalent to a force
+     *
+     * @return a new descriptor, equivalent to force
+     */
+    ComponentSelectionDescriptorInternal markAsEquivalentToForce();
+
+    /**
+     * Indicates whether the component selection descriptor is equivalent to a forced dependency
+     *
+     * @return {@code true} if equivalent to force, {@code false} otherwise
+     */
+    boolean isEquivalentToForce();
+
     Describable getDescribable();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultComponentSelectionDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultComponentSelectionDescriptor.java
@@ -25,19 +25,26 @@ public class DefaultComponentSelectionDescriptor implements ComponentSelectionDe
     private final Describable description;
     private final boolean hasCustomDescription;
     private final int hashCode;
+    private final boolean isEquivalentToForce;
 
     public DefaultComponentSelectionDescriptor(ComponentSelectionCause cause) {
-        this.cause = cause;
-        this.description = Describables.of(cause.getDefaultReason());
-        this.hasCustomDescription = false;
-        this.hashCode = cause.hashCode();
+        this(cause, Describables.of(cause.getDefaultReason()), false, cause == ComponentSelectionCause.FORCED);
     }
 
     public DefaultComponentSelectionDescriptor(ComponentSelectionCause cause, Describable description) {
+        this(cause, description, true, cause == ComponentSelectionCause.FORCED);
+    }
+
+    private DefaultComponentSelectionDescriptor(ComponentSelectionCause cause, Describable description, boolean hasCustomDescription, boolean isEquivalentToForce) {
         this.cause = cause;
         this.description = description;
-        this.hasCustomDescription = true;
-        this.hashCode = Objects.hashCode(cause, description);
+        this.hasCustomDescription = hasCustomDescription;
+        this.isEquivalentToForce = isEquivalentToForce;
+        if (hasCustomDescription) {
+            this.hashCode = Objects.hashCode(cause, description, isEquivalentToForce);
+        } else {
+            this.hashCode = Objects.hashCode(cause, isEquivalentToForce);
+        }
     }
 
     @Override
@@ -70,6 +77,7 @@ public class DefaultComponentSelectionDescriptor implements ComponentSelectionDe
         }
         DefaultComponentSelectionDescriptor that = (DefaultComponentSelectionDescriptor) o;
         return cause == that.cause
+            && isEquivalentToForce == that.isEquivalentToForce
             && Objects.equal(description, that.description);
     }
 
@@ -88,6 +96,16 @@ public class DefaultComponentSelectionDescriptor implements ComponentSelectionDe
         if (description.equals(reason)) {
             return this;
         }
-        return new DefaultComponentSelectionDescriptor(cause, reason);
+        return new DefaultComponentSelectionDescriptor(cause, reason, true, isEquivalentToForce);
+    }
+
+    @Override
+    public ComponentSelectionDescriptorInternal markAsEquivalentToForce() {
+        return new DefaultComponentSelectionDescriptor(cause, description, hasCustomDescription, true);
+    }
+
+    @Override
+    public boolean isEquivalentToForce() {
+        return isEquivalentToForce;
     }
 }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/groovy/build.gradle
@@ -1,8 +1,12 @@
+// Need to have at least one configuration declared, otherwise the rules are never evaluated
+configurations {
+    conf
+}
 
 // tag::module_to_project_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute module("org.utils:api") with project(":api") because "we work with the unreleased development version"
+        substitute module("org.utils:api") because "we work with the unreleased development version" with project(":api")
         substitute module("org.utils:util:2.5") with project(":util")
     }
 }
@@ -10,7 +14,7 @@ configurations.all {
 // tag::project_to_module_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
-        substitute project(":api") with module("org.utils:api:1.3") because "we use a stable version of utils"
+        substitute project(":api") because "we use a stable version of org.utils:api" with module("org.utils:api:1.3")
     }
 }
 // end::project_to_module_substitution[]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/groovy/settings.gradle
@@ -1,1 +1,3 @@
 rootProject.name = 'dependency-substitution'
+
+include 'api', 'util'

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/kotlin/build.gradle.kts
@@ -1,3 +1,6 @@
+// Need to have at least one configuration declared, otherwise the rules are never evaluated
+val conf by configurations.creating
+
 // tag::module_to_project_substitution[]
 configurations.all {
     resolutionStrategy.dependencySubstitution {
@@ -14,7 +17,7 @@ configurations.all {
     resolutionStrategy.dependencySubstitution {
         substitute(project(":api")).apply {
             with(module("org.utils:api:1.3"))
-            because("we use a stable version of utils")
+            because("we use a stable version of org.utils:api")
         }
     }
 }

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/customizingResolution/substitutionRule/kotlin/settings.gradle.kts
@@ -1,1 +1,2 @@
 rootProject.name = "dependency-substitution"
+include("util", "api")


### PR DESCRIPTION
Specific substitutions are indeed a force and should be recognised as
such. This will enable the platform and force behaviour to be triggered
from a substitution as well.