### PR TITLE
Cleanup unused classloaders

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/classloading/ClassInfoCleaningGroovySystemLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classloading/ClassInfoCleaningGroovySystemLoader.java
@@ -100,7 +100,7 @@ public class ClassInfoCleaningGroovySystemLoader implements GroovySystemLoader {
                 Object classInfo = it.next();
                 if (classInfo != null) {
                     Class clazz = getClazz(classInfo);
-                    if (clazz.getClassLoader() == classLoader) {
+                    if (clazz != null && clazz.getClassLoader() == classLoader) {
                         removeFromGlobalClassValue.invoke(globalClassValue, clazz);
                         if (LOG.isDebugEnabled()) {
                             LOG.debug("Removed ClassInfo from {} loaded by {}", clazz.getName(), clazz.getClassLoader());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/ClassLoaderCache.java
@@ -24,8 +24,6 @@ import javax.annotation.Nullable;
 
 public interface ClassLoaderCache {
 
-    int size();
-
     /**
      * Returns an existing classloader from the cache, or creates it if it cannot be found.
      *

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -199,8 +199,10 @@ public class GradleUserHomeScopeServices {
         return new DefaultHashingClassLoaderFactory(classpathHasher);
     }
 
-    ClassLoaderCache createClassLoaderCache(HashingClassLoaderFactory classLoaderFactory, ClasspathHasher classpathHasher) {
-        return new DefaultClassLoaderCache(classLoaderFactory, classpathHasher);
+    ClassLoaderCache createClassLoaderCache(HashingClassLoaderFactory classLoaderFactory, ClasspathHasher classpathHasher, ListenerManager listenerManager) {
+        DefaultClassLoaderCache cache = new DefaultClassLoaderCache(classLoaderFactory, classpathHasher);
+        listenerManager.addListener(cache);
+        return cache;
     }
 
     CachedClasspathTransformer createCachedClasspathTransformer(CacheRepository cacheRepository, FileHasher fileHasher, FileAccessTimeJournal fileAccessTimeJournal,

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultClassLoaderScopeTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.initialization
 
-import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
+
 import org.gradle.api.internal.initialization.loadercache.DefaultClassLoaderCache
 import org.gradle.api.internal.initialization.loadercache.FileClasspathHasher
 import org.gradle.internal.classloader.CachingClassLoader
@@ -34,7 +34,7 @@ class DefaultClassLoaderScopeTest extends Specification {
     ClassLoaderScope scope
 
     def classpathHasher = new FileClasspathHasher()
-    ClassLoaderCache classLoaderCache = new DefaultClassLoaderCache(new DefaultHashingClassLoaderFactory(classpathHasher), classpathHasher)
+    DefaultClassLoaderCache classLoaderCache = new DefaultClassLoaderCache(new DefaultHashingClassLoaderFactory(classpathHasher), classpathHasher)
 
     @Rule
     TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/loadercache/DummyClassLoaderCache.java
@@ -43,9 +43,4 @@ public class DummyClassLoaderCache implements ClassLoaderCache {
     @Override
     public void remove(ClassLoaderId id) {
     }
-
-    @Override
-    public int size() {
-        return 0;
-    }
 }


### PR DESCRIPTION
Until now our classloader cache would only ever remove a classlaoder
if it was replaced by another one with the same ID. This works fine
if the daemon is used to build only one project. However, it becomes
a serious memory leak if the daemon builds many different projects.
This is a common scenario in Gradle integration tests, both in our
own code base and for users testing their plugins with TestKit.
In those cases the same daemon is used to build many different projects
and the JVM can eventually run out of metaspace.

This change adjusts the classloader cache so that it only retains
classloaders which were used either in the current build or the
previous build. All older unused classloaders are discarded to free
up memory.