### PR TITLE
Alignment fixes

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -123,7 +123,9 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
         given:
         buildFile << """
             dependencies {
-                conf 'org:xml:1.0'
+                conf('org:xml:1.0') {
+                    transitive = false
+                }
                 conf 'org:json:1.0'
                 conf 'org:core:1.1'
             }
@@ -144,7 +146,6 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
             root(":", ":test:") {
                 edge("org:xml:1.0", "org:xml:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
-                    module('org:core:1.1')
                 }
                 edge("org:json:1.0", "org:json:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -642,7 +642,7 @@ include 'other'
 
     }
 
-    @Unroll
+    @Unroll("can force a virtual platform version by forcing the platform itself via a dependency")
     def "can force a virtual platform version by forcing the platform itself via a dependency"() {
         repository {
             ['2.7.9', '2.9.4', '2.9.4.1'].each {
@@ -673,7 +673,7 @@ include 'other'
                 edge("org:core:2.9.4", "org:core:2.7.9") {
                     forced()
                 }
-                module("org:databind:2.7.9") {
+                edge("org:databind:2.9.4", "org:databind:2.7.9") {
                     module('org:annotations:2.7.9')
                     module('org:core:2.7.9')
                 }
@@ -695,7 +695,7 @@ include 'other'
         where: "order of dependencies doesn't matter"
         dependencies << [
             'conf("org:core:2.9.4")',
-            'conf("org:databind:2.7.9")',
+            'conf("org:databind:2.9.4")',
             'conf("org:kotlin:2.9.4.1")',
             'conf enforcedPlatform("org:platform:2.7.9")'
         ].permutations()*.join("\n")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.Version;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.CandidateModule;
@@ -361,5 +362,14 @@ class ModuleResolveState implements CandidateModule {
             }
         }
         return false;
+    }
+
+    void maybeCreateVirtualMetadata(ResolveState resolveState) {
+        for (ComponentState componentState : versions.values()) {
+            if (componentState.getMetadata() == null) {
+                // TODO LJA Using the root as the NodeState here is a bit of a cheat, investigate if we can track the proper NodeState
+                componentState.setMetadata(new LenientPlatformResolveMetadata((ModuleComponentIdentifier) componentState.getComponentId(), componentState.getId(), platformState, resolveState.getRoot(), resolveState));
+            }
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -184,16 +184,7 @@ class NodeState implements DependencyGraphNode {
 
         // Check if there are any transitive incoming edges at all. Don't traverse if not.
         if (transitiveIncoming.isEmpty() && !isRoot()) {
-            // If node was previously traversed, need to remove outgoing edges.
-            if (previousTraversalExclusions != null) {
-                removeOutgoingEdges();
-            }
-            boolean hasIncomingEdges = !incomingEdges.isEmpty();
-            if (hasIncomingEdges) {
-                LOGGER.debug("{} has no transitive incoming edges. ignoring outgoing edges.", this);
-            } else {
-                LOGGER.debug("{} has no incoming edges. ignoring.", this);
-            }
+            handleNonTransitiveNode(discoveredEdges);
             return;
         }
 
@@ -216,6 +207,25 @@ class NodeState implements DependencyGraphNode {
 
         visitDependencies(resolutionFilter, discoveredEdges);
         visitOwners(discoveredEdges);
+    }
+
+    /**
+     * Removes outgoing edges from no longer transitive node
+     * Also process {@code belongsTo} if node still has edges at all.
+     *
+     * @param discoveredEdges In/Out parameter collecting dependencies or platforms
+     */
+    private void handleNonTransitiveNode(Collection<EdgeState> discoveredEdges) {
+        // If node was previously traversed, need to remove outgoing edges.
+        if (previousTraversalExclusions != null) {
+            removeOutgoingEdges();
+        }
+        if (!incomingEdges.isEmpty()) {
+            LOGGER.debug("{} has no transitive incoming edges. ignoring outgoing edges.", this);
+            visitOwners(discoveredEdges);
+        } else {
+            LOGGER.debug("{} has no incoming edges. ignoring.", this);
+        }
     }
 
     /**

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -284,6 +284,8 @@ class NodeState implements DependencyGraphNode {
             // the platform doesn't exist, so we're building a lenient one
             metadata = new LenientPlatformResolveMetadata(platformComponentIdentifier, potentialEdge.toModuleVersionId, virtualPlatformState, this, resolveState);
             potentialEdge.component.setMetadata(metadata);
+            // And now let's make sure we do not have another version of that virtual platform missing its metadata
+            potentialEdge.component.getModule().maybeCreateVirtualMetadata(resolveState);
         }
         if (virtualEdges == null) {
             virtualEdges = Lists.newArrayList();


### PR DESCRIPTION
* First commit: Before this change, in order to use a dependency or a constraint on a
virtual platform, the version specified had to appear on a real module
in the graph. Following this change, the version can be unused.
* Second commit: This change makes sure that `belongsTo` gets processed even if the
dependency it is added on is declared as `transitive = false`.