### PR TITLE
Add public service for accessing the build start time

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -34,5 +34,12 @@ package org.gradle.api.invocation;
  * @since 5.0
  */
 public interface BuildInvocationDetails {
+    
+    /**
+     * The wall-clock time in millis that the build was started.
+     *
+     * The build is considered to have started as soon as the user, or some tool, initiated the build.
+     * During continuous build, subsequent builds are timed from when changes are noticed.
+     */
     long getBuildStartedTime();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.invocation;
 
+import org.gradle.api.Incubating;
+
 /**
  * Provides some useful information about the build invocation that triggered this build.
  * <p>
@@ -33,6 +35,7 @@ package org.gradle.api.invocation;
  * </pre>
  * @since 5.0
  */
+@Incubating
 public interface BuildInvocationDetails {
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.invocation;
+
+/**
+ * Provides some useful information about the build invocation that triggered this build.
+ * <p>
+ * An instance of the type can be injected into a task or plugin by annotating a public constructor or method with {@code javax.inject.Inject}.
+ *
+ * <pre class='autoTested'>
+ * public class MyPlugin implements Plugin<Project> {
+ *     // injection into a constructor
+ *     {@literal @}javax.inject.Inject
+ *     public MyPlugin(BuildInvocationDetails invocationDetails) {}
+ *
+ *     public void apply(Project project) {
+ *     }
+  * }
+ * </pre>
+ * @since 5.0
+ */
+public interface BuildInvocationDetails {
+    long getBuildStartedTime();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -34,7 +34,7 @@ package org.gradle.api.invocation;
  * @since 5.0
  */
 public interface BuildInvocationDetails {
-    
+
     /**
      * The wall-clock time in millis that the build was started.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -24,7 +24,7 @@ import org.gradle.api.Incubating;
  * An instance of the type can be injected into a task or plugin by annotating a public constructor or method with {@code javax.inject.Inject}.
  *
  * <pre class='autoTested'>
- * public class MyPlugin implements Plugin<Project> {
+ * public class MyPlugin implements Plugin{@literal <}Project> {
  *     // injection into a constructor
  *     {@literal @}javax.inject.Inject
  *     public MyPlugin(BuildInvocationDetails invocationDetails) {}

--- a/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/invocation/BuildInvocationDetails.java
@@ -24,7 +24,7 @@ import org.gradle.api.Incubating;
  * An instance of the type can be injected into a task or plugin by annotating a public constructor or method with {@code javax.inject.Inject}.
  *
  * <pre class='autoTested'>
- * public class MyPlugin implements Plugin{@literal <}Project> {
+ * public class MyPlugin implements Plugin{@literal <}Project{@literal >} {
  *     // injection into a constructor
  *     {@literal @}javax.inject.Inject
  *     public MyPlugin(BuildInvocationDetails invocationDetails) {}

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/invocation/BuildInvocationDetailsIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/invocation/BuildInvocationDetailsIntegTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.internal.invocation
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.internal.buildevents.BuildStartedTime
-import org.gradle.internal.scan.time.BuildScanBuildStartedTime
 
 class BuildInvocationDetailsIntegTest extends AbstractIntegrationSpec {
 

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/invocation/BuildInvocationDetailsIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/invocation/BuildInvocationDetailsIntegTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.invocation
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.internal.buildevents.BuildStartedTime
+import org.gradle.internal.scan.time.BuildScanBuildStartedTime
+
+class BuildInvocationDetailsIntegTest extends AbstractIntegrationSpec {
+
+    def "can access build started time"() {
+        when:
+        buildFile << """
+            tasks.register("timeTask", TimeConsumer)
+            
+            class TimeConsumer extends DefaultTask {
+                private invocationDetails
+
+                @javax.inject.Inject
+                TimeConsumer(BuildInvocationDetails invocationDetails) {
+                    this.invocationDetails = invocationDetails
+                }
+                
+                @TaskAction
+                def checkTime() {
+                    def internalTimer = project.services.get($BuildStartedTime.name)
+                    assert invocationDetails.buildStartedTime != 0
+                    assert invocationDetails.buildStartedTime == internalTimer.startTime
+                    
+                    println "startTime: " + invocationDetails.buildStartedTime
+                }
+            }
+                    
+                    
+        """
+
+        succeeds("timeTask")
+
+        then:
+        output.contains("startTime: ")
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/invocation/DefaultBuildInvocationDetails.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/invocation/DefaultBuildInvocationDetails.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.invocation;
+
+import org.gradle.api.invocation.BuildInvocationDetails;
+import org.gradle.internal.buildevents.BuildStartedTime;
+
+public class DefaultBuildInvocationDetails implements BuildInvocationDetails {
+    private final BuildStartedTime buildStartedTime;
+
+    public DefaultBuildInvocationDetails(BuildStartedTime buildStartedTime) {
+        this.buildStartedTime = buildStartedTime;
+    }
+
+    @Override
+    public long getBuildStartedTime() {
+        return buildStartedTime.getStartTime();
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -74,6 +74,7 @@ import org.gradle.api.internal.tasks.userinput.DefaultUserInputHandler;
 import org.gradle.api.internal.tasks.userinput.DefaultUserInputReader;
 import org.gradle.api.internal.tasks.userinput.NonInteractiveUserInputHandler;
 import org.gradle.api.internal.tasks.userinput.UserInputHandler;
+import org.gradle.api.invocation.BuildInvocationDetails;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.FileLockManager;
@@ -162,6 +163,7 @@ import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Clock;
+import org.gradle.internal.invocation.DefaultBuildInvocationDetails;
 import org.gradle.model.internal.inspect.ModelRuleSourceDetector;
 import org.gradle.plugin.management.internal.autoapply.AutoAppliedPluginHandler;
 import org.gradle.plugin.use.internal.PluginRequestApplicator;
@@ -468,5 +470,9 @@ public class BuildScopeServices extends DefaultServiceRegistry {
 
     protected BuildScanUserInputHandler createBuildScanUserInputHandler(UserInputHandler userInputHandler) {
         return new DefaultBuildScanUserInputHandler(userInputHandler);
+    }
+
+    protected BuildInvocationDetails createBuildInvocationDetails(BuildStartedTime buildStartedTime) {
+        return new DefaultBuildInvocationDetails(buildStartedTime);
     }
 }


### PR DESCRIPTION
This is the one thing required so that the nebula `gradle-metrics-plugin` does not require use of any internal APIs.