### PR TITLE
Make disabling worker daemon expiration intrinsic to the worker daemon itself

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -716,7 +716,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
 
     @Override
     public GradleExecuter withWorkerDaemonsExpirationDisabled() {
-        return withBuildJvmOpts("-Dorg.gradle.workers.internal.disable-daemons-expiration=true");
+        return withCommandLineGradleOpts("-Dorg.gradle.workers.internal.disable-daemons-expiration=true");
     }
 
     @Override

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonExpirationIntegrationTest.groovy
@@ -84,6 +84,6 @@ class WorkerDaemonExpirationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         outputDoesNotContain('Worker Daemon(s) expired to free some system memory')
-        outputContains 'Worker Daemons expiration is disabled, skipping'
+        outputContains 'Worker Daemon(s) had expiration disabled and were skipped'
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkerDaemonClient.java
@@ -23,12 +23,14 @@ import org.gradle.process.internal.health.memory.JvmMemoryStatus;
 import org.gradle.process.internal.worker.WorkerProcess;
 
 class WorkerDaemonClient implements Worker, Stoppable {
+    public static final String DISABLE_EXPIRATION_PROPERTY_KEY = "org.gradle.workers.internal.disable-daemons-expiration";
     private final DaemonForkOptions forkOptions;
     private final WorkerDaemonProcess workerDaemonProcess;
     private final WorkerProcess workerProcess;
     private final LogLevel logLevel;
     private int uses;
     private boolean failed;
+    private boolean cannotBeExpired = Boolean.getBoolean(DISABLE_EXPIRATION_PROPERTY_KEY);
 
     public WorkerDaemonClient(DaemonForkOptions forkOptions, WorkerDaemonProcess workerDaemonProcess, WorkerProcess workerProcess, LogLevel logLevel) {
         this.forkOptions = forkOptions;
@@ -87,5 +89,9 @@ class WorkerDaemonClient implements Worker, Stoppable {
 
     public void setFailed(boolean failed) {
         this.failed = failed;
+    }
+
+    public boolean isNotExpirable() {
+        return cannotBeExpired;
     }
 }


### PR DESCRIPTION
Another attempt at fixing flakiness around daemons expiring while `WorkerDaemonLifecycleTest` tests are running.