### PR TITLE
Remove links from build scans created on Travis

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
@@ -6,6 +6,7 @@ import org.gradle.internal.os.OperatingSystem
 
 object BuildEnvironment {
     val isCiServer = "CI" in System.getenv()
+    val isTravis = "TRAVIS" in System.getenv()
     val gradleKotlinDslVersion = "1.0-rc-13"
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()


### PR DESCRIPTION
- Remove report links (only works on TC)
- Remove links to `e.grdev.net` GE instance for current commit

The former caused Travis builds to fail when there were e.g. CodeNarc violations.

Uploaded build scan from Travis without the links:
https://scans.gradle.com/s/hcqnqjr5dkmr2