### PR TITLE
Migrate Pegdown to flexmark

### DIFF
--- a/buildSrc/subprojects/docs/docs.gradle.kts
+++ b/buildSrc/subprojects/docs/docs.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
-    implementation("com.vladsch.flexmark:flexmark-all:0.34.48")
+    implementation("com.vladsch.flexmark:flexmark-all:0.34.56")
     implementation("com.uwyn:jhighlight:1.0") {
         exclude(module = "servlet-api")
     }

--- a/buildSrc/subprojects/docs/docs.gradle.kts
+++ b/buildSrc/subprojects/docs/docs.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
-    implementation("org.pegdown:pegdown:1.6.0")
+    implementation("com.vladsch.flexmark:flexmark-all:0.34.48")
     implementation("com.uwyn:jhighlight:1.0") {
         exclude(module = "servlet-api")
     }

--- a/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/RenderMarkdownTask.kt
+++ b/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/RenderMarkdownTask.kt
@@ -33,13 +33,9 @@ open class RenderMarkdownTask @Inject constructor(
 
     @TaskAction
     fun process() {
-<<<<<<< HEAD:buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/PegDown.kt
-        val processor = PegDownProcessor(0, PEGDOWN_PARSING_TIMEOUT_MILLIS)
-=======
         val options = MutableDataSet().apply { set(Parser.EXTENSIONS, listOf(TablesExtension.create())) }
         val parser = Parser.builder(options).build()
         val renderer = HtmlRenderer.builder(options).build()
->>>>>>> Migrate Pegdown to flexmark:buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/RenderMarkdownTask.kt
         val markdown = markdownFile.readText(Charset.forName(inputEncoding))
         val html = renderer.render(parser.parse(markdown))
         destination.writeText(html, Charset.forName(outputEncoding))

--- a/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/RenderMarkdownTask.kt
+++ b/buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/RenderMarkdownTask.kt
@@ -1,5 +1,9 @@
 package org.gradle.gradlebuild.docs
 
+import com.vladsch.flexmark.ext.tables.TablesExtension
+import com.vladsch.flexmark.html.HtmlRenderer
+import com.vladsch.flexmark.parser.Parser
+import com.vladsch.flexmark.util.options.MutableDataSet
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -9,8 +13,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
-import org.pegdown.PegDownProcessor
-
 import java.io.File
 import java.nio.charset.Charset
 import java.nio.charset.Charset.defaultCharset
@@ -18,7 +20,7 @@ import javax.inject.Inject
 
 
 @CacheableTask
-open class PegDown @Inject constructor(
+open class RenderMarkdownTask @Inject constructor(
     @get:PathSensitive(PathSensitivity.NONE) @get:InputFile val markdownFile: File,
     @get:OutputFile val destination: File
 ) : DefaultTask() {
@@ -31,9 +33,15 @@ open class PegDown @Inject constructor(
 
     @TaskAction
     fun process() {
+<<<<<<< HEAD:buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/PegDown.kt
         val processor = PegDownProcessor(0, PEGDOWN_PARSING_TIMEOUT_MILLIS)
+=======
+        val options = MutableDataSet().apply { set(Parser.EXTENSIONS, listOf(TablesExtension.create())) }
+        val parser = Parser.builder(options).build()
+        val renderer = HtmlRenderer.builder(options).build()
+>>>>>>> Migrate Pegdown to flexmark:buildSrc/subprojects/docs/src/main/kotlin/org/gradle/gradlebuild/docs/RenderMarkdownTask.kt
         val markdown = markdownFile.readText(Charset.forName(inputEncoding))
-        val html = processor.markdownToHtml(markdown)
+        val html = renderer.render(parser.parse(markdown))
         destination.writeText(html, Charset.forName(outputEncoding))
     }
 }

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -29,7 +29,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.Copy
 import org.gradle.gradlebuild.PublicApi
-import org.gradle.gradlebuild.docs.PegDown
+import org.gradle.gradlebuild.docs.RenderMarkdownTask
 import org.gradle.kotlin.dsl.*
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry
 import org.gradle.plugins.ide.eclipse.model.Classpath
@@ -541,7 +541,7 @@ open class IdePlugin : Plugin<Project> {
     private
     fun getDefaultJunitVmParameters(docsProject: Project): String {
         val rootProject = docsProject.rootProject
-        val releaseNotesMarkdown: PegDown by docsProject.tasks
+        val releaseNotesMarkdown: RenderMarkdownTask by docsProject.tasks
         val releaseNotes: Copy by docsProject.tasks
         val distsDir = rootProject.layout.buildDirectory.dir(rootProject.base.distsDirName)
         val vmParameter = mutableListOf(

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -5,7 +5,7 @@ dependencies {
     implementation(project(":kotlinDsl"))
     implementation(project(":versioning"))
     implementation(project(":performance"))
-    implementation("org.pegdown:pegdown:1.6.0")
+    implementation("com.vladsch.flexmark:flexmark-all:0.34.48")
     implementation("org.jsoup:jsoup:1.11.3")
     implementation("com.google.guava:guava-jdk5:14.0.1")
     implementation("org.ow2.asm:asm:6.0")

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -5,7 +5,6 @@ dependencies {
     implementation(project(":kotlinDsl"))
     implementation(project(":versioning"))
     implementation(project(":performance"))
-    implementation("com.vladsch.flexmark:flexmark-all:0.34.48")
     implementation("org.jsoup:jsoup:1.11.3")
     implementation("com.google.guava:guava-jdk5:14.0.1")
     implementation("org.ow2.asm:asm:6.0")

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -26,7 +26,7 @@ import org.gradle.build.docs.releasenotes.checks.*
 import org.gradle.gradlebuild.BuildEnvironment
 import org.gradle.gradlebuild.ProjectGroups
 import org.gradle.gradlebuild.PublicApi
-import org.gradle.gradlebuild.docs.PegDown
+import org.gradle.gradlebuild.docs.RenderMarkdownTask
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 
 plugins {
@@ -100,7 +100,7 @@ dependencies {
     jquery "jquery:jquery.min:1.8.0@js"
     jqueryTipTip "com.drewwilson.code:jquery.tipTip:1.3:minified@js"
 
-    testCompile "org.pegdown:pegdown:1.1.0"
+    testCompile 'com.vladsch.flexmark:flexmark-all:0.34.48'
     testCompile testLibraries.jsoup
     testCompile("org.gebish:geb-spock:2.2")
     testCompile('org.seleniumhq.selenium:selenium-htmlunit-driver:2.42.2')
@@ -440,7 +440,7 @@ tasks.register("editReleaseNotes") {
     }
 }
 
-def releaseNotesMarkdown = tasks.register("releaseNotesMarkdown", PegDown, file("src/docs/release/notes.md"), new File(buildDir, "release-notes-raw/release-notes.html"))
+def releaseNotesMarkdown = tasks.register("releaseNotesMarkdown", RenderMarkdownTask, file("src/docs/release/notes.md"), new File(buildDir, "release-notes-raw/release-notes.html"))
 releaseNotesMarkdown.configure {
     group = "release notes"
 }

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -100,7 +100,6 @@ dependencies {
     jquery "jquery:jquery.min:1.8.0@js"
     jqueryTipTip "com.drewwilson.code:jquery.tipTip:1.3:minified@js"
 
-    testCompile 'com.vladsch.flexmark:flexmark-all:0.34.48'
     testCompile testLibraries.jsoup
     testCompile("org.gebish:geb-spock:2.2")
     testCompile('org.seleniumhq.selenium:selenium-htmlunit-driver:2.42.2')


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/1255.

We were using Pegdown to render markdown to html, but Pegdown is already deprecated. We also see timeout frequently recently, so I think it's time to get rid of it. `flexmark` is officially recommended as Pegdown's successor.

Currently supported features are:

- [x] `#Heading` 
- [x] `**bold text**`
- [x] `*italicized text*`
- [x] `> blockquote`
- [x] Ordered List: `1. First item`
- [x] Unordered List: `- First item`
- [x] `code`
- [x] Horizontal Rule: `---`
- [x] `[title](https://www.example.com)`
- [x] `![alt text](image.jpg)`
- [x] Table
- [x] Fenced Code Block : "```"
- [ ] Footnote:  `Here's a sentence with a footnote. [^1][^1]: This is the footnote.`
- [ ] Heading ID: `### My Great Heading {#custom-id}`
- [ ] Strikethrough: `~~The world is flat.~~`
- [ ] Task List: `- [x] Write the press release` 