### PR TITLE
Show requested version for each incoming edge in `dependencyInsight` report

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -956,7 +956,7 @@ org:new-leaf:77 (selected by rule)
 
 org:leaf:1.0 -> org:new-leaf:77
 \\--- org:foo:2.0
-     \\--- conf
+     \\--- conf (=> org:foo:1.0)
 
 org:leaf:2.0 -> org:new-leaf:77
 \\--- org:bar:1.0
@@ -2784,12 +2784,12 @@ planet:mercury:1.0.2
      \\--- compileClasspath
 
 planet:mercury:1.0.1 -> 1.0.2
-\\--- planet:venus:2.0.1 (conflict resolution between versions 2.0.0, 2.0.1 and 1.0)
-     +--- planet:earth:3.0.0
+\\--- planet:venus:2.0.1
+     +--- planet:earth:3.0.0 (=> planet:venus:2.0.0)
      |    \\--- compileClasspath
      +--- planet:mars:4.0.0
      |    \\--- compileClasspath
-     \\--- planet:jupiter:5.0.0
+     \\--- planet:jupiter:5.0.0 (=> planet:venus:1.0)
           \\--- compileClasspath
 """
         when:

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -956,7 +956,7 @@ org:new-leaf:77 (selected by rule)
 
 org:leaf:1.0 -> org:new-leaf:77
 \\--- org:foo:2.0
-     \\--- conf (=> org:foo:1.0)
+     \\--- conf (requested org:foo:1.0)
 
 org:leaf:2.0 -> org:new-leaf:77
 \\--- org:bar:1.0
@@ -2788,11 +2788,11 @@ planet:mercury:1.0.2
 
 planet:mercury:1.0.1 -> 1.0.2
 \\--- planet:venus:2.0.1
-     +--- planet:earth:3.0.0 (=> planet:venus:2.0.0)
+     +--- planet:earth:3.0.0 (requested planet:venus:2.0.0)
      |    \\--- compileClasspath
      +--- planet:mars:4.0.0
      |    \\--- compileClasspath
-     \\--- planet:jupiter:5.0.0 (=> planet:venus:1.0)
+     \\--- planet:jupiter:5.0.0 (requested planet:venus:1.0)
           \\--- compileClasspath
 """
         when:
@@ -2838,12 +2838,12 @@ planet:pluto:1.0.0
 \\--- planet:mercury:1.0.2
      +--- planet:jupiter:5.0.0
      |    \\--- compileClasspath
-     \\--- planet:venus:2.0.1 (=> planet:mercury:1.0.1)
-          +--- planet:earth:3.0.0 (=> planet:venus:2.0.0)
+     \\--- planet:venus:2.0.1 (requested planet:mercury:1.0.1)
+          +--- planet:earth:3.0.0 (requested planet:venus:2.0.0)
           |    \\--- compileClasspath
           +--- planet:mars:4.0.0
           |    \\--- compileClasspath
-          \\--- planet:jupiter:5.0.0 (=> planet:venus:1.0) (*)
+          \\--- planet:jupiter:5.0.0 (requested planet:venus:1.0) (*)
 """
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -461,6 +461,9 @@ public class DependencyInsightReportTask extends DefaultTask {
         public void renderNode(StyledTextOutput target, RenderableDependency node, boolean alreadyRendered) {
             boolean leaf = node.getChildren().isEmpty();
             target.text(leaf ? configuration.getName() : node.getName());
+            if (node.getDescription() != null) {
+                target.text(" ").withStyle(Description).text(node.getDescription());
+            }
             if (alreadyRendered && !leaf) {
                 target.withStyle(Info).text(" (*)");
             }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
@@ -17,8 +17,6 @@
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.artifacts.result.ComponentSelectionCause;
-import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 
@@ -30,17 +28,25 @@ import java.util.Set;
 /**
  * Children of this renderable dependency node are its dependents.
  */
-public class InvertedRenderableModuleResult extends RenderableModuleResult {
+public class InvertedRenderableModuleResult extends AbstractRenderableModuleResult {
+
+    private final ResolvedDependencyResult dependencyResult;
 
     public InvertedRenderableModuleResult(ResolvedComponentResult module) {
         super(module);
+        this.dependencyResult = null;
+    }
+
+    public InvertedRenderableModuleResult(ResolvedDependencyResult dependencyResult) {
+        super(dependencyResult.getFrom());
+        this.dependencyResult = dependencyResult;
     }
 
     @Override
     public Set<RenderableDependency> getChildren() {
         Map<ComponentIdentifier, RenderableDependency> children = new LinkedHashMap<ComponentIdentifier, RenderableDependency>();
         for (ResolvedDependencyResult dependent : module.getDependents()) {
-            InvertedRenderableModuleResult child = new InvertedRenderableModuleResult(dependent.getFrom());
+            InvertedRenderableModuleResult child = new InvertedRenderableModuleResult(dependent);
             if (!children.containsKey(child.getId())) {
                 children.put(child.getId(), child);
             }
@@ -49,14 +55,12 @@ public class InvertedRenderableModuleResult extends RenderableModuleResult {
     }
 
     @Override
-    public String getName() {
-        String base = super.getName();
-        for (ComponentSelectionDescriptor descriptor : module.getSelectionReason().getDescriptions()) {
-            if (descriptor.getCause() == ComponentSelectionCause.CONFLICT_RESOLUTION) {
-                return base + " (" + descriptor.getCause().getDefaultReason() + " " + descriptor.getDescription() + ")";
+    public String getDescription() {
+        if (dependencyResult != null) {
+            if (!dependencyResult.getRequested().matchesStrictly(dependencyResult.getSelected().getId())) {
+                return "(=> " + dependencyResult.getRequested() + ")";
             }
         }
-        return base;
+        return null;
     }
-
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
@@ -58,7 +58,7 @@ public class InvertedRenderableModuleResult extends AbstractRenderableModuleResu
     public String getDescription() {
         if (dependencyResult != null) {
             if (!dependencyResult.getRequested().matchesStrictly(dependencyResult.getSelected().getId())) {
-                return "(=> " + dependencyResult.getRequested() + ")";
+                return "(requested " + dependencyResult.getRequested() + ")";
             }
         }
         return null;


### PR DESCRIPTION
The `dependencyInsight` report shows detailed information about a particular
node in the dependency graph, including all incoming edges to that node traced from
the root. Understand which incoming edge is responsible for influencing the selected
version is an important use case for `dependencyInsight`.

A previous change added and conflict resolution reasons that were present for a
node on an incoming edge. This PR brings an improvement over this previous behaviour:
with this change we show the requested version for each edge where it is different
from the actual version that was selected.

An example of the new output:
```
planet:pluto:1.0.0
   variant "compile" [
      org.gradle.status             = release (not requested)
      org.gradle.usage              = java-api
      org.gradle.component.category = library (not requested)
   ]

planet:pluto:1.0.0
\--- planet:mercury:1.0.2
     +--- planet:jupiter:5.0.0
     |    \--- compileClasspath
     \--- planet:venus:2.0.1 (=> planet:mercury:1.0.1)
          +--- planet:earth:3.0.0 (=> planet:venus:2.0.0)
          |    \--- compileClasspath
          +--- planet:mars:4.0.0
          |    \--- compileClasspath
          \--- planet:jupiter:5.0.0 (=> planet:venus:1.0) (*)
```
