### PR TITLE
Add support for using Java 7/8 language features in public API types

### DIFF
--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,9 +1,9 @@
 dependencies {
-    compile(project(":buildPlatform"))
-    compile("commons-lang:commons-lang:2.6")
-    compile("com.google.guava:guava:26.0-jre")
-    compile("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11")
-    compile("org.asciidoctor:asciidoctorj:1.5.5")
-    compile("org.asciidoctor:asciidoctor-gradle-plugin:1.5.3")
-    compile("com.github.javaparser:javaparser-core")
+    implementation(project(":buildPlatform"))
+    implementation("commons-lang:commons-lang:2.6")
+    api("com.google.guava:guava:26.0-jre")
+    implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11")
+    implementation("org.asciidoctor:asciidoctorj:1.5.5")
+    implementation("org.asciidoctor:asciidoctor-gradle-plugin:1.5.3")
+    implementation("com.github.javaparser:javaparser-core")
 }

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,7 +1,9 @@
 dependencies {
+    compile(project(":buildPlatform"))
     compile("commons-lang:commons-lang:2.6")
     compile("com.google.guava:guava:26.0-jre")
     compile("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11")
     compile("org.asciidoctor:asciidoctorj:1.5.5")
     compile("org.asciidoctor:asciidoctor-gradle-plugin:1.5.3")
+    compile("com.github.javaparser:javaparser-core")
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTask.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.build.docs.dsl.source
 
+import com.github.javaparser.JavaParser
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
 import groovyjarjarantlr.collections.AST
@@ -89,57 +90,14 @@ class ExtractDslMetaDataTask extends SourceTask {
     }
 
     def parse(File sourceFile, ClassMetaDataRepository<ClassMetaData> repository) {
+        if (!sourceFile.name.endsWith('.java')) {
+            throw new DocGenerationException("Parsing non-Java files is not supported: $sourceFile")
+        }
         try {
-            sourceFile.withReader { reader ->
-                if (sourceFile.name.endsWith('.java')) {
-                    parseJava(reader, repository)
-                } else {
-                    parseGroovy(reader, repository)
-                }
-            }
+            JavaParser.parse(sourceFile).accept(new SourceMetaDataVisitor(), repository)
         } catch (Exception e) {
             throw new DocGenerationException("Could not parse '$sourceFile'.", e)
         }
-    }
-
-    def parseJava(Reader input, ClassMetaDataRepository<ClassMetaData> repository) {
-        SourceBuffer sourceBuffer = new SourceBuffer();
-        UnicodeEscapingReader unicodeReader = new UnicodeEscapingReader(input, sourceBuffer);
-        JavaLexer lexer = new JavaLexer(unicodeReader);
-        unicodeReader.setLexer(lexer);
-        JavaRecognizer parser = JavaRecognizer.make(lexer);
-        parser.setSourceBuffer(sourceBuffer);
-        String[] tokenNames = parser.getTokenNames();
-
-        parser.compilationUnit();
-        AST ast = parser.getAST();
-
-        // modify the Java AST into a Groovy AST (just token types)
-        Visitor java2groovyConverter = new Java2GroovyConverter(tokenNames);
-        AntlrASTProcessor java2groovyTraverser = new PreOrderTraversal(java2groovyConverter);
-        java2groovyTraverser.process(ast);
-
-        def visitor = new SourceMetaDataVisitor(sourceBuffer, repository, false)
-        AntlrASTProcessor traverser = new SourceCodeTraversal(visitor);
-        traverser.process(ast);
-        visitor.complete()
-    }
-
-    def parseGroovy(Reader input, ClassMetaDataRepository<ClassMetaData> repository) {
-        SourceBuffer sourceBuffer = new SourceBuffer();
-        UnicodeEscapingReader unicodeReader = new UnicodeEscapingReader(input, sourceBuffer);
-        GroovyLexer lexer = new GroovyLexer(unicodeReader);
-        unicodeReader.setLexer(lexer);
-        GroovyRecognizer parser = GroovyRecognizer.make(lexer);
-        parser.setSourceBuffer(sourceBuffer);
-
-        parser.compilationUnit();
-        AST ast = parser.getAST();
-
-        def visitor = new SourceMetaDataVisitor(sourceBuffer, repository, true)
-        AntlrASTProcessor traverser = new SourceCodeTraversal(visitor);
-        traverser.process(ast);
-        visitor.complete()
     }
 
     def fullyQualifyAllTypeNames(ClassMetaData classMetaData, TypeNameResolver resolver) {

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/SourceMetaDataVisitor.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/SourceMetaDataVisitor.java
@@ -15,492 +15,222 @@
  */
 package org.gradle.build.docs.dsl.source;
 
-import groovyjarjarantlr.collections.AST;
-import org.apache.commons.lang.StringUtils;
-import org.codehaus.groovy.antlr.GroovySourceAST;
-import org.codehaus.groovy.antlr.LineColumn;
-import org.codehaus.groovy.antlr.SourceBuffer;
-import org.codehaus.groovy.antlr.treewalker.VisitorAdapter;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
+import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.body.TypeDeclaration;
+import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.LiteralStringValueExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
+import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
+import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import org.gradle.build.docs.dsl.source.model.*;
 import org.gradle.build.docs.dsl.source.model.ClassMetaData.MetaType;
 import org.gradle.build.docs.model.ClassMetaDataRepository;
 
-import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.codehaus.groovy.antlr.parser.GroovyTokenTypes.*;
-
-public class SourceMetaDataVisitor extends VisitorAdapter {
-    private static final Pattern PREV_JAVADOC_COMMENT_PATTERN = Pattern.compile("(?s)/\\*\\*(.*?)\\*/");
+public class SourceMetaDataVisitor extends VoidVisitorAdapter<ClassMetaDataRepository<ClassMetaData>> {
     private static final Pattern GETTER_METHOD_NAME = Pattern.compile("(get|is)(.+)");
     private static final Pattern SETTER_METHOD_NAME = Pattern.compile("set(.+)");
-    private final SourceBuffer sourceBuffer;
-    private final LinkedList<GroovySourceAST> parseStack = new LinkedList<GroovySourceAST>();
-    private final List<String> imports = new ArrayList<String>();
-    private final ClassMetaDataRepository<ClassMetaData> repository;
     private final List<ClassMetaData> allClasses = new ArrayList<ClassMetaData>();
-    private final LinkedList<ClassMetaData> classStack = new LinkedList<ClassMetaData>();
-    private final Map<GroovySourceAST, ClassMetaData> typeTokens = new HashMap<GroovySourceAST, ClassMetaData>();
-    private final boolean groovy;
+    private final Deque<ClassMetaData> classStack = new LinkedList<ClassMetaData>();
     private String packageName;
-    private LineColumn lastLineCol;
 
-    SourceMetaDataVisitor(SourceBuffer sourceBuffer, ClassMetaDataRepository<ClassMetaData> repository,
-                          boolean isGroovy) {
-        this.sourceBuffer = sourceBuffer;
-        this.repository = repository;
-        groovy = isGroovy;
-        lastLineCol = new LineColumn(1, 1);
+    @Override
+    public void visit(CompilationUnit compilationUnit, ClassMetaDataRepository<ClassMetaData> repository) {
+        super.visit(compilationUnit, repository);
+        compilationUnit.getImports().stream()
+            .filter(anImport -> !anImport.isStatic())
+            .map(anImport -> anImport.getNameAsString() + (anImport.isAsterisk() ? ".*" : ""))
+            .forEach(anImport -> allClasses.forEach(classMetaData -> classMetaData.addImport(anImport)));
     }
 
-    public void complete() {
-        for (String anImport : imports) {
-            for (ClassMetaData classMetaData : allClasses) {
-                classMetaData.addImport(anImport);
-            }
+    @Override
+    public void visit(PackageDeclaration packageDeclaration, ClassMetaDataRepository<ClassMetaData> repository) {
+        this.packageName = packageDeclaration.getNameAsString();
+        super.visit(packageDeclaration, repository);
+    }
+
+    @Override
+    public void visit(ClassOrInterfaceDeclaration classDeclaration, ClassMetaDataRepository<ClassMetaData> repository) {
+        visitTypeDeclaration(classDeclaration, repository, classDeclaration.isInterface() ? MetaType.INTERFACE : MetaType.CLASS, () -> {
+            visitExtendedTypes(classDeclaration);
+            visitImplementedTypes(classDeclaration);
+            super.visit(classDeclaration, repository);
+        });
+    }
+
+    @Override
+    public void visit(EnumDeclaration enumDeclaration, ClassMetaDataRepository<ClassMetaData> repository) {
+        visitTypeDeclaration(enumDeclaration, repository, MetaType.ENUM, () -> {
+            visitImplementedTypes(enumDeclaration);
+            enumDeclaration.getEntries().forEach(entry -> getCurrentClass().addEnumConstant(entry.getNameAsString()));
+            super.visit(enumDeclaration, repository);
+        });
+    }
+
+    @Override
+    public void visit(AnnotationDeclaration annotationDeclaration, ClassMetaDataRepository<ClassMetaData> repository) {
+        visitTypeDeclaration(annotationDeclaration, repository, MetaType.ANNOTATION, () -> {
+            super.visit(annotationDeclaration, repository);
+        });
+    }
+
+    private void visitTypeDeclaration(TypeDeclaration<?> typeDeclaration, ClassMetaDataRepository<ClassMetaData> repository, ClassMetaData.MetaType metaType, Runnable action) {
+        ClassMetaData outerClass = classStack.isEmpty() ? null : getCurrentClass();
+        String baseName = typeDeclaration.getNameAsString();
+        String className = outerClass == null ? packageName + '.' + baseName : outerClass.getClassName() + '.' + baseName;
+        String comment = getJavadocComment(typeDeclaration);
+        ClassMetaData currentClass = new ClassMetaData(className, packageName, metaType, false, comment);
+        if (outerClass != null) {
+            outerClass.addInnerClassName(className);
+            currentClass.setOuterClassName(outerClass.getClassName());
         }
-    }
+        findAnnotations(typeDeclaration, currentClass);
 
-    @Override
-    public void visitPackageDef(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            packageName = extractName(t);
-        }
-    }
+        allClasses.add(currentClass);
+        repository.put(className, currentClass);
 
-    @Override
-    public void visitImport(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            imports.add(extractName(t));
-        }
-    }
-
-    @Override
-    public void visitClassDef(GroovySourceAST t, int visit) {
-        visitTypeDef(t, visit, MetaType.CLASS);
-    }
-
-    @Override
-    public void visitInterfaceDef(GroovySourceAST t, int visit) {
-        visitTypeDef(t, visit, MetaType.INTERFACE);
-    }
-
-    @Override
-    public void visitEnumDef(GroovySourceAST t, int visit) {
-        visitTypeDef(t, visit, MetaType.ENUM);
-    }
-
-    @Override
-    public void visitAnnotationDef(GroovySourceAST t, int visit) {
-        visitTypeDef(t, visit, MetaType.ANNOTATION);
-    }
-
-    private void visitTypeDef(GroovySourceAST t, int visit, ClassMetaData.MetaType metaType) {
-        if (visit == OPENING_VISIT) {
-            ClassMetaData outerClass = getCurrentClass();
-            String baseName = extractIdent(t);
-            String className = outerClass != null ? outerClass.getClassName() + '.' + baseName
-                    : packageName + '.' + baseName;
-            String comment = getJavaDocCommentsBeforeNode(t);
-            ClassMetaData currentClass = new ClassMetaData(className, packageName, metaType, groovy, comment);
-            if (outerClass != null) {
-                outerClass.addInnerClassName(className);
-                currentClass.setOuterClassName(outerClass.getClassName());
-            }
-            findAnnotations(t, currentClass);
-            classStack.addFirst(currentClass);
-            allClasses.add(currentClass);
-            typeTokens.put(t, currentClass);
-            repository.put(className, currentClass);
-        }
+        classStack.push(currentClass);
+        action.run();
+        classStack.pop();
     }
 
     private ClassMetaData getCurrentClass() {
-        return classStack.isEmpty() ? null : classStack.getFirst();
+        return classStack.peek();
     }
 
-    @Override
-    public void visitExtendsClause(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            ClassMetaData currentClass = getCurrentClass();
-            for (
-                    GroovySourceAST child = (GroovySourceAST) t.getFirstChild(); child != null;
-                    child = (GroovySourceAST) child.getNextSibling()) {
-                if (!currentClass.isInterface()) {
-                    currentClass.setSuperClassName(extractName(child));
-                } else {
-                    currentClass.addInterfaceName(extractName(child));
-                }
+    private void visitExtendedTypes(NodeWithExtends<?> node) {
+        ClassMetaData currentClass = getCurrentClass();
+        for (ClassOrInterfaceType extendedType : node.getExtendedTypes()) {
+            if (currentClass.isInterface()) {
+                currentClass.addInterfaceName(extractName(extendedType));
+            } else {
+                currentClass.setSuperClassName(extractName(extendedType));
             }
         }
     }
 
-    @Override
-    public void visitImplementsClause(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            ClassMetaData currentClass = getCurrentClass();
-            for (
-                    GroovySourceAST child = (GroovySourceAST) t.getFirstChild(); child != null;
-                    child = (GroovySourceAST) child.getNextSibling()) {
-                currentClass.addInterfaceName(extractName(child));
-            }
+    private void visitImplementedTypes(NodeWithImplements<?> node) {
+        ClassMetaData currentClass = getCurrentClass();
+        for (ClassOrInterfaceType implementedType : node.getImplementedTypes()) {
+            currentClass.addInterfaceName(extractName(implementedType));
         }
     }
 
     @Override
-    public void visitEnumConstantDef(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            String name = extractName(t);
-            getCurrentClass().addEnumConstant(name);
-            skipJavaDocComment(t);
-        }
-    }
+    public void visit(MethodDeclaration methodDeclaration, ClassMetaDataRepository<ClassMetaData> repository) {
+        String name = methodDeclaration.getNameAsString();
 
-    @Override
-    public void visitMethodDef(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            maybeAddMethod(t);
-            skipJavaDocComment(t);
-        }
-    }
+        String rawCommentText = getJavadocComment(methodDeclaration);
+        TypeMetaData returnType = extractTypeName(methodDeclaration.getType());
+        MethodMetaData methodMetaData = getCurrentClass().addMethod(name, returnType, rawCommentText);
 
-    private void maybeAddMethod(GroovySourceAST t) {
-        String name = extractName(t);
-        if (!groovy && name.equals(getCurrentClass().getSimpleName())) {
-            // A constructor. The java grammar treats a constructor as a method, the groovy grammar does not.
-            return;
-        }
-
-        ASTIterator children = new ASTIterator(t);
-        if (groovy) {
-            children.skip(TYPE_PARAMETERS);
-            children.skip(MODIFIERS);
-        } else {
-            children.skip(MODIFIERS);
-            children.skip(TYPE_PARAMETERS);
-        }
-
-        String rawCommentText = getJavaDocCommentsBeforeNode(t);
-        TypeMetaData returnType = extractTypeName(children.current);
-        MethodMetaData method = getCurrentClass().addMethod(name, returnType, rawCommentText);
-
-        findAnnotations(t, method);
-        extractParameters(t, method);
+        findAnnotations(methodDeclaration, methodMetaData);
+        extractParameters(methodDeclaration, methodMetaData);
 
         Matcher matcher = GETTER_METHOD_NAME.matcher(name);
         if (matcher.matches()) {
             int startName = matcher.start(2);
             String propName = name.substring(startName, startName + 1).toLowerCase() + name.substring(startName + 1);
-            PropertyMetaData property = getCurrentClass().addReadableProperty(propName, returnType, rawCommentText, method);
-            for (String annotation : method.getAnnotationTypeNames()) {
-                property.addAnnotationTypeName(annotation);
-            }
+            PropertyMetaData property = getCurrentClass().addReadableProperty(propName, returnType, rawCommentText, methodMetaData);
+            methodMetaData.getAnnotationTypeNames().forEach(property::addAnnotationTypeName);
             return;
         }
 
-        if (method.getParameters().size() != 1) {
+        if (methodMetaData.getParameters().size() != 1) {
             return;
         }
         matcher = SETTER_METHOD_NAME.matcher(name);
         if (matcher.matches()) {
             int startName = matcher.start(1);
             String propName = name.substring(startName, startName + 1).toLowerCase() + name.substring(startName + 1);
-            TypeMetaData type = method.getParameters().get(0).getType();
-            getCurrentClass().addWriteableProperty(propName, type, rawCommentText, method);
+            TypeMetaData type = methodMetaData.getParameters().get(0).getType();
+            getCurrentClass().addWriteableProperty(propName, type, rawCommentText, methodMetaData);
         }
     }
 
-    private void extractParameters(GroovySourceAST t, MethodMetaData method) {
-        GroovySourceAST paramsAst = t.childOfType(PARAMETERS);
-        for (
-                GroovySourceAST child = (GroovySourceAST) paramsAst.getFirstChild(); child != null;
-                child = (GroovySourceAST) child.getNextSibling()) {
-            assert child.getType() == PARAMETER_DEF || child.getType() == VARIABLE_PARAMETER_DEF;
-            TypeMetaData type = extractTypeName((GroovySourceAST) child.getFirstChild().getNextSibling());
-            if (child.getType() == VARIABLE_PARAMETER_DEF) {
-                type.setVarargs();
+    private void extractParameters(MethodDeclaration n, MethodMetaData method) {
+        for (Parameter parameter : n.getParameters()) {
+            TypeMetaData typeMetaData = extractTypeName(parameter.getType());
+            if (parameter.isVarArgs()) {
+                typeMetaData.setVarargs();
             }
-            method.addParameter(extractIdent(child), type);
+            method.addParameter(parameter.getNameAsString(), typeMetaData);
         }
     }
 
     @Override
-    public void visitVariableDef(GroovySourceAST t, int visit) {
-        if (visit == OPENING_VISIT) {
-            maybeAddPropertyFromField(t);
-            skipJavaDocComment(t);
-        }
-    }
-
-    private void maybeAddPropertyFromField(GroovySourceAST t) {
-        GroovySourceAST parentNode = getParentNode();
-        boolean isField = parentNode != null && parentNode.getType() == OBJBLOCK;
-        if (!isField) {
-            return;
-        }
-
-        int modifiers = extractModifiers(t);
-        boolean isConst = getCurrentClass().isInterface() || (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers));
+    public void visit(FieldDeclaration fieldDeclaration, ClassMetaDataRepository<ClassMetaData> arg) {
+        boolean isConst = getCurrentClass().isInterface() || (fieldDeclaration.isStatic() && fieldDeclaration.isFinal());
         if (isConst) {
-            visitConst(t);
-            return;
-        }
-
-        boolean isProp = groovy && !Modifier.isStatic(modifiers) && !Modifier.isPublic(modifiers)
-                && !Modifier.isProtected(modifiers) && !Modifier.isPrivate(modifiers);
-        if (!isProp) {
-            return;
-        }
-
-        ASTIterator children = new ASTIterator(t);
-        children.skip(MODIFIERS);
-
-        String propertyName = extractIdent(t);
-        TypeMetaData propertyType = extractTypeName(children.current);
-        ClassMetaData currentClass = getCurrentClass();
-
-        MethodMetaData getterMethod = currentClass.addMethod(String.format("get%s", StringUtils.capitalize(
-                propertyName)), propertyType, "");
-        PropertyMetaData property = currentClass.addReadableProperty(propertyName, propertyType, getJavaDocCommentsBeforeNode(t), getterMethod);
-        findAnnotations(t, property);
-        if (!Modifier.isFinal(modifiers)) {
-            MethodMetaData setterMethod = currentClass.addMethod(String.format("set%s", StringUtils.capitalize(
-                    propertyName)), TypeMetaData.VOID, "");
-            setterMethod.addParameter(propertyName, propertyType);
-            currentClass.addWriteableProperty(propertyName, propertyType, getJavaDocCommentsBeforeNode(t), setterMethod);
+            fieldDeclaration.getVariables().forEach(variableDeclarator -> {
+                String constName = variableDeclarator.getNameAsString();
+                String value = variableDeclarator.getInitializer()
+                    .filter(Expression::isLiteralStringValueExpr)
+                    .map(Expression::asLiteralStringValueExpr)
+                    .map(LiteralStringValueExpr::getValue)
+                    .orElse(null);
+                getCurrentClass().getConstants().put(constName, value);
+            });
         }
     }
 
-    private void visitConst(GroovySourceAST t) {
-        String constName = extractIdent(t);
-        GroovySourceAST assign = t.childOfType(ASSIGN);
-        String value = null;
-        if (assign != null) {
-            value = extractLiteral(assign.getFirstChild());
-        }
-        getCurrentClass().getConstants().put(constName, value);
+    private TypeMetaData extractTypeName(Type type) {
+        TypeMetaData typeMetaData = new TypeMetaData();
+        type.ifArrayType(arrayType -> typeMetaData.setArrayDimensions(arrayType.getArrayLevel()));
+        extractElementTypeName(type.getElementType(), typeMetaData);
+        return typeMetaData;
     }
 
-    private String extractLiteral(AST ast) {
-        switch (ast.getType()) {
-            case EXPR:
-                // The java grammar wraps initialisers in an EXPR token
-                return extractLiteral(ast.getFirstChild());
-            case NUM_INT:
-            case NUM_LONG:
-            case NUM_FLOAT:
-            case NUM_DOUBLE:
-            case NUM_BIG_INT:
-            case NUM_BIG_DECIMAL:
-            case STRING_LITERAL:
-                return ast.getText();
-        }
-        return null;
-    }
-
-    public GroovySourceAST pop() {
-        if (!parseStack.isEmpty()) {
-            GroovySourceAST ast = parseStack.removeFirst();
-            ClassMetaData classMetaData = typeTokens.remove(ast);
-            if (classMetaData != null) {
-                assert classMetaData == classStack.getFirst();
-                classStack.removeFirst();
+    private void extractElementTypeName(Type elementType, TypeMetaData typeMetaData) {
+        elementType.ifVoidType(voidType -> typeMetaData.setName("void"));
+        elementType.ifPrimitiveType(primitiveType -> typeMetaData.setName(primitiveType.asString()));
+        elementType.ifWildcardType(wildcardType -> {
+            if (!wildcardType.getExtendedType().isPresent() && !wildcardType.getSuperType().isPresent()) {
+                typeMetaData.setWildcard();
+            } else {
+                wildcardType.getExtendedType().ifPresent(referenceType -> typeMetaData.setUpperBounds(extractTypeName(referenceType)));
+                wildcardType.getSuperType().ifPresent(referenceType -> typeMetaData.setLowerBounds(extractTypeName(referenceType)));
             }
-            return ast;
-        }
-        return null;
+        });
+        elementType.ifClassOrInterfaceType(classOrInterfaceType -> {
+            typeMetaData.setName(extractName(classOrInterfaceType));
+            classOrInterfaceType.getTypeArguments().ifPresent(typeArguments -> {
+                typeArguments.forEach(arg -> typeMetaData.addTypeArg(extractTypeName(arg)));
+            });
+        });
     }
 
-    @Override
-    public void push(GroovySourceAST t) {
-        parseStack.addFirst(t);
-    }
-
-    private GroovySourceAST getParentNode() {
-        if (parseStack.size() > 1) {
-            return parseStack.get(1);
-        }
-        return null;
-    }
-
-    private int extractModifiers(GroovySourceAST ast) {
-        GroovySourceAST modifiers = ast.childOfType(MODIFIERS);
-        if (modifiers == null) {
-            return 0;
-        }
-        int modifierFlags = 0;
-        for (
-                GroovySourceAST child = (GroovySourceAST) modifiers.getFirstChild(); child != null;
-                child = (GroovySourceAST) child.getNextSibling()) {
-            switch (child.getType()) {
-                case LITERAL_private:
-                    modifierFlags |= Modifier.PRIVATE;
-                    break;
-                case LITERAL_protected:
-                    modifierFlags |= Modifier.PROTECTED;
-                    break;
-                case LITERAL_public:
-                    modifierFlags |= Modifier.PUBLIC;
-                    break;
-                case FINAL:
-                    modifierFlags |= Modifier.FINAL;
-                    break;
-                case LITERAL_static:
-                    modifierFlags |= Modifier.STATIC;
-                    break;
-            }
-        }
-        return modifierFlags;
-    }
-
-    private TypeMetaData extractTypeName(GroovySourceAST ast) {
-        TypeMetaData type = new TypeMetaData();
-        switch (ast.getType()) {
-            case TYPE:
-                GroovySourceAST typeName = (GroovySourceAST) ast.getFirstChild();
-                extractTypeName(typeName, type);
-                break;
-            case WILDCARD_TYPE:
-                // In the groovy grammar, the bounds are sibling of the ?, in the java grammar, they are the child
-                GroovySourceAST bounds = (GroovySourceAST) (groovy ? ast.getNextSibling() : ast.getFirstChild());
-                if (bounds == null) {
-                    type.setWildcard();
-                } else if (bounds.getType() == TYPE_UPPER_BOUNDS) {
-                    type.setUpperBounds(extractTypeName((GroovySourceAST) bounds.getFirstChild()));
-                } else if (bounds.getType() == TYPE_LOWER_BOUNDS) {
-                    type.setLowerBounds(extractTypeName((GroovySourceAST) bounds.getFirstChild()));
-                }
-                break;
-            case IDENT:
-            case DOT:
-                extractTypeName(ast, type);
-                break;
-            default:
-                throw new RuntimeException(String.format("Unexpected token in type name: %s", ast));
-        }
-
-        return type;
-    }
-
-    private void extractTypeName(GroovySourceAST ast, TypeMetaData type) {
-        if (ast == null) {
-            type.setName("java.lang.Object");
-            return;
-        }
-        switch (ast.getType()) {
-            case LITERAL_boolean:
-                type.setName("boolean");
-                return;
-            case LITERAL_byte:
-                type.setName("byte");
-                return;
-            case LITERAL_char:
-                type.setName("char");
-                return;
-            case LITERAL_double:
-                type.setName("double");
-                return;
-            case LITERAL_float:
-                type.setName("float");
-                return;
-            case LITERAL_int:
-                type.setName("int");
-                return;
-            case LITERAL_long:
-                type.setName("long");
-                return;
-            case LITERAL_void:
-                type.setName("void");
-                return;
-            case ARRAY_DECLARATOR:
-                extractTypeName((GroovySourceAST) ast.getFirstChild(), type);
-                type.addArrayDimension();
-                return;
-        }
-
-        type.setName(extractName(ast));
-        GroovySourceAST typeArgs = ast.childOfType(TYPE_ARGUMENTS);
-        if (typeArgs != null) {
-            for (
-                    GroovySourceAST child = (GroovySourceAST) typeArgs.getFirstChild(); child != null;
-                    child = (GroovySourceAST) child.getNextSibling()) {
-                assert child.getType() == TYPE_ARGUMENT;
-                type.addTypeArg(extractTypeName((GroovySourceAST) child.getFirstChild()));
-            }
+    private void findAnnotations(NodeWithAnnotations<?> node, AbstractLanguageElement currentElement) {
+        for (AnnotationExpr child : node.getAnnotations()) {
+            currentElement.addAnnotationTypeName(child.getNameAsString());
         }
     }
 
-    private void skipJavaDocComment(GroovySourceAST t) {
-        lastLineCol = new LineColumn(t.getLine(), t.getColumn());
+    private String extractName(ClassOrInterfaceType type) {
+        if (type.getScope().isPresent()) {
+            return extractName(type.getScope().get()) + "." + type.getNameAsString();
+        }
+        return type.getNameAsString();
     }
 
-    private String getJavaDocCommentsBeforeNode(GroovySourceAST t) {
-        String result = "";
-        LineColumn thisLineCol = new LineColumn(t.getLine(), t.getColumn());
-        String text = sourceBuffer.getSnippet(lastLineCol, thisLineCol);
-        if (text != null) {
-            Matcher m = PREV_JAVADOC_COMMENT_PATTERN.matcher(text);
-            if (m.find()) {
-                result = m.group(1);
-            }
-        }
-        lastLineCol = thisLineCol;
-        return result;
+    private String getJavadocComment(NodeWithJavadoc<?> node) {
+        return node.getJavadocComment().map(Comment::getContent).orElse("");
     }
 
-    private void findAnnotations(GroovySourceAST t, AbstractLanguageElement currentElement) {
-        GroovySourceAST modifiers = t.childOfType(MODIFIERS);
-        if (modifiers != null) {
-            List<GroovySourceAST> children = modifiers.childrenOfType(ANNOTATION);
-            for (GroovySourceAST child : children) {
-                String identifier = extractIdent(child);
-                currentElement.addAnnotationTypeName(identifier);
-            }
-        }
-    }
-
-    private String extractIdent(GroovySourceAST t) {
-        return t.childOfType(IDENT).getText();
-    }
-
-    private String extractName(GroovySourceAST t) {
-        if (t.getType() == DOT) {
-            GroovySourceAST firstChild = (GroovySourceAST) t.getFirstChild();
-            GroovySourceAST secondChild = (GroovySourceAST) firstChild.getNextSibling();
-            return extractName(firstChild) + "." + extractName(secondChild);
-        }
-        if (t.getType() == IDENT) {
-            return t.getText();
-        }
-        if (t.getType() == STAR) {
-            return t.getText();
-        }
-
-        GroovySourceAST child = t.childOfType(DOT);
-        if (child != null) {
-            return extractName(child);
-        }
-        child = t.childOfType(IDENT);
-        if (child != null) {
-            return extractName(child);
-        }
-
-        throw new RuntimeException(String.format("Unexpected token in name: %s", t));
-    }
-
-    private static class ASTIterator {
-        GroovySourceAST current;
-
-        private ASTIterator(GroovySourceAST parent) {
-            this.current = (GroovySourceAST) parent.getFirstChild();
-        }
-
-        void skip(int token) {
-            if (current != null && current.getType() == token) {
-                current = (GroovySourceAST) current.getNextSibling();
-            }
-        }
-    }
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/TypeMetaData.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/TypeMetaData.java
@@ -55,8 +55,8 @@ public class TypeMetaData implements Serializable, TypeContainer {
         return arrayDimensions + (varargs ? 1 : 0);
     }
 
-    public TypeMetaData addArrayDimension() {
-        arrayDimensions++;
+    public TypeMetaData setArrayDimensions(int arrayDimensions) {
+        this.arrayDimensions = arrayDimensions;
         return this;
     }
 

--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/docbook/LinkRendererTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/docbook/LinkRendererTest.groovy
@@ -138,7 +138,7 @@ class LinkRendererTest extends XmlSpecification {
     def type(String name, boolean isArray = false) {
         TypeMetaData type = new TypeMetaData(name)
         if (isArray) {
-            type.addArrayDimension()
+            type.arrayDimensions = 1
         }
         return type
     }

--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/source/model/TypeMetaDataTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/source/model/TypeMetaDataTest.groovy
@@ -26,8 +26,7 @@ class TypeMetaDataTest extends Specification {
     }
 
     def rawTypeForArrayType() {
-        type.addArrayDimension()
-        type.addArrayDimension()
+        type.arrayDimensions = 2
 
         expect:
         type.rawType.signature == 'org.gradle.SomeType[][]'
@@ -41,15 +40,14 @@ class TypeMetaDataTest extends Specification {
         type.rawType.signature == 'org.gradle.SomeType[]'
 
         when:
-        type.addArrayDimension()
+        type.arrayDimensions = 1
 
         then:
         type.rawType.signature == 'org.gradle.SomeType[][]'
     }
 
     def rawTypeForParameterizedArrayType() {
-        type.addArrayDimension()
-        type.addArrayDimension()
+        type.arrayDimensions = 2
         type.addTypeArg(new TypeMetaData('Type1'))
 
         expect:
@@ -91,16 +89,14 @@ class TypeMetaDataTest extends Specification {
     }
 
     def formatsSignatureForArrayType() {
-        type.addArrayDimension()
-        type.addArrayDimension()
+        type.arrayDimensions = 2
 
         expect:
         type.signature == 'org.gradle.SomeType[][]'
     }
 
     def formatsSignatureForArrayAndVarargsType() {
-        type.addArrayDimension()
-        type.addArrayDimension()
+        type.arrayDimensions = 2
         type.setVarargs()
 
         expect:
@@ -149,8 +145,7 @@ class TypeMetaDataTest extends Specification {
 
     def visitsSignatureForArrayType() {
         TypeMetaData.SignatureVisitor visitor = Mock()
-        type.addArrayDimension()
-        type.addArrayDimension()
+        type.arrayDimensions = 2
 
         when:
         type.visitSignature(visitor)

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/A.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/A.groovy
@@ -1,4 +1,0 @@
-package org.gradle.test
-
-class A {
-}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/A.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/A.java
@@ -1,0 +1,4 @@
+package org.gradle.test;
+
+class A {
+}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/CombinedInterface.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/CombinedInterface.java
@@ -1,0 +1,4 @@
+package org.gradle.test;
+
+public interface CombinedInterface extends Interface1, Interface2 {
+}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyClass.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyClass.groovy
@@ -3,11 +3,11 @@ package org.gradle.test
 /**
  * This is a groovy class.
  */
-class GroovyClass extends A implements GroovyInterface, JavaInterface {
+class GroovyClass extends A implements CombinedInterface, JavaInterface {
     /**
      * A groovy property.
      */
-    GroovyInterface groovyProp
+    CombinedInterface groovyProp
 
     /**
      * A read-only groovy property.
@@ -34,11 +34,11 @@ class GroovyClass extends A implements GroovyInterface, JavaInterface {
     /**
      * A property.
      */
-    GroovyInterface getSomeProp() {
+    CombinedInterface getSomeProp() {
         this
     }
 
-    void setSomeProp(GroovyInterface value) {
+    void setSomeProp(CombinedInterface value) {
     }
 
     /**

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyClassWithMethods.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyClassWithMethods.groovy
@@ -22,7 +22,7 @@ class GroovyClassWithMethods {
     /**
      * A method that returns a reference type.
      */
-    public final GroovyInterface refTypeMethod(JavaInterface someThing, boolean aFlag) {
+    public final CombinedInterface refTypeMethod(JavaInterface someThing, boolean aFlag) {
         null
     }
 

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyClassWithParameterizedTypes.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyClassWithParameterizedTypes.groovy
@@ -1,17 +1,17 @@
 package org.gradle.test
 
 class GroovyClassWithParameterizedTypes {
-    Set<GroovyInterface> setProp
+    Set<CombinedInterface> setProp
 
-    Map<GroovyInterface, GroovyClassWithParameterizedTypes> mapProp
+    Map<CombinedInterface, GroovyClassWithParameterizedTypes> mapProp
 
     List<?> wildcardProp
 
-    List<? extends GroovyInterface> upperBoundProp
+    List<? extends CombinedInterface> upperBoundProp
 
-    List<? super GroovyInterface> lowerBoundProp
+    List<? super CombinedInterface> lowerBoundProp
 
-    List<? super Set<? extends Map<?, GroovyInterface[]>>>[] nestedProp
+    List<? super Set<? extends Map<?, CombinedInterface[]>>>[] nestedProp
 
     static <T> T paramMethod(T param) {
         null

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyInterface.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/GroovyInterface.groovy
@@ -1,4 +1,0 @@
-package org.gradle.test
-
-public interface GroovyInterface extends Interface1, Interface2 {
-}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/Interface2.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/Interface2.java
@@ -1,4 +1,4 @@
-package org.gradle.test
+package org.gradle.test;
 
 public interface Interface2 {
 

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/Java8Interface.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/Java8Interface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.build.docs;
 
-import org.gradle.internal.exceptions.Contextual;
+package org.gradle.test;
 
-@Contextual
-public class DocGenerationException extends RuntimeException {
-    public DocGenerationException(String message) {
-        super(message);
-    }
+import java.io.IOException;
+import java.util.function.Supplier;
 
-    public DocGenerationException(String message, Throwable throwable) {
-        super(message, throwable);
+/**
+ * An interface that uses Java 8 source features.
+ */
+public interface Java8Interface extends CombinedInterface, JavaInterface {
+    default String getName() {
+        try (Writer writer = new StringWriter()) {
+            Supplier<String> methodReference = this::toString;
+            Supplier<String> lambda = () -> this.toString();
+        } catch (IOException ignore) {
+        }
+        return "foo";
     }
 }

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClass.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClass.java
@@ -3,7 +3,7 @@ package org.gradle.test;
 /**
  * This is a java class.
  */
-public class JavaClass extends A implements GroovyInterface, JavaInterface {
+public class JavaClass extends A implements CombinedInterface, JavaInterface {
     /**
      * A read-only property.
      */

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithFullyQualifiedNames.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithFullyQualifiedNames.java
@@ -1,6 +1,6 @@
 package org.gradle.test;
 
-public class JavaClassWithFullyQualifiedNames extends org.gradle.test.sub.SubGroovyClass implements org.gradle.test.sub.SubJavaInterface, java.lang.Runnable {
+public class JavaClassWithFullyQualifiedNames extends org.gradle.test.sub.SubClass implements org.gradle.test.sub.SubJavaInterface, java.lang.Runnable {
     org.gradle.test.sub.SubJavaInterface getProp() {
         return this;
     }

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithImports.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithImports.java
@@ -1,12 +1,12 @@
 package org.gradle.test;
 
 import org.gradle.test.sub.*;
-import org.gradle.test.sub2.GroovyInterface;
+import org.gradle.test.sub2.Sub2Interface;
 
 import java.io.Closeable;
 import java.io.IOException;
 
-public class JavaClassWithImports extends SubGroovyClass implements SubJavaInterface, GroovyInterface, Closeable {
+public class JavaClassWithImports extends SubClass implements SubJavaInterface, Sub2Interface, Closeable {
     public void close() throws IOException {
     }
 }

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithInnerTypes.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithInnerTypes.java
@@ -1,8 +1,8 @@
 package org.gradle.test;
 
-import org.gradle.test.sub2.GroovyInterface;
+import org.gradle.test.sub2.Sub2Interface;
 
-public class JavaClassWithInnerTypes implements GroovyInterface {
+public class JavaClassWithInnerTypes implements Sub2Interface {
     /**
      * This is an inner enum.
      */
@@ -23,12 +23,12 @@ public class JavaClassWithInnerTypes implements GroovyInterface {
         }
     }
 
-    GroovyInterface getSomeProp() {
+    Sub2Interface getSomeProp() {
         // ignore classes in method bodies
         class IgnoreMe {}
 
         // ignore anonymous classes
-        return new GroovyInterface() { };
+        return new Sub2Interface() { };
     }
 
     // ignore anonymous classes

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithMethods.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithMethods.java
@@ -20,7 +20,7 @@ public class JavaClassWithMethods {
     /**
      * A method that returns a reference type.
      */
-    GroovyInterface refTypeMethod(JavaInterface refParam, boolean aFlag) {
+    CombinedInterface refTypeMethod(JavaInterface refParam, boolean aFlag) {
         return null;
     }
 

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithParameterizedTypes.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithParameterizedTypes.java
@@ -3,17 +3,17 @@ package org.gradle.test;
 import java.util.*;
 
 public class JavaClassWithParameterizedTypes {
-    Set<GroovyInterface> getSetProp() { return null; }
+    Set<CombinedInterface> getSetProp() { return null; }
 
-    Map<GroovyInterface, JavaClassWithParameterizedTypes> getMapProp() { return null; }
+    Map<CombinedInterface, JavaClassWithParameterizedTypes> getMapProp() { return null; }
 
     List<?> getWildcardProp() { return null; }
 
-    List<? extends GroovyInterface> getUpperBoundProp() { return null; }
+    List<? extends CombinedInterface> getUpperBoundProp() { return null; }
 
-    List<? super GroovyInterface> getLowerBoundProp() { return null; }
+    List<? super CombinedInterface> getLowerBoundProp() { return null; }
 
-    List<? super Set<? extends Map<?, GroovyInterface[]>>>[] getNestedProp() { return null; }
+    List<? super Set<? extends Map<?, CombinedInterface[]>>>[] getNestedProp() { return null; }
 
     <T extends JavaInterface> T paramMethod(T param) {
         return null;

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithStaticImport.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/JavaClassWithStaticImport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.build.docs;
 
-import org.gradle.internal.exceptions.Contextual;
+package org.gradle.test;
 
-@Contextual
-public class DocGenerationException extends RuntimeException {
-    public DocGenerationException(String message) {
-        super(message);
-    }
+import static java.util.Collections.emptyList;
 
-    public DocGenerationException(String message, Throwable throwable) {
-        super(message, throwable);
-    }
+import java.util.List;
+
+public class JavaClassWithStaticImport {
+    List<String> getProperty() { return emptyList(); }
 }

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub/SubClass.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub/SubClass.java
@@ -1,0 +1,4 @@
+package org.gradle.test.sub;
+
+public class SubClass {
+}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub/SubGroovyClass.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub/SubGroovyClass.groovy
@@ -1,4 +1,0 @@
-package org.gradle.test.sub
-
-class SubGroovyClass {
-}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub2/GroovyInterface.groovy
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub2/GroovyInterface.groovy
@@ -1,5 +1,0 @@
-package org.gradle.test.sub2
-
-public interface GroovyInterface {
-
-}

--- a/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub2/Sub2Interface.java
+++ b/buildSrc/subprojects/build/src/test/resources/org/gradle/test/sub2/Sub2Interface.java
@@ -1,0 +1,5 @@
+package org.gradle.test.sub2;
+
+public interface SubInterface {
+
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ContentFilterable.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ContentFilterable.java
@@ -70,6 +70,7 @@ public interface ContentFilterable {
      */
     ContentFilterable filter(Closure closure);
 
+    //TODO:rbo Change the parameter type to `Transformer<String, @Nullable String>` once we migrate to Java 8
     /**
      * Adds a content filter based on the provided transformer.  The Closure will be called with each line (stripped of line
      * endings) and should return a String to replace the line or {@code null} to remove the line.  If every line is
@@ -78,7 +79,6 @@ public interface ContentFilterable {
      * @param transformer to implement line based filtering
      * @return this
      */
-    //TODO:rbo Change the parameter type to `Transformer<String, @Nullable String>` once we migrate to Java 8
     ContentFilterable filter(Transformer<String, String> transformer);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/CopyProcessingSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/CopyProcessingSpec.java
@@ -46,6 +46,7 @@ public interface CopyProcessingSpec extends ContentFilterable {
      */
     CopyProcessingSpec rename(Closure closure);
 
+    //TODO:rbo Change the parameter type to `Transformer<String, @Nullable String>` once we migrate to Java 8
     /**
      * Renames a source file. The function will be called with a single parameter, the name of the file.
      * The function should return a new target name. The function may return null,
@@ -54,7 +55,6 @@ public interface CopyProcessingSpec extends ContentFilterable {
      * @param renamer rename function
      * @return this
      */
-    //TODO:rbo Change the parameter type to `Transformer<String, @Nullable String>` once we migrate to Java 8
     CopyProcessingSpec rename(Transformer<String, String> renamer);
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseWtpFacet.java
@@ -72,7 +72,6 @@ import static org.gradle.util.ConfigureUtil.configure;
  *
  * </pre>
  */
-
 public class EclipseWtpFacet {
 
     private final XmlFileContentMerger file;

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoTaskExtension.java
@@ -136,7 +136,7 @@ public class JacocoTaskExtension {
      *
      * @deprecated The Jacoco plugin now deletes the old coverage file before task execution, so the data will never be appended to an existing coverage file from another task.
      * Use {@link org.gradle.testing.jacoco.tasks.JacocoMerge} to merge different execution files or use {@link org.gradle.testing.jacoco.tasks.JacocoReportBase#setExecutionData(FileCollection)} to generate a report from multiple execution files at once.
-     * Append is set to true for the agent since this allows multiple JVMs spawned by one task to write to the same {@link #destinationFile}.
+     * Append is set to true for the agent since this allows multiple JVMs spawned by one task to write to the same {@link #getDestinationFile() destination file}.
      */
     @Deprecated
     @Input

--- a/subprojects/platform-play/src/main/java/org/gradle/play/PlayApplicationBinarySpec.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/PlayApplicationBinarySpec.java
@@ -62,11 +62,11 @@ public interface PlayApplicationBinarySpec extends ApplicationBinarySpec {
      */
     File getAssetsJarFile();
 
+    // TODO: Replace this with `JvmAssembly` once that type is public
     /**
      * A buildable object representing the class files and resources that will be included in the application jar file.
      * @return the JvmClasses for this binary
      */
-    // TODO: Replace this with `JvmAssembly` once that type is public
     JvmClasses getClasses();
 
     /**

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.plugins.signing;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -68,20 +67,6 @@ public class Sign extends DefaultTask implements SignatureSpec {
 
     private static final Pattern JAVA_PARTS = Pattern.compile("[^\\p{javaJavaIdentifierPart}]");
 
-    private static final Function<Signature, File> SIGNATURE_TO_SIGN_FILE_FUNCTION = new Function<Signature, File>() {
-        @Override
-        public File apply(Signature input) {
-            return input.getToSign();
-        }
-    };
-
-    private static final Function<Signature, File> SIGNATURE_FILE_FUNCTION = new Function<Signature, File>() {
-        @Override
-        public File apply(Signature input) {
-            return input.getFile();
-        }
-    };
-
     @Internal
     private SignatureType signatureType;
     /**
@@ -95,12 +80,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
 
     public Sign() {
         // If we aren't required and don't have a signatory then we just don't run
-        onlyIf(new Spec<Task>() {
-            @Override
-            public boolean isSatisfiedBy(Task element) {
-                return isRequired() || getSignatory() != null;
-            }
-        });
+        onlyIf(task -> isRequired() || getSignatory() != null);
 
         getInputs().property("signatory", new Callable<Object>() {
             @Override
@@ -114,7 +94,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputFiles
     public Iterable<File> getInputFiles() {
-        return Iterables.transform(signatures, SIGNATURE_TO_SIGN_FILE_FUNCTION);
+        return Iterables.transform(signatures, Signature::getToSign);
     }
 
     @OutputFiles
@@ -375,7 +355,7 @@ public class Sign extends DefaultTask implements SignatureSpec {
     @Internal
     public FileCollection getSignatureFiles() {
         return getFileCollectionFactory().fixed("Task \'" + getPath() + "\' signature files",
-            Lists.newLinkedList(Iterables.filter(Iterables.transform(signatures, SIGNATURE_FILE_FUNCTION), Predicates.notNull())));
+            Lists.newLinkedList(Iterables.filter(Iterables.transform(signatures, Signature::getFile), Predicates.notNull())));
     }
 
     public SignatureType getSignatureType() {

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/type/pgp/ArmoredSignatureType.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/type/pgp/ArmoredSignatureType.java
@@ -16,13 +16,13 @@
 package org.gradle.plugins.signing.type.pgp;
 
 import org.bouncycastle.bcpg.ArmoredOutputStream;
+import org.gradle.api.UncheckedIOException;
 import org.gradle.plugins.signing.signatory.Signatory;
 import org.gradle.plugins.signing.type.AbstractSignatureType;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
-import static org.gradle.internal.IoActions.uncheckedClose;
 
 /**
  * Armored signature type.
@@ -36,11 +36,10 @@ public class ArmoredSignatureType extends AbstractSignatureType {
 
     @Override
     public void sign(Signatory signatory, InputStream toSign, OutputStream destination) {
-        ArmoredOutputStream armoredOutputStream = new ArmoredOutputStream(destination);
-        try {
+        try (OutputStream armoredOutputStream = new ArmoredOutputStream(destination)) {
             super.sign(signatory, toSign, armoredOutputStream);
-        } finally {
-            uncheckedClose(armoredOutputStream);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }


### PR DESCRIPTION
The `dslMetaData` task now uses JavaParser instead of the Java parser that ships with Groovy and can now handle Java 7/8 language features as demonstrated by the second commit. Please note that I didn't refactor the `Sign` task completely, because there are pending changes in #7565. Support for Groovy files is removed because we no longer have any as part of the public API.