### PR TITLE
Set default value to annotationProcessorGeneratedSourcesDirectory

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.compile.CompileOptions.xml
@@ -5,7 +5,7 @@
             <thead>
                 <tr>
                     <td>Name</td>
-                    <td>Default</td>
+                    <td>Default with <literal>java</literal> plugin</td>
                 </tr>
             </thead>
             <tr>
@@ -74,11 +74,11 @@
             </tr>
             <tr>
                 <td>annotationProcessorPath</td>
-                <td><literal>null</literal></td>
+                <td><literal><replaceable>sourceSet</replaceable>.annotationProcessorPath</literal></td>
             </tr>
             <tr>
                 <td>annotationProcessorGeneratedSourcesDirectory</td>
-                <td><literal>null</literal></td>
+                <td><literal><replaceable>${project.buildDir}</replaceable>/generated/sources/annotationProcessor/<replaceable>${sourceDirectorySet.name}</replaceable>/<replaceable>${sourceSet.name}</replaceable></literal></td>
             </tr>
             <tr>
                 <td>headerOutputDirectory</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -3,9 +3,7 @@ The Gradle team is excited to announce Gradle 5.2.
 This release features [1](), [2](), ... [n](), and more.
 
 We would like to thank the following community contributors to this release of Gradle:
-<!-- 
- [Some person](https://github.com/some-person), // name only, details in separate section
--->
+[Thomas Broyer](https://github.com/tbroyer).
 
 <!-- 
 ## 1
@@ -56,9 +54,7 @@ See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn 
 
 We would like to thank the following community members for making contributions to this release of Gradle.
 
-<!--
- - [Some person](https://github.com/some-person) - fixed some issue (gradle/gradle#1234)
--->
+ - [Thomas Broyer](https://github.com/tbroyer) - Provide default value for annotationProcessorGeneratedSourcesDirectory (gradle/gradle#7551)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractIntegrationSpec.groovy
@@ -161,6 +161,22 @@ class AbstractIntegrationSpec extends Specification {
         file("build/classes/", language, sourceSet, fqcn)
     }
 
+    TestFile javaGeneratedSourceFile(String fqcn) {
+        generatedSourceFile("java", "main", fqcn)
+    }
+
+    TestFile groovyGeneratedSourceFile(String fqcn) {
+        generatedSourceFile("groovy", "main", fqcn)
+    }
+
+    TestFile scalaGeneratedSourceFile(String fqcn) {
+        generatedSourceFile("scala", "main", fqcn)
+    }
+
+    TestFile generatedSourceFile(String language, String sourceSet, String fqcn) {
+        file("build/generated/sources/annotationProcessor/", language, sourceSet, fqcn)
+    }
+
     protected GradleExecuter sample(Sample sample) {
         inDirectory(sample.dir)
     }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/AggregatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -150,14 +150,14 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.snapshot { run "compileJava" }
 
         then:
-        file("build/classes/java/main/ServiceRegistry.java").exists()
+        file("build/generated/sources/annotationProcessor/java/main/ServiceRegistry.java").exists()
 
         when:
         a.delete()
         run "compileJava"
 
         then:
-        !file("build/classes/java/main/ServiceRegistry.java").exists()
+        !file("build/generated/sources/annotationProcessor/java/main/ServiceRegistry.java").exists()
     }
 
     def "generated files and classes are deleted when processor is removed"() {
@@ -168,14 +168,14 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
         outputs.snapshot { run "compileJava" }
 
         then:
-        file("build/classes/java/main/ServiceRegistry.java").exists()
+        file("build/generated/sources/annotationProcessor/java/main/ServiceRegistry.java").exists()
 
         when:
         buildFile << "compileJava.options.annotationProcessorPath = files()"
         run "compileJava"
 
         then:
-        !file("build/classes/java/main/ServiceRegistry.java").exists()
+        !file("build/generated/sources/annotationProcessor/java/main/ServiceRegistry.java").exists()
 
         and:
         outputs.deletedClasses("ServiceRegistry")
@@ -253,7 +253,7 @@ class AggregatingIncrementalAnnotationProcessingIntegrationTest extends Abstract
     }
 
     private boolean serviceRegistryReferences(String... services) {
-        def registry = file("build/classes/java/main/ServiceRegistry.java").text
+        def registry = file("build/generated/sources/annotationProcessor/java/main/ServiceRegistry.java").text
         services.every() {
             registry.contains("get$it")
         }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -125,14 +125,14 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.snapshot { run "compileJava" }
 
         then:
-        file("build/classes/java/main/AHelper.java").exists()
+        file("build/generated/sources/annotationProcessor/java/main/AHelper.java").exists()
 
         when:
         a.delete()
         run "compileJava"
 
         then:
-        !file("build/classes/java/main/AHelper.java").exists()
+        !file("build/generated/sources/annotationProcessor/java/main/AHelper.java").exists()
     }
 
     def "generated files and classes are deleted when processor is removed"() {
@@ -143,14 +143,14 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.snapshot { run "compileJava" }
 
         then:
-        file("build/classes/java/main/AHelper.java").exists()
+        file("build/generated/sources/annotationProcessor/java/main/AHelper.java").exists()
 
         when:
         buildFile << "compileJava.options.annotationProcessorPath = files()"
         run "compileJava"
 
         then:
-        !file("build/classes/java/main/AHelper.java").exists()
+        !file("build/generated/sources/annotationProcessor/java/main/AHelper.java").exists()
 
         and:
         outputs.deletedClasses("AHelper")
@@ -202,7 +202,7 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
         outputs.snapshot { run "compileJava" }
 
         when:
-        file("build/classes/java/main/AHelper.java").delete()
+        file("build/generated/sources/annotationProcessor/java/main/AHelper.java").delete()
         run "compileJava"
 
         then:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
@@ -138,7 +138,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
         run "compileJava"
 
         then:
-        file("build/classes/java/main/TestAppHelper.java").text == 'class TestAppHelper {    String getValue() { return "fromOptions"; }}'
+        file("build/generated/sources/annotationProcessor/java/main/TestAppHelper.java").text == 'class TestAppHelper {    String getValue() { return "fromOptions"; }}'
     }
 
     def "processors in the compile classpath are ignored"() {
@@ -266,7 +266,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5448")
-    def "can add classes directory as source"() {
+    def "can add generated sources directory as source"() {
         // This is sometimes done for IDE support.
         // We should deprecate this behaviour, since output directories are added as inputs.
         buildFile << """
@@ -274,7 +274,7 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
                 compileOnly project(":annotation")
                 annotationProcessor project(":processor")
             }
-            sourceSets.main.java.srcDir("build/classes/java/main")
+            sourceSets.main.java.srcDir("build/generated/sources/annotationProcessor/java/main")
         """
 
         expect:

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/UnknownIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/UnknownIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -80,14 +80,14 @@ class UnknownIncrementalAnnotationProcessingIntegrationTest extends AbstractIncr
         outputs.snapshot { run "compileJava" }
 
         then:
-        file("build/classes/java/main/AThing.java").exists()
+        file("build/generated/sources/annotationProcessor/java/main/AThing.java").exists()
 
         when:
         buildFile << "compileJava.options.annotationProcessorPath = files()"
         run "compileJava", "--info"
 
         then:
-        !file("build/classes/java/main/AThing.java").exists()
+        !file("build/generated/sources/annotationProcessor/java/main/AThing.java").exists()
 
         and:
         outputs.deletedClasses("AThing")

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -163,10 +163,6 @@ public class JavaCompilerArgumentsBuilder {
             args.add("-extdirs");
             args.add(compileOptions.getExtensionDirs());
         }
-        if (compileOptions.getAnnotationProcessorGeneratedSourcesDirectory() != null) {
-            args.add("-s");
-            args.add(compileOptions.getAnnotationProcessorGeneratedSourcesDirectory().getPath());
-        }
         if (compileOptions.getHeaderOutputDirectory() != null) {
             args.add("-h");
             args.add(compileOptions.getHeaderOutputDirectory().getPath());
@@ -191,6 +187,10 @@ public class JavaCompilerArgumentsBuilder {
             } else {
                 args.add("-processorpath");
                 args.add(Joiner.on(File.pathSeparator).join(annotationProcessorPath));
+            }
+            if (compileOptions.getAnnotationProcessorGeneratedSourcesDirectory() != null) {
+                args.add("-s");
+                args.add(compileOptions.getAnnotationProcessorGeneratedSourcesDirectory().getPath());
             }
         }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -209,10 +209,8 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         def outputDir = new File("build/generated-sources")
         spec.compileOptions.annotationProcessorGeneratedSourcesDirectory = outputDir
 
-        when:
-        def args = builder.build()
-        then:
-        args == ["-s", outputDir.path] + defaultOptions
+        expect:
+        builder.build() == ["-g", "-sourcepath", "", "-proc:none", "-s", outputDir.path, USE_UNSHARED_COMPILER_TABLE_OPTION, "-classpath", ""]
     }
 
     def "adds custom compiler args last"() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/groovy/compile/BasicGroovyCompilerIntegrationSpec.groovy
@@ -75,7 +75,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         then:
         succeeds("compileGroovy")
         groovyClassFile('Groovy.class').exists()
-        groovyClassFile('Groovy$$Generated.java').exists()
+        groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
     }
 
@@ -99,7 +99,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
 
         file('build/classes/stub/Groovy.java').exists()
         groovyClassFile('Groovy.class').exists()
-        groovyClassFile('Groovy$$Generated.java').exists()
+        groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
     }
 
@@ -119,7 +119,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         // No Groovy stubs will be created if there are no java files
         // and an annotation processor is not on the classpath
         !file('build/classes/stub/Groovy.java').exists()
-        !groovyClassFile('Groovy$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         !groovyClassFile('Groovy.class').exists()
         !groovyClassFile('Groovy$$Generated.class').exists()
     }
@@ -146,7 +146,7 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         // Because annotation processing is disabled
         // No Groovy stubs will be created
         !file('build/classes/stub/Groovy.java').exists()
-        !groovyClassFile('Groovy$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
         !groovyClassFile('Groovy.class').exists()
         !groovyClassFile('Groovy$$Generated.class').exists()
     }
@@ -189,8 +189,8 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         succeeds("compileGroovy")
         groovyClassFile('Groovy.class').exists()
         groovyClassFile('Java.class').exists()
-        groovyClassFile('Groovy$$Generated.java').exists()
-        groovyClassFile('Java$$Generated.java').exists()
+        groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
+        groovyGeneratedSourceFile('Java$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
         groovyClassFile('Java$$Generated.class').exists()
     }
@@ -207,8 +207,8 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         succeeds("compileGroovy")
         groovyClassFile('Java.class').exists()
         groovyClassFile('Groovy.class').exists()
-        !groovyClassFile('Groovy$$Generated.java').exists()
-        groovyClassFile('Java$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
+        groovyGeneratedSourceFile('Java$$Generated.java').exists()
         !groovyClassFile('Groovy$$Generated.class').exists()
         groovyClassFile('Java$$Generated.class').exists()
     }
@@ -238,8 +238,8 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         file('build/classes/stub/Groovy.java').exists()
         groovyClassFile('Groovy.class').exists()
         groovyClassFile('Java.class').exists()
-        groovyClassFile('Groovy$$Generated.java').exists()
-        groovyClassFile('Java$$Generated.java').exists()
+        groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
+        groovyGeneratedSourceFile('Java$$Generated.java').exists()
         groovyClassFile('Groovy$$Generated.class').exists()
         groovyClassFile('Java$$Generated.class').exists()
     }
@@ -263,8 +263,8 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         succeeds("compileGroovy")
         groovyClassFile('Groovy.class').exists()
         groovyClassFile('Java.class').exists()
-        !groovyClassFile('Groovy$$Generated.java').exists()
-        !groovyClassFile('Java$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Java$$Generated.java').exists()
         !groovyClassFile('Groovy$$Generated.class').exists()
         !groovyClassFile('Java$$Generated.class').exists()
     }
@@ -295,8 +295,8 @@ abstract class BasicGroovyCompilerIntegrationSpec extends MultiVersionIntegratio
         file('build/classes/stub/Groovy.java').exists()
         !groovyClassFile('Groovy.class').exists()
         groovyClassFile('Java.class').exists()
-        !groovyClassFile('Groovy$$Generated.java').exists()
-        !groovyClassFile('Java$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Groovy$$Generated.java').exists()
+        !groovyGeneratedSourceFile('Java$$Generated.java').exists()
         !groovyClassFile('Groovy$$Generated.class').exists()
         !groovyClassFile('Java$$Generated.class').exists()
     }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/compile/BasicJavaCompilerIntegrationSpec.groovy
