### PR TITLE
Do not ignore build event listener failures

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildEventsErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildEventsErrorIntegrationTest.groovy
@@ -17,14 +17,14 @@
 package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import spock.lang.Ignore
+import spock.lang.Unroll
 
-public class BuildEventsErrorIntegrationTest extends AbstractIntegrationSpec {
+class BuildEventsErrorIntegrationTest extends AbstractIntegrationSpec {
 
-    def "produces reasonable error message when taskGraph.whenReady action fails"() {
+    def "produces reasonable error message when taskGraph.whenReady closure fails"() {
         buildFile << """
     gradle.taskGraph.whenReady {
-        throw new RuntimeException('broken closure')
+        throw new RuntimeException('broken')
     }
     task a
 """
@@ -33,33 +33,54 @@ public class BuildEventsErrorIntegrationTest extends AbstractIntegrationSpec {
         fails()
 
         then:
-        failure.assertHasDescription("broken closure")
+        failure.assertHasDescription("broken")
                 .assertHasNoCause()
                 .assertHasFileName("Build file '$buildFile'")
                 .assertHasLineNumber(3);
     }
 
-    def "produces reasonable error message when task dependency closure throws exception"() {
+    def "produces reasonable error message when taskGraph.whenReady action fails"() {
         buildFile << """
+    def action = {
+            throw new RuntimeException('broken')
+    } as Action
+    gradle.taskGraph.whenReady(action) 
     task a
-    a.dependsOn {
-        throw new RuntimeException('broken')
-    }
 """
+
         when:
-        fails "a"
+        fails()
 
         then:
-        failure.assertHasDescription("Could not determine the dependencies of task ':a'.")
-                .assertHasCause('broken')
+        failure.assertHasDescription("broken")
+                .assertHasNoCause()
                 .assertHasFileName("Build file '$buildFile'")
-                .assertHasLineNumber(4)
+                .assertHasLineNumber(3);
+    }
+
+    def "produces reasonable error message when taskGraph listener fails"() {
+        buildFile << """
+    def listener = {
+            throw new RuntimeException('broken')
+    } as TaskExecutionGraphListener
+    gradle.taskGraph.addTaskExecutionGraphListener(listener) 
+    task a
+"""
+
+        when:
+        fails()
+
+        then:
+        failure.assertHasDescription("broken")
+                .assertHasNoCause()
+                .assertHasFileName("Build file '$buildFile'")
+                .assertHasLineNumber(3);
     }
 
     def "produces reasonable error when Gradle.allprojects action fails"() {
         def initScript = file("init.gradle") << """
 allprojects {
-    throw new RuntimeException("broken closure")
+    throw new RuntimeException("broken")
 }
 """
         when:
@@ -67,28 +88,99 @@ allprojects {
         fails "a"
 
         then:
-        failure.assertHasDescription("broken closure")
+        failure.assertHasDescription("broken")
                 .assertHasNoCause()
                 .assertHasFileName("Initialization script '$initScript'")
                 .assertHasLineNumber(3);
     }
 
-    @Ignore
-    def "produces reasonable error when Gradle.buildFinished action fails"() {
-        def initScript = file("init.gradle") << """
-rootProject { task a }
-buildFinished {
-    throw new RuntimeException("broken closure")
+    @Unroll
+    def "produces reasonable error when Gradle.#method closure fails"() {
+        settingsFile << """
+gradle.${method} {
+    throw new RuntimeException("broken")
 }
+gradle.rootProject { task a }
 """
         when:
-        executer.usingInitScript(initScript)
         fails "a"
 
         then:
-        failure.assertHasDescription("broken closure")
+        failure.assertHasDescription("broken")
                 .assertHasNoCause()
-                .assertHasFileName("Initialization script '$initScript'")
-                .assertHasLineNumber(3);
+        // TODO - include location information for buildFinished failure and get rid of the misleading 'build successful'
+        if (hasLocation) {
+            failure.assertHasFileName("Settings file '$settingsFile'")
+                    .assertHasLineNumber(3)
+        }
+
+        where:
+        method              | hasLocation
+        "settingsEvaluated" | true
+        "projectsLoaded"    | true
+        "projectsEvaluated" | true
+        "buildFinished"     | false
+    }
+
+    @Unroll
+    def "produces reasonable error when Gradle.#method action fails"() {
+        settingsFile << """
+def action = {
+    throw new RuntimeException("broken")
+} as Action
+gradle.${method}(action)
+gradle.rootProject { task a }
+"""
+        when:
+        fails "a"
+
+        then:
+        failure.assertHasDescription("broken")
+                .assertHasNoCause()
+        // TODO - include location information for buildFinished failure and get rid of the misleading 'build successful'
+        if (hasLocation) {
+            failure.assertHasFileName("Settings file '$settingsFile'")
+                    .assertHasLineNumber(3)
+        }
+
+        where:
+        method              | hasLocation
+        "settingsEvaluated" | true
+        "projectsLoaded"    | true
+        "projectsEvaluated" | true
+        "buildFinished"     | false
+    }
+
+    @Unroll
+    def "produces reasonable error when BuildListener.#method method fails"() {
+        settingsFile << """
+def listener = new BuildAdapter() {
+    @Override
+    void ${method}(${params}) {
+        throw new RuntimeException("broken")
+    }
+}
+
+gradle.addListener(listener)
+gradle.rootProject { task a }
+"""
+        when:
+        fails "a"
+
+        then:
+        failure.assertHasDescription("broken")
+                .assertHasNoCause()
+        // TODO - include location information for buildFinished failure and get rid of the misleading 'build successful'
+        if (hasLocation) {
+            failure.assertHasFileName("Settings file '$settingsFile'")
+                    .assertHasLineNumber(5)
+        }
+
+        where:
+        method              | params               | hasLocation
+        "settingsEvaluated" | "Settings settings"  | true
+        "projectsLoaded"    | "Gradle gradle"      | true
+        "projectsEvaluated" | "Gradle gradle"      | true
+        "buildFinished"     | "BuildResult result" | false
     }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectConfigureEventsErrorIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/ProjectConfigureEventsErrorIntegrationTest.groovy
@@ -18,13 +18,13 @@ package org.gradle.api
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
-public class ProjectConfigureEventsErrorIntegrationTest extends AbstractIntegrationSpec {
+class ProjectConfigureEventsErrorIntegrationTest extends AbstractIntegrationSpec {
 
     def "setup"() {
         settingsFile << "rootProject.name = 'projectConfigure'"
     }
 
-    def "produces reasonable error message when beforeProject action fails"() {
+    def "produces reasonable error message when Gradle.beforeProject closure fails"() {
         when:
         settingsFile << """
     gradle.beforeProject {
@@ -42,7 +42,26 @@ public class ProjectConfigureEventsErrorIntegrationTest extends AbstractIntegrat
                 .assertHasLineNumber(3)
     }
 
-    def "produces reasonable error message when afterProject action fails"() {
+    def "produces reasonable error message when Gradle.beforeProject action fails"() {
+        when:
+        settingsFile << """
+    def action = {
+        throw new RuntimeException("beforeProject failure")
+    } as Action
+    gradle.beforeProject(action)
+"""
+        buildFile << """
+    task test
+"""
+        then:
+        fails('test')
+        failure.assertHasDescription("A problem occurred configuring root project 'projectConfigure'.")
+                .assertHasCause("beforeProject failure")
+                .assertHasFileName("Settings file '${settingsFile.path}'")
+                .assertHasLineNumber(3)
+    }
+
+    def "produces reasonable error message when Gradle.afterProject closure fails"() {
         when:
         settingsFile << """
     gradle.afterProject {
@@ -60,12 +79,92 @@ public class ProjectConfigureEventsErrorIntegrationTest extends AbstractIntegrat
                 .assertHasLineNumber(3)
     }
 
-    def "produces reasonable error message when afterEvaluate action fails"() {
+    def "produces reasonable error message when Gradle.afterProject action fails"() {
+        when:
+        settingsFile << """
+    def action = {
+        throw new RuntimeException("afterProject failure")
+    } as Action
+    gradle.afterProject(action)
+"""
+        buildFile << """
+    task test
+"""
+        then:
+        fails('test')
+        failure.assertHasDescription("A problem occurred configuring root project 'projectConfigure'.")
+                .assertHasCause("afterProject failure")
+                .assertHasFileName("Settings file '${settingsFile.path}'")
+                .assertHasLineNumber(3)
+    }
+
+    def "produces reasonable error message when ProjectEvaluationListener.beforeEvaluate fails"() {
+        when:
+        settingsFile << """
+    class ListenerImpl implements ProjectEvaluationListener {
+        void beforeEvaluate(Project project) {
+            throw new RuntimeException("afterProject failure")
+        }
+        void afterEvaluate(Project project, ProjectState state) {}
+    }
+    gradle.addProjectEvaluationListener(new ListenerImpl())
+"""
+        buildFile << """
+    task test
+"""
+        then:
+        fails('test')
+        failure.assertHasDescription("A problem occurred configuring root project 'projectConfigure'.")
+                .assertHasCause("afterProject failure")
+                .assertHasFileName("Settings file '${settingsFile.path}'")
+                .assertHasLineNumber(4)
+    }
+
+    def "produces reasonable error message when ProjectEvaluationListener.afterEvalutate fails"() {
+        when:
+        settingsFile << """
+    class ListenerImpl implements ProjectEvaluationListener {
+        void beforeEvaluate(Project project) { }
+        void afterEvaluate(Project project, ProjectState state) {
+            throw new RuntimeException("afterProject failure")
+        }
+    }
+    gradle.addProjectEvaluationListener(new ListenerImpl())
+"""
+        buildFile << """
+    task test
+"""
+        then:
+        fails('test')
+        failure.assertHasDescription("A problem occurred configuring root project 'projectConfigure'.")
+                .assertHasCause("afterProject failure")
+                .assertHasFileName("Settings file '${settingsFile.path}'")
+                .assertHasLineNumber(5)
+    }
+
+    def "produces reasonable error message when Project.afterEvaluate closure fails"() {
         when:
         buildFile << """
     project.afterEvaluate {
         throw new RuntimeException("afterEvaluate failure")
     }
+    task test
+"""
+        then:
+        fails('test')
+        failure.assertHasDescription("A problem occurred configuring root project 'projectConfigure'.")
+                .assertHasCause("afterEvaluate failure")
+                .assertHasFileName("Build file '${buildFile.path}'")
+                .assertHasLineNumber(3)
+    }
+
+    def "produces reasonable error message when Project.afterEvaluate action fails"() {
+        when:
+        buildFile << """
+    def action = project.afterEvaluate {
+        throw new RuntimeException("afterEvaluate failure")
+    }
+    project.afterEvaluate(action)
     task test
 """
         then:

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -293,19 +293,36 @@ The following types/formats are supported:
         result.assertTasksExecuted(":b")
     }
 
+    def "produces reasonable error message when task dependency closure throws exception"() {
+        buildFile << """
+    task a
+    a.dependsOn {
+        throw new RuntimeException('broken')
+    }
+"""
+        when:
+        fails "a"
+
+        then:
+        failure.assertHasDescription("Could not determine the dependencies of task ':a'.")
+                .assertHasCause('broken')
+                .assertHasFileName("Build file '$buildFile'")
+                .assertHasLineNumber(4)
+    }
+
     def "dependency declared using provider with no value fails"() {
         buildFile << """
             def provider = objects.property(String)
-            tasks.register("b") {
+            tasks.register("a") {
                 dependsOn provider
             }
         """
 
         when:
-        fails("b")
+        fails("a")
 
         then:
-        failure.assertHasDescription("Could not determine the dependencies of task ':b'.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':a'.")
         failure.assertHasCause("No value has been specified for this provider.")
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
@@ -46,7 +46,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
     private static interface ComboListener extends BuildListener, ProjectEvaluationListener, TaskExecutionGraphListener, BuildCompletionListener {}
 
     def buildOperationExecutor = new TestBuildOperationExecutor()
-    DefaultListenerBuildOperationDecorator decorator = new DefaultListenerBuildOperationDecorator(buildOperationExecutor)
+    def decorator = new DefaultListenerBuildOperationDecorator(buildOperationExecutor)
     def context = decorator.@userCodeApplicationContext
 
     def 'ignores implementors of InternalListener'() {
@@ -102,6 +102,29 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
 
         and:
         verifyExpectedOp('foo', id)
+    }
+
+    def 'decorated action propagates exception'() {
+        given:
+        def action = Mock(Action)
+        def failure = new RuntimeException()
+        def arg = new Object()
+        def id = context.push()
+
+        def decoratedAction = decorator.decorate('foo', action)
+
+        when:
+        decoratedAction.execute(arg)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.is(failure)
+
+        and:
+        1 * action.execute(arg) >> { throw failure }
+
+        and:
+        verifyExpectedOp('foo', id, failure)
     }
 
     def 'decorates closures of same single arity'() {
@@ -210,6 +233,28 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         verifyExpectedOp('foo', id)
     }
 
+    def 'decorated closure propagates exception'() {
+        given:
+        def failure = new RuntimeException()
+        def arg = new Object()
+        def closure = { passedArg ->
+            throw failure
+        }
+        def id = context.push()
+
+        def decoratedClosure = decorator.decorate('foo', closure)
+
+        when:
+        decoratedClosure.call(arg)
+
+        then:
+        def e = thrown(RuntimeException)
+        e.is(failure)
+
+        and:
+        verifyExpectedOp('foo', id, failure)
+    }
+
     @Unroll
     def 'decorates BuildListener listeners'() {
         given:
@@ -276,6 +321,87 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
 
         where:
         decorateAsObject << [true, false]
+    }
+
+    def 'decorated BuildListener rethrows failures'() {
+        given:
+        def buildStartedArg = Mock(Gradle)
+        def settingsEvaluatedArg = Mock(Settings)
+        def projectsLoadedArg = Mock(Gradle)
+        def projectsEvaluatedArg = Mock(Gradle)
+        def buildFinishedArg = new BuildResult(null, null)
+        def listener = Mock(BuildListener)
+        def failure = new RuntimeException()
+        def id = context.push()
+
+        def decoratedListener = decorator.decorate('foo', BuildListener, listener)
+
+        when:
+        decoratedListener.buildStarted(buildStartedArg)
+
+        then:
+        def e1 = thrown(RuntimeException)
+        e1.is(failure)
+
+        and:
+        1 * listener.buildStarted(buildStartedArg) >> { throw failure }
+
+        and:
+        verifyNoOp()
+
+        when:
+        decoratedListener.settingsEvaluated(settingsEvaluatedArg)
+
+        then:
+        def e2 = thrown(RuntimeException)
+        e2.is(failure)
+
+        and:
+        1 * listener.settingsEvaluated(settingsEvaluatedArg) >> { throw failure }
+
+        and:
+        verifyNoOp()
+
+        when:
+        decoratedListener.projectsLoaded(projectsLoadedArg)
+
+        then:
+        def e3 = thrown(RuntimeException)
+        e3.is(failure)
+
+        and:
+        1 * listener.projectsLoaded(projectsLoadedArg) >> { throw failure }
+
+        and:
+        verifyExpectedOp('foo', id, failure)
+
+        when:
+        resetOps()
+        decoratedListener.projectsEvaluated(projectsEvaluatedArg)
+
+        then:
+        def e4 = thrown(RuntimeException)
+        e4.is(failure)
+
+        and:
+        1 * listener.projectsEvaluated(projectsEvaluatedArg) >> { throw failure }
+
+        and:
+        verifyExpectedOp('foo', id, failure)
+
+        when:
+        resetOps()
+        decoratedListener.buildFinished(buildFinishedArg)
+
+        then:
+        def e5 = thrown(RuntimeException)
+        e5.is(failure)
+
+        and:
+        1 * listener.buildFinished(buildFinishedArg) >> { throw failure }
+
+        and:
+        verifyNoOp()
     }
 
     @Unroll
@@ -446,10 +572,12 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
         assert buildOperationExecutor.operations.empty
     }
 
-    private void verifyExpectedOp(String expectedRegistrationPoint, UserCodeApplicationId id) {
-        assert buildOperationExecutor.operations.size() == 1
-        def op = buildOperationExecutor.operations.first()
+    private void verifyExpectedOp(String expectedRegistrationPoint, UserCodeApplicationId id, Throwable failure = null) {
+        assert buildOperationExecutor.log.records.size() == 1
+        def record = buildOperationExecutor.log.records.first()
+        def op = record.descriptor
         assert op.displayName == "Execute $expectedRegistrationPoint listener"
         assert (op.details as ExecuteListenerBuildOperationType.Details).applicationId == id.longValue()
+        assert record.failure == failure
     }
 }


### PR DESCRIPTION
### Context

This PR fixes error handling for various listener types so that exceptions thrown by these listeners are not ignored:

- `BuildListener` instances added via `Gradle`
- `TaskExecutionGraphListener` instances added via `TaskGraph`
- `Action` instances added via `TaskGraph`
- `ProjectEvaluationListener` instances added via `Gradle`

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
