### PR TITLE
Improve declared inputs and outputs of `Sign` task

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -52,7 +52,11 @@ Use `setFrom` instead.
 
     validateTaskProperties.getClasses().setFrom(fileCollection)
     validateTaskProperties.getClasspath().setFrom(fileCollection)
-    
+
+### Properties `inputFiles` and `outputFiles` of `Sign` task
+
+Input and output files of `Sign` tasks are now tracked via `Signature.getToSign()` and `Signature.getFile()`, respectively, of the task's `signatures`.
+
 ## Potential breaking changes
 
 <!--

--- a/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
+++ b/subprojects/signing/src/integTest/groovy/org/gradle/plugins/signing/SigningTasksIntegrationSpec.groovy
@@ -16,7 +16,15 @@
 package org.gradle.plugins.signing
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+import org.gradle.plugins.signing.signatory.internal.gnupg.GnupgSignatoryProvider
+import org.gradle.plugins.signing.signatory.pgp.PgpSignatoryProvider
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.Requires
 import spock.lang.IgnoreIf
+import spock.lang.Unroll
+
+import static org.gradle.plugins.signing.SigningIntegrationSpec.SignMethod.GPG_CMD
+import static org.gradle.plugins.signing.SigningIntegrationSpec.SignMethod.OPEN_GPG
 
 class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
