### PR TITLE
 Support concurrent access in DefaultCachedMetadata 

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -33,28 +33,33 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
 
     private volatile Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
 
-    public DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
+    DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
         this.moduleSource = entry.moduleSource;
         this.ageMillis = timeProvider.getCurrentTime() - entry.createTimestamp;
         this.metadata = metadata;
     }
 
+    @Override
     public boolean isMissing() {
         return metadata == null;
     }
 
+    @Override
     public ModuleSource getModuleSource() {
         return moduleSource;
     }
 
+    @Override
     public ResolvedModuleVersion getModuleVersion() {
         return isMissing() ? null : new DefaultResolvedModuleVersion(getMetadata().getModuleVersionId());
     }
 
+    @Override
     public ModuleComponentResolveMetadata getMetadata() {
         return metadata;
     }
 
+    @Override
     public long getAgeMillis() {
         return ageMillis;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/DefaultCachedMetadata.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
-import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.dynamicversions.DefaultResolvedModuleVersion;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
@@ -25,12 +24,14 @@ import org.gradle.util.BuildCommencedTimeProvider;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     private final ModuleSource moduleSource;
     private final long ageMillis;
     private final ModuleComponentResolveMetadata metadata;
-    private Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
+
+    private volatile Map<Integer, ModuleComponentResolveMetadata> processedMetadataByRules;
 
     public DefaultCachedMetadata(ModuleMetadataCacheEntry entry, ModuleComponentResolveMetadata metadata, BuildCommencedTimeProvider timeProvider) {
         this.moduleSource = entry.moduleSource;
@@ -68,12 +69,12 @@ class DefaultCachedMetadata implements ModuleMetadataCache.CachedMetadata {
     }
 
     @Override
-    public void putProcessedMetadata(int hash, ModuleComponentResolveMetadata processed) {
+    public synchronized void putProcessedMetadata(int hash, ModuleComponentResolveMetadata processed) {
         if (processedMetadataByRules == null) {
             processedMetadataByRules = Collections.singletonMap(hash, processed);
             return;
         } else if (processedMetadataByRules.size() == 1) {
-            processedMetadataByRules = Maps.newHashMap(processedMetadataByRules);
+            processedMetadataByRules = new ConcurrentHashMap<>(processedMetadataByRules);
         }
         processedMetadataByRules.put(hash, processed);
     }


### PR DESCRIPTION
The code was optimized to have a singleton map as much as possible. But
lacked the necessary protections to move out of that case.
As soon as we move beyond a single mapping, we use a concurrent map
underneath and the map swap is now properly protected.