### PR TITLE
Better support for constraints in `dependencies` report

### DIFF
--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -15,7 +15,7 @@
  */
 package org.gradle.api.tasks.diagnostics
 
-import groovy.transform.NotYetImplemented
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 
 class DependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
@@ -881,52 +881,74 @@ api (n)
 """
     }
 
-    @NotYetImplemented
-    void "reports custom selection reasons"() {
-        given:
-        mavenRepo.module("org", "foo", "1.0").publish()
-        mavenRepo.module("org", "foo", "2.0").publish()
-        mavenRepo.module("org", "bar", "1.0").publish()
-        mavenRepo.module("org.test", "bar", "2.0").publish()
-        mavenRepo.module("org", "baz", "1.0").publish()
+    def "renders dependency constraints non-transitively"() {
+        def moduleC = mavenRepo.module('group', 'moduleC', '1.0').publish()
+        def moduleB = mavenRepo.module('group', 'moduleB', '1.0').dependsOn(moduleC).publish()
+        def moduleA = mavenRepo.module('group', 'moduleA', '2.0').dependsOn(moduleB).publish()
 
-        file("build.gradle") << """
+        buildFile << """
             repositories {
                 maven { url "${mavenRepo.uri}" }
             }
-            configurations {
-                conf {
-                    resolutionStrategy.eachDependency {
-                        switch (it.requested.name) {
-                           case 'foo':
-                              it.because('because I am in control').useVersion('2.0')
-                              break
-                           case 'bar':
-                              it.because('why not?').useTarget('org.test:bar:2.0')
-                              break
-                           default:
-                              useVersion(it.requested.version)
-                        }
-                    }
+            configurations { conf }
+            dependencies {
+                constraints {
+                    conf 'group:moduleA:2.0'
+                    conf 'group:moduleC:1.0'
                 }
             }
             dependencies {
-                conf 'org:foo:1.0'
-                conf 'org:bar:1.0'
-                conf 'org:baz:1.0'
+                conf 'group:moduleA'
             }
-        """
-
+"""
         when:
         run ":dependencies", "--configuration", "conf"
 
         then:
         output.contains """
 conf
-+--- org:foo:1.0 -> 2.0 (because I am in control)
-+--- org:bar:1.0 -> org.test:bar:2.0 (why not?)
-\\--- org:baz:1.0 (selected by rule)
++--- group:moduleA -> 2.0
+|    \\--- group:moduleB:1.0
+|         \\--- group:moduleC:1.0
++--- group:moduleA:2.0 (c)
+\\--- group:moduleC:1.0 (c)
+"""
+    }
 
+    def "reports imported BOM as a set of dependency constraints"() {
+        def moduleC = mavenRepo.module('group', 'moduleC', '1.0').publish()
+        def moduleB = mavenRepo.module('group', 'moduleB', '1.0').dependsOn(moduleC).publish()
+        def moduleA = mavenRepo.module('group', 'moduleA', '2.0').dependsOn(moduleB).publish()
+        mavenRepo.module('group', 'bom', '1.0')
+                .hasType("pom")
+                .dependencyConstraint(moduleA)
+                .dependencyConstraint(moduleC)
+                .publish()
+
+        buildFile << """
+            apply plugin: 'java' // Java plugin required for BOM import
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            dependencies {
+                implementation platform('group:bom:1.0')
+                implementation 'group:moduleA'
+            }
+"""
+        when:
+        run ":dependencies", "--configuration", "compileClasspath"
+
+        then:
+        output.contains """
+compileClasspath - Compile classpath for source set 'main'.
++--- group:bom:1.0
+|    +--- group:moduleA:2.0 (c)
+|    \\--- group:moduleC:1.0 (c)
+\\--- group:moduleA -> 2.0
+     \\--- group:moduleB:1.0
+          \\--- group:moduleC:1.0
+
+(c) - dependency constraint
 """
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -330,6 +330,7 @@ public class DependencyInsightReportTask extends DefaultTask {
                     out.withStyle(Failure).text(" FAILED");
                     break;
                 case RESOLVED:
+                case RESOLVED_CONSTRAINT:
                     break;
                 case UNRESOLVED:
                     out.withStyle(Failure).text(" (n)");

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/LegendRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/LegendRenderer.java
@@ -24,12 +24,17 @@ public class LegendRenderer {
 
     private boolean hasCyclicDependencies;
     private boolean hasUnresolvableConfigurations;
+    private boolean hasConstraints;
 
     public LegendRenderer(StyledTextOutput output) {
         this.output = output;
     }
 
     public void printLegend() {
+        if (hasConstraints) {
+            output.println();
+            output.withStyle(Info).text("(c) - dependency constraint");
+        }
         if (hasCyclicDependencies) {
             output.println();
             output.withStyle(Info).println("(*) - dependencies omitted (listed previously)");
@@ -46,5 +51,9 @@ public class LegendRenderer {
 
     public void setHasCyclicDependencies(boolean hasCyclicDependencies) {
         this.hasCyclicDependencies = hasCyclicDependencies;
+    }
+
+    public void setHasConstraints(boolean hasConstraints) {
+        this.hasConstraints = hasConstraints;
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/SimpleNodeRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/SimpleNodeRenderer.java
@@ -35,6 +35,9 @@ public class SimpleNodeRenderer implements NodeRenderer {
                     output.withStyle(Info).text(" (*)");
                 }
                 break;
+            case RESOLVED_CONSTRAINT:
+                output.withStyle(Info).text(" (c)");
+                break;
             case UNRESOLVED:
                 output.withStyle(Info).text(" (n)");
                 break;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependency.java
@@ -38,6 +38,7 @@ public interface RenderableDependency {
     enum ResolutionState {
         FAILED,
         RESOLVED,
+        RESOLVED_CONSTRAINT,
         UNRESOLVED
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependencyResult.java
@@ -34,7 +34,7 @@ public class RenderableDependencyResult extends AbstractRenderableDependencyResu
 
     @Override
     public ResolutionState getResolutionState() {
-        return ResolutionState.RESOLVED;
+        return dependency.isConstraint() ? ResolutionState.RESOLVED_CONSTRAINT : ResolutionState.RESOLVED;
     }
 
     @Override


### PR DESCRIPTION
When a constraint is in the graph, it means that another "hard" dependency also links to the same target component. This PR makes the "hard" dependency primary in the `dependencies` report, by never showing child nodes for a constraint edge.

See 82a707e5ac32987708d68b266405c8c43ac73e64 for more details.

Note that this PR is based on #7607, and will need to be merged accordingly.