### PR TITLE
Improve init-command comments for Kotlin projects

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
@@ -54,7 +54,7 @@ public class KotlinApplicationProjectInitDescriptor extends LanguageLibraryProje
         buildScriptBuilder
             .fileComment("This generated file contains a sample Kotlin application project to get you started.")
             .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM", "org.jetbrains.kotlin.jvm", kotlinVersion)
-            .plugin("Apply the application to add support for building a CLI application", "application")
+            .plugin("Apply the application plugin to add support for building a CLI application", "application")
             .implementationDependency("Use the Kotlin JDK 8 standard library", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
             .testImplementationDependency("Use the Kotlin test library", "org.jetbrains.kotlin:kotlin-test")
             .testImplementationDependency("Use the Kotlin JUnit integration", "org.jetbrains.kotlin:kotlin-test-junit")

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinApplicationProjectInitDescriptor.java
@@ -53,13 +53,13 @@ public class KotlinApplicationProjectInitDescriptor extends LanguageLibraryProje
         String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
         buildScriptBuilder
             .fileComment("This generated file contains a sample Kotlin application project to get you started.")
-            .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM", "org.jetbrains.kotlin.jvm", kotlinVersion)
-            .plugin("Apply the application plugin to add support for building a CLI application", "application")
-            .implementationDependency("Use the Kotlin JDK 8 standard library", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-            .testImplementationDependency("Use the Kotlin test library", "org.jetbrains.kotlin:kotlin-test")
-            .testImplementationDependency("Use the Kotlin JUnit integration", "org.jetbrains.kotlin:kotlin-test-junit")
+            .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.", "org.jetbrains.kotlin.jvm", kotlinVersion)
+            .plugin("Apply the application plugin to add support for building a CLI application.", "application")
+            .implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+            .testImplementationDependency("Use the Kotlin test library.", "org.jetbrains.kotlin:kotlin-test")
+            .testImplementationDependency("Use the Kotlin JUnit integration.", "org.jetbrains.kotlin:kotlin-test-junit")
             .conventionPropertyAssignment(
-                "Define the main class for the application",
+                "Define the main class for the application.",
                 "application", "mainClassName", withPackage(settings, "AppKt"));
 
         TemplateOperation kotlinSourceTemplate = fromClazzTemplate("kotlinapp/App.kt.template", settings, "main");

--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinLibraryProjectInitDescriptor.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/KotlinLibraryProjectInitDescriptor.java
@@ -53,10 +53,10 @@ public class KotlinLibraryProjectInitDescriptor extends LanguageLibraryProjectIn
         String kotlinVersion = libraryVersionProvider.getVersion("kotlin");
         buildScriptBuilder
             .fileComment("This generated file contains a sample Kotlin library project to get you started.")
-            .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM", "org.jetbrains.kotlin.jvm", kotlinVersion)
-            .implementationDependency("Use the Kotlin JDK 8 standard library", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-            .testImplementationDependency("Use the Kotlin test library", "org.jetbrains.kotlin:kotlin-test")
-            .testImplementationDependency("Use the Kotlin JUnit integration", "org.jetbrains.kotlin:kotlin-test-junit");
+            .plugin("Apply the Kotlin JVM plugin to add support for Kotlin on the JVM.", "org.jetbrains.kotlin.jvm", kotlinVersion)
+            .implementationDependency("Use the Kotlin JDK 8 standard library.", "org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+            .testImplementationDependency("Use the Kotlin test library.", "org.jetbrains.kotlin:kotlin-test")
+            .testImplementationDependency("Use the Kotlin JUnit integration.", "org.jetbrains.kotlin:kotlin-test-junit");
 
         TemplateOperation kotlinSourceTemplate = fromClazzTemplate("kotlinlibrary/Library.kt.template", settings, "main");
         TemplateOperation kotlinTestTemplate = fromClazzTemplate("kotlinlibrary/LibraryTest.kt.template", settings, "test");


### PR DESCRIPTION
### Context

These are generic consistency fixes for comments generated by the `init` command for Kotlin projects.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
