### PR TITLE
Fork a single-use daemon of client VM has too little memory

### DIFF
--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
@@ -109,6 +109,19 @@ class BuildProcessTest extends Specification {
         buildProcess.configureForBuild(emptyRequest)
     }
 
+    def "current VM does not match if it was started with the default client heap size"() {
+        given:
+        def currentJvmOptions = new JvmOptions(fileResolver)
+        currentJvmOptions.maxHeapSize = "64m"
+        def emptyRequest = buildParameters([])
+
+        when:
+        def buildProcess = new BuildProcess(currentJvm, currentJvmOptions)
+
+        then:
+        !buildProcess.configureForBuild(emptyRequest)
+    }
+
     def "current and requested build vm match if no arguments are requested even if the daemon defaults are applied"() {
         //if the user does not configure any jvm args Gradle uses some defaults
         //however, we don't want those defaults to influence the decision whether to use existing process or not


### PR DESCRIPTION
We lowered the client VMs memory to 64m by default, which is plenty
for displaying log output, but not enough to run the vast majority
of builds. Users who really want to run their build inside the client
process should set a higher memory requirement via GRADLE_OPTS.
For all others we now automatically fork a single-use daemon, so their
build doesn't fail in environments that automatically append the "--no-daemon" flag.
These environments unfortunately include popular ones like Travis and TeamCity.