### PR TITLE
Minor edit to java_plugin.adoc to clarify that all annotation processors must opt into incap to support incremental compilation.

### DIFF
--- a/subprojects/docs/src/docs/userguide/java_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_plugin.adoc
@@ -558,7 +558,7 @@ To help you understand how incremental compilation works, the following provides
 === Incremental annotation processing
 
 Starting with Gradle 4.7, the incremental compiler also supports incremental annotation processing.
-Annotation processors need to opt in to this feature, otherwise they will trigger a full recompilation.
+All annotation processors need to opt in to this feature, otherwise they will trigger a full recompilation.
 
 As a user you can see which annotation processors are triggering full recompilations in the `--info` log.
 Incremental annotation processing will be deactivated if a custom `executable` or `javaHome` is configured on the compile task.


### PR DESCRIPTION
Signed-off-by: Tony Robalik <tony.robalik@gmail.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

@oehme and I were discussing this issue in Slack, and he suggested I could file a pull request to make this minor update.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
