### PR TITLE
Add a `constraint` property to edges in `ResolutionResult`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/DependencyResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/DependencyResult.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.artifacts.result;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -45,4 +46,14 @@ public interface DependencyResult {
      * @return the origin of the dependency
      */
     ResolvedComponentResult getFrom();
+
+    /**
+     * Indicates if this dependency edge originated from a dependency constraint.
+     *
+     * @return true if the dependency is a constraint.
+     * @since 5.1
+     */
+    @Incubating
+    boolean isConstraint();
+
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -146,9 +146,10 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             root(":", ":test:") {
                 module("org:first-level:1.0") {
                     if (available) {
-                        def module = module("org:foo:1.1")
                         if (GradleMetadataResolveRunner.gradleMetadataEnabled) {
-                            module.byConstraint('published dependency constraint')
+                            constraint("org:foo:1.1", "org:foo:1.1").byConstraint('published dependency constraint')
+                        } else {
+                            constraint("org:foo:1.1", "org:foo:1.1")
                         }
                     }
                 }
@@ -213,7 +214,7 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             root(":", ":test:") {
                 module("org:first-level1:1.0") {
                     if (available) {
-                        module("org:foo:1.1")
+                        constraint("org:foo:1.1", "org:foo:1.1")
                     }
                 }
                 module("org:first-level2:1.0") {
@@ -290,7 +291,7 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
                 }
                 module("org:first-level:1.0") {
                     if (available) {
-                        edge("org:foo:[1.0,1.1]", "org:foo:1.1")
+                        constraint("org:foo:[1.0,1.1]", "org:foo:1.1")
                     }
                 }
             }
@@ -391,7 +392,7 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
             root(":", ":test:") {
                 module("org:first-level:1.0") {
                     if (available) {
-                        edge("org:bar:1.1", "org:foo:1.1").selectedByRule()
+                        constraint("org:bar:1.1", "org:foo:1.1").selectedByRule()
                         edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1")
                     } else {
                         module("org:foo:1.0")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -105,8 +105,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:1.0.0", "org:foo:1.1.0")
-                edge("org:foo:1.1.0", "org:foo:1.1.0")
+                constraint("org:foo:1.0.0", "org:foo:1.1.0")
+                constraint("org:foo:1.1.0", "org:foo:1.1.0")
                 edge("org:foo:[1.0.0,2.0.0)", "org:foo:1.1.0") {
                     byConstraint()
                     byReason("didn't match version 2.0.0")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -684,10 +684,10 @@ include 'other'
                 }
                 module('org:platform:2.7.9:default') {
                     noArtifacts()
-                    module('org:core:2.7.9')
-                    module('org:databind:2.7.9')
-                    module('org:annotations:2.7.9')
-                    module('org:kotlin:2.7.9')
+                    constraint('org:core:2.7.9')
+                    constraint('org:databind:2.7.9')
+                    constraint('org:annotations:2.7.9')
+                    constraint('org:kotlin:2.7.9')
                 }
             }
         }
@@ -745,10 +745,10 @@ include 'other'
                     noArtifacts()
                     byConstraint("belongs to platform org:platform:2.7.9")
                     forced()
-                    module('org:core:2.7.9')
-                    module('org:databind:2.7.9')
-                    module('org:annotations:2.7.9')
-                    module('org:kotlin:2.7.9')
+                    constraint('org:core:2.7.9')
+                    constraint('org:databind:2.7.9')
+                    constraint('org:annotations:2.7.9')
+                    constraint('org:kotlin:2.7.9')
                 }
             }
             virtualConfiguration('org:platform:2.7.9')
@@ -817,10 +817,10 @@ include 'other'
                 }
                 String expectedVariant = GradleMetadataResolveRunner.isGradleMetadataEnabled()?'enforced-platform':'enforced-platform-runtime'
                 module("org:platform:2.7.9:$expectedVariant") {
-                    module('org:core:2.7.9')
-                    module('org:databind:2.7.9')
-                    module('org:annotations:2.7.9')
-                    module('org:kotlin:2.7.9')
+                    constraint('org:core:2.7.9')
+                    constraint('org:databind:2.7.9')
+                    constraint('org:annotations:2.7.9')
+                    constraint('org:kotlin:2.7.9')
                 }
             }
         }
@@ -889,10 +889,10 @@ include 'other'
                     noArtifacts()
                     byConstraint("belongs to platform org:platform:2.7.9")
                     forced()