@@ -280,7 +280,7 @@ class Main {
 
         then:
         succeeds("compileJava")
-        javaClassFile('Java$$Generated.java').exists()
+        javaGeneratedSourceFile('Java$$Generated.java').exists()
     }
 
     def writeAnnotationProcessorProject() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -176,7 +176,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
                         return sourceSet.getCompileClasspath();
                     }
                 });
-                SourceSetUtil.configureAnnotationProcessorPath(sourceSet, compileTask.getOptions(), target);
+                SourceSetUtil.configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, compileTask.getOptions(), target);
                 compileTask.setDestinationDir(target.provider(new Callable<File>() {
                     @Override
                     public File call() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/SourceSetUtil.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/SourceSetUtil.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Project;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
 import org.gradle.api.tasks.SourceSet;
@@ -33,7 +34,7 @@ public class SourceSetUtil {
 
     public static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, CompileOptions options, final Project target) {
         configureForSourceSet(sourceSet, sourceDirectorySet, compile, target);
-        configureAnnotationProcessorPath(sourceSet, options, target);
+        configureAnnotationProcessorPath(sourceSet, sourceDirectorySet, options, target);
     }
 
     private static void configureForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, AbstractCompile compile, final Project target) {
@@ -52,11 +53,19 @@ public class SourceSetUtil {
         }));
     }
 
