### PR TITLE
Add teamcity build id to performance tests

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -131,6 +131,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
     protected List<ScenarioBuildResultData> generateResultsForReport() {
         finishedBuilds.collect { workerBuildId, scenarioResult ->
             new ScenarioBuildResultData(
+                teamCityBuildId: workerBuildId,
                 scenarioName: scheduledBuilds.get(workerBuildId).id,
                 webUrl: scenarioResult.buildResult.webUrl.toString(),
                 successful: scenarioResult.buildResult.status == 'SUCCESS',

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -74,6 +74,7 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
 
     // Modify this class with care, see class org.gradle.performance.results.ScenarioBuildResultData
     static class ScenarioBuildResultData {
+        String teamCityBuildId
         String scenarioName
         String webUrl
         String testFailure

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/fixture/BuildScanPerformanceTestRunner.groovy
@@ -46,7 +46,8 @@ class BuildScanPerformanceTestRunner extends CrossBuildPerformanceTestRunner {
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId, pluginCommitSha],
             startTime: clock.getCurrentTime(),
-            channel: determineChannel()
+            channel: determineChannel(),
+            teamCityBuildId: determineTeamCityBuildId()
         )
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/AbstractToolingApiCrossVersionPerformanceTest.groovy
@@ -199,7 +199,9 @@ abstract class AbstractToolingApiCrossVersionPerformanceTest extends Specificati
                 args: [],
                 gradleOpts: [],
                 daemon: true,
-                channel: ResultsStoreHelper.determineChannel())
+                channel: ResultsStoreHelper.determineChannel(),
+                teamCityBuildId: ResultsStoreHelper.determineTeamCityBuildId()
+            )
             def resolver = new ToolingApiDistributionResolver().withDefaultRepository()
             try {
                 List<String> baselines = CrossVersionPerformanceTestRunner.toBaselineVersions(RELEASES, experiment.targetVersions, experiment.minimumVersion).toList()

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractGradleBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/AbstractGradleBuildPerformanceTestRunner.groovy
@@ -119,4 +119,8 @@ abstract class AbstractGradleBuildPerformanceTestRunner<R extends PerformanceTes
     protected static String determineChannel() {
         ResultsStoreHelper.determineChannel()
     }
+
+    protected static String determineTeamCityBuildId() {
+        ResultsStoreHelper.determineTeamCityBuildId()
+    }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossBuildPerformanceTestRunner.groovy
@@ -57,7 +57,8 @@ class CrossBuildPerformanceTestRunner extends AbstractGradleBuildPerformanceTest
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId],
             startTime: clock.getCurrentTime(),
-            channel: determineChannel()
+            channel: determineChannel(),
+            teamCityBuildId: determineTeamCityBuildId()
         )
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -106,7 +106,8 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
             vcsBranch: Git.current().branchName,
             vcsCommits: [Git.current().commitId],
             startTime: clock.getCurrentTime(),
-            channel: ResultsStoreHelper.determineChannel()
+            channel: ResultsStoreHelper.determineChannel(),
+            teamCityBuildId: ResultsStoreHelper.determineTeamCityBuildId()
         )
 
         def baselineVersions = toBaselineVersions(releases, targetVersions, minimumVersion).collect { results.baseline(it) }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossBuildPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossBuildPerformanceTestHistory.java
@@ -134,6 +134,11 @@ public class CrossBuildPerformanceTestHistory implements PerformanceTestHistory 
         }
 
         @Override
+        public String getTeamCityBuildId() {
+            return results.getTeamCityBuildId();
+        }
+
+        @Override
         public String getVersionUnderTest() {
             return results.getVersionUnderTest();
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/CrossVersionPerformanceTestHistory.java
@@ -167,6 +167,11 @@ public class CrossVersionPerformanceTestHistory implements PerformanceTestHistor
             return String.valueOf(Math.abs(getVcsCommits() != null ? getVcsCommits().hashCode() : hashCode()));
         }
 
+        @Override
+        public String getTeamCityBuildId() {
+            return result.getTeamCityBuildId();
+        }
+
         public String getVersionUnderTest() {
             return result.getVersionUnderTest();
         }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -37,7 +37,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
     public static final int ENOUGH_REGRESSION_CONFIDENCE_THRESHOLD = 90;
