### PR TITLE
Fail early when plugin version is not supported

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigManager.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanConfigManager.java
@@ -29,6 +29,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import static org.gradle.internal.scan.config.BuildScanPluginCompatibility.UNSUPPORTED_PLUGIN_VERSION_MESSAGE;
+import static org.gradle.internal.scan.config.BuildScanPluginCompatibility.isNotSupported;
+
 /**
  * This is the meeting point between Gradle and the build scan plugin during initialization. This is effectively build scoped.
  */
@@ -105,11 +108,14 @@ class BuildScanConfigManager implements BuildScanConfigInit, BuildScanConfigProv
             throw new IllegalStateException("Configuration has already been collected.");
         }
 
+        VersionNumber pluginVersion = VersionNumber.parse(pluginMetadata.getVersion()).getBaseVersion();
+        if (isNotSupported(pluginVersion)) {
+            throw new UnsupportedBuildScanPluginVersionException(UNSUPPORTED_PLUGIN_VERSION_MESSAGE);
+        }
+
         collected = true;
         BuildScanConfig.Attributes configAttributes = this.configAttributes.create();
-
-        VersionNumber pluginVersion = VersionNumber.parse(pluginMetadata.getVersion()).getBaseVersion();
-        String unsupportedReason = compatibility.unsupportedReason(pluginVersion);
+        String unsupportedReason = compatibility.unsupportedReason();
 
         if (unsupportedReason != null) {
             if (isPluginAwareOfUnsupported(pluginVersion)) {

--- a/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/scan/config/BuildScanPluginCompatibility.java
@@ -30,20 +30,15 @@ class BuildScanPluginCompatibility {
     public static final String UNSUPPORTED_TOGGLE = "org.gradle.internal.unsupported-scan-plugin";
     public static final String UNSUPPORTED_TOGGLE_MESSAGE = "Build scan support disabled by secret toggle";
 
-    String unsupportedReason(VersionNumber pluginVersion) {
-        if (isEarlierThan(pluginVersion, MIN_SUPPORTED_VERSION)) {
-            return UNSUPPORTED_PLUGIN_VERSION_MESSAGE;
-        }
-
+    String unsupportedReason() {
         if (Boolean.getBoolean(UNSUPPORTED_TOGGLE)) {
             return UNSUPPORTED_TOGGLE_MESSAGE;
         }
-
         return null;
     }
 
-    private static boolean isEarlierThan(VersionNumber pluginVersion, VersionNumber minSupportedVersion) {
-        return pluginVersion.compareTo(minSupportedVersion) < 0;
+    static boolean isNotSupported(VersionNumber pluginVersion) {
+        return pluginVersion.compareTo(BuildScanPluginCompatibility.MIN_SUPPORTED_VERSION) < 0;
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/scan/config/BuildScanConfigManagerTest.groovy
@@ -86,6 +86,15 @@ class BuildScanConfigManagerTest extends Specification {
         }
     }
 
+    def "fails if plugin version is not supported"() {
+        when:
+        // 1.16 is older than BuildScanPluginCompatibility.MIN_SUPPORTED_VERSION, hence not supported
+        config("1.16")
+
+        then:
+        thrown(UnsupportedBuildScanPluginVersionException)
+    }
+
     BuildScanConfigManager manager() {
         def startParameter = Mock(StartParameter) {
             isBuildScan() >> scanEnabled

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -24,7 +24,7 @@ import static org.gradle.internal.scan.config.BuildScanPluginCompatibility.MIN_S
 
 class BuildScanPluginSmokeTest extends AbstractSmokeTest {
 
-    private static final List<String> GRACEFULLY_UNSUPPORTED_WITHOUT_FAILURE = [
+    private static final List<String> UNSUPPORTED = [
             "2.0.1",
             "2.0",
             "1.16",
@@ -50,13 +50,12 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     }
 
     @Unroll
-    "gracefully succeeds without capturing scan with unsupported version #version"() {
+    "fail without capturing scan with unsupported version #version"() {
         when:
-
         usePluginVersion version
 
         and:
-        def output = build("--scan").output
+        def output = buildAndFail("--scan").output
 
         then:
         output.contains("This version of Gradle requires version $MIN_SUPPORTED_VERSION of the build scan plugin or later.")
@@ -65,7 +64,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
         output.contains("Please see https://gradle.com/scans/help/gradle-incompatible-plugin-version for more information.")
 
         where:
-        version << GRACEFULLY_UNSUPPORTED_WITHOUT_FAILURE
+        version << UNSUPPORTED
     }
 
     BuildResult build(String... args) {


### PR DESCRIPTION
### Context
Fails early when an unsupported plugin is used. See https://github.com/gradle/gradle/pull/7560#issuecomment-433897853 for more context.