@@ -77,6 +85,210 @@ class SigningTasksIntegrationSpec extends SigningIntegrationSpec {
 
         then:
         [":signJar", ":signJavadocJar", ":signSourcesJar"].every { it in skippedTasks }
+    }
+
+    @Requires(adhoc = { GpgCmdFixture.getAvailableGpg() != null })
+    def "out-of-date when signatory changes"() {
+        given:
+        def originalSignMethod = signMethod
+        buildFile << """
+            ${keyInfo.addAsPropertiesScript()}
+            signing {
+                ${signingConfiguration()}
+                sign(jar)
+            }
+        """
+
+        when:
+        run "signJar"
+
+        then:
+        ":signJar" in nonSkippedTasks
+
+        when:
+        def newSignMethod = originalSignMethod == GPG_CMD ? OPEN_GPG : GPG_CMD
+        if (newSignMethod == GPG_CMD) {
+            setupGpgCmd()
+        }
+        def signatoryProviderClass = newSignMethod == GPG_CMD ? GnupgSignatoryProvider : PgpSignatoryProvider
+        buildFile << """
+            signing {
+                signatories = new ${signatoryProviderClass.name}()
+            }
+        """
+        run "signJar"
+
+        then:
+        ":signJar" in nonSkippedTasks
+
+        when:
+        run "signJar"
+
+        then:
+        ":signJar" in skippedTasks
+    }
+
+    def "out-of-date when signatureType changes"() {
+        given:
+        buildFile << """
+            ${keyInfo.addAsPropertiesScript()}
+            signing {
+                ${signingConfiguration()}
+                sign(jar)
+            }
+        """
+
+        when:
+        run "signJar"
+
+        then:
+        ":signJar" in nonSkippedTasks
+
+        when:
+        buildFile << """
+            signing {
+                signatureTypes.defaultType = 'sig'
+            }
+        """
+        run "signJar"
+
+        then:
+        ":signJar" in nonSkippedTasks
+
+        when:
+        run "signJar"
+
+        then:
+        ":signJar" in skippedTasks
+    }
+
+    def "out-of-date when input file changes"() {
+        given:
+        def inputFile = file("input.txt")
+        inputFile.text = "foo"
+        buildFile << """
+            ${keyInfo.addAsPropertiesScript()}
+            signing {
+                ${signingConfiguration()}
+            }
+            task signCustomFile(type: Sign) {
+                sign(file("input.txt"))
+            }
+        """
+
+        when:
+        run "signCustomFile"
+
+        then:
+        ":signCustomFile" in nonSkippedTasks
+        file("input.txt.asc").exists()
+
+        when:
+        inputFile.text = "bar"
+        run "signCustomFile"
+
+        then:
+        ":signCustomFile" in nonSkippedTasks
+
+        when:
+        run "signCustomFile"
+
+        then:
+        ":signCustomFile" in skippedTasks
+    }
+
+    def "out-of-date when output file is deleted"() {
+        given:
+        file("input.txt") << "foo"
+        buildFile << """
+            ${keyInfo.addAsPropertiesScript()}
+            signing {
+                ${signingConfiguration()}
+            }
+            task signCustomFile(type: Sign) {
+                sign(file("input.txt"))
+            }
+        """
+
+        when:
+        run "signCustomFile"
+
+        then:
+        ":signCustomFile" in nonSkippedTasks
+        def outputFile = file("input.txt.asc")
+        outputFile.exists()
+
+        when:
+        outputFile.delete()
+        run "signCustomFile"
+
+        then:
+        ":signCustomFile" in nonSkippedTasks
+
+        when:
+        run "signCustomFile"
+
+        then:
+        ":signCustomFile" in skippedTasks
+    }
+
+    def "up-to-date when order of signed files changes"() {
+        given:
+        def inputFile1 = file("input1.txt") << "foo"
+        def inputFile2 = file("input2.txt") << "bar"
+        def writeBuildFile = { TestFile... inputFiles ->
+            buildFile.text = """
+            apply plugin: 'signing'
+            ${keyInfo.addAsPropertiesScript()}
+            signing {
+                ${signingConfiguration()}
+            }
+            task signCustomFiles(type: Sign) {
+                sign(${inputFiles.collect { "file('${it.name}')" }.join(', ')})
+            }
+        """
+        }
+
+        when:
+        writeBuildFile(inputFile1, inputFile2)
+        run "signCustomFiles"
+
+        then:
+        ":signCustomFiles" in nonSkippedTasks
+        file("input1.txt.asc").exists()
+        file("input2.txt.asc").exists()
+
+        when:
+        writeBuildFile(inputFile2, inputFile1)
+        run "signCustomFiles"
+
+        then:
+        ":signCustomFiles" in skippedTasks
+    }
+
+    @Unroll
+    def "emits deprecation warning when Sign.#method is used"() {
+        given:
+        buildFile << """
+            ${keyInfo.addAsPropertiesScript()}
+            signing {
+                ${signingConfiguration()}
+                sign jar
+            }
+            signJar.doLast {
+                println $method
+            }
+        """
+
+        when:
+        executer.expectDeprecationWarning()
+        succeeds("signJar")
+
+        then:
+        outputContains("The Sign.$method method has been deprecated")
+
+        where:
+        method << ["getInputFiles()", "getOutputFiles()"]
     }
 
     def "trying to sign a task that isn't an archive task gives nice enough message"() {

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -15,13 +15,10 @@
  */
 package org.gradle.plugins.signing;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.DefaultTask;
@@ -39,23 +36,23 @@ import org.gradle.api.publish.PublicationArtifact;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.OutputFiles;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.type.SignatureType;
+import org.gradle.util.SingleMessageLogger;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.regex.Pattern;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * A task for creating digital signature files for one or more; tasks, files, publishable artifacts or configurations.
@@ -65,65 +62,30 @@ import java.util.regex.Pattern;
  */
 public class Sign extends DefaultTask implements SignatureSpec {
 
-    private static final Pattern JAVA_PARTS = Pattern.compile("[^\\p{javaJavaIdentifierPart}]");
-
-    @Internal
     private SignatureType signatureType;
-    /**
-     * The signatory to the generated signatures.
-     */
-    @Internal
     private Signatory signatory;
-
     private boolean required = true;
     private final DefaultDomainObjectSet<Signature> signatures = new DefaultDomainObjectSet<Signature>(Signature.class);
 
     public Sign() {
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf(task -> isRequired() || getSignatory() != null);
-
-        getInputs().property("signatory", new Callable<Object>() {
-            @Override
-            public Object call() throws Exception {
-                Signatory signatory = getSignatory();
-                return signatory == null ? null : signatory.getKeyId();
-            }
-        }).optional(true);
     }
 
-    @PathSensitive(PathSensitivity.NAME_ONLY)
-    @InputFiles
+    @Internal
+    @Deprecated
     public Iterable<File> getInputFiles() {
+        SingleMessageLogger.nagUserOfDiscontinuedMethod("Sign.getInputFiles()",
+            "Please use Sign.getSignatures() and Signature.getToSign() instead.");
         return Iterables.transform(signatures, Signature::getToSign);
     }
 
-    @OutputFiles
+    @Internal
+    @Deprecated
     public Map<String, File> getOutputFiles() {
-        ArrayListMultimap<String, File> filesWithPotentialNameCollisions = ArrayListMultimap.create();
-        for (Signature signature : getSignatures()) {
-            String name = JAVA_PARTS.matcher(signature.getName()).replaceAll("_");
-            if (name.length() > 0 && !Character.isJavaIdentifierStart(name.codePointAt(0))) {
-                name = "_" + name.substring(1);
-            }
-
-            filesWithPotentialNameCollisions.put(name, signature.getFile());
-        }
-
-        Map<String, File> files = Maps.newHashMap();
-        for (Map.Entry<String, Collection<File>> entry : filesWithPotentialNameCollisions.asMap().entrySet()) {
-            File[] filesWithSameName = entry.getValue().toArray(new File[0]);
-            boolean hasMoreThanOneFileWithSameName = filesWithSameName.length > 1;
-            for (int i = 0; i < filesWithSameName.length; i++) {
-                File file = filesWithSameName[i];
-                String key = entry.getKey();
-                if (hasMoreThanOneFileWithSameName) {
-                    key += "$" + (i + 1);
-                }
-                files.put(key, file);
-            }
-        }
-
-        return files;
+        SingleMessageLogger.nagUserOfDiscontinuedMethod("Sign.getOutputFiles()",
+            "Please use Sign.getSignatures() and Signature.getFile() instead.");
+        return signatures.stream().collect(toMap(Signature::toKey, Signature::getFile));
     }
 
     /**
@@ -222,7 +184,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
 
     }
 
-    private Optional<Signature> signatureFor(Buildable source) {
+    private com.google.common.base.Optional<Signature> signatureFor(Buildable source) {
         return Iterables.tryFind(signatures, new Predicate<Signature>() {
             @Override
             public boolean apply(Signature input) {
@@ -278,7 +240,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     }
 
     private void removeSignature(final Buildable source) {
-        Optional<Signature> signature = signatureFor(source);
+        com.google.common.base.Optional<Signature> signature = signatureFor(source);
         if (signature.isPresent()) {
             signatures.remove(signature.get());
         }
@@ -318,6 +280,16 @@ public class Sign extends DefaultTask implements SignatureSpec {
     @Internal
     public DomainObjectSet<Signature> getSignatures() {
         return signatures;
+    }
+
+    /**
+     * The signatures generated by this task mapped by a unique key used for up-to-date checking.
+     * @since 5.1
+     */
+    @Nested
+    @Incubating
+    public Map<String, Signature> getSignaturesByKey() {
+        return signatures.stream().collect(toMap(Signature::toKey, identity()));
     }
 
     /**
@@ -362,6 +334,8 @@ public class Sign extends DefaultTask implements SignatureSpec {
             Lists.newLinkedList(Iterables.filter(Iterables.transform(signatures, Signature::getFile), Predicates.notNull())));
     }
 
+    @Nested
+    @Optional
     public SignatureType getSignatureType() {
         return signatureType;
     }
@@ -374,6 +348,8 @@ public class Sign extends DefaultTask implements SignatureSpec {
      * Returns the signatory for this signing task.
      * @return the signatory
      */
+    @Nested
+    @Optional
     public Signatory getSignatory() {
         return signatory;
     }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -15,11 +15,9 @@
  */
 package org.gradle.plugins.signing;
 
-import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import org.gradle.api.Action;
 import org.gradle.api.Buildable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.DomainObjectSet;
@@ -34,7 +32,6 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationArtifact;
 import org.gradle.api.publish.internal.PublicationInternal;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
@@ -50,6 +47,7 @@ import java.io.File;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.function.Predicate;
 
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
@@ -94,7 +92,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     public void sign(Task... tasks) {
         for (Task task : tasks) {
             if (!(task instanceof AbstractArchiveTask)) {
-                throw new InvalidUserDataException("You cannot sign tasks that are not \'archive\' tasks, such as \'jar\', \'zip\' etc. (you tried to sign " + String.valueOf(task) + ")");
+                throw new InvalidUserDataException("You cannot sign tasks that are not \'archive\' tasks, such as \'jar\', \'zip\' etc. (you tried to sign " + task + ")");
             }
 
             signTask((AbstractArchiveTask) task);
@@ -104,15 +102,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
 
     private void signTask(final AbstractArchiveTask archiveTask) {
         dependsOn(archiveTask);
-        addSignature(new Signature(new Callable<File>() {
-            public File call() {
-                return archiveTask.getArchivePath();
-            }
-        }, new Callable<String>() {
-            public String call() {
-                return archiveTask.getClassifier();
-            }
-        }, this, this));
+        addSignature(new Signature(archiveTask::getArchivePath, archiveTask::getClassifier, this, this));
     }
 
     /**
@@ -131,11 +121,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     }
 
     private void signArtifact(final PublicationArtifact publicationArtifact) {
-        addSignature(new Signature(publicationArtifact, new Callable<File>() {
-            public File call() {
-                return publicationArtifact.getFile();
-            }
-        }, null, null, this, this));
+        addSignature(new Signature(publicationArtifact, publicationArtifact::getFile, null, null, this, this));
     }
 
     /**
@@ -163,34 +149,18 @@ public class Sign extends DefaultTask implements SignatureSpec {
      */
     public void sign(Configuration... configurations) {
         for (Configuration configuration : configurations) {
-            configuration.getAllArtifacts().all(
-                new Action<PublishArtifact>() {
-                    @Override
-                    public void execute(PublishArtifact artifact) {
-                        if (artifact instanceof Signature || signatureFor(artifact).isPresent()) {
-                            return;
-                        }
-
-                        signArtifact(artifact);
-                    }
-                });
-            configuration.getAllArtifacts().whenObjectRemoved(new Action<PublishArtifact>() {
-                @Override
-                public void execute(final PublishArtifact publishArtifact) {
-                    removeSignature(publishArtifact);
+            configuration.getAllArtifacts().all(artifact -> {
+                if (artifact instanceof Signature || hasSignatureFor(artifact)) {
+                    return;
                 }
+                signArtifact(artifact);
             });
+            configuration.getAllArtifacts().whenObjectRemoved(this::removeSignature);
         }
-
     }
 
-    private com.google.common.base.Optional<Signature> signatureFor(Buildable source) {
-        return Iterables.tryFind(signatures, new Predicate<Signature>() {
-            @Override
-            public boolean apply(Signature input) {
-                return input.getSource().equals(source);
-            }
-        });
+    private boolean hasSignatureFor(Buildable source) {
+        return signatures.stream().anyMatch(hasSource(source));
     }
 
     /**
@@ -201,33 +171,16 @@ public class Sign extends DefaultTask implements SignatureSpec {
     @Incubating
     public void sign(Publication... publications) {
         for (Publication publication : publications) {
-            final PublicationInternal<?> publicationInternal = (PublicationInternal<?>) publication;
-            dependsOn(new Callable<Set<? extends PublicationArtifact>>() {
-                @Override
-                public Set<? extends PublicationArtifact> call() {
-                    return publicationInternal.getPublishableArtifacts().matching(new Spec<PublicationArtifact>() {
-                        @Override
-                        public boolean isSatisfiedBy(PublicationArtifact artifact) {
-                            return isNoSignatureArtifact(artifact);
-                        }
-                    });
+            PublicationInternal<?> publicationInternal = (PublicationInternal<?>) publication;
+            dependsOn((Callable<Set<? extends PublicationArtifact>>) () -> {
+                return publicationInternal.getPublishableArtifacts().matching(this::isNoSignatureArtifact);
+            });
+            publicationInternal.allPublishableArtifacts(artifact -> {
+                if (isNoSignatureArtifact(artifact)) {
+                    signArtifact(artifact);
                 }
             });
-            publicationInternal.allPublishableArtifacts(
-                new Action<PublicationArtifact>() {
-                    @Override
-                    public void execute(PublicationArtifact artifact) {
-                        if (isNoSignatureArtifact(artifact)) {
-                            signArtifact(artifact);
-                        }
-                    }
-                });
-            publicationInternal.whenPublishableArtifactRemoved(new Action<PublicationArtifact>() {
-                @Override
-                public void execute(final PublicationArtifact artifact) {
-                    removeSignature(artifact);
-                }
-            });
+            publicationInternal.whenPublishableArtifactRemoved(this::removeSignature);
         }
     }
 
@@ -240,10 +193,11 @@ public class Sign extends DefaultTask implements SignatureSpec {
     }
 
     private void removeSignature(final Buildable source) {
-        com.google.common.base.Optional<Signature> signature = signatureFor(source);
-        if (signature.isPresent()) {
-            signatures.remove(signature.get());
-        }
+        signatures.removeIf(hasSource(source));
+    }
+
+    private Predicate<Signature> hasSource(Buildable source) {
+        return signature -> signature.getSource().equals(source);
     }
 
     /**
@@ -300,15 +254,10 @@ public class Sign extends DefaultTask implements SignatureSpec {
      */
     @Internal
     public Signature getSingleSignature() {
-        final DomainObjectSet<Signature> signatureSet = getSignatures();
-        if (signatureSet.size() == 0) {
-            throw new IllegalStateException("Expected %s to contain exactly one signature, however, it contains no signatures.");
-        } else if (signatureSet.size() == 1) {
-            return signatureSet.iterator().next();
-        } else {
-            throw new IllegalStateException("Expected %s to contain exactly one signature, however, it contains no " + String.valueOf(signatureSet.size()) + " signatures.");
+        if (signatures.size() == 1) {
+            return signatures.iterator().next();
         }
-
+        throw new IllegalStateException("Expected %s to contain exactly one signature, however, it contains " + signatures.size() + " signatures.");
     }
 
     @Inject
@@ -322,7 +271,8 @@ public class Sign extends DefaultTask implements SignatureSpec {
      */
     @Internal
     public FileCollection getFilesToSign() {
-        return getFileCollectionFactory().fixed("Task \'" + getPath() + "\' files to sign", Lists.newLinkedList(Iterables.filter(getInputFiles(), Predicates.notNull())));
+        return getFileCollectionFactory().fixed("Task \'" + getPath() + "\' files to sign",
+            Lists.newLinkedList(Iterables.filter(getInputFiles(), Predicates.notNull())));
     }
 
     /**

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Signature.java
@@ -20,6 +20,12 @@ import org.gradle.api.Buildable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.internal.artifacts.publish.AbstractPublishArtifact;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.type.SignatureType;
 
@@ -193,6 +199,8 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The file. May be {@code null} if unknown at this time.
      */
+    @PathSensitive(PathSensitivity.NONE)
+    @InputFile
     public File getToSign() {
         File toSign = uncheckedCall(toSignGenerator);
         return toSign != null ? toSign : null;
@@ -209,6 +217,7 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The name. May be {@code null} if unknown at this time.
      */
+    @Internal
     public String getName() {
         return name != null ? name : defaultName();
     }
@@ -235,6 +244,7 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The extension. May be {@code null} if unknown at this time.
      */
+    @Internal
     public String getExtension() {
         return extension != null ? extension : signatureTypeExtension();
     }
@@ -257,6 +267,7 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The type. May be {@code null} if the file to sign or signature type are unknown at this time.
      */
+    @Internal
     public String getType() {
         return type != null ? type : defaultType();
     }
@@ -281,8 +292,13 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The classifier. May be {@code null} if unknown at this time.
      */
+    @Internal
     public String getClassifier() {
-        return classifier != null ? classifier : uncheckedCall(classifierGenerator);
+        return classifier != null ? classifier : defaultClassifier();
+    }
+
+    private String defaultClassifier() {
+        return classifierGenerator == null ? null : uncheckedCall(classifierGenerator);
     }
 
     public void setDate(Date date) {
@@ -296,6 +312,7 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The date of the signature. May be {@code null} if unknown at this time.
      */
+    @Internal
     public Date getDate() {
         return date != null ? date : defaultDate();
     }
@@ -323,6 +340,7 @@ public class Signature extends AbstractPublishArtifact {
      * @return The signature file. May be {@code null} if unknown at this time.
      * @see SignatureType#fileFor(File)
      */
+    @OutputFile
     public File getFile() {
         File toSign = getToSign();
         SignatureType signatureType = getSignatureType();
@@ -336,6 +354,7 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The signatory. May be {@code null} if unknown at this time.
      */
+    @Internal("already tracked as part of the Sign task")
     public Signatory getSignatory() {
         return signatureSpec.getSignatory();
     }
@@ -345,6 +364,7 @@ public class Signature extends AbstractPublishArtifact {
      *
      * @return The signature type. May be {@code null} if unknown at this time.
      */
+    @Internal("already tracked as part of the Sign task")
     public SignatureType getSignatureType() {
         return signatureSpec.getSignatureType();
     }
@@ -353,12 +373,24 @@ public class Signature extends AbstractPublishArtifact {
         this.signatureSpec = signatureSpec;
     }
 
+    @Internal
     public SignatureSpec getSignatureSpec() {
         return signatureSpec;
     }
 
+    @Internal
     Buildable getSource() {
         return source;
+    }
+
+    @Internal
+    @Override
+    public TaskDependency getBuildDependencies() {
+        return super.getBuildDependencies();
+    }
+
+    String toKey() {
+        return String.join(":", getName(), getType(), getExtension(), getClassifier());
     }
 
     /**
@@ -382,7 +414,7 @@ public class Signature extends AbstractPublishArtifact {
         Signatory signatory = getSignatory();
         if (signatory == null) {
             if (signatureSpec.isRequired()) {
-                throw new InvalidUserDataException("Unable to generate signature for \'" + String.valueOf(toSign) + "\' as no signatory is available to sign");
+                throw new InvalidUserDataException("Unable to generate signature for \'" + toSign + "\' as no signatory is available to sign");
             } else {
                 return;
             }
@@ -391,7 +423,7 @@ public class Signature extends AbstractPublishArtifact {
         SignatureType signatureType = getSignatureType();
         if (signatureType == null) {
             if (signatureSpec.isRequired()) {
-                throw new InvalidUserDataException("Unable to generate signature for \'" + String.valueOf(toSign) + "\' as no signature type has been configured");
+                throw new InvalidUserDataException("Unable to generate signature for \'" + toSign + "\' as no signature type has been configured");
             } else {
                 return;
             }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/Signatory.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/Signatory.java
@@ -16,6 +16,8 @@
 package org.gradle.plugins.signing.signatory;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -32,6 +34,7 @@ public interface Signatory {
      *
      * <p>The name must be constant for the life of the signatory and should uniquely identify it within a project.</p>
      */
+    @Internal
     String getName();
 
     /**
@@ -55,5 +58,6 @@ public interface Signatory {
      *
      * @return The key id
      */
+    @Input
     String getKeyId();
 }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/type/SignatureType.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/type/SignatureType.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.plugins.signing.type;
 
+import org.gradle.api.tasks.Input;
 import org.gradle.plugins.signing.signatory.Signatory;
 
 import java.io.File;
@@ -29,6 +30,7 @@ public interface SignatureType {
     /**
      * The file extension (without the leading dot) associated to this type of signature.
      */
+    @Input
     String getExtension();
 
     /**

--- a/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningTasksSpec.groovy
+++ b/subprojects/signing/src/test/groovy/org/gradle/plugins/signing/SigningTasksSpec.groovy
@@ -70,11 +70,12 @@ class SigningTasksSpec extends SigningProjectSpec {
         addSigningProperties()
 
         when:
-        def signTask = signing.sign(jar).first()
+        Sign signTask = signing.sign(jar).first()
 
         then:
         File libsDir = jar.outputs.files.singleFile.parentFile
-        signTask.outputFiles == ["test_jar_asc": new File(libsDir, "test.jar.asc")]
+        signTask.outputFiles == ["test.jar.asc:jar.asc:asc:": new File(libsDir, "test.jar.asc")]
+        signTask.signaturesByKey == ["test.jar.asc:jar.asc:asc:": signTask.singleSignature]
     }
 
     def "sign task has description"() {


### PR DESCRIPTION
Input and output files are now tracked via the task's `Signatures`. In
addition, the `Signatory` and `SignatureType` are now inputs.

Resolves #7381.