-                    module('org:core:2.7.9')
-                    module('org:databind:2.7.9')
-                    module('org:annotations:2.7.9')
-                    module('org:kotlin:2.7.9')
+                    constraint('org:core:2.7.9')
+                    constraint('org:databind:2.7.9')
+                    constraint('org:annotations:2.7.9')
+                    constraint('org:kotlin:2.7.9')
                 }
             }
             virtualConfiguration('org:platform:2.7.9')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -626,7 +626,7 @@ include 'other'
             root(":", ":test:") {
                 module("bom:bom:1.0") {
                     configuration = 'platform-runtime'
-                    edgeFromConstraint("org:xml:2.0", "org:xml:1.0")
+                    constraint("org:xml:2.0", "org:xml:1.0")
                 }
                 module("root:root:1.0") {
                     module('org:webapp:1.0') {
@@ -741,7 +741,7 @@ include 'other'
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                edgeFromConstraint('org:platform:2.7.9', 'org:platform:2.7.9') {
+                constraint('org:platform:2.7.9', 'org:platform:2.7.9') {
                     noArtifacts()
                     byConstraint("belongs to platform org:platform:2.7.9")
                     forced()
@@ -885,7 +885,7 @@ include 'other'
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                edgeFromConstraint('org:platform:2.7.9', 'org:platform:2.7.9') {
+                constraint('org:platform:2.7.9', 'org:platform:2.7.9') {
                     noArtifacts()
                     byConstraint("belongs to platform org:platform:2.7.9")
                     forced()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -98,7 +98,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         resolve.expectGraph {
             root(":", ":test:") {
                 edge('org:test', 'org:test:1.0')
-                edge('org:test:1.0', 'org:test:1.0')
+                constraint('org:test:1.0', 'org:test:1.0')
             }
         }
 
@@ -464,7 +464,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
                     configuration = expectedVariant
                     variant(expectedVariant, expectedAttributes)
                 }
-                module('org:test:1.0') {
+                constraint('org:test:1.0', 'org:test:1.0') {
                     configuration = expectedVariant
                     variant(expectedVariant, expectedAttributes)
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -64,7 +64,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edgeFromConstraint("org:foo:1.1","org:foo:1.0")
+                constraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
@@ -117,7 +117,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edgeFromConstraint("org:foo:1.1","org:foo:1.0")
+                constraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }
@@ -149,7 +149,7 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edgeFromConstraint("org:foo:1.1","org:foo:1.0")
+                constraint("org:foo:1.1","org:foo:1.0")
                 module("org:bar:1.0") {
                     edge("org:foo:1.0","org:foo:1.0")
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -72,6 +72,18 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                     conf 'org:foo:1.1'
                 }
             }
+            
+            task checkConstraints {
+                doLast {
+                    def root = configurations.conf.incoming.resolutionResult.root
+                    
+                    def hardEdge = root.dependencies.find { it.requested.version == '' }
+                    assert !hardEdge.constraint
+                    
+                    def constraintEdge = root.dependencies.find { it.requested.version == '1.1' }
+                    assert constraintEdge.constraint
+                }
+            }                        
         """
 
         when:
@@ -84,6 +96,10 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 module("org:foo:1.1")
             }
         }
+
+        expect:
+        // TODO:DAZ This is a temporary check pending full support in `ResolveTestFixture`
+        succeeds "checkConstraints"
     }
 
     void "dependency constraint can be used to declare incompatibility"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -137,7 +137,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 module("org:bar:1.0") {
                     edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.0 and 1.1")
                 }
-                edgeFromConstraint("org:foo:1.1", "org:foo:1.1")
+                constraint("org:foo:1.1", "org:foo:1.1")
             }
         }
     }
@@ -232,7 +232,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
                 module("org:bar:1.0") {
                     edge("org:foo:[1.0,1.2]", "org:foo:1.1").byConstraint('didn\'t match version 1.2 because tested versions')
                 }
-                edgeFromConstraint("org:foo:[1.0,1.1]", "org:foo:1.1").byConstraint('didn\'t match version 1.2 because tested versions')
+                constraint("org:foo:[1.0,1.1]", "org:foo:1.1").byConstraint('didn\'t match version 1.2 because tested versions')
             }
         }
     }
@@ -504,8 +504,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:foo:1.1") {
-                    graph.constraints.add(delegate)
+                constraint("org:foo:1.1", "org:foo:1.1") {
                     artifact(classifier: 'shaded')
                 }
                 module("org:bar:1.0") {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -68,7 +68,7 @@ dependencies {
                 edge("org:foo:1.+", "org:foo:1.0") {
                     byReason("rejected version 1.1")
                 }
-                edge("org:foo:1.0", "org:foo:1.0") {
+                constraint("org:foo:1.0", "org:foo:1.0") {
                     byConstraint("dependency was locked to version '1.0'")
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -61,7 +61,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0:platform-runtime") {
-                    module("group:moduleA:2.0")
+                    constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
                 edge("group:moduleA", "group:moduleA:2.0")
@@ -89,7 +89,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0:platform-runtime") {
-                    module("group:moduleA:2.0")
+                    constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
                 edge("group:moduleA", "group:moduleA:2.0")
@@ -125,11 +125,11 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0:platform-runtime") {
-                    module("group:moduleA:2.0")
+                    constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
                 module("group:bom2:1.0:platform-runtime") {
-                    module("group:moduleA:2.0")
+                    constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
                 edge("group:moduleA", "group:moduleA:2.0")
@@ -289,7 +289,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0:platform-runtime") {
-                    module("group:moduleA:2.0")
+                    constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
                 edge("group:moduleA", "group:moduleA:2.0")
@@ -318,7 +318,7 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0:platform-runtime") {
-                    module("group:moduleA:2.0")
+                    constraint("group:moduleA:2.0", "group:moduleA:2.0")
                     noArtifacts()
                 }
                 edge("group:moduleA", "group:moduleA:2.0")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -101,7 +101,11 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
             root(':', ':test:') {
                 edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
-                    module('org.test:moduleB:1.0')
+                    if (thing == "dependencies") {
+                        edge('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
+                    } else {
+                        constraint('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
+                    }
                 }
             }
         }
@@ -155,7 +159,11 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
             root(':', ':test:') {
                 edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
-                    module('org.test:moduleB:1.0')
+                    if (thing == "dependencies") {
+                        edge('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
+                    } else {
+                        constraint('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
+                    }
                 }
             }
         }
@@ -434,7 +442,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
             root(':', ':test:') {
                 edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
-                    module('org.test:moduleB:1.0')
+                    constraint('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
                 }
             }
         }
@@ -575,7 +583,11 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 edge('org.test:moduleC', 'org.test:moduleC:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     module("org.test:moduleB:1.0") {
-                        module('org.test:moduleC:1.0')
+                        if (thing == "dependencies") {
+                            edge('org.test:moduleC:1.0', 'org.test:moduleC:1.0')
+                        } else {
+                            constraint('org.test:moduleC:1.0', 'org.test:moduleC:1.0')
+                        }
                     }
                 }
             }
@@ -1002,7 +1014,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                             edge("org.test:moduleC:1.0", "org.test:moduleC:1.1")
                             byReason('can set a custom reason in a rule')
                         }
-                        module("org.test:moduleC:1.1").byConflictResolution("between versions 1.0 and 1.1")
+                        constraint("org.test:moduleC:1.1", "org.test:moduleC:1.1").byConflictResolution("between versions 1.0 and 1.1")
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphComponent.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphComponent.java
@@ -23,10 +23,10 @@ import javax.annotation.Nullable;
 import java.util.Collection;
 
 /**
- * A {@link ComponentResult} that is used during the resolution of the dependency graph.
+ * A {@link ResolvedGraphComponent} that is used during the resolution of the dependency graph.
  * Additional fields in this interface are not required to reconstitute the serialized graph.
  */
-public interface DependencyGraphComponent extends ComponentResult {
+public interface DependencyGraphComponent extends ResolvedGraphComponent {
     /**
      * Returns the meta-data for the component. Resolves if not already resolved.
      *

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -26,9 +26,10 @@ import javax.annotation.Nullable;
 import java.util.List;
 
 /**
- * An edge in the dependency graph, between 2 nodes.
+ * A {@link ResolvedGraphDependency} that is used during the resolution of the dependency graph.
+ * Additional fields in this interface are not required to reconstitute the serialized graph, but are using during construction of the graph.
  */
-public interface DependencyGraphEdge extends DependencyResult {
+public interface DependencyGraphEdge extends ResolvedGraphDependency {
     DependencyGraphNode getFrom();
 
     DependencyGraphSelector getSelector();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphPathResolver.java
@@ -33,7 +33,7 @@ public class DependencyGraphPathResolver {
     public static Collection<List<ComponentIdentifier>> calculatePaths(List<DependencyGraphNode> fromNodes, DependencyGraphNode toNode) {
         // Include the shortest path from each version that has a direct dependency on the broken dependency, back to the root
 
-        Map<ComponentResult, List<ComponentIdentifier>> shortestPaths = new LinkedHashMap<ComponentResult, List<ComponentIdentifier>>();
+        Map<ResolvedGraphComponent, List<ComponentIdentifier>> shortestPaths = new LinkedHashMap<ResolvedGraphComponent, List<ComponentIdentifier>>();
         List<ComponentIdentifier> rootPath = new ArrayList<ComponentIdentifier>();
         rootPath.add(toNode.getOwner().getComponentId());
         shortestPaths.put(toNode.getOwner(), rootPath);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
  * The final representation of a component in the resolved dependency graph.
  * This is the type that is serialized on resolve and deserialized when we later need to build a `ResolutionResult`.
  */
-public interface ComponentResult {
+public interface ResolvedGraphComponent {
     /**
      * Returns a simple id for this component, unique across components in the same graph.
      * This id cannot be used across graphs.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
@@ -44,4 +44,6 @@ public interface ResolvedGraphDependency {
      */
     @Nullable
     ComponentSelectionReason getReason();
+
+    boolean isConstraint();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphDependency.java
@@ -22,7 +22,11 @@ import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 import javax.annotation.Nullable;
 
-public interface DependencyResult {
+/**
+ * The final representation of a dependency in the resolved dependency graph.
+ * This is the type that is serialized on resolve and deserialized when we later need to build a `ResolutionResult`.
+ */
+public interface ResolvedGraphDependency {
 
     ComponentSelector getRequested();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -243,6 +243,11 @@ class EdgeState implements DependencyGraphEdge {
         return selector.getSelectionReason();
     }
 
+    @Override
+    public boolean isConstraint() {
+        return dependencyMetadata.isConstraint();
+    }
+
     private ComponentState getSelectedComponent() {
         return selector.getTargetModule().getSelected();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactory.java
@@ -37,19 +37,19 @@ public class CachingDependencyResultFactory {
     private final Map<List, DefaultUnresolvedDependencyResult> unresolvedDependencies = new HashMap<List, DefaultUnresolvedDependencyResult>();
     private final Map<List, DefaultResolvedDependencyResult> resolvedDependencies = new HashMap<List, DefaultResolvedDependencyResult>();
 
-    public UnresolvedDependencyResult createUnresolvedDependency(ComponentSelector requested, ResolvedComponentResult from,
-                                                       ComponentSelectionReason reason, ModuleVersionResolveException failure) {
-        List<Object> key = asList(requested, from);
+    public UnresolvedDependencyResult createUnresolvedDependency(ComponentSelector requested, ResolvedComponentResult from, boolean constraint,
+                                                                 ComponentSelectionReason reason, ModuleVersionResolveException failure) {
+        List<Object> key = asList(requested, from, constraint);
         if (!unresolvedDependencies.containsKey(key)) {
-            unresolvedDependencies.put(key, new DefaultUnresolvedDependencyResult(requested, reason, from, failure));
+            unresolvedDependencies.put(key, new DefaultUnresolvedDependencyResult(requested, constraint, reason, from, failure));
         }
         return unresolvedDependencies.get(key);
     }
 
-    public ResolvedDependencyResult createResolvedDependency(ComponentSelector requested, ResolvedComponentResult from, DefaultResolvedComponentResult selected) {
-        List<Object> key = asList(requested, from, selected);
+    public ResolvedDependencyResult createResolvedDependency(ComponentSelector requested, ResolvedComponentResult from, DefaultResolvedComponentResult selected, boolean constraint) {
+        List<Object> key = asList(requested, from, selected, constraint);
         if (!resolvedDependencies.containsKey(key)) {
-            resolvedDependencies.put(key, new DefaultResolvedDependencyResult(requested, selected, from));
+            resolvedDependencies.put(key, new DefaultResolvedDependencyResult(requested, constraint, selected, from));
         }
         return resolvedDependencies.get(key);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializer.java
@@ -22,14 +22,14 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionIdentifierSerializer;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
 import java.io.IOException;
 
-public class ComponentResultSerializer implements Serializer<ComponentResult> {
+public class ComponentResultSerializer implements Serializer<ResolvedGraphComponent> {
 
     private final ModuleVersionIdentifierSerializer idSerializer;
     private final ComponentSelectionReasonSerializer reasonSerializer;
@@ -43,7 +43,7 @@ public class ComponentResultSerializer implements Serializer<ComponentResult> {
         componentIdSerializer = new ComponentIdentifierSerializer();
     }
 
-    public ComponentResult read(Decoder decoder) throws IOException {
+    public ResolvedGraphComponent read(Decoder decoder) throws IOException {
         long resultId = decoder.readSmallLong();
         ModuleVersionIdentifier id = idSerializer.read(decoder);
         ComponentSelectionReason reason = reasonSerializer.read(decoder);
@@ -54,7 +54,7 @@ public class ComponentResultSerializer implements Serializer<ComponentResult> {
         return new DetachedComponentResult(resultId, id, reason, componentId, variantName, attributes, repositoryName);
     }
 
-    public void write(Encoder encoder, ComponentResult value) throws IOException {
+    public void write(Encoder encoder, ResolvedGraphComponent value) throws IOException {
         encoder.writeSmallLong(value.getResultId());
         idSerializer.write(encoder, value.getModuleVersion());
         reasonSerializer.write(encoder, value.getSelectionReason());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -71,10 +71,10 @@ public class DefaultResolutionResultBuilder {
         for (ResolvedGraphDependency d : dependencies) {
             DependencyResult dependencyResult;
             if (d.getFailure() != null) {
-                dependencyResult = dependencyResultFactory.createUnresolvedDependency(d.getRequested(), from, d.getReason(), d.getFailure());
+                dependencyResult = dependencyResultFactory.createUnresolvedDependency(d.getRequested(), from, d.isConstraint(), d.getReason(), d.getFailure());
             } else {
                 DefaultResolvedComponentResult selected = modules.get(d.getSelected());
-                dependencyResult = dependencyResultFactory.createResolvedDependency(d.getRequested(), from, selected);
+                dependencyResult = dependencyResultFactory.createResolvedDependency(d.getRequested(), from, selected, d.isConstraint());
                 selected.addDependent((ResolvedDependencyResult) dependencyResult);
             }
             from.addDependency(dependencyResult);
@@ -92,9 +92,8 @@ public class DefaultResolutionResultBuilder {
         for (UnresolvedDependency failure : extraFailures) {
             ModuleVersionSelector failureSelector = failure.getSelector();
             ModuleComponentSelector failureComponentSelector = DefaultModuleComponentSelector.newSelector(failureSelector.getModule(), failureSelector.getVersion());
-            root.addDependency(dependencyResultFactory.createUnresolvedDependency(failureComponentSelector,
-                root,
-                ComponentSelectionReasons.of(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT, Describables.of("Dependency locking"))),
+            root.addDependency(dependencyResultFactory.createUnresolvedDependency(failureComponentSelector, root, true,
+                    ComponentSelectionReasons.of(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT, Describables.of("Dependency locking"))),
                 new ModuleVersionResolveException(failureComponentSelector, "Dependency lock state out of date", failure.getProblem())));
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -23,12 +23,13 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionCause;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
+import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
@@ -57,26 +58,26 @@ public class DefaultResolutionResultBuilder {
         return new DefaultResolutionResult(new RootFactory(modules.get(rootId)));
     }
 
-    public void visitComponent(ComponentResult component) {
+    public void visitComponent(ResolvedGraphComponent component) {
         create(component.getResultId(), component.getModuleVersion(), component.getSelectionReason(), component.getComponentId(), variantDetails(component), component.getRepositoryName());
     }
 
-    private static ResolvedVariantResult variantDetails(ComponentResult component) {
+    private static ResolvedVariantResult variantDetails(ResolvedGraphComponent component) {
         return new DefaultResolvedVariantResult(component.getVariantName(), component.getVariantAttributes());
     }
 
-    public void visitOutgoingEdges(Long fromComponent, Collection<? extends DependencyResult> dependencies) {
+    public void visitOutgoingEdges(Long fromComponent, Collection<? extends ResolvedGraphDependency> dependencies) {
         DefaultResolvedComponentResult from = modules.get(fromComponent);
-        for (DependencyResult d : dependencies) {
-            org.gradle.api.artifacts.result.DependencyResult dependency;
+        for (ResolvedGraphDependency d : dependencies) {
+            DependencyResult dependencyResult;
             if (d.getFailure() != null) {
-                dependency = dependencyResultFactory.createUnresolvedDependency(d.getRequested(), from, d.getReason(), d.getFailure());
+                dependencyResult = dependencyResultFactory.createUnresolvedDependency(d.getRequested(), from, d.getReason(), d.getFailure());
             } else {
                 DefaultResolvedComponentResult selected = modules.get(d.getSelected());
-                dependency = dependencyResultFactory.createResolvedDependency(d.getRequested(), from, selected);
-                selected.addDependent((ResolvedDependencyResult) dependency);
+                dependencyResult = dependencyResultFactory.createResolvedDependency(d.getRequested(), from, selected);
+                selected.addDependent((ResolvedDependencyResult) dependencyResult);
             }
-            from.addDependency(dependency);
+            from.addDependency(dependencyResult);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DependencyResultSerializer.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
@@ -32,18 +32,18 @@ public class DependencyResultSerializer {
     private final static byte FAILED = 1;
     private final ComponentSelectionReasonSerializer componentSelectionReasonSerializer = new ComponentSelectionReasonSerializer();
 
-    public DependencyResult read(Decoder decoder, Map<Long, ComponentSelector> selectors, Map<ComponentSelector, ModuleVersionResolveException> failures) throws IOException {
+    public ResolvedGraphDependency read(Decoder decoder, Map<Long, ComponentSelector> selectors, Map<ComponentSelector, ModuleVersionResolveException> failures) throws IOException {
         Long selectorId = decoder.readSmallLong();
         ComponentSelector requested = selectors.get(selectorId);
 
         byte resultByte = decoder.readByte();
         if (resultByte == SUCCESSFUL) {
             Long selectedId = decoder.readSmallLong();
-            return new DefaultDependencyResult(requested, selectedId, null, null);
+            return new DetachedResolvedGraphDependency(requested, selectedId, null, null);
         } else if (resultByte == FAILED) {
             ComponentSelectionReason reason = componentSelectionReasonSerializer.read(decoder);
             ModuleVersionResolveException failure = failures.get(requested);
-            return new DefaultDependencyResult(requested, null, reason, failure);
+            return new DetachedResolvedGraphDependency(requested, null, reason, failure);
         } else {
             throw new IllegalArgumentException("Unknown result type: " + resultByte);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedComponentResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedComponentResult.java
@@ -20,15 +20,15 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 
 /**
- * A {@link ComponentResult} implementation that is detached from the original resolution process.
+ * A {@link ResolvedGraphComponent} implementation that is detached from the original resolution process.
  * Instances are created when de-serializing the resolution result.
  */
-public class DetachedComponentResult implements ComponentResult {
+public class DetachedComponentResult implements ResolvedGraphComponent {
     private final Long resultId;
     private final ModuleVersionIdentifier id;
     private final ComponentSelectionReason reason;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
@@ -31,11 +31,13 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
     private final Long selected;
     private final ComponentSelectionReason reason;
     private ModuleVersionResolveException failure;
+    private boolean constraint;
 
     public DetachedResolvedGraphDependency(ComponentSelector requested,
                                            Long selected,
                                            ComponentSelectionReason reason,
-                                           ModuleVersionResolveException failure) {
+                                           ModuleVersionResolveException failure,
+                                           boolean constraint) {
         assert requested != null;
         assert failure != null || selected != null;
 
@@ -43,21 +45,31 @@ public class DetachedResolvedGraphDependency implements ResolvedGraphDependency 
         this.reason = reason;
         this.selected = selected;
         this.failure = failure;
+        this.constraint = constraint;
     }
 
+    @Override
     public ComponentSelector getRequested() {
         return requested;
     }
 
+    @Override
     public Long getSelected() {
         return selected;
     }
 
+    @Override
     public ComponentSelectionReason getReason() {
         return reason;
     }
 
+    @Override
     public ModuleVersionResolveException getFailure() {
         return failure;
+    }
+
+    @Override
+    public boolean isConstraint() {
+        return constraint;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedResolvedGraphDependency.java
@@ -18,20 +18,24 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
-public class DefaultDependencyResult implements DependencyResult {
+/**
+ * The deserialized representation of an edge in the resolution result.
+ * This is produced by first serializing an `EdgeState` and later deserializing when required.
+ */
+public class DetachedResolvedGraphDependency implements ResolvedGraphDependency {
 
     private final ComponentSelector requested;
     private final Long selected;
     private final ComponentSelectionReason reason;
     private ModuleVersionResolveException failure;
 
-    public DefaultDependencyResult(ComponentSelector requested,
-                                   Long selected,
-                                   ComponentSelectionReason reason,
-                                   ModuleVersionResolveException failure) {
+    public DetachedResolvedGraphDependency(ComponentSelector requested,
+                                           Long selected,
+                                           ComponentSelectionReason reason,
+                                           ModuleVersionResolveException failure) {
         assert requested != null;
         assert failure != null || selected != null;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -22,13 +22,13 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphEdge;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
 import org.gradle.api.logging.Logger;
@@ -205,7 +205,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
                             LOG.debug("Loaded resolution results ({}) from {}", clock.getElapsed(), data);
                             return root;
                         case COMPONENT:
-                            ComponentResult component = componentResultSerializer.read(decoder);
+                            ResolvedGraphComponent component = componentResultSerializer.read(decoder);
                             builder.visitComponent(component);
                             break;
                         case SELECTOR:
@@ -217,7 +217,7 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
                             Long fromId = decoder.readSmallLong();
                             int size = decoder.readSmallInt();
                             if (size > 0) {
-                                List<DependencyResult> deps = Lists.newArrayListWithExpectedSize(size);
+                                List<ResolvedGraphDependency> deps = Lists.newArrayListWithExpectedSize(size);
                                 for (int i = 0; i < size; i++) {
                                     deps.add(dependencyResultSerializer.read(decoder, selectors, failures));
                                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/AbstractDependencyResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/AbstractDependencyResult.java
@@ -23,13 +23,15 @@ import org.gradle.api.artifacts.result.ResolvedComponentResult;
 public class AbstractDependencyResult implements DependencyResult {
     private final ComponentSelector requested;
     private final ResolvedComponentResult from;
+    private boolean constraint;
 
-    public AbstractDependencyResult(ComponentSelector requested, ResolvedComponentResult from) {
+    public AbstractDependencyResult(ComponentSelector requested, ResolvedComponentResult from, boolean constraint) {
         assert requested != null;
         assert from != null;
 
         this.from = from;
         this.requested = requested;
+        this.constraint = constraint;
     }
 
     public ComponentSelector getRequested() {
@@ -39,4 +41,10 @@ public class AbstractDependencyResult implements DependencyResult {
     public ResolvedComponentResult getFrom() {
         return from;
     }
+
+    @Override
+    public boolean isConstraint() {
+        return constraint;
+    }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedDependencyResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedDependencyResult.java
@@ -23,8 +23,8 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 public class DefaultResolvedDependencyResult extends AbstractDependencyResult implements ResolvedDependencyResult {
     private final ResolvedComponentResult selected;
 
-    public DefaultResolvedDependencyResult(ComponentSelector requested, ResolvedComponentResult selected, ResolvedComponentResult from) {
-        super(requested, from);
+    public DefaultResolvedDependencyResult(ComponentSelector requested, boolean constraint, ResolvedComponentResult selected, ResolvedComponentResult from) {
+        super(requested, from, constraint);
         this.selected = selected;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultUnresolvedDependencyResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultUnresolvedDependencyResult.java
@@ -26,9 +26,9 @@ public class DefaultUnresolvedDependencyResult extends AbstractDependencyResult 
     private final ComponentSelectionReason reason;
     private final ModuleVersionResolveException failure;
 
-    public DefaultUnresolvedDependencyResult(ComponentSelector requested, ComponentSelectionReason reason,
+    public DefaultUnresolvedDependencyResult(ComponentSelector requested, boolean constraint, ComponentSelectionReason reason,
                                              ResolvedComponentResult from, ModuleVersionResolveException failure) {
-        super(requested, from);
+        super(requested, from, constraint);
         this.reason = reason;
         this.failure = failure;
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
@@ -36,18 +36,20 @@ class CachingDependencyResultFactoryTest extends Specification {
         def selectedModule = newModule('selected')
 
         when:
-        def dep = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule)
-        def same = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule)
+        def dep = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule, false)
+        def same = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule, false)
 
-        def differentRequested = factory.createResolvedDependency(selector('xxx'), fromModule, selectedModule)
-        def differentFrom = factory.createResolvedDependency(selector('requested'), newModule('xxx'), selectedModule)
-        def differentSelected = factory.createResolvedDependency(selector('requested'), fromModule, newModule('xxx'))
+        def differentRequested = factory.createResolvedDependency(selector('xxx'), fromModule, selectedModule, false)
+        def differentFrom = factory.createResolvedDependency(selector('requested'), newModule('xxx'), selectedModule, false)
+        def differentSelected = factory.createResolvedDependency(selector('requested'), fromModule, newModule('xxx'), false)
+        def differentConstraint = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule, true)
 
         then:
         dep.is(same)
         !dep.is(differentFrom)
         !dep.is(differentRequested)
         !dep.is(differentSelected)
+        !dep.is(differentConstraint)
     }
 
     def "creates and caches resolved dependencies with attributes"() {
@@ -55,12 +57,12 @@ class CachingDependencyResultFactoryTest extends Specification {
         def selectedModule = newModule('selected', 'a', '1', selectedByRule(), newVariant('custom', [attr1: 'foo', attr2: 'bar']))
 
         when:
-        def dep = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule)
-        def same = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule)
+        def dep = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule, false)
+        def same = factory.createResolvedDependency(selector('requested'), fromModule, selectedModule, false)
 
-        def differentRequested = factory.createResolvedDependency(selector('xxx'), fromModule, selectedModule)
-        def differentFrom = factory.createResolvedDependency(selector('requested'), newModule('xxx'), selectedModule)
-        def differentSelected = factory.createResolvedDependency(selector('requested'), fromModule, newModule('xxx'))
+        def differentRequested = factory.createResolvedDependency(selector('xxx'), fromModule, selectedModule, false)
+        def differentFrom = factory.createResolvedDependency(selector('requested'), newModule('xxx'), selectedModule, false)
+        def differentSelected = factory.createResolvedDependency(selector('requested'), fromModule, newModule('xxx'), false)
 
         then:
         dep.is(same)
@@ -74,17 +76,19 @@ class CachingDependencyResultFactoryTest extends Specification {
         def selectedModule = Mock(ComponentSelectionReason)
 
         when:
-        def dep = factory.createUnresolvedDependency(selector('requested'), fromModule, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
-        def same = factory.createUnresolvedDependency(selector('requested'), fromModule, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def dep = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def same = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
 
-        def differentRequested = factory.createUnresolvedDependency(selector('xxx'), fromModule, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('xxx'), "foo"))
-        def differentFrom = factory.createUnresolvedDependency(selector('requested'), newModule('xxx'), selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
-        def differentFailure = factory.createUnresolvedDependency(selector('requested'), fromModule, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def differentRequested = factory.createUnresolvedDependency(selector('xxx'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('xxx'), "foo"))
+        def differentFrom = factory.createUnresolvedDependency(selector('requested'), newModule('xxx'), false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def differentConstraint = factory.createUnresolvedDependency(selector('requested'), fromModule, true, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def differentFailure = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
 
         then:
         dep.is(same)
         !dep.is(differentFrom)
         !dep.is(differentRequested)
+        !dep.is(differentConstraint)
         dep.is(differentFailure) //the same dependency edge cannot have different failures
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -23,8 +23,8 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ComponentResult
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyResult
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency
 import org.gradle.internal.DisplayName
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -249,11 +249,11 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         moduleVersion
     }
 
-    private void resolvedConf(String module, List<DependencyResult> deps) {
+    private void resolvedConf(String module, List<ResolvedGraphDependency> deps) {
         builder.visitOutgoingEdges(id(module), deps)
     }
 
-    private DependencyResult dep(String requested, Exception failure = null, String selected = requested) {
+    private ResolvedGraphDependency dep(String requested, Exception failure = null, String selected = requested) {
         def selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId("x", requested), DefaultImmutableVersionConstraint.of("1"))
         def moduleVersionSelector = newSelector(DefaultModuleIdentifier.newId("x", requested), "1")
         failure = failure == null ? null : new ModuleVersionResolveException(moduleVersionSelector, failure)
@@ -264,7 +264,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         return module.hashCode()
     }
 
-    class DummyModuleVersionSelection implements ComponentResult {
+    class DummyModuleVersionSelection implements ResolvedGraphComponent {
         Long resultId
         ModuleVersionIdentifier moduleVersion
         ComponentSelectionReason selectionReason
@@ -274,7 +274,7 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         String repositoryName
     }
 
-    class DummyInternalDependencyResult implements DependencyResult {
+    class DummyInternalDependencyResult implements ResolvedGraphDependency {
         ComponentSelector requested
         Long selected
         ModuleVersionResolveException failure

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -279,5 +279,6 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         Long selected
         ModuleVersionResolveException failure
         ComponentSelectionReason reason
+        boolean constraint
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.tasks.diagnostics.internal.graph.nodes.UnresolvedDependencyEdge
 import org.gradle.internal.Factory
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
@@ -91,7 +90,7 @@ class DefaultResolutionResultTest extends Specification {
         def root = newModule('a', 'a', '1')
         def dep1 = newDependency('b', 'b', '1')
         root.addDependency(dep1)
-        dep1.selected.addDependency(new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('a', 'a'), new DefaultMutableVersionConstraint('1')), root, dep1.selected))
+        dep1.selected.addDependency(new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('a', 'a'), '1'), false, root, dep1.selected))
 
         when:
         def deps = new DefaultResolutionResult({root} as Factory).allDependencies
@@ -134,7 +133,7 @@ class DefaultResolutionResultTest extends Specification {
         )
         def mid = DefaultModuleVersionIdentifier.newId("foo", "bar", "1.0")
         def dep = new DefaultUnresolvedDependencyResult(
-            Stub(ComponentSelector),
+            Stub(ComponentSelector), false,
             Stub(ComponentSelectionReason),
             new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, Stub(ResolvedVariantResult), null),
             new ModuleVersionNotFoundException(Stub(ModuleComponentSelector), "too bad")

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -17,11 +17,11 @@
 package org.gradle.api.internal.artifacts.result
 
 import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.artifacts.component.ModuleComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons
 import org.gradle.internal.Describables
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -35,12 +35,12 @@ import static org.gradle.api.internal.artifacts.DefaultModuleVersionSelector.new
 class ResolutionResultDataBuilder {
 
     static DefaultResolvedDependencyResult newDependency(String group='a', String module='a', String version='1', String selectedVersion='1') {
-        new DefaultResolvedDependencyResult(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version)), newModule(group, module, selectedVersion), newModule())
+        new DefaultResolvedDependencyResult(newSelector(group, module, version), false, newModule(group, module, selectedVersion), newModule())
     }
 
     static DefaultUnresolvedDependencyResult newUnresolvedDependency(String group='x', String module='x', String version='1', String selectedVersion='1') {
-        def requested = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), new DefaultMutableVersionConstraint(version))
-        new DefaultUnresolvedDependencyResult(requested, ComponentSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), version), "broken"))
+        def requested = newSelector(group, module, version)
+        new DefaultUnresolvedDependencyResult(requested, false, ComponentSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), version), "broken"))
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1', ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested(), ResolvedVariantResult variant = newVariant(), String repoId = null) {
@@ -48,7 +48,7 @@ class ResolutionResultDataBuilder {
     }
 
     static DefaultResolvedDependencyResult newDependency(ComponentSelector componentSelector, String group='a', String module='a', String selectedVersion='1') {
-        new DefaultResolvedDependencyResult(componentSelector, newModule(group, module, selectedVersion), newModule())
+        new DefaultResolvedDependencyResult(componentSelector, false, newModule(group, module, selectedVersion), newModule())
     }
 
     static ResolvedVariantResult newVariant(String name = 'default', Map<String, String> attributes = [:]) {
@@ -57,5 +57,9 @@ class ResolutionResultDataBuilder {
             mutableAttributes.attribute(Attribute.of(it.key, String), it.value)
         }
         return new DefaultResolvedVariantResult(Describables.of(name), mutableAttributes)
+    }
+
+    static ModuleComponentSelector newSelector(String group, String module, String version) {
+        DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(group, module), version)
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
@@ -123,6 +123,11 @@ class ResolutionErrorRenderer implements Action<Throwable> {
                 public ResolvedComponentResult getFrom() {
                     return null;
                 }
+
+                @Override
+                public boolean isConstraint() {
+                    return false;
+                }
             });
         }
         return matchesSpec;

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.tasks.diagnostics.internal.insight
 
 import org.gradle.api.artifacts.result.ComponentSelectionReason
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
-import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser
@@ -192,9 +191,10 @@ class DependencyInsightReporterSpec extends Specification {
 
     private static DefaultResolvedDependencyResult dep(String group, String name, String requested, String selected = requested, ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested()) {
         def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant(), "repoId")
-        new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId(group, name), new DefaultMutableVersionConstraint(requested)),
-            selectedModule,
-            new DefaultResolvedComponentResult(newId("a", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant(), "repoId"))
+        new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId(group, name), requested),
+                false,
+                selectedModule,
+                new DefaultResolvedComponentResult(newId("a", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant(), "repoId"))
     }
 
     private static DefaultResolvedVariantResult defaultVariant() {
@@ -206,7 +206,7 @@ class DependencyInsightReporterSpec extends Specification {
         List<DefaultResolvedDependencyResult> pathElements = (path.split(' -> ') as List).reverse().collect {
             def (name, version) = it.split(':')
             def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), ComponentSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('group', name), version), defaultVariant(), "repoId")
-            def result = new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId("group", name), version), componentResult, from)
+            def result = new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId("group", name), version), false, componentResult, from)
             from = componentResult
             result
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.artifacts.result.ComponentSelectionCause
-import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedVariantResult
 import org.gradle.api.attributes.AttributeContainer
@@ -136,7 +135,7 @@ allprojects {
         compareNodes("components in graph", parseNodes(actualComponents), parseNodes(expectedComponents))
 
         def actualEdges = findLines(configDetails, 'dependency')
-        def expectedEdges = graph.edges.collect { "[from:${it.from.id}][${it.requested}->${it.selected.id}]" }
+        def expectedEdges = graph.edges.collect { "${it.constraint ? '[constraint]' : ''}[from:${it.from.id}][${it.requested}->${it.selected.id}]" }
         compare("edges in graph", actualEdges, expectedEdges)
 
         def expectedArtifacts = graph.artifactNodes.collect { "[${it.moduleVersionId}][${it.artifactName}]" }
@@ -596,7 +595,7 @@ allprojects {
         /**
          * Defines a link between nodes created through a dependency constraint.
          */
-        NodeBuilder constraint(String requested, String selectedModuleVersionId, @DelegatesTo(NodeBuilder) Closure cl = {}) {
+        NodeBuilder constraint(String requested, String selectedModuleVersionId = requested, @DelegatesTo(NodeBuilder) Closure cl = {}) {
             def node = graph.node(selectedModuleVersionId, selectedModuleVersionId)
             def edge = new EdgeBuilder(this, requested, node)
             edge.constraint = true
@@ -793,7 +792,7 @@ class GenerateGraphTask extends DefaultTask {
                 writer.println("component:${formatComponent(it)}")
             }
             configuration.incoming.resolutionResult.allDependencies.each {
-                writer.println("dependency:[from:${it.from.id}][${it.requested}->${it.selected.id}]")
+                writer.println("dependency:${it.constraint ? '[constraint]' : '' }[from:${it.from.id}][${it.requested}->${it.selected.id}]")
             }
             if (buildArtifacts) {
                 configuration.files.each {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BomSupportPluginsSmokeTest.groovy
@@ -109,19 +109,19 @@ class BomSupportPluginsSmokeTest extends AbstractSmokeTest {
             root(':', ':springbootproject:') {
                 if (directBomDependency) {
                     module("org.springframework.boot:spring-boot-dependencies:$bomVersion:${bomSupportProvider == 'gradle' ? 'platform-compile' : 'compile'}") {
-                        module("org.springframework:spring-core:${springVersion}")
-                        module("org.springframework:spring-aop:${springVersion}")
-                        module("org.springframework:spring-beans:${springVersion}")
-                        module("org.springframework:spring-context:${springVersion}")
-                        module("org.springframework:spring-expression:${springVersion}")
-                        module("org.springframework:spring-test:${springVersion}")
-                        module("org.springframework:spring-jcl:${springVersion}")
-                        module("org.springframework.boot:spring-boot:$bomVersion")
-                        module("org.springframework.boot:spring-boot-test:$bomVersion")
-                        module("org.springframework.boot:spring-boot-autoconfigure:$bomVersion")
-                        module("org.springframework.boot:spring-boot-test-autoconfigure:$bomVersion")
-                        module("junit:junit:4.12")
-                        module("org.hamcrest:hamcrest-core:1.3")
+                        constraint("org.springframework:spring-core:${springVersion}")
+                        constraint("org.springframework:spring-aop:${springVersion}")
+                        constraint("org.springframework:spring-beans:${springVersion}")
+                        constraint("org.springframework:spring-context:${springVersion}")
+                        constraint("org.springframework:spring-expression:${springVersion}")
+                        constraint("org.springframework:spring-test:${springVersion}")
+                        constraint("org.springframework:spring-jcl:${springVersion}")
+                        constraint("org.springframework.boot:spring-boot:$bomVersion")
+                        constraint("org.springframework.boot:spring-boot-test:$bomVersion")
+                        constraint("org.springframework.boot:spring-boot-autoconfigure:$bomVersion")
+                        constraint("org.springframework.boot:spring-boot-test-autoconfigure:$bomVersion")
+                        constraint("junit:junit:4.12")
+                        constraint("org.hamcrest:hamcrest-core:1.3")
                         noArtifacts()
                     }
                 }


### PR DESCRIPTION
It's important to be able to differentiate between hard dependencies and
dependency constraints when analysing the resolution result. This was done
by adding a simple boolean property to `DependencyResult`, indicating if
the source of the edge is a dependency constraint.

The new API is not yet used in any dependency reporting.