### PR TITLE
Fix bug that allowed duplicates in NamedDomainObjectList via `addAll()`

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectCollection.java
@@ -244,7 +244,7 @@ public class DefaultDomainObjectCollection<T> extends AbstractCollection<T> impl
         return doAdd(toAdd, notification);
     }
 
-    private <I extends T> boolean doAdd(I toAdd, Action<? super I> notification) {
+    protected <I extends T> boolean doAdd(I toAdd, Action<? super I> notification) {
         if (getStore().add(toAdd)) {
             didAdd(toAdd);
             notification.execute(toAdd);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectCollection.java
@@ -106,22 +106,16 @@ public class DefaultNamedDomainObjectCollection<T> extends DefaultDomainObjectCo
     }
 
     @Override
-    public boolean add(final T o) {
-        assertMutable("add(T)");
-        return add(o, getEventRegister().getAddActions());
-    }
-
-    @Override
-    protected <I extends T> boolean add(final I o, Action<? super I> notification) {
-        final String name = namer.determineName(o);
+    protected <I extends T> boolean doAdd(I toAdd, Action<? super I> notification) {
+        final String name = namer.determineName(toAdd);
         if (index.get(name) == null) {
-            boolean added = super.add(o, notification);
+            boolean added = super.doAdd(toAdd, notification);
             if (added) {
-                whenKnown.execute(new ObjectBackedElementInfo<T>(name, o));
+                whenKnown.execute(new ObjectBackedElementInfo<T>(name, toAdd));
             }
             return added;
         } else {
-            handleAttemptToAddItemWithNonUniqueName(o);
+            handleAttemptToAddItemWithNonUniqueName(toAdd);
             return false;
         }
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractDomainObjectCollectionSpec.groovy
@@ -86,6 +86,23 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         !iterator.hasNext()
     }
 
+    def "does not add elements with duplicate name"() {
+        given:
+        container.add(a)
+
+        when:
+        container.add(a)
+
+        then:
+        toList(container) == [a]
+
+        when:
+        container.addAll([a, b])
+
+        then:
+        toList(container) == [a, b]
+    }
+
     def "element added using provider is not realized when added"() {
         containerAllowsExternalProviders()
         def provider = Mock(ProviderInternal)
@@ -309,10 +326,6 @@ abstract class AbstractDomainObjectCollectionSpec<T> extends Specification {
         container.addAll(a, b, c, d)
 
         then:
-        // TODO:DAZ This indicates a bug in the list implementation: should not be firing for duplicates
-        if (container instanceof List) {
-            1 * action.execute(a)
-        }
         1 * action.execute(b)
         1 * action.execute(c)
         1 * action.execute(d)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultNamedDomainObjectListTest.groovy
@@ -212,7 +212,7 @@ class DefaultNamedDomainObjectListTest extends AbstractNamedDomainObjectCollecti
         list.addAll(['a', 'b', 'a'])
 
         expect:
-        list.lastIndexOf('a') == 2
+        list.lastIndexOf('a') == 0  // Duplicates are omitted
         list.lastIndexOf('other') == -1
     }
 


### PR DESCRIPTION
Before this change, added elements were being de-duplicated when added via `.add()`, but not via `.addAll()`.  This change makes the behaviour of `addAll` consistent with `add()`.
