### PR TITLE
Collect reasons for all executed dependency substitution rules

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesIntegrationTest.groovy
@@ -203,7 +203,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
         noExceptionThrown()
     }
 
-    void "can unforce the version"()
+    void "can override forced version with rule"()
     {
         mavenRepo.module("org.utils", "impl", '1.3').dependsOn('org.utils', 'api', '1.3').publish()
         mavenRepo.module("org.utils", "impl", '1.5').dependsOn('org.utils', 'api', '1.5').publish()
@@ -233,7 +233,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     deps.each {
                         assert it.selected.id.version == '1.3'
                         def reason = it.selected.selectionReason
-                        assert !reason.forced
+                        assert reason.forced
                         assert reason.selectedByRule
                     }
                 }
@@ -278,7 +278,7 @@ class DependencyResolveRulesIntegrationTest extends AbstractIntegrationSpec {
                     deps.each {
                         assert it.selected.id.version == '1.3'
                         def reason = it.selected.selectionReason
-                        assert !reason.forced
+                        assert reason.forced
                         assert reason.selectedByRule
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencySubstitutionInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencySubstitutionInternal.java
@@ -21,12 +21,14 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 
+import java.util.List;
+
 public interface DependencySubstitutionInternal extends DependencySubstitution {
     void useTarget(Object notation, ComponentSelectionDescriptor selectionDescription);
 
     ComponentSelector getTarget();
 
-    ComponentSelectionDescriptorInternal getSelectionDescription();
+    List<ComponentSelectionDescriptorInternal> getSelectionDescription();
 
     boolean isUpdated();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencySubstitutionInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencySubstitutionInternal.java
@@ -24,11 +24,11 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.Compone
 import java.util.List;
 
 public interface DependencySubstitutionInternal extends DependencySubstitution {
-    void useTarget(Object notation, ComponentSelectionDescriptor selectionDescription);
+    void useTarget(Object notation, ComponentSelectionDescriptor ruleDescriptor);
 
     ComponentSelector getTarget();
 
-    List<ComponentSelectionDescriptorInternal> getSelectionDescription();
+    List<ComponentSelectionDescriptorInternal> getRuleDescriptors();
 
     boolean isUpdated();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
@@ -48,7 +48,7 @@ public class DefaultDependencyResolveDetails implements DependencyResolveDetails
     private ComponentSelectionDescriptorInternal selectionReason() {
         return customDescription == null
             ? ComponentSelectionReasons.SELECTED_BY_RULE
-            : ComponentSelectionReasons.SELECTED_BY_RULE.withReason(Describables.of(customDescription));
+            : ComponentSelectionReasons.SELECTED_BY_RULE.withDescription(Describables.of(customDescription));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
@@ -36,14 +36,9 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
     private final List<ComponentSelectionDescriptorInternal> reasons = Lists.newArrayList();
     private ComponentSelector target;
 
-    public DefaultDependencySubstitution(ComponentSelector requested, String reason) {
+    public DefaultDependencySubstitution(ComponentSelector requested) {
         this.requested = requested;
         this.target = requested;
-        if (reason != null) {
-            reasons.add(ComponentSelectionReasons.REQUESTED.withReason(Describables.of(reason)));
-        } else {
-            reasons.add(ComponentSelectionReasons.REQUESTED);
-        }
     }
 
     @Override
@@ -80,7 +75,7 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
 
     @Override
     public boolean isUpdated() {
-        return reasons.size() > 1;
+        return !reasons.isEmpty();
     }
 
     public static void validateTarget(ComponentSelector componentSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
@@ -33,7 +33,7 @@ import static org.gradle.api.artifacts.result.ComponentSelectionCause.SELECTED_B
 
 public class DefaultDependencySubstitution implements DependencySubstitutionInternal {
     private final ComponentSelector requested;
-    private final List<ComponentSelectionDescriptorInternal> reasons = Lists.newArrayList();
+    private final List<ComponentSelectionDescriptorInternal> ruleDescriptors = Lists.newArrayList();
     private ComponentSelector target;
 
     public DefaultDependencySubstitution(ComponentSelector requested) {
@@ -57,15 +57,15 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
     }
 
     @Override
-    public void useTarget(Object notation, ComponentSelectionDescriptor selectionDescription) {
+    public void useTarget(Object notation, ComponentSelectionDescriptor ruleDescriptor) {
         this.target = ComponentSelectorParsers.parser().parseNotation(notation);
-        this.reasons.add((ComponentSelectionDescriptorInternal) selectionDescription);
+        this.ruleDescriptors.add((ComponentSelectionDescriptorInternal) ruleDescriptor);
         validateTarget(target);
     }
 
     @Override
-    public List<ComponentSelectionDescriptorInternal> getSelectionDescription() {
-        return reasons;
+    public List<ComponentSelectionDescriptorInternal> getRuleDescriptors() {
+        return ruleDescriptors;
     }
 
     @Override
@@ -75,7 +75,7 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
 
     @Override
     public boolean isUpdated() {
-        return !reasons.isEmpty();
+        return !ruleDescriptors.isEmpty();
     }
 
     public static void validateTarget(ComponentSelector componentSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitution.java
@@ -23,17 +23,18 @@ import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.internal.artifacts.DependencySubstitutionInternal;
 import org.gradle.api.internal.artifacts.dsl.ComponentSelectorParsers;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultComponentSelectionDescriptor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultComponentSelectionDescriptor;
 import org.gradle.internal.Describables;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.gradle.api.artifacts.result.ComponentSelectionCause.SELECTED_BY_RULE;
 
 public class DefaultDependencySubstitution implements DependencySubstitutionInternal {
     private final ComponentSelector requested;
-    private final List<ComponentSelectionDescriptorInternal> ruleDescriptors = Lists.newArrayList();
+    private List<ComponentSelectionDescriptorInternal> ruleDescriptors;
     private ComponentSelector target;
 
     public DefaultDependencySubstitution(ComponentSelector requested) {
@@ -59,13 +60,16 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
     @Override
     public void useTarget(Object notation, ComponentSelectionDescriptor ruleDescriptor) {
         this.target = ComponentSelectorParsers.parser().parseNotation(notation);
+        if (this.ruleDescriptors == null) {
+            this.ruleDescriptors = Lists.newArrayList();
+        }
         this.ruleDescriptors.add((ComponentSelectionDescriptorInternal) ruleDescriptor);
         validateTarget(target);
     }
 
     @Override
     public List<ComponentSelectionDescriptorInternal> getRuleDescriptors() {
-        return ruleDescriptors;
+        return ruleDescriptors == null ? Collections.emptyList() : ruleDescriptors;
     }
 
     @Override
@@ -75,7 +79,7 @@ public class DefaultDependencySubstitution implements DependencySubstitutionInte
 
     @Override
     public boolean isUpdated() {
-        return !ruleDescriptors.isEmpty();
+        return ruleDescriptors != null;
     }
 
     public static void validateTarget(ComponentSelector componentSelector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
@@ -29,6 +29,7 @@ public class DefaultDependencySubstitutionApplicator implements DependencySubsti
 
     @Override
     public SubstitutionResult apply(DependencyMetadata dependency) {
+        // TODO:DAZ Instead of building a list of reasons here, we should be appending to a single list.
         DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector(), dependency.getReason());
         try {
             rule.execute(details);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
@@ -29,8 +29,7 @@ public class DefaultDependencySubstitutionApplicator implements DependencySubsti
 
     @Override
     public SubstitutionResult apply(DependencyMetadata dependency) {
-        // TODO:DAZ Instead of building a list of reasons here, we should be appending to a single list.
-        DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector(), dependency.getReason());
+        DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector());
         try {
             rule.execute(details);
         } catch (Throwable e) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutions.java
@@ -138,7 +138,7 @@ public class DefaultDependencySubstitutions implements DependencySubstitutionsIn
             ComponentSelectionDescriptorInternal substitutionReason = (ComponentSelectionDescriptorInternal) reason;
             @Override
             public Substitution because(String description) {
-                substitutionReason = substitutionReason.withReason(Describables.of(description));
+                substitutionReason = substitutionReason.withDescription(Describables.of(description));
                 return this;
             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DependencySubstitutionApplicator.java
@@ -27,7 +27,7 @@ public interface DependencySubstitutionApplicator {
     DependencySubstitutionApplicator NO_OP = new DependencySubstitutionApplicator() {
         @Override
         public SubstitutionResult apply(DependencyMetadata dependency) {
-            return SubstitutionResult.of(new DefaultDependencySubstitution(dependency.getSelector(), dependency.getReason()));
+            return SubstitutionResult.of(new DefaultDependencySubstitution(dependency.getSelector()));
         }
     };
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ComponentResolutionState.java
@@ -39,7 +39,7 @@ public interface ComponentResolutionState extends StringVersioned {
     @Nullable
     ComponentResolveMetadata getMetadata();
 
-    void addCause(ComponentSelectionDescriptorInternal componentSelectionDescription);
+    void addCause(ComponentSelectionDescriptorInternal componentSelectionDescriptor);
 
     void reject();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -220,8 +220,8 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     @Override
-    public void addCause(ComponentSelectionDescriptorInternal reason) {
-        selectionCauses.add(reason);
+    public void addCause(ComponentSelectionDescriptorInternal componentSelectionDescriptor) {
+        selectionCauses.add(componentSelectionDescriptor);
     }
 
     public void setRoot() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.Describables;
@@ -25,6 +26,7 @@ import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
+import java.util.List;
 import java.util.Set;
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.*;
@@ -32,7 +34,7 @@ import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.
 class DependencyState {
     private final ComponentSelector requested;
     private final DependencyMetadata dependency;
-    private final ComponentSelectionDescriptorInternal ruleDescriptor;
+    private final List<ComponentSelectionDescriptorInternal> ruleDescriptors;
     private final ComponentSelectorConverter componentSelectorConverter;
 
     private ModuleIdentifier moduleIdentifier;
@@ -42,10 +44,10 @@ class DependencyState {
         this(dependency, dependency.getSelector(), null, componentSelectorConverter);
     }
 
-    private DependencyState(DependencyMetadata dependency, ComponentSelector requested, ComponentSelectionDescriptorInternal ruleDescriptor, ComponentSelectorConverter componentSelectorConverter) {
+    private DependencyState(DependencyMetadata dependency, ComponentSelector requested, List<ComponentSelectionDescriptorInternal> ruleDescriptors, ComponentSelectorConverter componentSelectorConverter) {
         this.dependency = dependency;
         this.requested = requested;
-        this.ruleDescriptor = ruleDescriptor;
+        this.ruleDescriptors = ruleDescriptors;
         this.componentSelectorConverter = componentSelectorConverter;
     }
 
@@ -64,14 +66,25 @@ class DependencyState {
         return moduleIdentifier;
     }
 
-    public DependencyState withTarget(ComponentSelector target, ComponentSelectionDescriptorInternal ruleDescriptor) {
+    public DependencyState withTarget(ComponentSelector target, List<ComponentSelectionDescriptorInternal> ruleDescriptors) {
         DependencyMetadata targeted = dependency.withTarget(target);
-        return new DependencyState(targeted, requested, ruleDescriptor, componentSelectorConverter);
+        return new DependencyState(targeted, requested, ruleDescriptors, componentSelectorConverter);
+    }
+
+    /**
+     * Descriptor for any rules that modify this DependencyState from the original.
+     */
+    public List<ComponentSelectionDescriptorInternal> getRuleDescriptors() {
+        return ruleDescriptors;
     }
 
     public boolean isForced() {
-        if (ruleDescriptor != null && ruleDescriptor.isEquivalentToForce()) {
-            return true;
+        if (ruleDescriptors != null) {
+            for (ComponentSelectionDescriptorInternal ruleDescriptor : ruleDescriptors) {
+                if (ruleDescriptor.getCause() == ComponentSelectionCause.FORCED) {
+                    return true;
+                }
+            }
         }
         return isDependencyForced();
     }
@@ -92,8 +105,8 @@ class DependencyState {
         }
         reasons.add(dependencyDescriptor);
 
-        if (ruleDescriptor != null) {
-            reasons.add(ruleDescriptor);
+        if (ruleDescriptors != null) {
+            reasons.addAll(ruleDescriptors);
         }
         if (isDependencyForced()) {
             reasons.add(FORCED);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
@@ -17,7 +17,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
-import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.internal.Describables;
@@ -81,7 +80,7 @@ class DependencyState {
     public boolean isForced() {
         if (ruleDescriptors != null) {
             for (ComponentSelectionDescriptorInternal ruleDescriptor : ruleDescriptors) {
-                if (ruleDescriptor.getCause() == ComponentSelectionCause.FORCED) {
+                if (ruleDescriptor.isEquivalentToForce()) {
                     return true;
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyState.java
@@ -100,7 +100,7 @@ class DependencyState {
         String reason = dependency.getReason();
         ComponentSelectionDescriptorInternal dependencyDescriptor = dependency.isConstraint() ? CONSTRAINT : REQUESTED;
         if (reason != null) {
-            dependencyDescriptor = dependencyDescriptor.withReason(Describables.of(reason));
+            dependencyDescriptor = dependencyDescriptor.withDescription(Describables.of(reason));
         }
         reasons.add(dependencyDescriptor);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -301,6 +301,7 @@ class NodeState implements DependencyGraphNode {
      * This may be better done as a decorator on ConfigurationMetadata.getDependencies()
      */
     static DependencyState maybeSubstitute(DependencyState dependencyState, DependencySubstitutionApplicator dependencySubstitutionApplicator) {
+        // TODO:DAZ Instead of building a separate list of reasons, we should be modifying the
         DependencySubstitutionApplicator.SubstitutionResult substitutionResult = dependencySubstitutionApplicator.apply(dependencyState.getDependency());
         if (substitutionResult.hasFailure()) {
             dependencyState.failure = new ModuleVersionResolveException(dependencyState.getRequested(), substitutionResult.getFailure());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -301,7 +301,6 @@ class NodeState implements DependencyGraphNode {
      * This may be better done as a decorator on ConfigurationMetadata.getDependencies()
      */
     static DependencyState maybeSubstitute(DependencyState dependencyState, DependencySubstitutionApplicator dependencySubstitutionApplicator) {
-        // TODO:DAZ Instead of building a separate list of reasons, we should be modifying the
         DependencySubstitutionApplicator.SubstitutionResult substitutionResult = dependencySubstitutionApplicator.apply(dependencyState.getDependency());
         if (substitutionResult.hasFailure()) {
             dependencyState.failure = new ModuleVersionResolveException(dependencyState.getRequested(), substitutionResult.getFailure());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -309,7 +309,7 @@ class NodeState implements DependencyGraphNode {
 
         DependencySubstitutionInternal details = substitutionResult.getResult();
         if (details != null && details.isUpdated()) {
-            return dependencyState.withTarget(details.getTarget(), details.getSelectionDescription());
+            return dependencyState.withTarget(details.getTarget(), details.getRuleDescriptors());
         }
         return dependencyState;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -276,9 +276,9 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
                     rejectedBySelector.add(version);
                 } else if (rejectedVersion instanceof RejectedByRuleVersion) {
                     String reason = ((RejectedByRuleVersion) rejectedVersion).getReason();
-                    selectionReason.addCause(ComponentSelectionReasons.REJECTION.withReason(new RejectedByRuleReason(version, reason)));
+                    selectionReason.addCause(ComponentSelectionReasons.REJECTION.withDescription(new RejectedByRuleReason(version, reason)));
                 } else if (rejectedVersion instanceof RejectedByAttributesVersion) {
-                    selectionReason.addCause(ComponentSelectionReasons.REJECTION.withReason(new RejectedByAttributesReason((RejectedByAttributesVersion) rejectedVersion)));
+                    selectionReason.addCause(ComponentSelectionReasons.REJECTION.withDescription(new RejectedByAttributesReason((RejectedByAttributesVersion) rejectedVersion)));
                 }
             }
         }
@@ -286,9 +286,9 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         for (ComponentSelectionDescriptorInternal descriptor : dependencyReasons) {
             if (descriptor.getCause() == ComponentSelectionCause.REQUESTED || descriptor.getCause() == ComponentSelectionCause.CONSTRAINT) {
                 if (rejectedBySelector != null) {
-                    descriptor = descriptor.withReason(new RejectedBySelectorReason(rejectedBySelector, descriptor));
+                    descriptor = descriptor.withDescription(new RejectedBySelectorReason(rejectedBySelector, descriptor));
                 } else if (result != null && !result.getUnmatchedVersions().isEmpty()) {
-                    descriptor = descriptor.withReason(new UnmatchedVersionsReason(result.getUnmatchedVersions(), descriptor));
+                    descriptor = descriptor.withDescription(new UnmatchedVersionsReason(result.getUnmatchedVersions(), descriptor));
                 }
             }
             selectionReason.addCause(descriptor);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -106,7 +106,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
             if (details.hasResult()) {
                 resolutionAction.execute(details);
                 CapabilityInternal capability = (CapabilityInternal) conflict.descriptors.iterator().next();
-                details.getSelected().addCause(ComponentSelectionReasons.CONFLICT_RESOLUTION.withReason(Describables.of("latest version of capability", capability.getCapabilityId())));
+                details.getSelected().addCause(ComponentSelectionReasons.CONFLICT_RESOLUTION.withDescription(Describables.of("latest version of capability", capability.getCapabilityId())));
                 return;
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictHandler.java
@@ -92,9 +92,9 @@ public class DefaultConflictHandler implements ModuleConflictHandler {
             ModuleReplacementsData.Replacement replacement = moduleReplacements.getReplacementFor(identifier);
             if (replacement != null) {
                 String reason = replacement.getReason();
-                ComponentSelectionDescriptorInternal moduleReplacement = ComponentSelectionReasons.SELECTED_BY_RULE.withReason(Describables.of(identifier, "replaced with", replacement.getTarget()));
+                ComponentSelectionDescriptorInternal moduleReplacement = ComponentSelectionReasons.SELECTED_BY_RULE.withDescription(Describables.of(identifier, "replaced with", replacement.getTarget()));
                 if (reason != null) {
-                    moduleReplacement = moduleReplacement.withReason(Describables.of(reason));
+                    moduleReplacement = moduleReplacement.withDescription(Describables.of(reason));
                 }
                 selected.addCause(moduleReplacement);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/VersionConflictResolutionDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/VersionConflictResolutionDetails.java
@@ -100,7 +100,7 @@ public class VersionConflictResolutionDetails implements Describable {
             for (ComponentSelectionDescriptorInternal descriptor : descriptors) {
                 if (isByVersionConflict(descriptor)) {
                     if (!added) {
-                        merged.add(ComponentSelectionReasons.CONFLICT_RESOLUTION.withReason(new VersionConflictResolutionDetails(allCandidates)));
+                        merged.add(ComponentSelectionReasons.CONFLICT_RESOLUTION.withDescription(new VersionConflictResolutionDetails(allCandidates)));
                     }
                     added = true;
                 } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolver.java
@@ -207,7 +207,7 @@ public class SelectorStateResolver<T extends ComponentResolutionState> {
             throw UncheckedException.throwAsUncheckedException(details.getFailure());
         } else {
             ComponentSelectionDescriptorInternal desc = ComponentSelectionReasons.CONFLICT_RESOLUTION;
-            selected.addCause(desc.withReason(new VersionConflictResolutionDetails(candidates)));
+            selected.addCause(desc.withDescription(new VersionConflictResolutionDetails(candidates)));
         }
         return selected;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionDescriptorInternal.java
@@ -22,11 +22,11 @@ public interface ComponentSelectionDescriptorInternal extends ComponentSelection
     /**
      * Updates the description of this component selection descriptor.
      *
-     * @param reason a new textual description of the descriptor.
+     * @param description a new textual description of the descriptor.
      *
      * @return this descriptor
      */
-    ComponentSelectionDescriptorInternal withReason(Describable reason);
+    ComponentSelectionDescriptorInternal withDescription(Describable description);
 
     /**
      * Determines if a custom description was provided. This can be used in reporting to determine if additional details should

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultComponentSelectionDescriptor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultComponentSelectionDescriptor.java
@@ -92,11 +92,11 @@ public class DefaultComponentSelectionDescriptor implements ComponentSelectionDe
     }
 
     @Override
-    public ComponentSelectionDescriptorInternal withReason(Describable reason) {
-        if (description.equals(reason)) {
+    public ComponentSelectionDescriptorInternal withDescription(Describable description) {
+        if (this.description.equals(description)) {
             return this;
         }
-        return new DefaultComponentSelectionDescriptor(cause, reason, true, isEquivalentToForce);
+        return new DefaultComponentSelectionDescriptor(cause, description, true, isEquivalentToForce);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -22,9 +22,11 @@ import org.gradle.api.artifacts.result.ComponentSelectionCause
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import spock.lang.Specification
+
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.SELECTED_BY_RULE
 
 class DefaultDependencyResolveDetailsSpec extends Specification {
 
@@ -36,7 +38,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         !details.delegate.updated
-        details.delegate.selectionDescription == ComponentSelectionReasons.REQUESTED
+        details.delegate.selectionDescription == [REQUESTED]
 
         when:
         details.useVersion("1.0") //the same version
@@ -45,7 +47,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         details.delegate.updated
-        details.delegate.selectionDescription == ComponentSelectionReasons.SELECTED_BY_RULE
+        details.delegate.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
 
         when:
         details.useVersion("2.0") //different version
@@ -54,7 +56,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "2.0")
         details.delegate.updated
-        details.delegate.selectionDescription == ComponentSelectionReasons.SELECTED_BY_RULE
+        details.delegate.selectionDescription == [REQUESTED, SELECTED_BY_RULE, SELECTED_BY_RULE]
     }
 
     def "does not allow null version"() {
@@ -76,7 +78,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:bar:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription == ComponentSelectionReasons.SELECTED_BY_RULE
+        details.delegate.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
     }
 
     def "can mix configuring version and target module"() {
@@ -111,8 +113,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:bar:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.description == "forcefully upgrade dependency"
+        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
 
     }
 
@@ -126,8 +128,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:foo:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.description == "forcefully upgrade dependency"
+        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
 
     }
 
@@ -141,8 +143,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:bar:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.description == "forcefully upgrade dependency"
+        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
 
     }
 
@@ -156,8 +158,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:foo:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.description == "forcefully upgrade dependency"
+        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
 
     }
 
@@ -168,8 +170,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:foo:1.0'
         !details.delegate.updated
-        details.delegate.selectionDescription.cause == ComponentSelectionCause.REQUESTED
-        details.delegate.selectionDescription.description == "with a custom description"
+        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.REQUESTED
+        details.delegate.selectionDescription.last().description == "with a custom description"
 
     }
 
@@ -184,8 +186,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:foo:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.description == "forcefully upgrade dependency"
+        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
 
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution
 
+
 import org.gradle.api.artifacts.ModuleVersionSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionCause
@@ -25,7 +26,6 @@ import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionCon
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import spock.lang.Specification
 
-import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.SELECTED_BY_RULE
 
 class DefaultDependencyResolveDetailsSpec extends Specification {
@@ -38,7 +38,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         !details.delegate.updated
-        details.delegate.selectionDescription == [REQUESTED]
+        details.delegate.selectionDescription == []
 
         when:
         details.useVersion("1.0") //the same version
@@ -47,7 +47,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         details.delegate.updated
-        details.delegate.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
+        details.delegate.selectionDescription == [SELECTED_BY_RULE]
 
         when:
         details.useVersion("2.0") //different version
@@ -56,7 +56,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "2.0")
         details.delegate.updated
-        details.delegate.selectionDescription == [REQUESTED, SELECTED_BY_RULE, SELECTED_BY_RULE]
+        details.delegate.selectionDescription == [SELECTED_BY_RULE, SELECTED_BY_RULE]
     }
 
     def "does not allow null version"() {
@@ -78,7 +78,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:bar:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
+        details.delegate.selectionDescription == [SELECTED_BY_RULE]
     }
 
     def "can mix configuring version and target module"() {
@@ -112,10 +112,10 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
         then:
         details.target.toString() == 'org:bar:2.0'
-        details.delegate.updated
-        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
-
+        with (getReason(details)) {
+            cause == ComponentSelectionCause.SELECTED_BY_RULE
+            description == "forcefully upgrade dependency"
+        }
     }
 
     def "can provide a custom selection reason with useVersion"() {
@@ -127,10 +127,10 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
         then:
         details.target.toString() == 'org:foo:2.0'
-        details.delegate.updated
-        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
-
+        with (getReason(details)) {
+            cause == ComponentSelectionCause.SELECTED_BY_RULE
+            description == "forcefully upgrade dependency"
+        }
     }
 
     def "can provide a custom selection reason with useTarget before calling withDescription"() {
@@ -142,10 +142,10 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
         then:
         details.target.toString() == 'org:bar:2.0'
-        details.delegate.updated
-        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
-
+        with (getReason(details)) {
+            cause == ComponentSelectionCause.SELECTED_BY_RULE
+            description == "forcefully upgrade dependency"
+        }
     }
 
     def "can provide a custom selection reason with useVersion before calling withDescription"() {
@@ -157,22 +157,10 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
         then:
         details.target.toString() == 'org:foo:2.0'
-        details.delegate.updated
-        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
-
-    }
-
-    def "can provide a custom selection reason on dependency details"() {
-        when:
-        def details = newDependencyResolveDetails("org", "foo", "1.0", 'with a custom description')
-
-        then:
-        details.target.toString() == 'org:foo:1.0'
-        !details.delegate.updated
-        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.REQUESTED
-        details.delegate.selectionDescription.last().description == "with a custom description"
-
+        with (getReason(details)) {
+            cause == ComponentSelectionCause.SELECTED_BY_RULE
+            description == "forcefully upgrade dependency"
+        }
     }
 
     def "overwrites dependency reason"() {
@@ -185,14 +173,20 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
         then:
         details.target.toString() == 'org:foo:2.0'
-        details.delegate.updated
-        details.delegate.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.delegate.selectionDescription.last().description == "forcefully upgrade dependency"
+        with (getReason(details)) {
+            cause == ComponentSelectionCause.SELECTED_BY_RULE
+            description == "forcefully upgrade dependency"
+        }
+    }
 
+    private static def getReason(DefaultDependencyResolveDetails details) {
+        assert details.delegate.updated
+        assert details.delegate.selectionDescription.size() == 1
+        return details.delegate.selectionDescription[0]
     }
 
     private static def newDependencyResolveDetails(String group, String name, String version, String reason = null) {
-        return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version), reason), newVersionSelector(group, name, version))
+        return new DefaultDependencyResolveDetails(new DefaultDependencySubstitution(newComponentSelector(group, name, version)), newVersionSelector(group, name, version))
     }
 
     private static ModuleComponentSelector newComponentSelector(String group, String module, String version) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetailsSpec.groovy
@@ -38,7 +38,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         !details.delegate.updated
-        details.delegate.selectionDescription == []
+        details.delegate.ruleDescriptors == []
 
         when:
         details.useVersion("1.0") //the same version
@@ -47,7 +47,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "1.0")
         details.delegate.updated
-        details.delegate.selectionDescription == [SELECTED_BY_RULE]
+        details.delegate.ruleDescriptors == [SELECTED_BY_RULE]
 
         when:
         details.useVersion("2.0") //different version
@@ -56,7 +56,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         details.requested == newVersionSelector("org", "foo", "1.0")
         details.target == newVersionSelector("org", "foo", "2.0")
         details.delegate.updated
-        details.delegate.selectionDescription == [SELECTED_BY_RULE, SELECTED_BY_RULE]
+        details.delegate.ruleDescriptors == [SELECTED_BY_RULE, SELECTED_BY_RULE]
     }
 
     def "does not allow null version"() {
@@ -78,7 +78,7 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
         then:
         details.target.toString() == 'org:bar:2.0'
         details.delegate.updated
-        details.delegate.selectionDescription == [SELECTED_BY_RULE]
+        details.delegate.ruleDescriptors == [SELECTED_BY_RULE]
     }
 
     def "can mix configuring version and target module"() {
@@ -181,8 +181,8 @@ class DefaultDependencyResolveDetailsSpec extends Specification {
 
     private static def getReason(DefaultDependencyResolveDetails details) {
         assert details.delegate.updated
-        assert details.delegate.selectionDescription.size() == 1
-        return details.delegate.selectionDescription[0]
+        assert details.delegate.ruleDescriptors.size() == 1
+        return details.delegate.ruleDescriptors[0]
     }
 
     private static def newDependencyResolveDetails(String group, String name, String version, String reason = null) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -28,12 +28,11 @@ import org.gradle.util.Path
 import spock.lang.Specification
 
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.FORCED
-import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED
 import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.SELECTED_BY_RULE
 
 class DefaultDependencySubstitutionSpec extends Specification {
     def componentSelector = Mock(ComponentSelector)
-    def details = new DefaultDependencySubstitution(componentSelector, null)
+    def details = new DefaultDependencySubstitution(componentSelector)
 
     def "can override target and selection reason for project"() {
         when:
@@ -46,7 +45,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target.module == "foo"
         details.target.version == "3.0"
         details.updated
-        details.selectionDescription == [REQUESTED, FORCED, SELECTED_BY_RULE]
+        details.selectionDescription == [FORCED, SELECTED_BY_RULE]
     }
 
     def "does not allow null target"() {
@@ -71,7 +70,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ModuleComponentSelector
         details.target.toString() == 'org:bar:2.0'
         details.updated
-        details.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
+        details.selectionDescription == [SELECTED_BY_RULE]
     }
 
     def "can specify custom selection reason"() {
@@ -103,6 +102,6 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ProjectComponentSelector
         details.target.projectPath == ":bar"
         details.updated
-        details.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
+        details.selectionDescription == [SELECTED_BY_RULE]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -20,7 +20,6 @@ import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionCause
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.service.DefaultServiceRegistry
@@ -28,14 +27,18 @@ import org.gradle.internal.typeconversion.UnsupportedNotationException
 import org.gradle.util.Path
 import spock.lang.Specification
 
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.FORCED
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.REQUESTED
+import static org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons.SELECTED_BY_RULE
+
 class DefaultDependencySubstitutionSpec extends Specification {
     def componentSelector = Mock(ComponentSelector)
     def details = new DefaultDependencySubstitution(componentSelector, null)
 
     def "can override target and selection reason for project"() {
         when:
-        details.useTarget("org:foo:2.0", ComponentSelectionReasons.FORCED)
-        details.useTarget("org:foo:3.0", ComponentSelectionReasons.SELECTED_BY_RULE)
+        details.useTarget("org:foo:2.0", FORCED)
+        details.useTarget("org:foo:3.0", SELECTED_BY_RULE)
 
         then:
         details.requested == componentSelector
@@ -43,7 +46,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target.module == "foo"
         details.target.version == "3.0"
         details.updated
-        details.selectionDescription == ComponentSelectionReasons.SELECTED_BY_RULE
+        details.selectionDescription == [REQUESTED, FORCED, SELECTED_BY_RULE]
     }
 
     def "does not allow null target"() {
@@ -54,7 +57,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         thrown(UnsupportedNotationException)
 
         when:
-        details.useTarget(null, ComponentSelectionReasons.SELECTED_BY_RULE)
+        details.useTarget(null, SELECTED_BY_RULE)
 
         then:
         thrown(UnsupportedNotationException)
@@ -68,7 +71,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ModuleComponentSelector
         details.target.toString() == 'org:bar:2.0'
         details.updated
-        details.selectionDescription == ComponentSelectionReasons.SELECTED_BY_RULE
+        details.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
     }
 
     def "can specify custom selection reason"() {
@@ -79,8 +82,8 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ModuleComponentSelector
         details.target.toString() == 'org:bar:2.0'
         details.updated
-        details.selectionDescription.cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.selectionDescription.description == 'with custom reason'
+        details.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.selectionDescription.last().description == 'with custom reason'
     }
 
     def "can specify target project"() {
@@ -100,6 +103,6 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ProjectComponentSelector
         details.target.projectPath == ":bar"
         details.updated
-        details.selectionDescription == ComponentSelectionReasons.SELECTED_BY_RULE
+        details.selectionDescription == [REQUESTED, SELECTED_BY_RULE]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionSpec.groovy
@@ -45,7 +45,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target.module == "foo"
         details.target.version == "3.0"
         details.updated
-        details.selectionDescription == [FORCED, SELECTED_BY_RULE]
+        details.ruleDescriptors == [FORCED, SELECTED_BY_RULE]
     }
 
     def "does not allow null target"() {
@@ -70,7 +70,7 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ModuleComponentSelector
         details.target.toString() == 'org:bar:2.0'
         details.updated
-        details.selectionDescription == [SELECTED_BY_RULE]
+        details.ruleDescriptors == [SELECTED_BY_RULE]
     }
 
     def "can specify custom selection reason"() {
@@ -81,8 +81,8 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ModuleComponentSelector
         details.target.toString() == 'org:bar:2.0'
         details.updated
-        details.selectionDescription.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
-        details.selectionDescription.last().description == 'with custom reason'
+        details.ruleDescriptors.last().cause == ComponentSelectionCause.SELECTED_BY_RULE
+        details.ruleDescriptors.last().description == 'with custom reason'
     }
 
     def "can specify target project"() {
@@ -102,6 +102,6 @@ class DefaultDependencySubstitutionSpec extends Specification {
         details.target instanceof ProjectComponentSelector
         details.target.projectPath == ":bar"
         details.updated
-        details.selectionDescription == [SELECTED_BY_RULE]
+        details.ruleDescriptors == [SELECTED_BY_RULE]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/AbstractConflictResolverTest.groovy
@@ -106,7 +106,7 @@ abstract class AbstractConflictResolverTest extends Specification {
         }
 
         @Override
-        void addCause(ComponentSelectionDescriptorInternal componentSelectionDescription) {
+        void addCause(ComponentSelectionDescriptorInternal componentSelectionDescriptor) {
 
         }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/TestComponentResolutionState.java
@@ -66,7 +66,7 @@ public class TestComponentResolutionState implements ComponentResolutionState {
     }
 
     @Override
-    public void addCause(ComponentSelectionDescriptorInternal componentSelectionDescription) {
+    public void addCause(ComponentSelectionDescriptorInternal componentSelectionDescriptor) {
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectionReasonSerializerTest.groovy
@@ -60,12 +60,12 @@ class ComponentSelectionReasonSerializerTest extends SerializerSpec {
 
     def "serializes custom reasons"() {
         expect:
-        check(ComponentSelectionReasons.CONFLICT_RESOLUTION.withReason(Describables.of("my conflict resolution")))
-        check(ComponentSelectionReasons.FORCED.withReason(Describables.of("forced by me")))
-        check(ComponentSelectionReasons.REQUESTED.withReason(Describables.of("I really asked for it")))
-        check(ComponentSelectionReasons.ROOT.withReason(Describables.of("I know this is the root of the graph")))
-        check(ComponentSelectionReasons.SELECTED_BY_RULE.withReason(Describables.of("Wouldn't it be nice to add custom reasons?")))
-        check(ComponentSelectionReasons.REQUESTED, ComponentSelectionReasons.SELECTED_BY_RULE.withReason(Describables.of("More details!")))
+        check(ComponentSelectionReasons.CONFLICT_RESOLUTION.withDescription(Describables.of("my conflict resolution")))
+        check(ComponentSelectionReasons.FORCED.withDescription(Describables.of("forced by me")))
+        check(ComponentSelectionReasons.REQUESTED.withDescription(Describables.of("I really asked for it")))
+        check(ComponentSelectionReasons.ROOT.withDescription(Describables.of("I know this is the root of the graph")))
+        check(ComponentSelectionReasons.SELECTED_BY_RULE.withDescription(Describables.of("Wouldn't it be nice to add custom reasons?")))
+        check(ComponentSelectionReasons.REQUESTED, ComponentSelectionReasons.SELECTED_BY_RULE.withDescription(Describables.of("More details!")))
     }
 
     def "multiple writes of the same custom reason"() {
@@ -87,13 +87,13 @@ class ComponentSelectionReasonSerializerTest extends SerializerSpec {
     }
 
     private static ComponentSelectionReason withReason(String reason) {
-        ComponentSelectionReasons.of(ComponentSelectionReasons.SELECTED_BY_RULE.withReason(Describables.of(reason)))
+        ComponentSelectionReasons.of(ComponentSelectionReasons.SELECTED_BY_RULE.withDescription(Describables.of(reason)))
     }
 
     private static ComponentSelectionReason withReasons(String... reasons) {
         int idx = -1
         ComponentSelectionReasons.of(reasons.collect {
-            reason(++idx).withReason(Describables.of(it))
+            reason(++idx).withDescription(Describables.of(it))
         }.toArray(new ComponentSelectionDescriptorInternal[0]))
     }
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -764,6 +764,11 @@ org:bar:2.0
       org.gradle.component.category = library (not requested)
    ]
    Selection reasons:
+      - Forced
+      - Selected by rule
+      - Selected by rule : RULE 2
+      - Selected by rule : SUBSTITUTION 1
+      - Selected by rule : SUBSTITUTION 2
       - Selected by rule : SUBSTITUTION 3
 
 org:foo:1.0 -> org:bar:2.0


### PR DESCRIPTION
Previously, we were only keeping the `ComponentSelectionDescriptor` for the _last executed_ rule when resolving a particular dependency. This resulted in missing information from the `dependencyInsight` report, and was likely to be the source of bugs when the first rule was `equivalentToForce` but this fact was erased by the application of a subsequent rule.
(Test coverage for this case is pending).

With this change, we collect all reasons generate for the chain of substitution rules applied. Note that "substitution rules" in this case includes:
a) Rule declared via `ResolutionStrategy.dependencySubstitution`
b) Rules declared via `ResolutionStrategy.eachDependency`
c) Modules forced via `ResolutionStrategy.force`