-    public static void configureAnnotationProcessorPath(final SourceSet sourceSet, CompileOptions options, final Project target) {
-        new DslObject(options).getConventionMapping().map("annotationProcessorPath", new Callable<Object>() {
+    public static void configureAnnotationProcessorPath(final SourceSet sourceSet, SourceDirectorySet sourceDirectorySet, CompileOptions options, final Project target) {
+        final ConventionMapping conventionMapping = new DslObject(options).getConventionMapping();
+        conventionMapping.map("annotationProcessorPath", new Callable<Object>() {
             @Override
             public Object call() {
                 return sourceSet.getAnnotationProcessorPath();
+            }
+        });
+        final String annotationProcessorGeneratedSourcesChildPath = "generated/sources/annotationProcessor/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
+        conventionMapping.map("annotationProcessorGeneratedSourcesDirectory", new Callable<Object>() {
+            @Override
+            public Object call() {
+                return new File(target.getBuildDir(), annotationProcessorGeneratedSourcesChildPath);
             }
         });
     }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -314,6 +314,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task dependsOn()
         task.classpath.is(project.sourceSets.main.compileClasspath)
         task.options.annotationProcessorPath.is(project.sourceSets.main.annotationProcessorPath)
+        task.options.annotationProcessorGeneratedSourcesDirectory == new File(project.buildDir, 'generated/sources/annotationProcessor/java/main')
         task.destinationDir == project.sourceSets.main.java.outputDir
         task.source.files == project.sourceSets.main.java.files
 
@@ -341,6 +342,7 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         task dependsOn(JavaPlugin.CLASSES_TASK_NAME)
         task.classpath.is(project.sourceSets.test.compileClasspath)
         task.options.annotationProcessorPath.is(project.sourceSets.test.annotationProcessorPath)
+        task.options.annotationProcessorGeneratedSourcesDirectory == new File(project.buildDir, 'generated/sources/annotationProcessor/java/test')
         task.destinationDir == project.sourceSets.test.java.outputDir
         task.source.files == project.sourceSets.test.java.files
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

Fixes #4956

Annotation processor generated sources should not end up into project artifacts.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
