### PR TITLE
Check in Intellij code style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@
 # ----
 !/.idea
 /.idea/*
+!/.idea/codeStyles
 !/.idea/inspectionProfiles
-.idea
+*/**/.idea
 .shelf
 /*.iml
 /*.ipr

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,62 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    <option name="IMPORT_LAYOUT_TABLE">
+      <value>
+        <package name="" withSubpackages="true" static="true" />
+        <emptyLine />
+        <package name="" withSubpackages="true" static="false" />
+        <emptyLine />
+        <package name="javax" withSubpackages="true" static="false" />
+        <package name="java" withSubpackages="true" static="false" />
+      </value>
+    </option>
+    <option name="RIGHT_MARGIN" value="200" />
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <GroovyCodeStyleSettings>
+      <option name="ALIGN_NAMED_ARGS_IN_MAP" value="false" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+    </GroovyCodeStyleSettings>
+    <JavaCodeStyleSettings>
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="JD_ALIGN_PARAM_COMMENTS" value="false" />
+      <option name="JD_ALIGN_EXCEPTION_COMMENTS" value="false" />
+      <option name="JD_P_AT_EMPTY_LINES" value="false" />
+      <option name="JD_KEEP_EMPTY_PARAMETER" value="false" />
+      <option name="JD_KEEP_EMPTY_EXCEPTION" value="false" />
+      <option name="JD_KEEP_EMPTY_RETURN" value="false" />
+    </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value>
+          <package name="org.gradle.kotlin.dsl" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+        </value>
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="Groovy">
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="IF_BRACE_FORCE" value="3" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="WHILE_BRACE_FORCE" value="3" />
+      <option name="FOR_BRACE_FORCE" value="3" />
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
+++ b/buildSrc/subprojects/ide/src/main/kotlin/org/gradle/gradlebuild/ide/IdePlugin.kt
@@ -41,9 +41,7 @@ import org.gradle.plugins.ide.idea.model.Module
 import org.gradle.plugins.ide.idea.model.ModuleLibrary
 import org.jetbrains.gradle.ext.ActionDelegationConfig
 import org.jetbrains.gradle.ext.Application
-import org.jetbrains.gradle.ext.CodeStyleConfig
 import org.jetbrains.gradle.ext.CopyrightConfiguration
-import org.jetbrains.gradle.ext.ForceBraces.FORCE_BRACES_ALWAYS
 import org.jetbrains.gradle.ext.GroovyCompilerConfiguration
 import org.jetbrains.gradle.ext.IdeaCompilerConfiguration
 import org.jetbrains.gradle.ext.Inspection
@@ -219,7 +217,6 @@ open class IdePlugin : Plugin<Project> {
                 settings {
                     configureCompilerSettings(rootProject)
                     configureCopyright()
-                    configureCodeStyle()
                     // TODO The idea-ext plugin does not yet support customizing inspections.
                     // TODO Delete .idea/inspectionProfiles and uncomment the code below when it does
                     // configureInspections()
@@ -596,9 +593,6 @@ fun ProjectSettings.groovyCompiler(configuration: GroovyCompilerConfiguration.()
 fun ProjectSettings.copyright(configuration: CopyrightConfiguration.() -> kotlin.Unit) = (this as ExtensionAware).configure(configuration)
 
 
-fun ProjectSettings.codeStyle(configuration: CodeStyleConfig.() -> kotlin.Unit) = (this as ExtensionAware).configure(configuration)
-
-
 fun ProjectSettings.delegateActions(configuration: ActionDelegationConfig.() -> kotlin.Unit) = (this as ExtensionAware).configure(configuration)
 
 
@@ -714,39 +708,6 @@ fun Element.inspectionTool(clazz: String, level: String = "INFORMATION", enabled
         .attr("enabled", enabled.toString())
         .attr("level", level)
         .attr("enabled_by_default", "false")
-}
-
-
-private
-fun ProjectSettings.configureCodeStyle() {
-    codeStyle {
-        @Suppress("DEPRECATION")
-        USE_SAME_INDENTS = true // deprecated!
-        hardWrapAt = 200
-        java {
-            classCountToUseImportOnDemand = 999
-            alignParameterDescriptions = false
-            alignThrownExceptionDescriptions = false
-            keepEmptyParamTags = false
-            keepEmptyThrowsTags = false
-            keepEmptyReturnTags = false
-            wrapCommentsAtRightMargin = true
-            keepControlStatementInOneLine = false
-            generatePTagOnEmptyLines = false
-            ifForceBraces = FORCE_BRACES_ALWAYS
-            doWhileForceBraces = FORCE_BRACES_ALWAYS
-            whileForceBraces = FORCE_BRACES_ALWAYS
-            forForceBraces = FORCE_BRACES_ALWAYS
-        }
-        groovy {
-            classCountToUseImportOnDemand = 999
-            alignMultilineNamedArguments = false
-            ifForceBraces = FORCE_BRACES_ALWAYS
-            doWhileForceBraces = FORCE_BRACES_ALWAYS
-            whileForceBraces = FORCE_BRACES_ALWAYS
-            forForceBraces = FORCE_BRACES_ALWAYS
-        }
-    }
 }
 
 


### PR DESCRIPTION
Instead of using the `idea-ext` plugin, the code style is now checked in.

This has the advantage that we can set all the aspects of the code style, not just things supported by the `idea-ext` plugin. The code style configuration also doesn't seem to change between IDEA versions.

The GE team has good experiences with having the code style checked in.