### PR TITLE
Add two graphs to individual performance test page 

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
@@ -57,24 +57,24 @@ public class FormatSupport {
     }
 
     public static Number getDifferencePercentage(MeasuredOperationList baseline, MeasuredOperationList current) {
-        return new BigDecimal(100.0 * getDifference(baseline.getTotalTime(), current.getTotalTime()).doubleValue()).setScale(2, RoundingMode.HALF_UP);
+        return new BigDecimal(100.0 * getDifferenceRatio(baseline.getTotalTime(), current.getTotalTime()).doubleValue()).setScale(2, RoundingMode.HALF_UP);
     }
 
-    public static Number getDifference(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
+    public static Number getDifferenceRatio(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
         double base = baselineVersion.getMedian().getValue().doubleValue();
         double current = currentVersion.getMedian().getValue().doubleValue();
         return (current - base) / base;
     }
 
-    public static String formatDifference(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
+    public static String getFormattedDifference(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
         Amount<Duration> base = baselineVersion.getMedian();
         Amount<Duration> current = currentVersion.getMedian();
         Amount<Duration> diff = current.minus(base);
 
-        return String.format("%s (%.2f%%)", diff.format(), FormatSupport.getDifference(baselineVersion, currentVersion).doubleValue());
+        return String.format("%s (%.2f%%)", diff.format(), FormatSupport.getDifferenceRatio(baselineVersion, currentVersion).doubleValue());
     }
 
-    public static String formatConfidence(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
+    public static String getFormattedConfidence(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
         return String.format("%.1f%%", 100.0 * confidenceInDifference(baselineVersion, currentVersion));
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
@@ -17,40 +17,64 @@
 package org.gradle.performance.results;
 
 import org.gradle.performance.measure.Amount;
-import org.gradle.performance.measure.DataAmount;
+import org.gradle.performance.measure.DataSeries;
 import org.gradle.performance.measure.Duration;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import static org.gradle.performance.measure.DataSeries.confidenceInDifference;
+
 public class FormatSupport {
-    private final DateFormat timeStampFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-    private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+    public static String executionTimestamp() {
+        return timestamp(new Date());
+    }
 
-    public FormatSupport() {
+    public static String timestamp(Date date) {
+        return format(date, "yyyy-MM-dd HH:mm:ss");
+    }
+
+    public static String date(Date date) {
+        return format(date, "yyyy-MM-dd");
+    }
+
+    private static String format(Date date, String format) {
+        DateFormat timeStampFormat = new SimpleDateFormat(format);
         timeStampFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
-
-    public String executionTimestamp() {
-        return timeStampFormat.format(new Date());
-    }
-
-    public String timestamp(Date date) {
         return timeStampFormat.format(date);
     }
 
-    public String date(Date date) {
-        return dateFormat.format(date);
+    public static Number getTotalTimeSeconds(MeasuredOperationList baseline, MeasuredOperationList current) {
+        return baseline.getTotalTime().getMedian().toUnits(Duration.SECONDS).getValue();
     }
 
-    public String seconds(Amount<Duration> duration) {
-        return duration.toUnits(Duration.SECONDS).getValue().toString();
+    public static Number getConfidencePercentage(MeasuredOperationList baseline, MeasuredOperationList current) {
+        return new BigDecimal(100.0 * confidenceInDifference(baseline.getTotalTime(), current.getTotalTime())).setScale(2, RoundingMode.HALF_UP);
     }
 
-    public String megabytes(Amount<DataAmount> amount) {
-        return amount.toUnits(DataAmount.MEGA_BYTES).getValue().toString();
+    public static Number getDifferencePercentage(MeasuredOperationList baseline, MeasuredOperationList current) {
+        return new BigDecimal(100.0 * getDifference(baseline.getTotalTime(), current.getTotalTime()).doubleValue()).setScale(2, RoundingMode.HALF_UP);
+    }
+
+    public static Number getDifference(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
+        double base = baselineVersion.getMedian().getValue().doubleValue();
+        double current = currentVersion.getMedian().getValue().doubleValue();
+        return (current - base) / base;
+    }
+
+    public static String formatDifference(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
+        Amount<Duration> base = baselineVersion.getMedian();
+        Amount<Duration> current = currentVersion.getMedian();
+        Amount<Duration> diff = current.minus(base);
+
+        return String.format("%s (%.2f%%)", diff.format(), FormatSupport.getDifference(baselineVersion, currentVersion).doubleValue());
+    }
+
+    public static String formatConfidence(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {
+        return String.format("%.1f%%", 100.0 * confidenceInDifference(baselineVersion, currentVersion));
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
@@ -34,10 +34,14 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
+
+import static org.gradle.performance.results.FormatSupport.executionTimestamp;
+import static org.gradle.performance.results.FormatSupport.getDifferenceRatio;
+import static org.gradle.performance.results.FormatSupport.getFormattedConfidence;
+import static org.gradle.performance.results.FormatSupport.getFormattedDifference;
 
 public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
     protected int getDepth() {
@@ -78,7 +82,7 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
     protected void footer(Html html) {
         html.div()
             .id("footer")
-            .text(String.format("Generated at %s by %s", FormatSupport.executionTimestamp(), GradleVersion.current()))
+            .text(String.format("Generated at %s by %s", executionTimestamp(), GradleVersion.current()))
             .end();
     }
 
@@ -169,8 +173,8 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                 .map((DataSeries<Duration> data) -> data.isEmpty() ? null : data)
                 .collect(Collectors.toList());
 
-            Amount<Duration> min = totalTimeMedianStream(experiments).min(Comparator.comparing(Function.identity())).orElse(null);
-            Amount<Duration> max = totalTimeMedianStream(experiments).max(Comparator.comparing(Function.identity())).orElse(null);
+            Amount<Duration> min = totalTimeMedianStream(experiments).min(Comparator.naturalOrder()).orElse(null);
+            Amount<Duration> max = totalTimeMedianStream(experiments).max(Comparator.naturalOrder()).orElse(null);
 
             if (min != null && min.equals(max)) {
                 min = null;
@@ -206,10 +210,10 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
             Optional<DataSeries<Duration>> first = executionVersions.stream().filter(Objects::nonNull).findFirst();
             Optional<DataSeries<Duration>> last = Lists.reverse(executionVersions).stream().filter(Objects::nonNull).findFirst();
             if (first.isPresent() && last.isPresent() && first.get() != last.get()) {
-                td().classAttr("numeric").text(FormatSupport.formatConfidence(first.get(), last.get())).end();
+                td().classAttr("numeric").text(getFormattedConfidence(first.get(), last.get())).end();
 
-                String differenceCss = FormatSupport.getDifference(first.get(), last.get()).doubleValue() > 0 ? "max-value" : "min-value";
-                td().classAttr("numeric " + differenceCss).text(FormatSupport.formatDifference(first.get(), last.get())).end();
+                String differenceCss = getDifferenceRatio(first.get(), last.get()).doubleValue() > 0 ? "max-value" : "min-value";
+                td().classAttr("numeric " + differenceCss).text(getFormattedDifference(first.get(), last.get())).end();
             } else {
                 td().text("").end();
                 td().text("").end();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/HtmlPageGenerator.java
@@ -18,25 +18,28 @@ package org.gradle.performance.results;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 import com.googlecode.jatl.Html;
-import org.gradle.api.Transformer;
 import org.gradle.performance.measure.Amount;
 import org.gradle.performance.measure.DataSeries;
-import org.gradle.performance.util.Git;
+import org.gradle.performance.measure.Duration;
 import org.gradle.reporting.ReportRenderer;
 import org.gradle.util.GradleVersion;
 
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
 import java.net.URLEncoder;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
-    protected final FormatSupport format = new FormatSupport();
-
     protected int getDepth() {
         return 0;
     }
@@ -75,7 +78,7 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
     protected void footer(Html html) {
         html.div()
             .id("footer")
-            .text(String.format("Generated at %s by %s", format.executionTimestamp(), GradleVersion.current()))
+            .text(String.format("Generated at %s by %s", FormatSupport.executionTimestamp(), GradleVersion.current()))
             .end();
     }
 
@@ -153,37 +156,34 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
             th().colspan(String.valueOf(getColumnsForSamples())).text(label).end();
         }
 
-        protected <T> void renderSamplesForExperiment(Iterable<MeasuredOperationList> experiments, Transformer<DataSeries<T>, MeasuredOperationList> transformer) {
-            List<DataSeries<T>> values = new ArrayList<DataSeries<T>>();
-            Amount<T> min = null;
-            Amount<T> max = null;
-            for (MeasuredOperationList testExecution : experiments) {
-                DataSeries<T> data = transformer.transform(testExecution);
-                if (data.isEmpty()) {
-                    values.add(null);
-                } else {
-                    Amount<T> value = data.getMedian();
-                    values.add(data);
-                    if (min == null || value.compareTo(min) < 0) {
-                        min = value;
-                    }
-                    if (max == null || value.compareTo(max) > 0) {
-                        max = value;
-                    }
-                }
-            }
+        private Stream<DataSeries<Duration>> totalTimeStream(Iterable<MeasuredOperationList> experiments) {
+            return StreamSupport.stream(experiments.spliterator(), false).map(MeasuredOperationList::getTotalTime);
+        }
+
+        private Stream<Amount<Duration>> totalTimeMedianStream(Iterable<MeasuredOperationList> experiments) {
+            return totalTimeStream(experiments).filter((DataSeries<Duration> data) -> !data.isEmpty()).map(DataSeries::getMedian);
+        }
+
+        protected void renderSamplesForExperiment(Iterable<MeasuredOperationList> experiments) {
+            List<DataSeries<Duration>> executionVersions = totalTimeStream(experiments)
+                .map((DataSeries<Duration> data) -> data.isEmpty() ? null : data)
+                .collect(Collectors.toList());
+
+            Amount<Duration> min = totalTimeMedianStream(experiments).min(Comparator.comparing(Function.identity())).orElse(null);
+            Amount<Duration> max = totalTimeMedianStream(experiments).max(Comparator.comparing(Function.identity())).orElse(null);
+
             if (min != null && min.equals(max)) {
                 min = null;
                 max = null;
             }
 
-            for (DataSeries<T> data : values) {
+            for (DataSeries<Duration> data : executionVersions) {
                 if (data == null) {
                     td().text("").end();
                     td().text("").end();
                 } else {
-                    Amount<T> value = data.getMedian();
-                    Amount<T> se = data.getStandardError();
+                    Amount<Duration> value = data.getMedian();
+                    Amount<Duration> se = data.getStandardError();
                     String classAttr = "numeric";
                     if (value.equals(min)) {
                         classAttr += " min-value";
@@ -202,20 +202,19 @@ public abstract class HtmlPageGenerator<T> extends ReportRenderer<T, Writer> {
                         .end();
                 }
             }
-        }
-    }
 
-    protected List<? extends PerformanceTestExecution> filterForRequestedCommit(List<? extends PerformanceTestExecution> results) {
-        String commitId = Git.current().getCommitId();
-        if (commitId == null) {
-            return results;
-        }
-        for (PerformanceTestExecution execution : results) {
-            if (execution.getVcsCommits().contains(commitId)) {
-                return results;
+            Optional<DataSeries<Duration>> first = executionVersions.stream().filter(Objects::nonNull).findFirst();
+            Optional<DataSeries<Duration>> last = Lists.reverse(executionVersions).stream().filter(Objects::nonNull).findFirst();
+            if (first.isPresent() && last.isPresent() && first.get() != last.get()) {
+                td().classAttr("numeric").text(FormatSupport.formatConfidence(first.get(), last.get())).end();
+
+                String differenceCss = FormatSupport.getDifference(first.get(), last.get()).doubleValue() > 0 ? "max-value" : "min-value";
+                td().classAttr("numeric " + differenceCss).text(FormatSupport.formatDifference(first.get(), last.get())).end();
+            } else {
+                td().text("").end();
+                td().text("").end();
             }
         }
-        return Collections.emptyList();
     }
 
     protected String urlEncode(String str) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -294,7 +294,7 @@ public class IndexPageGenerator extends HtmlPageGenerator<ResultsStore> {
                         tr();
                             DataSeries<Duration> baseVersion = execution.getBaseVersion().getTotalTime();
                             DataSeries<Duration> currentVersion = execution.getCurrentVersion().getTotalTime();
-                            td().text(format.timestamp(execution.getTime())).end();
+                            td().text(FormatSupport.timestamp(execution.getTime())).end();
                             td().a().target("_blank").href("https://github.com/gradle/gradle/commits/" + execution.getCommitId()).text(execution.getCommitId()).end().end();
                             td().classAttr(baseVersion.getMedian().compareTo(currentVersion.getMedian()) < 0 ? "text-success" : "text-danger").text(baseVersion.getMedian().format()).end();
                             td().classAttr("text-muted").text("se: " + baseVersion.getStandardError().format()).end();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -104,7 +104,7 @@ class ScenarioBuildResultData {
         }
 
         String getDifferenceDisplay() {
-            return FormatSupport.formatDifference(baseVersion.totalTime, currentVersion.totalTime)
+            return FormatSupport.getFormattedDifference(baseVersion.totalTime, currentVersion.totalTime)
         }
 
         double getDifferencePercentage() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -17,7 +17,6 @@
 package org.gradle.performance.results
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
-import org.gradle.performance.measure.Amount
 import org.gradle.performance.measure.DataSeries
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -52,7 +51,7 @@ class ScenarioBuildResultData {
     }
 
     boolean isBuildFailed() {
-        return status == 'FAILURE'  && currentBuildExecutions.empty
+        return status == 'FAILURE' && currentBuildExecutions.empty
     }
 
     boolean isRegressed() {
@@ -105,17 +104,11 @@ class ScenarioBuildResultData {
         }
 
         String getDifferenceDisplay() {
-            Amount base = baseVersion.totalTime.median
-            Amount current = currentVersion.totalTime.median
-            Amount diff = current - base
-
-            return String.format("%s (%s)", diff.format(), formattedDifferencePercentage)
+            return FormatSupport.formatDifference(baseVersion.totalTime, currentVersion.totalTime)
         }
 
         double getDifferencePercentage() {
-            double base = baseVersion.totalTime.median.value.doubleValue()
-            double current = currentVersion.totalTime.median.value.doubleValue()
-            return 100.0 * (current - base) / base
+            return FormatSupport.getDifferencePercentage(baseVersion, currentVersion).doubleValue()
         }
 
         double getConfidencePercentage() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -16,78 +16,151 @@
 
 package org.gradle.performance.results;
 
-import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
-import org.gradle.api.Transformer;
+import groovy.json.JsonGenerator;
 import org.gradle.reporting.ReportRenderer;
 
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Writer> {
-    protected final FormatSupport format = new FormatSupport();
 
     @Override
     public void render(PerformanceTestHistory testHistory, Writer output) throws IOException {
         PrintWriter out = new PrintWriter(output);
         List<? extends PerformanceTestExecution> sortedResults = Lists.reverse(testHistory.getExecutions());
-        out.println("{");
-        out.println("\"executionLabels\": [");
-        for (int i = 0; i < sortedResults.size(); i++) {
-            PerformanceTestExecution results = sortedResults.get(i);
-            if (i > 0) {
-                out.println(", ");
-            }
-            out.print("{");
-            out.print("\"id\": \"" + results.getExecutionId() + "\"");
-            out.print(", \"branch\":\"" + results.getVcsBranch() + "\"");
-            out.print(", \"date\":\"" + format.date(new Date(results.getStartTime())) + "\"");
-            out.print(", \"commits\":[\"");
-            out.print(Joiner.on("\",\"").join(results.getVcsCommits()));
-            out.print("\"]");
-            out.print("}");
-        }
-        out.println("],");
-        out.print("\"totalTime\":");
-        render(testHistory, new Transformer<String, MeasuredOperationList>() {
-            public String transform(MeasuredOperationList original) {
-                return format.seconds(original.getTotalTime().getMedian());
-            }
-        }, out);
-        out.println("}");
+
+        List<ExecutionLabel> executionLabels = sortedResults.stream().map(ExecutionLabel::new).collect(Collectors.toList());
+        List<ExecutionData> totalTimeData = testHistory.getScenarioLabels()
+            .stream()
+            .map(label -> executionDataForLabel(testHistory, label, FormatSupport::getTotalTimeSeconds, Function.identity()))
+            .collect(Collectors.toList());
+        List<ExecutionData> confidenceData = extractBaselineData(testHistory, FormatSupport::getConfidencePercentage);
+        List<ExecutionData> differenceData = extractBaselineData(testHistory, FormatSupport::getDifferencePercentage);
+
+        String json = new JsonGenerator.Options().excludeNulls().build().toJson(new AllExecutionData(executionLabels, totalTimeData, confidenceData, differenceData));
+        out.print(json);
         out.flush();
     }
 
-    void render(PerformanceTestHistory testHistory, Transformer<String, MeasuredOperationList> valueRenderer, PrintWriter out) {
-        List<? extends PerformanceTestExecution> sortedResults = Lists.reverse(testHistory.getExecutions());
-        out.println("  [");
-        List<String> labels = testHistory.getScenarioLabels();
-        for (int i = 0; i < labels.size(); i++) {
-            if (i > 0) {
-                out.println(",");
-            }
-            out.println("  {");
-            out.println("    \"label\": \"" + labels.get(i) + "\",");
-            out.print("\"data\": [");
-            boolean empty = true;
-            for (int j = 0; j < sortedResults.size(); j++) {
-                PerformanceTestExecution results = sortedResults.get(j);
-                MeasuredOperationList measuredOperations = results.getScenarios().get(i);
-                if (!measuredOperations.isEmpty()) {
-                    if (!empty) {
-                        out.print(", ");
-                    }
-                    out.print("[" + j + ", " + valueRenderer.transform(measuredOperations) + "]");
-                    empty = false;
-                }
-            }
-            out.println("]");
-            out.print("  }");
+    private List<ExecutionData> extractBaselineData(PerformanceTestHistory testHistory, DataExtractor dataExtractor) {
+        if (testHistory instanceof CrossVersionPerformanceTestHistory) {
+            return ((CrossVersionPerformanceTestHistory) testHistory).getBaselineVersions()
+                .stream()
+                .map(label -> executionDataForLabel(testHistory, label, dataExtractor, mainVsBaselineLabelFormatter(testHistory)))
+                .collect(Collectors.toList());
+        } else {
+            return null;
         }
-        out.println();
-        out.println("]");
+    }
+
+    private ExecutionData executionDataForLabel(PerformanceTestHistory testHistory, String label, DataExtractor dataExtractor, Function<String, String> labelFormatter) {
+        List<? extends PerformanceTestExecution> sortedExecutions = Lists.reverse(testHistory.getExecutions());
+        List<List<Number>> data = IntStream.range(0, sortedExecutions.size()).mapToObj(index -> {
+            PerformanceTestExecution results = sortedExecutions.get(index);
+            MeasuredOperationList baselineVersion = results.getScenarios().get(testHistory.getScenarioLabels().indexOf(label));
+            MeasuredOperationList currentVersion = results.getScenarios().get(testHistory.getScenarioLabels().size() - 1);
+            return baselineVersion.isEmpty() ? null : Arrays.asList(index, dataExtractor.apply(baselineVersion, currentVersion));
+        }).filter(Objects::nonNull).collect(Collectors.toList());
+        return new ExecutionData(labelFormatter.apply(label), data);
+    }
+
+    private Function<String, String> mainVsBaselineLabelFormatter(PerformanceTestHistory testHistory) {
+        return label -> {
+            String mainLabel = testHistory.getScenarioLabels().get(testHistory.getScenarioLabels().size() - 1);
+            return mainLabel + " vs " + label;
+        };
+    }
+
+    private interface DataExtractor extends BiFunction<MeasuredOperationList, MeasuredOperationList, Number> {
+        @Override
+        Number apply(MeasuredOperationList baseline, MeasuredOperationList current);
+    }
+
+    static class AllExecutionData {
+        private List<ExecutionLabel> executionLabels;
+        private List<ExecutionData> totalTime;
+        private List<ExecutionData> confidence;
+        private List<ExecutionData> difference;
+
+        AllExecutionData(List<ExecutionLabel> executionLabels, List<ExecutionData> totalTime, List<ExecutionData> confidence, List<ExecutionData> difference) {
+            this.executionLabels = executionLabels;
+            this.totalTime = totalTime;
+            this.confidence = confidence;
+            this.difference = difference;
+        }
+
+        public List<ExecutionLabel> getExecutionLabels() {
+            return executionLabels;
+        }
+
+        public List<ExecutionData> getTotalTime() {
+            return totalTime;
+        }
+
+        public List<ExecutionData> getConfidence() {
+            return confidence;
+        }
+
+        public List<ExecutionData> getDifference() {
+            return difference;
+        }
+    }
+
+    static class ExecutionData {
+        private String label;
+        private List<List<Number>> data;
+
+        private ExecutionData(String label, List<List<Number>> data) {
+            this.label = label;
+            this.data = data;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public List<List<Number>> getData() {
+            return data;
+        }
+    }
+
+    class ExecutionLabel {
+        private String id;
+        private String branch;
+        private String date;
+        private List<String> commits;
+
+        private ExecutionLabel(PerformanceTestExecution execution) {
+            this.id = execution.getExecutionId();
+            this.branch = execution.getVcsBranch();
+            this.date = FormatSupport.date(new Date(execution.getStartTime()));
+            this.commits = execution.getVcsCommits();
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getBranch() {
+            return branch;
+        }
+
+        public String getDate() {
+            return date;
+        }
+
+        public List<String> getCommits() {
+            return commits;
+        }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -60,7 +60,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             p().text("Tasks: " + getTasks(testHistory)).end();
             p().text("Clean tasks: " + getCleanTasks(testHistory)).end();
 
-                addPerformanceGraphs();
+            addPerformanceGraphs();
 
             div().id("tooltip").end();
             div().id("controls").end();
@@ -197,9 +197,9 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 }
 
                 charts.forEach(chart -> {
-                    h3().text(StringUtils.capitalize(chart.getLabel())).end();
+                    h3().text(StringUtils.capitalize(chart.getLabel()) + " (" + chart.getUnit() + ")").end();
                     div().classAttr("chart").id(chart.getChartId());
-                        p().text("Locading...").end();
+                        p().text("Loading...").end();
                     end();
                 });
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -20,10 +20,8 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.googlecode.jatl.Html;
+import groovy.json.JsonOutput;
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.Transformer;
-import org.gradle.performance.measure.DataSeries;
-import org.gradle.performance.measure.Duration;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -48,6 +46,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
     @Override
     public void render(final PerformanceTestHistory testHistory, Writer writer) throws IOException {
         // TODO: Add test name to the report
+        // @formatter:off
         new MetricsHtml(writer) {{
             html();
             head();
@@ -61,7 +60,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             p().text("Tasks: " + getTasks(testHistory)).end();
             p().text("Clean tasks: " + getCleanTasks(testHistory)).end();
 
-            addPerformanceGraph("Average total time", "totalTimeChart", "totalTime", "total time", "s");
+                addPerformanceGraphs();
 
             div().id("tooltip").end();
             div().id("controls").end();
@@ -105,6 +104,8 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             for (String label : testHistory.getScenarioLabels()) {
                 renderHeaderForSamples(label);
             }
+            th().text("Confidence").end();
+            th().text("Difference").end();
             th().text("Test version").end();
             th().text("Operating System").end();
             th().text("Host").end();
@@ -128,12 +129,7 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 renderVcsLinks(results, findPreviousExecutionInSameBranch(results, testHistory, i));
                 end();
 
-                final List<MeasuredOperationList> scenarios = results.getScenarios();
-                renderSamplesForExperiment(scenarios, new Transformer<DataSeries<Duration>, MeasuredOperationList>() {
-                    public DataSeries<Duration> transform(MeasuredOperationList original) {
-                        return original.getTotalTime();
-                    }
-                });
+                renderSamplesForExperiment(results.getScenarios());
                 textCell(results.getVersionUnderTest());
                 textCell(results.getOperatingSystem());
                 textCell(results.getHost());
@@ -154,8 +150,8 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
 
             private void renderDateAndLink(PerformanceTestExecution results) {
                 td();
-                    String date = format.timestamp(new Date(results.getStartTime()));
-                    if(results.getTeamCityBuildId() == null) {
+                    String date = FormatSupport.timestamp(new Date(results.getStartTime()));
+                    if (results.getTeamCityBuildId() == null) {
                         text(date);
                     } else {
                         a().href("https://builds.gradle.org/viewLog.html?buildId=" + results.getTeamCityBuildId()).target("_blank").text(date).end();
@@ -193,16 +189,56 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 return previousResults;
             }
 
-            private void addPerformanceGraph(String heading, String chartId, String jsonFieldName, String fieldLabel, String fieldUnit) {
-                h3().text(heading).end();
-                div().id(chartId).classAttr("chart");
-                p().text("Loading...").end();
+            private void addPerformanceGraphs() {
+                List<Chart> charts = Lists.newArrayList(new Chart("totalTime", "total time", "s", "totalTimeChart"));
+                if(testHistory instanceof CrossVersionPerformanceTestHistory) {
+                    charts.add(new Chart("confidence", "confidence", "%", "confidenceChart"));
+                    charts.add(new Chart("difference", "difference", "%", "differenceChart"));
+                }
+
+                charts.forEach(chart -> {
+                    h3().text(StringUtils.capitalize(chart.getLabel())).end();
+                    div().classAttr("chart").id(chart.getChartId());
+                        p().text("Locading...").end();
+                    end();
+                });
+
                 script();
-                text("performanceTests.createPerformanceGraph('" + urlEncode(testHistory.getId()) + ".json', function(data) { return data." + jsonFieldName + "}, '" + fieldLabel + "', '" + fieldUnit + "', '" + chartId + "');");
-                end();
+                    raw("performanceTests.createPerformanceGraph('" + urlEncode(testHistory.getId()) + ".json', " + JsonOutput.toJson(charts) + ")");
                 end();
             }
         };
+    }
+    // @formatter:on
+
+    private static class Chart {
+        private String field;
+        private String label;
+        private String unit;
+        private String chartId;
+
+        private Chart(String field, String label, String unit, String chartId) {
+            this.field = field;
+            this.label = label;
+            this.unit = unit;
+            this.chartId = chartId;
+        }
+
+        public String getField() {
+            return field;
+        }
+
+        public String getLabel() {
+            return label;
+        }
+
+        public String getUnit() {
+            return unit;
+        }
+
+        public String getChartId() {
+            return chartId;
+        }
     }
 
     private static String getTasks(PerformanceTestHistory testHistory) {

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
@@ -1,113 +1,137 @@
 (function ($) {
-  var renderCommitIds = function(commits) {
-    return commits.map(function(commit) {
-        return commit.substring(0, 7);
-    }).join('|');
-  }
+    var renderCommitIds = function(commits) {
+        return commits.map(function(commit) {
+            return commit.substring(0, 7);
+        }).join('|');
+    }
 
-  var plots = [];
+    var plots = [];
 
-  var togglePlot = function(chartId, label) {
-    var plot = plots[chartId];
-    var plotData = plot.getData();
-    $.each(plotData, function(index, value) {
-        if(value.label == label) {
-            value.points.show = value.lines.show = !value.lines.show;
+    var togglePlot = function(chartId, label) {
+        var plot = plots[chartId];
+        var plotData = plot.getData();
+        $.each(plotData, function(index, value) {
+            if(value.label == label) {
+                value.points.show = value.lines.show = !value.lines.show;
+            }
+        });
+        plot.setData(plotData);
+        plot.draw();
+    }
+
+    function renderGraphs(allDataJson, charts) {
+        charts.forEach(function(chart) {
+            renderGraph(allDataJson[chart.field], allDataJson.executionLabels, chart.label, chart.unit, chart.chartId)
+        })
+    }
+
+    function renderGraph(data, executionLabels, label, unit, chartId) {
+        if(!data) {
+            return
         }
-    });
-    plot.setData(plotData);
-    plot.draw();
-  }
-
-  var createPerformanceGraph = function(jsonFile, dataSelector, label, unit, chartId) {
-    $(function() {
-      $.ajax({ url: jsonFile, dataType: 'json',
-        success: function(allData) {
-          var executionLabels = allData.executionLabels;
-          var options = {
+        var options = {
             series: {
-              points: { show: true },
-              lines: { show: true }
+                points: { show: true },
+                lines: { show: true }
             },
             legend: {
-                noColumns: 0,
+                noColumns: 2,
                 margin: 1,
                 position: "se",
                 labelFormatter:
                     function(label, series) {
-                       return '<a href="#" class="chart-legend" onClick="performanceTests.togglePlot(\''+chartId+'\', \''+label+'\'); return false;">'+label+'</a>';
+                        return '<a href="#" class="chart-legend" onClick="performanceTests.togglePlot(\''+chartId+'\', \''+label+'\'); return false;">'+label+'</a>';
                     }
             },
             grid: { hoverable: true, clickable: true },
             xaxis: { tickFormatter:
-                function(index, value) {
-                    if (index === parseInt(index, 10)) { // portable way to check if sth is an integer
-                        var executionLabel = executionLabels[index];
-                        return executionLabel ? executionLabel.date : "";
-                    } else {
-                        return "";
+                    function(index, value) {
+                        if (index === parseInt(index, 10)) { // portable way to check if sth is an integer
+                            var executionLabel = executionLabels[index];
+                            return executionLabel ? executionLabel.date : "";
+                        } else {
+                            return "";
+                        }
                     }
-                }
             },
-            yaxis: { min: 0 }, selection: { mode: 'xy' } };
-          var data = dataSelector(allData)
-          var chart = $.plot('#' + chartId, data, options);
-          plots[chartId] = chart;
-          var zoomFunction = function(plot, reset) {
+            yaxis: { min: determineMinY(data, unit) }, selection: { mode: 'xy' } };
+        var chart = $.plot('#' + chartId, data, options);
+        plots[chartId] = chart;
+        var zoomFunction = function(plot, reset) {
             var reset = reset || false;
             return function (event, ranges) {
-              $.each(plot.getXAxes(), function(_, axis) {
-                var opts = axis.options;
-                opts.min = reset ? null : ranges.xaxis.from;
-                opts.max = reset ? null : ranges.xaxis.to;
-              });
-              $.each(plot.getYAxes(), function(_, axis) {
-                var opts = axis.options;
-                opts.min = reset ? 0 : ranges.yaxis.from;
-                opts.max = reset ? null : ranges.yaxis.to;
-              });
-              plot.setupGrid();
-              plot.draw();
-              plot.clearSelection();
-            };
-          };
-          $('#' + chartId).bind('plothover', function (event, pos, item) {
-            if (!item) {
-              $('#tooltip').hide();
-            } else {
-              var executionLabel = executionLabels[item.datapoint[0]];
-              var revLabel;
-              if(item.series.label == executionLabel.branch) {
-                revLabel = 'rev: ' + renderCommitIds(executionLabel.commits) + '/' + executionLabel.branch;
-              } else {
-                revLabel = 'Version: ' + item.series.label;
-              }
-              var text = revLabel + ', date: ' + executionLabel.date + ', '+ label + ' ' + item.datapoint[1] + unit;
-              $('#tooltip').html(text).css({top: item.pageY - 10, left: item.pageX + 10}).show();
-            }
-          }).bind('plotselected', zoomFunction(chart)).bind('dblclick', zoomFunction(chart, true))
-          .bind("plotclick",
-            function (event, pos, item) {
-              var executionLabel = executionLabels[item.datapoint[0]];
-              var resultRowId = 'result' + executionLabel.id;
-              var resultRow = $('#' + resultRowId);
-              if (resultRow) {
-                $('.history tr').css("background-color","");
-                resultRow.css("background-color","orange");
-                $('html, body').animate({scrollTop: resultRow.offset().top}, 1000, function() {
-                    window.location.hash = resultRowId;
+                $.each(plot.getXAxes(), function(_, axis) {
+                    var opts = axis.options;
+                    opts.min = reset ? null : ranges.xaxis.from;
+                    opts.max = reset ? null : ranges.xaxis.to;
                 });
-              }
-          });
-        }
-      });
-    });
-  };
+                $.each(plot.getYAxes(), function(_, axis) {
+                    var opts = axis.options;
+                    opts.min = reset ? 0 : ranges.yaxis.from;
+                    opts.max = reset ? null : ranges.yaxis.to;
+                });
+                plot.setupGrid();
+                plot.draw();
+                plot.clearSelection();
+            };
+        };
+        $('#' + chartId).bind('plothover', function (event, pos, item) {
+            if (!item) {
+                $('#tooltip').hide();
+            } else {
+                var executionLabel = executionLabels[item.datapoint[0]];
+                var revLabel;
+                if(item.series.label == executionLabel.branch) {
+                    revLabel = 'rev: ' + renderCommitIds(executionLabel.commits) + '/' + executionLabel.branch;
+                } else {
+                    revLabel = 'Version: ' + item.series.label;
+                }
+                var text = revLabel + ', date: ' + executionLabel.date + ', '+ label + ': ' + item.datapoint[1] + unit;
+                $('#tooltip').html(text).css({top: item.pageY - 10, left: item.pageX + 10}).show();
+            }
+        }).bind('plotselected', zoomFunction(chart)).bind('dblclick', zoomFunction(chart, true))
+            .bind("plotclick",
+                function (event, pos, item) {
+                    var executionLabel = executionLabels[item.datapoint[0]];
+                    var resultRowId = 'result' + executionLabel.id;
+                    var resultRow = $('#' + resultRowId);
+                    if (resultRow) {
+                        $('.history tr').css("background-color","");
+                        resultRow.css("background-color","orange");
+                        $('html, body').animate({scrollTop: resultRow.offset().top}, 1000, function() {
+                            window.location.hash = resultRowId;
+                        });
+                    }
+                });
+    }
 
-  window.performanceTests = {
-    createPerformanceGraph: createPerformanceGraph,
-    togglePlot: togglePlot
-  }
+    function determineMinY(data, unit) {
+        if (unit == '%') {
+            var min = 0
+            for(var i = 0; i < data.length; ++i) {
+                if(data[i][1] < min) {
+                    min = data[i][1]
+                }
+            }
+            return min - 10
+        } else {
+            return 0
+        }
+    }
+
+    var createPerformanceGraph = function(jsonFile, charts) {
+        $(function() {
+            $.ajax({ url: jsonFile,
+                dataType: 'json',
+                success: allData => renderGraphs(allData, charts)
+            });
+        });
+    };
+
+    window.performanceTests = {
+        createPerformanceGraph: createPerformanceGraph,
+        togglePlot: togglePlot
+    }
 })($, window);
 
 $(document).ready(function() {

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
@@ -19,9 +19,14 @@ package org.gradle.performance
 import org.gradle.performance.measure.Amount
 import org.gradle.performance.measure.Duration
 import org.gradle.performance.measure.MeasuredOperation
+import org.gradle.performance.results.BuildDisplayInfo
 import org.gradle.performance.results.CrossBuildPerformanceResults
+import org.gradle.performance.results.CrossBuildPerformanceTestHistory
 import org.gradle.performance.results.CrossVersionPerformanceResults
+import org.gradle.performance.results.CrossVersionPerformanceTestHistory
 import org.gradle.performance.results.GradleVsMavenBuildPerformanceResults
+import org.gradle.performance.results.MeasuredOperationList
+import org.gradle.performance.results.PerformanceTestHistory
 import org.joda.time.DateTime
 import spock.lang.Specification
 
@@ -89,5 +94,47 @@ abstract class ResultSpecification extends Specification {
         operation.end = args.end instanceof DateTime ? args.end : new DateTime(args?.end ?: 0)
         operation.exception = args?.failure
         return operation
+    }
+
+    BuildDisplayInfo buildDisplayInfo(String displayName) {
+        return new BuildDisplayInfo('test-project', displayName, [], [], [], [], false)
+    }
+
+    PerformanceTestHistory mockCrossVersionHistory() {
+        CrossVersionPerformanceResults result1 = crossVersionResults([startTime: 100])
+        result1.version('5.0-mockbaseline-1').results.addAll(measuredOperations([1]))
+        result1.version('master').results.addAll(measuredOperations([2]))
+
+        CrossVersionPerformanceResults result2 = crossVersionResults([startTime: 200])
+        result2.version('5.0-mockbaseline-2').results.addAll(measuredOperations([2]))
+        result2.version('master').results.addAll(measuredOperations([1]))
+
+        return new CrossVersionPerformanceTestHistory('mockCrossVersion',
+            ['5.0-mockbaseline-1', '5.0-mockbaseline-2'],
+            ['master'],
+            [result2, result1]
+        )
+    }
+
+    PerformanceTestHistory mockCrossBuildHistory() {
+        BuildDisplayInfo info1 = buildDisplayInfo('build1')
+        CrossBuildPerformanceResults result1  = crossBuildResults(startTime: 100)
+        result1.buildResult(info1).addAll(measuredOperations([1]))
+
+        BuildDisplayInfo info2 = buildDisplayInfo('build2')
+        CrossBuildPerformanceResults result2  = crossBuildResults(startTime: 200)
+        result1.buildResult(info2).addAll(measuredOperations([2]))
+
+        return new CrossBuildPerformanceTestHistory('mockCrossBuild', [info1, info2], [result2, result1])
+    }
+
+    List<MeasuredOperation> measuredOperations(List<Integer> values) {
+        return values.collect { new MeasuredOperation(totalTime: Amount.valueOf(it, Duration.SECONDS)) }
+    }
+
+    MeasuredOperationList measuredOperationList(List<Integer> values) {
+        MeasuredOperationList ret = new MeasuredOperationList()
+        ret.addAll(measuredOperations(values))
+        return ret
     }
 }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/IndexPageGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/IndexPageGeneratorTest.groovy
@@ -16,16 +16,12 @@
 
 package org.gradle.performance.results
 
-
-import org.gradle.performance.measure.Amount
-import org.gradle.performance.measure.Duration
-import org.gradle.performance.measure.MeasuredOperation
+import org.gradle.performance.ResultSpecification
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.junit.Rule
-import spock.lang.Specification
 import spock.lang.Subject
 
-class IndexPageGeneratorTest extends Specification {
+class IndexPageGeneratorTest extends ResultSpecification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
 
@@ -79,15 +75,10 @@ class IndexPageGeneratorTest extends Specification {
     }
 
     private ScenarioBuildResultData createResult(String name, List<Integer> baseVersionResult, List<Integer> currentVersionResult) {
-        MeasuredOperationList baseVersion = experiment(baseVersionResult)
-        MeasuredOperationList currentVersion = experiment(currentVersionResult)
+        MeasuredOperationList baseVersion = measuredOperationList(baseVersionResult)
+        MeasuredOperationList currentVersion = measuredOperationList(currentVersionResult)
         ScenarioBuildResultData.ExecutionData execution = new ScenarioBuildResultData.ExecutionData(new Date().getTime(), '', baseVersion, currentVersion)
         return new ScenarioBuildResultData(scenarioName: name, status: 'SUCCESS', currentBuildExecutions: [execution])
     }
 
-    private MeasuredOperationList experiment(List<Integer> values) {
-        MeasuredOperationList measuredOperationList = new MeasuredOperationList()
-        measuredOperationList.addAll(values.collect { new MeasuredOperation(totalTime: Amount.valueOf(it, Duration.SECONDS)) })
-        return measuredOperationList
-    }
 }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -23,66 +23,63 @@ import spock.lang.Subject
 class TestDataGeneratorTest extends ResultSpecification {
     @Subject
     TestDataGenerator generator = new TestDataGenerator()
-    Writer writer = Mock()
+    StringWriter writer = new StringWriter()
 
     def "can generate cross version json data"() {
         when:
         generator.render(mockCrossVersionHistory(), writer)
 
         then:
-        1 * writer.write(_, _, _) >> { String json, int off, int len ->
-            assert new JsonSlurper().parseText(json) == [
-                executionLabels: [
-                    [
-                        id: '1450575490',
-                        branch: 'master',
-                        date: '1970-01-01',
-                        commits: ['123456']
-                    ],
-                    [
-                        id: '1450575490',
-                        branch: 'master',
-                        date: '1970-01-01',
-                        commits: ['123456']
-                    ]
+        assert new JsonSlurper().parseText(writer.toString()) == [
+            executionLabels: [
+                [
+                    id: '1450575490',
+                    branch: 'master',
+                    date: '1970-01-01',
+                    commits: ['123456']
                 ],
-                totalTime: [
-                    [
-                        label: '5.0-mockbaseline-1',
-                        data: [[0, 1]]
-                    ],
-                    [
-                        label: '5.0-mockbaseline-2',
-                        data: [[1, 2]]
-                    ],
-                    [
-                        label: 'master',
-                        data: [[0, 2], [1, 1]]
-                    ]
+                [
+                    id: '1450575490',
+                    branch: 'master',
+                    date: '1970-01-01',
+                    commits: ['123456']
+                ]
+            ],
+            totalTime: [
+                [
+                    label: '5.0-mockbaseline-1',
+                    data: [[0, 1]]
                 ],
-                difference: [
-                    [
-                        label: 'master vs 5.0-mockbaseline-1',
-                        data: [[0, 100]]
-                    ],
-                    [
-                        label: 'master vs 5.0-mockbaseline-2',
-                        data: [[1, -50]]
-                    ],
+                [
+                    label: '5.0-mockbaseline-2',
+                    data: [[1, 2]]
                 ],
-                confidence: [
-                    [
-                        label: 'master vs 5.0-mockbaseline-1',
-                        data: [[0, 68.27]]
-                    ],
-                    [
-                        label: 'master vs 5.0-mockbaseline-2',
-                        data: [[1, 68.27]]
-                    ],
+                [
+                    label: 'master',
+                    data: [[0, 2], [1, 1]]
+                ]
+            ],
+            difference: [
+                [
+                    label: 'master vs 5.0-mockbaseline-1',
+                    data: [[0, 100]]
                 ],
-            ]
-        }
-        1 * writer.flush()
+                [
+                    label: 'master vs 5.0-mockbaseline-2',
+                    data: [[1, -50]]
+                ],
+            ],
+            confidence: [
+                [
+                    label: 'master vs 5.0-mockbaseline-1',
+                    data: [[0, 68.27]]
+                ],
+                [
+                    label: 'master vs 5.0-mockbaseline-2',
+                    data: [[1, 68.27]]
+                ],
+            ],
+        ]
     }
 
     def "can generate cross build json data"() {
@@ -90,34 +87,31 @@ class TestDataGeneratorTest extends ResultSpecification {
         generator.render(mockCrossBuildHistory(), writer)
 
         then:
-        1 * writer.write(_, _, _) >> { String json, int off, int len ->
-            assert new JsonSlurper().parseText(json) == [
-                executionLabels: [
-                    [
-                        id: '1424385918',
-                        branch: 'master',
-                        date: '1970-01-01',
-                        commits: ['abcdef']
-                    ],
-                    [
-                        id: '1424385918',
-                        branch: 'master',
-                        date: '1970-01-01',
-                        commits: ['abcdef']
-                    ]
+        assert new JsonSlurper().parseText(writer.toString()) == [
+            executionLabels: [
+                [
+                    id: '1424385918',
+                    branch: 'master',
+                    date: '1970-01-01',
+                    commits: ['abcdef']
                 ],
-                totalTime: [
-                    [
-                        label: 'build1',
-                        data: [[0, 1]]
-                    ],
-                    [
-                        label: 'build2',
-                        data: [[0, 2]]
-                    ]
+                [
+                    id: '1424385918',
+                    branch: 'master',
+                    date: '1970-01-01',
+                    commits: ['abcdef']
+                ]
+            ],
+            totalTime: [
+                [
+                    label: 'build1',
+                    data: [[0, 1]]
+                ],
+                [
+                    label: 'build2',
+                    data: [[0, 2]]
                 ]
             ]
-        }
-        1 * writer.flush()
+        ]
     }
 }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results
+
+import groovy.json.JsonSlurper
+import org.gradle.performance.ResultSpecification
+import spock.lang.Subject
+
+class TestDataGeneratorTest extends ResultSpecification {
+    @Subject
+    TestDataGenerator generator = new TestDataGenerator()
+    Writer writer = Mock()
+
+    def "can generate cross version json data"() {
+        when:
+        generator.render(mockCrossVersionHistory(), writer)
+
+        then:
+        1 * writer.write(_, _, _) >> { String json, int off, int len ->
+            assert new JsonSlurper().parseText(json) == [
+                executionLabels: [
+                    [
+                        id: '1450575490',
+                        branch: 'master',
+                        date: '1970-01-01',
+                        commits: ['123456']
+                    ],
+                    [
+                        id: '1450575490',
+                        branch: 'master',
+                        date: '1970-01-01',
+                        commits: ['123456']
+                    ]
+                ],
+                totalTime: [
+                    [
+                        label: '5.0-mockbaseline-1',
+                        data: [[0, 1]]
+                    ],
+                    [
+                        label: '5.0-mockbaseline-2',
+                        data: [[1, 2]]
+                    ],
+                    [
+                        label: 'master',
+                        data: [[0, 2], [1, 1]]
+                    ]
+                ],
+                difference: [
+                    [
+                        label: 'master vs 5.0-mockbaseline-1',
+                        data: [[0, 100]]
+                    ],
+                    [
+                        label: 'master vs 5.0-mockbaseline-2',
+                        data: [[1, -50]]
+                    ],
+                ],
+                confidence: [
+                    [
+                        label: 'master vs 5.0-mockbaseline-1',
+                        data: [[0, 68.27]]
+                    ],
+                    [
+                        label: 'master vs 5.0-mockbaseline-2',
+                        data: [[1, 68.27]]
+                    ],
+                ],
+            ]
+        }
+        1 * writer.flush()
+    }
+
+    def "can generate cross build json data"() {
+        when:
+        generator.render(mockCrossBuildHistory(), writer)
+
+        then:
+        1 * writer.write(_, _, _) >> { String json, int off, int len ->
+            assert new JsonSlurper().parseText(json) == [
+                executionLabels: [
+                    [
+                        id: '1424385918',
+                        branch: 'master',
+                        date: '1970-01-01',
+                        commits: ['abcdef']
+                    ],
+                    [
+                        id: '1424385918',
+                        branch: 'master',
+                        date: '1970-01-01',
+                        commits: ['abcdef']
+                    ]
+                ],
+                totalTime: [
+                    [
+                        label: 'build1',
+                        data: [[0, 1]]
+                    ],
+                    [
+                        label: 'build2',
+                        data: [[0, 2]]
+                    ]
+                ]
+            ]
+        }
+        1 * writer.flush()
+    }
+}


### PR DESCRIPTION
### Context

This PR closes https://github.com/gradle/gradle-private/issues/1619

- Add graph for the confidence of the failure.
- Add graph showing relative differences from to the current version.
- Use Java8 stream to refactor old data processing code.
- Refactor to get rid of old JSON string concatenation.
- Add tests for JSON data generation.

