### PR TITLE
Avoid using Jetty for flaky tests

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/IntegrationTestBuildContext.java
@@ -73,7 +73,7 @@ public class IntegrationTestBuildContext {
 
     /**
      * The timestamped version used in the docs and the bin and all zips. This should be different to {@link GradleVersion#getVersion()}.
-     * Note that the binary distribution used for testing (testBinZip and intTestImage) has {@link GradleVersion#getVersion()} as version.
+     * Note that the binary distribution used for testing (binZip and intTestImage) has {@link GradleVersion#getVersion()} as version.
      *
      * @return timestamped version
      */

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiRemoteIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiRemoteIntegrationTest.groovy
@@ -48,7 +48,7 @@ class ToolingApiRemoteIntegrationTest extends AbstractIntegrationSpec {
     final ToolingApi toolingApi = new ToolingApi(distribution, temporaryFolder)
 
     void setup() {
-        assert distribution.binDistribution.exists() : "bin distribution must exist to run this test, you need to run the 'testBinZip' task"
+        assert distribution.binDistribution.exists() : "bin distribution must exist to run this test, you need to run the 'binZip' task"
         server.start()
         toolingApi.requireIsolatedUserHome()
     }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperChecksumVerificationTest.groovy
@@ -15,27 +15,25 @@
  */
 
 package org.gradle.integtests
+
 import org.gradle.internal.hash.HashUtil
-import org.gradle.test.fixtures.server.http.HttpServer
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Issue
 
 @Issue('https://github.com/gradle/gradle-private/issues/1537')
-@Requires(TestPrecondition.OLD_JETTY_COMPATIBLE)
 class WrapperChecksumVerificationTest extends AbstractWrapperIntegrationSpec {
     @Rule
-    HttpServer server = new HttpServer()
+    BlockingHttpServer server = new BlockingHttpServer()
 
     def setup() {
-        server.allowGetOrHead('/gradle-bin.zip', distribution.binDistribution)
+        server.expect(server.file("/gradle-bin.zip", distribution.binDistribution))
         server.start()
     }
 
     def "wrapper execution fails when using bad checksum"() {
         given:
-        prepareWrapper(new URI("${server.address}/gradle-bin.zip"))
+        prepareWrapper(new URI("${server.uri}/gradle-bin.zip"))
 
         and:
         file('gradle/wrapper/gradle-wrapper.properties') << 'distributionSha256Sum=bad'
@@ -51,7 +49,7 @@ Verification of Gradle distribution failed!
 Your Gradle distribution may have been tampered with.
 Confirm that the 'distributionSha256Sum' property in your gradle-wrapper.properties file is correct and you are downloading the wrapper from a trusted source.
 
- Distribution Url: ${server.address}/gradle-bin.zip
+ Distribution Url: ${server.uri}/gradle-bin.zip
 Download Location: $f.absolutePath
 Expected checksum: 'bad'
   Actual checksum: '${HashUtil.sha256(distribution.binDistribution).asZeroPaddedHexString(64)}'
@@ -60,7 +58,7 @@ Expected checksum: 'bad'
 
     def "wrapper successfully verifies good checksum"() {
         given:
-        prepareWrapper(new URI("${server.address}/gradle-bin.zip"))
+        prepareWrapper(new URI("${server.uri}/gradle-bin.zip"))
 
         and:
         file('gradle/wrapper/gradle-wrapper.properties') << "distributionSha256Sum=${HashUtil.sha256(distribution.binDistribution).asZeroPaddedHexString(64)}"

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperConcurrentDownloadTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperConcurrentDownloadTest.groovy
@@ -14,64 +14,29 @@
  * limitations under the License.
  */
 package org.gradle.integtests
-import org.apache.commons.io.IOUtils
-import org.gradle.test.fixtures.file.TestFile
+
+
+import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
-import org.junit.rules.ExternalResource
-import org.mortbay.jetty.Connector
-import org.mortbay.jetty.Server
-import org.mortbay.jetty.bio.SocketConnector
-import org.mortbay.jetty.handler.AbstractHandler
 import spock.lang.Issue
 
-import javax.servlet.ServletException
-import javax.servlet.http.HttpServletRequest
-import javax.servlet.http.HttpServletResponse
-
 class WrapperConcurrentDownloadTest extends AbstractWrapperIntegrationSpec {
-    @Rule BlockingDownloadHttpServer server = new BlockingDownloadHttpServer(distribution.binDistribution)
+    @Rule BlockingHttpServer server = new BlockingHttpServer()
+
+    def setup() {
+        server.expect(server.file("/gradle-bin.zip", distribution.binDistribution))
+        server.start()
+    }
 
     @Issue("https://issues.gradle.org/browse/GRADLE-2699")
     def "concurrent downloads do not stomp over each other"() {
         given:
-        prepareWrapper(server.distUri)
+        prepareWrapper(server.uri("gradle-bin.zip"))
 
         when:
         def results = [1..4].collect { wrapperExecuter.start() }*.waitForFinish()
 
         then:
         results.findAll { it.output.contains("Downloading") }.size() == 1
-    }
-
-    static class BlockingDownloadHttpServer extends ExternalResource {
-        private final Server server = new Server()
-        private final TestFile binZip
-
-        BlockingDownloadHttpServer(TestFile binZip) {
-            this.binZip = binZip
-        }
-
-        URI getDistUri() {
-            return new URI("http://localhost:${server.connectors[0].localPort}/gradle-bin.zip")
-        }
-
-        @Override
-        protected void before() throws Throwable {
-            server.connectors = [new SocketConnector()] as Connector[]
-            server.addHandler(new AbstractHandler() {
-                void handle(String target, HttpServletRequest request, HttpServletResponse response, int dispatch) throws IOException, ServletException {
-                    binZip.withInputStream { instr ->
-                        IOUtils.copy(instr, response.outputStream)
-                    }
-                    request.handled = true
-                }
-            })
-            server.start()
-        }
-
-        @Override
-        protected void after() {
-            server.stop()
-        }
     }
 }

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperHttpsIntegrationTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests
+
+import org.gradle.integtests.fixtures.TestResources
+import org.gradle.test.fixtures.keystore.TestKeyStore
+import org.gradle.test.fixtures.server.http.HttpServer
+import org.gradle.test.fixtures.server.http.TestProxyServer
+import org.gradle.util.GradleVersion
+import org.junit.Rule
+
+import static org.gradle.test.matchers.UserAgentMatcher.matchesNameAndVersion
+
+class WrapperHttpsIntegrationTest extends AbstractWrapperIntegrationSpec {
+    @Rule HttpServer server = new HttpServer()
+    @Rule TestProxyServer proxyServer = new TestProxyServer()
+    @Rule TestResources resources = new TestResources(temporaryFolder)
+
+    def setup() {
+        server.start()
+        server.expectUserAgent(matchesNameAndVersion("gradlew", GradleVersion.current().getVersion()))
+        file("build.gradle") << """
+    task hello {
+        doLast {
+            println 'hello'
+        }
+    }
+
+    task echoProperty {
+        doLast {
+            println "fooD=" + project.properties["fooD"]
+        }
+    }
+"""
+    }
+
+    private prepareWrapper(String baseUrl) {
+        prepareWrapper(new URI("${baseUrl}/gradlew/dist"))
+    }
+
+    def "does not warn about using basic authentication over secure connection"() {
+        given:
+        TestKeyStore keyStore = TestKeyStore.init(resources.dir)
+        keyStore.enableSslWithServerCert(server)
+        // We need to set the SSL properties as arguments here even for non-embedded test mode
+        // because we want them to be set on the wrapper client JVM, not the daemon one
+        wrapperExecuter.withArgument("-Djavax.net.ssl.trustStore=$keyStore.trustStore.path")
+        wrapperExecuter.withArgument("-Djavax.net.ssl.trustStorePassword=$keyStore.trustStorePassword")
+
+        and:
+        prepareWrapper("https://jdoe:changeit@localhost:${server.sslPort}")
+        server.expectGet("/gradlew/dist", "jdoe", "changeit", distribution.binDistribution)
+
+        when:
+        result = wrapperExecuter.withTasks('hello').run()
+
+        then:
+        outputDoesNotContain('WARNING Using HTTP Basic Authentication over an insecure connection to download the Gradle distribution. Please consider using HTTPS.')
+    }
+}


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Fixes https://github.com/gradle/gradle-native-private/issues/179

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fflaky%2Favoid-using-jetty)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