@@ -76,11 +77,11 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
     private ScenarioBuildResultData queryExecutionData(ScenarioBuildResultData scenario) {
         PerformanceTestHistory history = resultsStore.getTestResults(scenario.getScenarioName(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel());
         List<? extends PerformanceTestExecution> recentExecutions = history.getExecutions();
-        List<? extends PerformanceTestExecution> currentCommitExecutions = recentExecutions.stream().filter(execution -> execution.getVcsCommits().contains(commitId)).collect(toList());
+        List<? extends PerformanceTestExecution> currentCommitExecutions = recentExecutions.stream().filter(execution -> Objects.equals(execution.getTeamCityBuildId(), scenario.getTeamCityBuildId())).collect(toList());
         if (currentCommitExecutions.isEmpty()) {
             scenario.setRecentExecutions(recentExecutions.stream().map(this::extractExecutionData).filter(Objects::nonNull).collect(toList()));
         } else {
-            scenario.setCurrentCommitExecutions(currentCommitExecutions.stream().map(this::extractExecutionData).filter(Objects::nonNull).collect(toList()));
+            scenario.setCurrentBuildExecutions(currentCommitExecutions.stream().map(this::extractExecutionData).filter(Objects::nonNull).collect(toList()));
         }
 
         scenario.setCrossBuild(history instanceof CrossBuildPerformanceTestHistory);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -77,11 +77,11 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
     private ScenarioBuildResultData queryExecutionData(ScenarioBuildResultData scenario) {
         PerformanceTestHistory history = resultsStore.getTestResults(scenario.getScenarioName(), DEFAULT_RETRY_COUNT, PERFORMANCE_DATE_RETRIEVE_DAYS, ResultsStoreHelper.determineChannel());
         List<? extends PerformanceTestExecution> recentExecutions = history.getExecutions();
-        List<? extends PerformanceTestExecution> currentCommitExecutions = recentExecutions.stream().filter(execution -> Objects.equals(execution.getTeamCityBuildId(), scenario.getTeamCityBuildId())).collect(toList());
-        if (currentCommitExecutions.isEmpty()) {
+        List<? extends PerformanceTestExecution> currentBuildExecutions = recentExecutions.stream().filter(execution -> Objects.equals(execution.getTeamCityBuildId(), scenario.getTeamCityBuildId())).collect(toList());
+        if (currentBuildExecutions.isEmpty()) {
             scenario.setRecentExecutions(recentExecutions.stream().map(this::extractExecutionData).filter(Objects::nonNull).collect(toList()));
         } else {
-            scenario.setCurrentBuildExecutions(currentCommitExecutions.stream().map(this::extractExecutionData).filter(Objects::nonNull).collect(toList()));
+            scenario.setCurrentBuildExecutions(currentBuildExecutions.stream().map(this::extractExecutionData).filter(Objects::nonNull).collect(toList()));
         }
 
         scenario.setCrossBuild(history instanceof CrossBuildPerformanceTestHistory);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestExecution.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestExecution.java
@@ -28,6 +28,8 @@ public interface PerformanceTestExecution {
      */
     String getExecutionId();
 
+    String getTeamCityBuildId();
+
     String getVersionUnderTest();
     String getVcsBranch();
     long getStartTime();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestResult.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceTestResult.java
@@ -19,19 +19,19 @@ package org.gradle.performance.results;
 import java.util.List;
 
 public abstract class PerformanceTestResult {
-
-    String testId;
-    String jvm;
-    String operatingSystem;
-    String host;
-    long startTime;
-    long endTime;
-    String vcsBranch;
-    List<String> vcsCommits;
-    List<String> previousTestIds;
-    String versionUnderTest;
-    String channel;
-    Throwable whereAmI;
+    private String testId;
+    private String teamCityBuildId;
+    private String jvm;
+    private String operatingSystem;
+    private String host;
+    private long startTime;
+    private long endTime;
+    private String vcsBranch;
+    private List<String> vcsCommits;
+    private List<String> previousTestIds;
+    private String versionUnderTest;
+    private String channel;
+    private Throwable whereAmI;
 
     public  PerformanceTestResult() {
         whereAmI = new Throwable();
@@ -52,6 +52,14 @@ public abstract class PerformanceTestResult {
 
     public void setTestId(String testId) {
         this.testId = testId;
+    }
+
+    public String getTeamCityBuildId() {
+        return teamCityBuildId;
+    }
+
+    public void setTeamCityBuildId(String teamCityBuildId) {
+        this.teamCityBuildId = teamCityBuildId;
     }
 
     public List<String> getPreviousTestIds() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ResultsStoreHelper.java
@@ -55,6 +55,10 @@ public class ResultsStoreHelper {
         return System.getProperty(SYSPROP_PERFORMANCE_TEST_CHANNEL, "commits");
     }
 
+    public static String determineTeamCityBuildId() {
+        return System.getenv("BUILD_ID");
+    }
+
     public static boolean isAdhocPerformanceTest() {
         return "adhoc".equals(determineChannel());
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -22,12 +22,13 @@ import org.gradle.performance.measure.DataSeries
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 class ScenarioBuildResultData {
+    String teamCityBuildId
     String scenarioName
     String webUrl
     String testFailure
     boolean successful
     boolean crossBuild
-    List<ExecutionData> currentCommitExecutions = []
+    List<ExecutionData> currentBuildExecutions = []
     List<ExecutionData> recentExecutions = []
 
     boolean isAboutToRegress() {
@@ -39,11 +40,11 @@ class ScenarioBuildResultData {
     }
 
     boolean isBuildFailed() {
-        return !successful && currentCommitExecutions.empty
+        return !successful && currentBuildExecutions.empty
     }
 
     boolean isFromCache() {
-        return successful && currentCommitExecutions.empty
+        return successful && currentBuildExecutions.empty
     }
 
     double getDifferenceSortKey() {
@@ -63,7 +64,7 @@ class ScenarioBuildResultData {
     }
 
     List<ExecutionData> getExecutions() {
-        return currentCommitExecutions.isEmpty() ? recentExecutions : currentCommitExecutions
+        return currentBuildExecutions.isEmpty() ? recentExecutions : currentBuildExecutions
     }
 
     List<ExecutionData> getExecutionsToDisplayInRow() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -115,7 +115,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 PerformanceTestExecution results = testHistory.getExecutions().get(i);
                 tr();
                 id("result" + results.getExecutionId());
-                textCell(format.timestamp(new Date(results.getStartTime())));
+                renderDateAndLink(results);
                 textCell(results.getVcsBranch());
 
                 td();
@@ -145,6 +145,16 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             footer(this);
             endAll();
         }
+
+            private void renderDateAndLink(PerformanceTestExecution results) {
+                td();
+                    String date = format.timestamp(new Date(results.getStartTime()));
+                    if(results.getTeamCityBuildId() == null) {
+                        text(date);
+                    }
+                    a().href("https://builds.gradle.org/viewLog.html?buildId=" + results.getTeamCityBuildId()).target("_blank").text(date).end();
+                end();
+            }
 
             private void renderVcsLinks(PerformanceTestExecution results, PerformanceTestExecution previousResults) {
                 List<GitHubLink> vcsCommits = createGitHubLinks(results.getVcsCommits());

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/IndexPageGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/IndexPageGeneratorTest.groovy
@@ -55,7 +55,7 @@ class IndexPageGeneratorTest extends Specification {
     }
 
     private ScenarioBuildResultData createFailedData() {
-        return new ScenarioBuildResultData(scenarioName: 'failed', successful: false, currentCommitExecutions: [Mock(ScenarioBuildResultData.ExecutionData)])
+        return new ScenarioBuildResultData(scenarioName: 'failed', successful: false, currentBuildExecutions: [Mock(ScenarioBuildResultData.ExecutionData)])
     }
 
     private ScenarioBuildResultData createHighConfidenceImprovedData() {
@@ -82,7 +82,7 @@ class IndexPageGeneratorTest extends Specification {
         MeasuredOperationList baseVersion = experiment(baseVersionResult)
         MeasuredOperationList currentVersion = experiment(currentVersionResult)
         ScenarioBuildResultData.ExecutionData execution = new ScenarioBuildResultData.ExecutionData(new Date().getTime(), '', baseVersion, currentVersion)
-        return new ScenarioBuildResultData(scenarioName: name, successful: true, currentCommitExecutions: [execution])
+        return new ScenarioBuildResultData(scenarioName: name, successful: true, currentBuildExecutions: [execution])
     }
 
     private MeasuredOperationList experiment(List<Integer> values) {


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/1535

Previously, we only don't have buildId recorded in performance database, which might cause incorrect result if running multiple performance builds against same commit. This PR adds `teamCityBuildId` column to performance test database.

A bonus is that we now have build url link in performance graph page:

![image](https://user-images.githubusercontent.com/12689835/47485768-6b6cda00-d871-11e8-8ab2-59189cd9f534.png)
