### PR TITLE
Update release notes and upgrade guide to reflect 5.1 release

### DIFF
--- a/subprojects/docs/README.md
+++ b/subprojects/docs/README.md
@@ -55,6 +55,10 @@ This will generate:
 Note that PNG files in the source are generated from ".graphml" files in the same directory.  You can edit these files
 with tools like [yEd](http://www.yworks.com/en/products_yed_about.html) and then generate the associated PNG.
 
+If you just need to see a change to one of the userguide sections, try:
+
+    ./gradlew :docs:userguide -x :docs:userguideSinglePage
+
 ### Authoring with AsciiDoc
 
 To write a chapter in Asciidoctor format, simply place it in `src/docs/userguide` called `<chapter>.adoc`.

--- a/subprojects/docs/src/docs/release/notes-template.md
+++ b/subprojects/docs/src/docs/release/notes-template.md
@@ -1,17 +1,25 @@
-## New and noteworthy
+The Gradle team is excited to announce Gradle {gradleVersion}.
 
-Here are the new features introduced in this Gradle release.
+This release features [1](), [2](), ... [n](), and more.
 
-<!--
-IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
-Add-->
+We would like to thank the following community contributors to this release of Gradle:
+<!-- 
+ [Some person](https://github.com/some-person), // name only, details in separate section
+-->
 
-<!--
-### Example new and noteworthy
+<!-- 
+## 1
+
+details of 1
+
+## 2
+
+details of 2
+
+## n
 -->
 
 ## Promoted features
-
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
 
@@ -22,6 +30,10 @@ The following are the features that have been promoted in this Gradle release.
 -->
 
 ## Fixed issues
+
+## Known issues
+
+Known issues are problems that were discovered post release that are directly related to changes made in this release.
 
 ## Deprecations
 
@@ -34,11 +46,11 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
-## Potential breaking changes
+### Breaking changes
 
-<!--
-### Example breaking change
--->
+<!-- summary and links -->
+
+See the [Gradle 5.x upgrade guide](userguide/upgrading_version_{previous-gradle-version}.html) to learn about breaking changes and considerations for upgrading from Gradle 5.x.
 
 ## External contributions
 
@@ -50,6 +62,19 @@ We would like to thank the following community members for making contributions 
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 
-## Known issues
-
 Known issues are problems that were discovered post release that are directly related to changes made in this release.
+
+## Upgrade Instructions
+
+Switch your build to use Gradle {gradleVersion} by updating your wrapper properties:
+
+`./gradlew wrapper --gradle-version={gradleVersion}`
+
+Standalone downloads are available at [gradle.org/release-candidate](https://gradle.org/release-candidate). 
+
+## Reporting Problems
+
+If you find a problem with this release, please file a bug on [GitHub Issues](https://github.com/gradle/gradle/issues) adhering to our issue guidelines. 
+If you're not sure you're encountering a bug, please use the [forum](https://discuss.gradle.org/c/help-discuss).
+
+We hope you will build happiness with Gradle, and we look forward to your feedback via [Twitter](https://twitter.com/gradle) or on [GitHub](https://github.com/gradle).

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -1,16 +1,16 @@
-## New and noteworthy
+The Gradle team is excited to announce Gradle 5.1.
 
-Here are the new features introduced in this Gradle release.
+This release features [Stricter validation with `validateTaskProperties`](userguide/java_gradle_plugin.html), [2](), ... [n](), and more.
 
-<!--
-IMPORTANT: if this is a patch release, ensure that a prominent link is included in the foreword to all releases of the same minor stream.
-Add-->
+We would like to thank the following community contributors to this release of Gradle:
+[Mike Kobit](https://github.com/mkobit),
+[Kent Fletcher](https://github.com/fletcher-sumglobal),
+[Niklas Grebe](https://github.com/ThYpHo0n),
+[Jonathan Leitschuh](https://github.com/JLLeitschuh),
+[Sebastian Schuberth](https://github.com/sschuberth),
+[Dan Sănduleac](https://github.com/dansanduleac),
 
-<!--
-### Example new and noteworthy
--->
-
-### Stricter validation with `validateTaskProperties`
+## Stricter validation with `validateTaskProperties`
 
 Cacheable tasks are validated stricter than non-cacheable tasks by the `validateTaskProperties` task, which is added automatically by the [`java-gradle-plugin`](userguide/java_gradle_plugin.html).
 For example, all file inputs are required to have a normalization declared, like e.g. `@PathSensitive(RELATIVE)`.
@@ -34,16 +34,14 @@ The following are the features that have been promoted in this Gradle release.
 Previously, only exclude rules directly declared on published configurations (e.g. `apiElements` and `runtimeElements` for the `java` component defined by the [Java Library Plugin](userguide/java_library_plugin.html#sec:java_library_configurations_graph)) were published in the Ivy descriptor and POM when using the [Ivy Publish Plugin](userguide/publishing_ivy.html) or [Maven Publish Plugins](userguide/publishing_maven.html), respectively.
 Now, inherited exclude rules defined on extended configurations (e.g. `api` for Java libraries) are also taken into account.
 
+## Known issues
+
 ## Deprecations
 
 Features that have become superseded or irrelevant due to the natural evolution of Gradle become *deprecated*, and scheduled to be removed
-in the next major Gradle version (Gradle 5.0). See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
+in the next major Gradle version. See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
-
-<!--
-### Example deprecation
--->
 
 ### Setters for `classes` and `classpath` on `ValidateTaskProperties`
 
@@ -52,11 +50,13 @@ Use `setFrom` instead.
 
     validateTaskProperties.getClasses().setFrom(fileCollection)
     validateTaskProperties.getClasspath().setFrom(fileCollection)
+    
+### Breaking changes
 
-### Properties `inputFiles` and `outputFiles` of `Sign` task
+<!-- add any notable changes here in a summary -->
 
-Input and output files of `Sign` tasks are now tracked via `Signature.getToSign()` and `Signature.getFile()`, respectively, of the task's `signatures`.
-
+See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn about breaking changes and considerations for upgrading from Gradle 5.x.
+    
 ## Potential breaking changes
 
 <!--
@@ -91,10 +91,6 @@ We would like to thank the following community members for making contributions 
  - [Jonathan Leitschuh](https://github.com/JLLeitschuh) - Add Provider API types to `AbstractArchiveTask` task types (gradle/gradle#7435)
  - [Sebastian Schuberth](https://github.com/sschuberth) - Improve init-command comments for Kotlin projects (gradle/gradle#7592)
  - [Dan Sănduleac](https://github.com/dansanduleac) - Don't share dependency resolution listeners list when copying configuration (gradle/gradle#6996)
-
-<!--
- - [Some person](https://github.com/some-person) - fixed some issue (gradle/gradle#1234)
--->
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -1,0 +1,81 @@
+// Copyright 2018 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+[[upgrading_version_5]]
+= Upgrading your build from Gradle 5.x
+
+This chapter provides the information you need to migrate your Gradle 5.x builds to Gradle {gradleVersion}. For migrating from Gradle 4.x, complete the <<upgrading_version_4.adoc#upgrading_version_4, 4.x to 5.0 guide>> first.
+
+We recommend the following steps for all users:
+
+. Try running `gradle help --scan` and view the https://gradle.com/enterprise/releases/2018.4/#identify-usages-of-deprecated-gradle-functionality[deprecations view] of the generated build scan.
++
+image::deprecations.png[Deprecations View of a Gradle Build Scan]
++
+This is so that you can see any deprecation warnings that apply to your build.
++
+Alternatively, you could run `gradle help --warning-mode=all` to see the deprecations in the console, though it may not report as much detailed information.
+. Update your plugins.
++
+Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed. The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.
++
+. Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
+. Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
+
+[[changes_5.1]]
+== Upgrading from 5.0 and earlier
+
+=== Potential breaking changes
+
+The changes in this section have the potential to break your build, but the vast majority have been deprecated for quite some time and few builds will be affected by a large number of them.
+
+The following changes were not previously deprecated:
+
+* Passing arguments to Windows Resource Compiler
+
++
+To follow idiomatic <<#lazy_configuration.adoc, Provider API>> practices, the `WindowsResourceCompile` task has been converted to use the Provider API.
++
+Passing additional compiler arguments now follow the same pattern as `CppCompile` and other tasks.
+* Input and output files of `Sign` tasks are now tracked via `Signature.getToSign()` and `Signature.getFile()`, respectively.
+* The list of `beforeResolve` actions are no longer shared between a copied configuration and the original.
+Instead, a copied configuration receives a copy of the `beforeResolve` actions at the time the copy is made.
+Any `beforeResolve` actions added after copying (to either configuration) will not be shared between the original and the copy.
+This may break plugins that relied on the previous behaviour.
+
+////
+The following breaking changes will appear as deprecation warnings with Gradle 5.X:
+ *
+////
+
+=== Deprecated classes, methods and properties
+
+Follow the API links to learn how to deal with these deprecations (if no extra information is provided here):
+
+ * Setters for `classes` and `classpath` on link:{javadocPath}/org/gradle/plugin/devel/tasks/ValidateTaskProperties.html[`ValidateTaskProperties`]
+
+ * There should not be setters for lazy properties like link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[`ConfigurableFileCollection`].  Use `setFrom` instead. For example,
+----
+    validateTaskProperties.getClasses().setFrom(fileCollection)
+    validateTaskProperties.getClasspath().setFrom(fileCollection)
+----
+
+////
+== Changes in detail
+
+[[rel5.X:title]]
+=== [5.X] Title
+
+Details...
+////

--- a/subprojects/docs/src/docs/userguide/userguide_single.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide_single.adoc
@@ -39,6 +39,7 @@ include::installation.adoc[leveloffset=+2]
 
 include::kotlin_dsl.adoc[leveloffset=+2]
 
+include::upgrading_version_5.adoc[leveloffset=+2]
 include::upgrading_version_4.adoc[leveloffset=+2]
 
 == Using Gradle Builds

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -102,7 +102,8 @@
             <li><a href="/userguide/installation.html">Installing Gradle</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#upgrading-gradle" aria-expanded="false" aria-controls="upgrading-gradle">Upgrading Gradle</a>
                 <ul id="upgrading-gradle">
-                    <li><a href="/userguide/upgrading_version_4.html">version 4.x to 5.0</a></li>
+                    <li><a href="/userguide/upgrading_version_5.html">version 5.X</a></li>
+                    <li><a href="/userguide/upgrading_version_4.html">version 4.X to 5.0</a></li>
                 </ul>
             </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#migrating-to-gradle" aria-expanded="false" aria-controls="migrating-to-gradle">Migrating to Gradle</a>


### PR DESCRIPTION
 - adds Gradle [5.X upgrade guide](https://builds.gradle.org/repository/download/Gradle_Check_BuildDistributions/17304718:id/distributions/gradle-5.1-all.zip%21/gradle-5.1-20181105173900%2B0100/docs/userguide/upgrading_version_5.html)
 - applies [new template for release notes](https://builds.gradle.org/repository/download/Gradle_Check_BuildDistributions/17304718:id/distributions/gradle-5.1-all.zip%21/gradle-5.1-20181105173900%2B0100/docs/release-notes.html) to this branch
 - moves breaking changes from release notes to upgrade guide