### PR TITLE
Split performance test results into two tables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,8 @@ plugins {
     id("org.gradle.ci.tag-single-build")
 }
 
+Thread.sleep(1000)
+
 defaultTasks("assemble")
 
 base.archivesBaseName = "gradle"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,8 +39,6 @@ plugins {
     id("org.gradle.ci.tag-single-build")
 }
 
-Thread.sleep(1000)
-
 defaultTasks("assemble")
 
 base.archivesBaseName = "gradle"

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -132,8 +132,8 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
                     body();
                         div().id("acoordion").classAttr("mx-auto");
                         renderHeader();
-                        renderTable("Cross version scenarios", ScenarioBuildResultData::isCrossVersion);
-                        renderTable("Cross build scenarios", ScenarioBuildResultData::isCrossBuild);
+                        renderTable("Cross version scenarios", "Compare the performance of the same build on different code versions.", ScenarioBuildResultData::isCrossVersion);
+                        renderTable("Cross build scenarios", "Compare the performance of different builds", ScenarioBuildResultData::isCrossBuild);
                         renderPopoverDiv();
                     end();
                 footer(this);
@@ -197,9 +197,11 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
                 end();
             }
 
-            private void renderTable(String title, Predicate<ScenarioBuildResultData> predicate) {
+            private void renderTable(String title, String description, Predicate<ScenarioBuildResultData> predicate) {
                 div().classAttr("row alert alert-primary m-0");
-                    div().classAttr("col-12 p-0").text(title).end();
+                    div().classAttr("col-12 p-0").text(title);
+                i().classAttr("fa fa-info-circle").attr("data-toggle", "tooltip").title(description).text(" ").end();
+                    end();
                 end();
                 scenarios.stream().filter(predicate).forEach(scenario -> renderScenario(counter.incrementAndGet(), scenario));
             }
@@ -319,7 +321,6 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
 
     private enum Tag {
         FROM_CACHE("FROM-CACHE", "badge badge-info", "The test is not really executed - its results are fetched from build cache."),
-        CROSS_BUILD("CROSS-BUILD", "badge badge-info", "This scenario is comparing two builds' performance difference, not versions'. Therefore, it's not seen as regression."),
         FAILED("FAILED", "badge badge-danger", "Regression confidence > 99% despite retries."),
         NEARLY_FAILED("NEARLY-FAILED", "badge badge-warning", "Regression confidence > 90%, we're going to fail soon."),
         REGRESSED("REGRESSED", "badge badge-danger", "Regression confidence > 99% despite retries."),
@@ -349,9 +350,6 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
             Set<Tag> result = new HashSet<>();
             if (scenario.isFromCache()) {
                 result.add(FROM_CACHE);
-            }
-            if (scenario.isCrossBuild()) {
-                result.add(CROSS_BUILD);
             }
             if(scenario.isUnknown()) {
                 result.add(UNKNOWN);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -31,6 +31,10 @@ class ScenarioBuildResultData {
     List<ExecutionData> currentBuildExecutions = []
     List<ExecutionData> recentExecutions = []
 
+    boolean isCrossVersion() {
+        return !crossBuild
+    }
+
     boolean isAboutToRegress() {
         return !crossBuild && executions.any { it.confidentToSayWorse() }
     }

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceReport.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceReport.js
@@ -1,5 +1,8 @@
-$(function enableAllTooltips() {
+function enableTooltips() {
     $('[data-toggle="tooltip"]').tooltip();
+}
+
+function enableSectionSign() {
     $('.data-row').mouseenter(function () {
         $('#section-sign-' + $(this).attr('scenario')).css('opacity', '1');
     }).mouseleave(function () {
@@ -13,15 +16,39 @@ $(function enableAllTooltips() {
         document.execCommand("copy");
         $temp.remove();
     });
+}
 
+function refreshCards(selectedTags) {
+    $('.card').each(function (index, row) {
+        var currentTags = $(row).attr('tag');
+        if (currentTags === undefined) {
+            currentTags = ''
+        }
+        currentTags = currentTags.split(',');
+        if (selectedTags.some(tag => currentTags.indexOf(tag) != -1)) {
+            $(row).show()
+        } else {
+            $(row).hide()
+        }
+    })
 
+    $("#filter-popover .form-check-input").toArray().forEach(function (checkbox) {
+        if (selectedTags.indexOf(checkbox.value) != -1) {
+            checkbox.setAttribute('checked', 'true');
+        } else {
+            checkbox.removeAttribute('checked')
+        }
+    })
+
+}
+
+function enableFilter() {
     $('[data-toggle="popover"]').popover({
         html: true,
         content: function () {
             return $('#filter-popover').html();
         }
     });
-
 
     $(document).on('click', '.form-check-input', function () {
         var currentSelectedTag = $(this).val();
@@ -31,18 +58,42 @@ $(function enableAllTooltips() {
 
         var selectedTags = $('.popover-body .form-check-input').toArray().filter(checkbox => checkbox.checked).map(checkbox => checkbox.value);
 
-        $('.card').each(function (index, row) {
-            var currentTags = $(row).attr('tag');
-            if (currentTags === undefined) {
-                currentTags = ''
-            }
-            currentTags = currentTags.split(',');
-            if (selectedTags.some(tag => currentTags.indexOf(tag) != -1)) {
-                $(row).show()
-            } else {
-                $(row).hide()
-            }
-        })
+        refreshCards(selectedTags)
     })
+}
 
+function failedScenarioButtonClicked() {
+    $('[data-toggle="popover"]').popover('hide')
+    $('#failed-scenarios').removeClass('btn-outline-danger').addClass('btn-danger')
+    $('#all-scenarios').addClass('btn-outline-primary').removeClass('btn-primary')
+    refreshCards(['FAILED', 'REGRESSED'])
+}
+
+function allScenarioButtonClicked() {
+    $('[data-toggle="popover"]').popover('hide')
+    $('#all-scenarios').removeClass('btn-outline-primary').addClass('btn-primary')
+    $('#failed-scenarios').addClass('btn-outline-danger').removeClass('btn-danger')
+
+    var allTags = $('#filter-popover .form-check-input').toArray().map(checkbox => checkbox.value);
+    refreshCards(allTags)
+}
+
+function initTabs() {
+    if (window.location.hash.length > 0) {
+        allScenarioButtonClicked()
+    } else if ($('#failed-scenarios').length > 0) {
+        failedScenarioButtonClicked()
+    }
+
+    $('#failed-scenarios').click(failedScenarioButtonClicked);
+
+    $('#all-scenarios').click(allScenarioButtonClicked);
+}
+
+
+$(function () {
+    enableTooltips();
+    enableSectionSign();
+    enableFilter();
+    initTabs();
 })

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceReport.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceReport.js
@@ -66,7 +66,7 @@ function failedScenarioButtonClicked() {
     $('[data-toggle="popover"]').popover('hide')
     $('#failed-scenarios').removeClass('btn-outline-danger').addClass('btn-danger')
     $('#all-scenarios').addClass('btn-outline-primary').removeClass('btn-primary')
-    refreshCards(['FAILED', 'REGRESSED'])
+    refreshCards(['FAILED', 'REGRESSED', 'UNKNOWN'])
 }
 
 function allScenarioButtonClicked() {


### PR DESCRIPTION
### Context

This closes https://github.com/gradle/gradle-private/issues/1560

Previously we have all performance tests in a single table, which might be somewhat misleading. This PR [split them into two tables: `Cross version` and `Cross build`](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/17071574:id/report-performance-performance-tests.zip%21/report/index.html):

![image](https://user-images.githubusercontent.com/12689835/47625550-d0218080-db60-11e8-8d50-4cbd14a9ac7d.png)

This brings a problem: if some failures happen in bottom table, do users need to scroll pages down to see it?

In this case, [by default we display all failures in a separate tab](https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/17053757:id/report-performance-performance-tests.zip%21/report/index.html):

![image](https://user-images.githubusercontent.com/12689835/47625598-0eb73b00-db61-11e8-9a6e-95de774260e1.png)
