### PR TITLE
Only use wide docs layout at 80rem or higher

### DIFF
--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -969,7 +969,7 @@ h3.releaseinfo {
 }
 
 /* Fixed intra-chapter navigation for desktops */
-@media screen and (min-width: 75rem) and (min-height: 48rem) {
+@media screen and (min-width: 80rem) and (min-height: 48rem) {
     .appendix .toc,
     .book .home .toc,
     .chapter .toc {

--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1283,7 +1283,7 @@ div.screenshot {
     text-decoration: none;
 }
 
-@media screen and (min-width: 75rem) and (min-height: 48rem) {
+@media screen and (min-width: 80rem) and (min-height: 48rem) {
     #header #toc {
         font-size: 1rem;
         background: #f7f7f8;
@@ -1855,7 +1855,7 @@ div.screenshot {
 }
 
 /* Fixed intra-chapter navigation for desktops */
-@media screen and (min-width: 75rem) and (min-height: 48rem) {
+@media screen and (min-width: 80rem) and (min-height: 48rem) {
     .appendix #header #toc,
     .book #header #toc,
     .chapter #header #toc {


### PR DESCRIPTION
This ensures there's always a little padding on the left so the
navigation can be read, inlining the TOC below 1280px (was 75rem).

Issue: #7024

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
