### PR TITLE
Show version constraint details in reporting and error messages

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/VersionConstraint.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.artifacts;
 
+import org.gradle.api.Describable;
 import org.gradle.api.Incubating;
 
 import javax.annotation.Nullable;
@@ -91,7 +92,7 @@ import java.util.List;
  * @since 4.4
  */
 @Incubating
-public interface VersionConstraint {
+public interface VersionConstraint extends Describable {
     /**
      * The branch to select versions from. When not {@code null} selects only those versions that were built from the specified branch.
      *

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -106,9 +106,9 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:[1.0,1.2]", "org:foo:1.2")
+                edge("org:foo:{strictly [1.0,1.2]}", "org:foo:1.2")
                 edge('org:bar:1.0', 'org:bar:1.0') {
-                    edge("org:foo:[1.1,1.3]", "org:foo:1.2")
+                    edge("org:foo:{strictly [1.1,1.3]}", "org:foo:1.2")
                 }
             }
         }
@@ -164,10 +164,10 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:bar:1') {
-                    edge("org:foo:1.1", "org:foo:1.1")
+                    edge("org:foo:{prefer 1.1}", "org:foo:1.1")
                 }
                 module('org:baz:1') {
-                    edge("org:foo:1.0", "org:foo:1.1")
+                    edge("org:foo:{prefer 1.0}", "org:foo:1.1")
                 }
                 edge("org:foo:[1.0,2.0)", "org:foo:1.1")
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -59,7 +59,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' strictly '15' because of the following reason: what not""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{strictly 15}' because of the following reason: what not""")
 
     }
 
@@ -209,8 +209,8 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' strictly '17'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' strictly '15'""")
+   Dependency path ':test:unspecified' --> 'org:foo:{strictly 17}'
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -247,7 +247,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.0' rejects '1.1'""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{require 1.0; reject 1.1}'""")
     }
 
     @Unroll
@@ -283,7 +283,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo:1.1'
-   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.0' rejects any of "${rejects.collect {"'$it'"}.join(', ')}\"""")
+   Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{require 1.0; reject ${rejects.join(' & ')}}'""")
 
         where:
         rejects << [
@@ -325,7 +325,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
    Dependency path ':test:unspecified' --> 'org:foo:1.0'
-   Constraint path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo' rejects all versions""")
+   Constraint path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{reject +}'""")
 
     }
 
@@ -380,7 +380,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' strictly '1.0' because of the following reason: Not following semantic versioning
+   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
    Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b:1.1'""")
 
         and:
@@ -439,7 +439,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:b' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b' strictly '1.0' because of the following reason: Not following semantic versioning
+   Dependency path ':test:unspecified' --> 'org:a:1.0' --> 'org:b:{strictly 1.0}' because of the following reason: Not following semantic versioning
    Dependency path ':test:unspecified' --> 'org:c:1.0' --> 'org:b:1.1'""")
 
         and:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedRichVersionConstraintsIntegrationTest.groovy
@@ -325,7 +325,7 @@ class PublishedRichVersionConstraintsIntegrationTest extends AbstractModuleDepen
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
    Dependency path ':test:unspecified' --> 'org:foo:1.0'
-   Constraint path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{reject +}'""")
+   Constraint path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:{reject all versions}'""")
 
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -245,7 +245,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' strictly '1.0'
+   Dependency path ':test:unspecified' --> 'org:foo:{strictly 1.0}'
    Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'""")
 
     }
@@ -454,7 +454,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo:17'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '15'""")
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -506,8 +506,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' strictly '17'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '15'""")
+   Dependency path ':test:unspecified' --> 'org:foo:{strictly 17}'
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo:{strictly 15}'""")
 
     }
 
@@ -562,8 +562,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo' strictly '[15,16]'
-   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo' strictly '[17,18]'""")
+   Dependency path ':test:unspecified' --> 'org:foo:{strictly [15,16]}'
+   Dependency path ':test:unspecified' --> 'test:other:unspecified' --> 'org:foo:{strictly [17,18]}'""")
 
     }
 
@@ -796,7 +796,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
-   Dependency path ':test:unspecified' --> 'org:foo:1.0' rejects '1.1'
+   Dependency path ':test:unspecified' --> 'org:foo:{require 1.0; reject 1.1}'
    Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'""")
     }
 
@@ -1013,7 +1013,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:bar' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:bar:1'
-   Constraint path ':test:unspecified' --> 'org:bar' strictly '1'
+   Constraint path ':test:unspecified' --> 'org:bar:{strictly 1}'
    Dependency path ':test:unspecified' --> 'org:foo:2' --> 'org:bar:2'""")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -598,7 +598,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org:foo:15'
-   Dependency path ':test:unspecified' --> 'org:foo' strictly '[0,1]'""")
+   Dependency path ':test:unspecified' --> 'org:foo:{strictly [0,1]}'""")
     }
 
     void "should pass if strict version ranges overlap"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RichVersionConstraintsIntegrationTest.groovy
@@ -57,7 +57,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:foo:1.0")
+                edge("org:foo:{strictly 1.0}", "org:foo:1.0")
             }
         }
     }
@@ -105,8 +105,8 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                constraint("org:foo:1.0.0", "org:foo:1.1.0")
-                constraint("org:foo:1.1.0", "org:foo:1.1.0")
+                constraint("org:foo:{prefer 1.0.0}", "org:foo:1.1.0")
+                constraint("org:foo:{prefer 1.1.0}", "org:foo:1.1.0")
                 edge("org:foo:[1.0.0,2.0.0)", "org:foo:1.1.0") {
                     byConstraint()
                     byReason("didn't match version 2.0.0")
@@ -154,7 +154,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:[1.0.0,2.0.0)", "org:foo:1.1.0")
+                edge("org:foo:{require [1.0.0,2.0.0); prefer 1.1.0}", "org:foo:1.1.0")
                 edge("org:foo:0.9", "org:foo:1.1.0").byConflictResolution("between versions 0.9 and 1.1.0")
             }
         }
@@ -199,7 +199,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:[1.0.0,2.0.0)", "org:foo:1.1.0")
+                edge("org:foo:{strictly [1.0.0,2.0.0); prefer 1.1.0}", "org:foo:1.1.0")
             }
         }
     }
@@ -286,7 +286,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge "org:foo:1.0", "org:foo:1.0"
+                edge "org:foo:{strictly 1.0}", "org:foo:1.0"
                 edge("org:bar:1.0", "org:bar:1.0") {
                     edge "org:foo:1.0", "org:foo:1.0"
                 }
@@ -333,7 +333,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge "org:foo:1.1", "org:foo:1.1"
+                edge "org:foo:{strictly 1.1}", "org:foo:1.1"
                 edge("org:bar:1.0", "org:bar:1.0") {
                     edge("org:foo:1.0", "org:foo:1.1").byConflictResolution("between versions 1.1 and 1.0")
                 }
@@ -396,7 +396,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
 
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:$directDependencyVersion", "org:foo:1.2")
+                edge("org:foo:{strictly $directDependencyVersion}", "org:foo:1.2")
                 edge("org:bar:1.0", "org:bar:1.0") {
                     edge("org:foo:$transitiveDependencyVersion", "org:foo:1.2")
                 }
@@ -654,11 +654,11 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:[1.0,1.2]", "org:foo:1.2")
+                edge("org:foo:{strictly [1.0,1.2]}", "org:foo:1.2")
                 project(':other', 'test:other:') {
                     configuration = 'conf'
                     noArtifacts()
-                    edge("org:foo:[1.1,1.3]", "org:foo:1.2")
+                    edge("org:foo:{strictly [1.1,1.3]}", "org:foo:1.2")
                 }
             }
         }
@@ -693,7 +693,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:foo:1.0")
+                edge("org:foo:{require 1.0; reject 1.1}", "org:foo:1.0")
             }
         }
     }
@@ -743,7 +743,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:$notation", "org:foo:1.0").byReason("rejected version 1.1")
+                edge("org:foo:{require $notation; reject 1.1}", "org:foo:1.0").byReason("rejected version 1.1")
             }
         }
 
@@ -832,7 +832,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:foo:[1.0,)", "org:foo:1.1").byReason("rejected versions 1.5, 1.4, 1.3, 1.2")
+                edge("org:foo:{require [1.0,); reject [1.2, 1.5]}", "org:foo:1.1").byReason("rejected versions 1.5, 1.4, 1.3, 1.2")
             }
         }
     }
@@ -865,7 +865,7 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                module("org:foo:1.0")
+                edge("org:foo:{require 1.0; reject 1.1 & 1.2}", "org:foo:1.0")
             }
         }
     }
@@ -883,11 +883,12 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
             }
         }
 
+        def rejectString = rejects.collect({"'${it}'"}).join(', ')
         buildFile << """
             dependencies {
                 conf('org:foo:$notation') {
                    version {
-                      reject $rejects
+                      reject $rejectString
                    }
                 }
             }           
@@ -915,26 +916,26 @@ class RichVersionConstraintsIntegrationTest extends AbstractModuleDependencyReso
         resolve.expectGraph {
             root(":", ":test:") {
                 String rejectedVersions = (selected+1..5).collect { "1.${it}" }.reverse().join(", ")
-                edge("org:foo:$notation", "org:foo:1.$selected").byReason("rejected versions ${rejectedVersions}")
+                edge("org:foo:{require $notation; reject ${rejects.join(' & ')}}", "org:foo:1.$selected").byReason("rejected versions ${rejectedVersions}")
             }
         }
 
         where:
         notation         | rejects                      | selected | requiresMetadata
-        '1+'             | "'1.4', '1.5'"               | 3        | false
-        '1.+'            | "'1.4', '1.5'"               | 3        | false
-        '[1.0,)'         | "'1.4', '1.5'"               | 3        | false
-        'latest.release' | "'1.4', '1.5'"               | 3        | true
+        '1+'             | ['1.4', '1.5']               | 3        | false
+        '1.+'            | ['1.4', '1.5']               | 3        | false
+        '[1.0,)'         | ['1.4', '1.5']               | 3        | false
+        'latest.release' | ['1.4', '1.5']               | 3        | true
 
-        '1+'             | "'[1.2,)', '1.5'"            | 1        | false
-        '1.+'            | "'[1.2,)', '1.5'"            | 1        | false
-        '[1.0,)'         | "'[1.2,)', '1.5'"            | 1        | false
-        'latest.release' | "'[1.2,)', '1.5'"            | 1        | true
+        '1+'             | ['[1.2,)', '1.5']            | 1        | false
+        '1.+'            | ['[1.2,)', '1.5']            | 1        | false
+        '[1.0,)'         | ['[1.2,)', '1.5']            | 1        | false
+        'latest.release' | ['[1.2,)', '1.5']            | 1        | true
 
-        '1+'             | "'1.5', '[1.1, 1.3]', '1.4'" | 0        | false
-        '1.+'            | "'1.5', '[1.1, 1.3]', '1.4'" | 0        | false
-        '[1.0,)'         | "'1.5', '[1.1, 1.3]', '1.4'" | 0        | false
-        'latest.release' | "'1.5', '[1.1, 1.3]', '1.4'" | 0        | true
+        '1+'             | ['1.5', '[1.1, 1.3]', '1.4'] | 0        | false
+        '1.+'            | ['1.5', '[1.1, 1.3]', '1.4'] | 0        | false
+        '[1.0,)'         | ['1.5', '[1.1, 1.3]', '1.4'] | 0        | false
+        'latest.release' | ['1.5', '[1.1, 1.3]', '1.4'] | 0        | true
     }
 
     def "adding rejectAll on a dependency is pointless and make it fail"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -110,7 +110,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
    Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'
-   Constraint path ':test:unspecified' --> 'org:foo' rejects all versions""")
+   Constraint path ':test:unspecified' --> 'org:foo:{reject +}'""")
     }
 
     void "dependency constraint is included into the result of resolution when a hard dependency is also added transitively"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsIntegrationTest.groovy
@@ -110,7 +110,7 @@ class DependencyConstraintsIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("""Module 'org:foo' has been rejected:
    Dependency path ':test:unspecified' --> 'org:bar:1.0' --> 'org:foo:1.1'
-   Constraint path ':test:unspecified' --> 'org:foo:{reject +}'""")
+   Constraint path ':test:unspecified' --> 'org:foo:{reject all versions}'""")
     }
 
     void "dependency constraint is included into the result of resolution when a hard dependency is also added transitively"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -111,8 +111,8 @@ dependencies {
         then:
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':depLock:unspecified' --> 'org:foo:1.+'
-   Dependency path ':depLock:unspecified' --> 'org:foo' strictly '1.1'
-   Constraint path ':depLock:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'"""
+   Dependency path ':depLock:unspecified' --> 'org:foo:{strictly 1.1}'
+   Constraint path ':depLock:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: dependency was locked to version '1.0'"""
     }
 
     def 'fails when lock file conflicts with declared version constraint'() {
@@ -149,7 +149,7 @@ dependencies {
         failure.assertHasCause """Cannot find a version of 'org:foo' that satisfies the version constraints: 
    Dependency path ':depLock:unspecified' --> 'org:foo:1.+'
    Dependency path ':depLock:unspecified' --> 'org:foo:1.1'
-   Constraint path ':depLock:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'"""
+   Constraint path ':depLock:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: dependency was locked to version '1.0'"""
     }
 
     def 'fails when lock file contains entry that is not in resolution result'() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -68,7 +68,7 @@ dependencies {
                 edge("org:foo:1.+", "org:foo:1.0") {
                     byReason("rejected version 1.1")
                 }
-                constraint("org:foo:1.0", "org:foo:1.0") {
+                constraint("org:foo:{strictly 1.0}", "org:foo:1.0") {
                     byConstraint("dependency was locked to version '1.0'")
                 }
             }
@@ -341,7 +341,7 @@ dependencies {
         outputContains """lockedConf
 +--- org:foo:1.+ FAILED
 +--- org:foo:1.1 FAILED
-\\--- org:foo:1.0 FAILED"""
+\\--- org:foo:{strictly 1.0} FAILED"""
     }
 
     def 'dependency report passes with FAILED dependencies for all out lock issues'() {
@@ -381,7 +381,7 @@ dependencies {
         outputContains """lockedConf
 +--- org:foo:[1.0, 1.1] FAILED
 +--- org:foo:1.1 FAILED
-+--- org:foo:1.0 FAILED
++--- org:foo:{strictly 1.0} FAILED
 \\--- org:bar:1.0 FAILED
 """
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -60,7 +60,7 @@ dependencies {
         succeeds 'dependencies'
 
         then:
-        outputContains('org:bar:1.0')
+        outputContains('org:bar')
         outputDoesNotContain('foo')
 
     }
@@ -131,7 +131,7 @@ dependencies {
         succeeds 'dependencies'
 
         then:
-        outputContains("org:bar:$resolvedVersion")
+        outputContains("org:bar:latest.${level} -> $resolvedVersion")
 
         where:
         level         | resolvedVersion

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/UsingLockingOnNonProjectConfigurationsIntegrationTest.groovy
@@ -58,7 +58,7 @@ buildscript {
         succeeds 'buildEnvironment'
 
         then:
-        outputContains('org.foo:foo-plugin:1.0')
+        outputContains('org.foo:foo-plugin:[1.0,2.0) -> 1.0')
         outputDoesNotContain('org.foo:foo-plugin:1.1')
     }
 
@@ -104,7 +104,7 @@ plugins {
         succeeds 'buildEnvironment'
 
         then:
-        outputContains('org.foo:foo-plugin:1.0')
+        outputContains('org.foo:foo-plugin:[1.0,2.0) -> 1.0')
         outputDoesNotContain('org.foo:foo-plugin:1.1')
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -796,7 +796,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB' strictly '1.0'"""
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB:{strictly 1.0}'"""
 
         where:
         thing                    | defineAsConstraint
@@ -868,7 +868,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         fails 'checkDep'
         failure.assertHasCause """Cannot find a version of 'org.test:moduleB' that satisfies the version constraints: 
    Dependency path ':test:unspecified' --> 'org.test:moduleB:1.1'
-   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB:1.+' rejects any of "'1.1', '1.2'\""""
+   ${defineAsConstraint? 'Constraint' : 'Dependency'} path ':test:unspecified' --> 'org.test:moduleA:1.0' --> 'org.test:moduleB:{require 1.+; reject 1.1 & 1.2}'"""
 
         where:
         thing                    | defineAsConstraint

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -160,9 +160,9 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                 edge('org.test:moduleB', 'org.test:moduleB:1.0')
                 module("org.test:moduleA:1.0:$expectedVariant") {
                     if (thing == "dependencies") {
-                        edge('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
+                        edge('org.test:moduleB:{strictly 1.0}', 'org.test:moduleB:1.0')
                     } else {
-                        constraint('org.test:moduleB:1.0', 'org.test:moduleB:1.0')
+                        constraint('org.test:moduleB:{strictly 1.0}', 'org.test:moduleB:1.0')
                     }
                 }
             }
@@ -353,7 +353,10 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                     context.details.withVariant("$variantToTest") { 
                         withDependencies {
                             it.each {
-                                it.version { ${keyword} '1.0' }
+                                it.version {
+                                    require '' 
+                                    ${keyword} '1.0' 
+                                }
                             }
                         }
                     }
@@ -380,10 +383,11 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
         then:
         succeeds 'checkDep'
         def expectedVariant = variantToTest
+        def versionConstraint = keyword == 'require' ? '1.0' : "{${keyword} 1.0}"
         resolve.expectGraph {
             root(':', ':test:') {
                 module("org.test:moduleA:1.0:$expectedVariant") {
-                    module('org.test:moduleB:1.0')
+                    edge('org.test:moduleB:' + versionConstraint, 'org.test:moduleB:1.0')
                 }
             }
         }
@@ -1014,7 +1018,7 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
                             edge("org.test:moduleC:1.0", "org.test:moduleC:1.1")
                             byReason('can set a custom reason in a rule')
                         }
-                        constraint("org.test:moduleC:1.1", "org.test:moduleC:1.1").byConflictResolution("between versions 1.0 and 1.1")
+                        constraint("org.test:moduleC:{strictly 1.1}", "org.test:moduleC:1.1").byConflictResolution("between versions 1.0 and 1.1")
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -45,10 +45,49 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
 
     @Override
     public String toString() {
-        return getRequiredVersion()
-            + (getPreferredVersion().isEmpty() ? "" : " {prefers: " + getPreferredVersion() + "}")
-            + (getStrictVersion().isEmpty() ? "" : " {strictly: " + getStrictVersion() + "}")
-            + (getRejectedVersions().isEmpty() ? "" : " {rejects: " + Joiner.on(" & ").join(getRejectedVersions()) + "}")
-            + (getBranch() == null ? "" : " {branch: " + getBranch() + "}");
+        return getDisplayName();
+    }
+
+    private void append(String name, String version, StringBuilder builder) {
+        if (version == null || version.isEmpty()) {
+            return;
+        }
+        if (builder.length() != 1) {
+            builder.append("; ");
+        }
+        builder.append(name);
+        builder.append(" ");
+        builder.append(version);
+    }
+
+    @Override
+    public String getDisplayName() {
+        String requiredVersion = getRequiredVersion();
+        if (requiredOnly()) {
+            return requiredVersion;
+        }
+
+        String strictVersion = getStrictVersion();
+        String preferVersion = getPreferredVersion();
+        StringBuilder builder = new StringBuilder();
+        builder.append("{");
+        append("strictly", strictVersion, builder);
+        if (!requiredVersion.equals(strictVersion)) {
+            append("require", requiredVersion, builder);
+        }
+        if (!(preferVersion.equals(requiredVersion) || preferVersion.equals(strictVersion))) {
+            append("prefer", getPreferredVersion(), builder);
+        }
+        append("reject", Joiner.on(" & ").join(getRejectedVersions()), builder);
+        append("branch", getBranch(), builder);
+        builder.append("}");
+        return builder.toString();
+    }
+
+    private boolean requiredOnly() {
+        return (getPreferredVersion().isEmpty() || getRequiredVersion().equals(getPreferredVersion()))
+                && getStrictVersion().isEmpty()
+                && getRejectedVersions().isEmpty()
+                && getBranch() == null;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractVersionConstraint.java
@@ -19,6 +19,8 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Objects;
 import org.gradle.api.artifacts.VersionConstraint;
 
+import java.util.List;
+
 public abstract class AbstractVersionConstraint implements VersionConstraint {
     @Override
     public boolean equals(Object o) {
@@ -78,7 +80,7 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
         if (!(preferVersion.equals(requiredVersion) || preferVersion.equals(strictVersion))) {
             append("prefer", getPreferredVersion(), builder);
         }
-        append("reject", Joiner.on(" & ").join(getRejectedVersions()), builder);
+        append("reject", rejectedVersionsString(), builder);
         append("branch", getBranch(), builder);
         builder.append("}");
         return builder.toString();
@@ -89,5 +91,14 @@ public abstract class AbstractVersionConstraint implements VersionConstraint {
                 && getStrictVersion().isEmpty()
                 && getRejectedVersions().isEmpty()
                 && getBranch() == null;
+    }
+
+    private String rejectedVersionsString() {
+        List<String> rejectedVersions = getRejectedVersions();
+        if (rejectedVersions.size() == 1 && rejectedVersions.get(0).equals("+")) {
+            return "all versions";
+        } else {
+            return Joiner.on(" & ").join(rejectedVersions);
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -184,7 +184,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
             if (isDependencyImportScoped(currentDependencyMgt)) {
                 ModuleComponentSelector importedId = DefaultModuleComponentSelector.newSelector(
                     DefaultModuleIdentifier.newId(currentDependencyMgt.getGroupId(), currentDependencyMgt.getArtifactId()),
-                    new DefaultMutableVersionConstraint(currentDependencyMgt.getVersion()));
+                    new DefaultImmutableVersionConstraint(currentDependencyMgt.getVersion()));
                 PomReader importedPom = parsePomForSelector(parseContext, importedId, Maps.<String, String>newHashMap());
                 for (Map.Entry<MavenDependencyKey, PomDependencyMgt> entry : importedPom.getDependencyMgt().entrySet()) {
                     if (!importedDependencyMgts.containsKey(entry.getKey())) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/RejectedModuleMessageBuilder.java
@@ -18,20 +18,15 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionDescriptor;
-import org.gradle.api.internal.artifacts.ResolvedVersionConstraint;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.CompositeVersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.InverseVersionSelector;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelector;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 
 import java.util.List;
 import java.util.Set;
 
-public class RejectedModuleMessageBuilder {
-    public String buildFailureMessage(ModuleResolveState module) {
+class RejectedModuleMessageBuilder {
+    String buildFailureMessage(ModuleResolveState module) {
         boolean hasRejectAll = false;
         for (SelectorState candidate : module.getSelectors()) {
             hasRejectAll |= candidate.getVersionConstraint().isRejectAll();
@@ -63,56 +58,8 @@ public class RejectedModuleMessageBuilder {
         }
     }
 
-    static void renderSelector(StringBuilder sb, SelectorState selectorState) {
-        ResolvedVersionConstraint constraint = selectorState.getVersionConstraint();
-        ModuleIdentifier moduleId = selectorState.getTargetModule().getId();
-
-        sb.append('\'').append(moduleId.getGroup()).append(':').append(moduleId.getName());
-
-        if (constraint.isRejectAll()) {
-            sb.append("' rejects all versions");
-            return;
-        }
-
-        VersionSelector requiredSelector = constraint.getRequiredSelector();
-        VersionSelector rejectedSelector = constraint.getRejectedSelector();
-
-        if (rejectedSelector instanceof InverseVersionSelector) {
-            sb.append("' strictly '").append(requiredSelector.getSelector()).append("'");
-            return;
-        }
-
-        if (requiredSelector != null) {
-            sb.append(':').append(requiredSelector.getSelector());
-        }
-        sb.append("'");
-
-        if (constraint.getPreferredSelector() != null) {
-            sb.append(" prefers '").append(constraint.getPreferredSelector().getSelector()).append("'");
-        }
-
-        if (rejectedSelector == null) {
-            return;
-        }
-
-        sb.append(" rejects ");
-        if (rejectedSelector instanceof CompositeVersionSelector) {
-            sb.append("any of \"");
-            int i = 0;
-            for (VersionSelector selector : ((CompositeVersionSelector) rejectedSelector).getSelectors()) {
-                if (i++ > 0) {
-                    sb.append(", ");
-                }
-                sb.append('\'');
-                sb.append(selector.getSelector());
-                sb.append('\'');
-            }
-            sb.append("\"");
-        } else {
-            sb.append('\'');
-            sb.append(rejectedSelector.getSelector());
-            sb.append('\'');
-        }
+    private static void renderSelector(StringBuilder sb, SelectorState selectorState) {
+        sb.append('\'').append(selectorState.getRequested()).append('\'');
     }
 
     private static void renderReason(StringBuilder sb, SelectorState selector) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -70,9 +70,7 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     }
 
     public String getVersion() {
-        return versionConstraint.getRequiredVersion().isEmpty()
-            ? versionConstraint.getPreferredVersion()
-            : versionConstraint.getRequiredVersion();
+        return versionConstraint.getRequiredVersion();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -49,19 +49,14 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     public String getDisplayName() {
         String group = moduleIdentifier.getGroup();
         String module = moduleIdentifier.getName();
-        String version = getVersion();
         StringBuilder builder = new StringBuilder(group.length() + module.length() + versionConstraint.getRequiredVersion().length() + 2);
         builder.append(group);
         builder.append(":");
         builder.append(module);
-        if (version.length() > 0) {
+        String versionString = versionConstraint.getDisplayName();
+        if (versionString.length() > 0) {
             builder.append(":");
-            builder.append(version);
-        }
-        if (versionConstraint.getBranch() != null) {
-            builder.append(" (branch: ");
-            builder.append(versionConstraint.getBranch());
-            builder.append(")");
+            builder.append(versionString);
         }
         return builder.toString();
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
@@ -146,4 +146,26 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         c.strictVersion == v.strictVersion
         c.rejectedVersions == v.rejectedVersions
     }
+
+
+    def "has useful displayName"() {
+        expect:
+        displayNameFor('1.0', '', '', []) == "{prefer 1.0}"
+        displayNameFor('', '1.0', '', []) == "1.0"
+        displayNameFor('', '', '1.0', []) == "{strictly 1.0}"
+        displayNameFor('', '', '', ['1.0', '2.0']) == "{reject 1.0 & 2.0}"
+
+        displayNameFor('1.0', '2.0', '3.0', ['1.0', '2.0']) == "{strictly 3.0; require 2.0; prefer 1.0; reject 1.0 & 2.0}"
+        displayNameFor('1.0', '', '', [], 'br') == "{prefer 1.0; branch br}"
+
+        displayNameFor('1.0', '1.0', '', []) == "1.0" // prefer == require
+        displayNameFor('', '1.0', '1.0', []) == "{strictly 1.0}" // strictly == require
+        displayNameFor('1.0', '', '1.0', []) == "{strictly 1.0}" // strictly == prefer
+        displayNameFor('1.0', '1.0', '1.0', []) == "{strictly 1.0}" // strictly == prefer == require
+    }
+
+    private String displayNameFor(String preferred, String required, String strict, List<String> rejects, branch = null) {
+        new DefaultImmutableVersionConstraint(preferred, required, strict, rejects, branch).displayName
+    }
+
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dependencies/DefaultImmutableVersionConstraintTest.groovy
@@ -154,6 +154,7 @@ class DefaultImmutableVersionConstraintTest extends Specification {
         displayNameFor('', '1.0', '', []) == "1.0"
         displayNameFor('', '', '1.0', []) == "{strictly 1.0}"
         displayNameFor('', '', '', ['1.0', '2.0']) == "{reject 1.0 & 2.0}"
+        displayNameFor('', '', '', ['+']) == "{reject all versions}"
 
         displayNameFor('1.0', '2.0', '3.0', ['1.0', '2.0']) == "{strictly 3.0; require 2.0; prefer 1.0; reject 1.0 & 2.0}"
         displayNameFor('1.0', '', '', [], 'br') == "{prefer 1.0; branch br}"

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultModuleComponentSelectorTest.groovy
@@ -64,12 +64,12 @@ class DefaultModuleComponentSelectorTest extends Specification {
         versionSelector.toString() == "some-group:some-name:1.0"
 
         def branchSelector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('some-group', 'some-name'), b('release'))
-        branchSelector.displayName == "some-group:some-name (branch: release)"
-        branchSelector.toString() == "some-group:some-name (branch: release)"
+        branchSelector.displayName == "some-group:some-name:{branch release}"
+        branchSelector.toString() == "some-group:some-name:{branch release}"
 
         def bothSelector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('some-group', 'some-name'), v('1.0', 'release'))
-        bothSelector.displayName == "some-group:some-name:1.0 (branch: release)"
-        bothSelector.toString() == "some-group:some-name:1.0 (branch: release)"
+        bothSelector.displayName == "some-group:some-name:{require 1.0; branch release}"
+        bothSelector.toString() == "some-group:some-name:{require 1.0; branch release}"
 
         def noSelector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId('some-group', 'some-name'), v(''))
         noSelector.displayName == "some-group:some-name"

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -527,7 +527,7 @@ org:foo:1.0 FAILED
                Constraint path ':insight-test:unspecified' --> 'org:foo:1.1'
                Constraint path ':insight-test:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: dependency was locked to version '1.0'
 
-org:foo:{strictly 1.0} FAILED
+org:foo:{strictly 1.0} -> 1.0 FAILED
 \\--- lockedConf
 
 org:foo:1.1 (by constraint) FAILED

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -521,7 +521,7 @@ org:foo:1.0 FAILED
    Selection reasons:
       - By constraint : dependency was locked to version '1.0'
    Failures:
-      - Could not resolve org:foo:1.0.:
+      - Could not resolve org:foo:{requires 1.0; strictly 1.0}.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
                Dependency path ':insight-test:unspecified' --> 'org:foo:1.+'
                Constraint path ':insight-test:unspecified' --> 'org:foo:1.1'

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -2556,12 +2556,12 @@ org:bar: FAILED
    Selection reasons:
       - By constraint : Nope, you won't use this
    Failures:
-      - Could not resolve org:bar:{reject +}.:
+      - Could not resolve org:bar:{reject all versions}.:
           - Module 'org:bar' has been rejected:
                Dependency path ':insight-test:unspecified' --> 'org:bar:[1.0,)'
-               Constraint path ':insight-test:unspecified' --> 'org:bar:{reject +}' because of the following reason: Nope, you won't use this
+               Constraint path ':insight-test:unspecified' --> 'org:bar:{reject all versions}' because of the following reason: Nope, you won't use this
 
-org:bar:{reject +} FAILED
+org:bar:{reject all versions} FAILED
 \\--- compileClasspath
 
 org:bar:[1.0,) FAILED

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -525,7 +525,7 @@ org:foo:1.0 FAILED
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
                Dependency path ':insight-test:unspecified' --> 'org:foo:1.+'
                Constraint path ':insight-test:unspecified' --> 'org:foo:1.1'
-               Constraint path ':insight-test:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'
+               Constraint path ':insight-test:unspecified' --> 'org:foo:{strictly 1.0}' because of the following reason: dependency was locked to version '1.0'
 
 org:foo:{strictly 1.0} FAILED
 \\--- lockedConf
@@ -2559,7 +2559,7 @@ org:bar: FAILED
       - Could not resolve org:bar:{reject +}.:
           - Module 'org:bar' has been rejected:
                Dependency path ':insight-test:unspecified' --> 'org:bar:[1.0,)'
-               Constraint path ':insight-test:unspecified' --> 'org:bar' rejects all versions because of the following reason: Nope, you won't use this
+               Constraint path ':insight-test:unspecified' --> 'org:bar:{reject +}' because of the following reason: Nope, you won't use this
 
 org:bar:{reject +} FAILED
 \\--- compileClasspath
@@ -2576,7 +2576,7 @@ org:foo: (by constraint) FAILED
       - Could not resolve org:foo:{reject 1.0 & 1.1 & 1.2}.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
                Dependency path ':insight-test:unspecified' --> 'org:foo:[1.0,)'
-               Constraint path ':insight-test:unspecified' --> 'org:foo:' rejects any of "'1.0', '1.1', '1.2'"
+               Constraint path ':insight-test:unspecified' --> 'org:foo:{reject 1.0 & 1.1 & 1.2}'
 
 org:foo:{reject 1.0 & 1.1 & 1.2} FAILED
 \\--- compileClasspath

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -521,13 +521,13 @@ org:foo:1.0 FAILED
    Selection reasons:
       - By constraint : dependency was locked to version '1.0'
    Failures:
-      - Could not resolve org:foo:{requires 1.0; strictly 1.0}.:
+      - Could not resolve org:foo:{strictly 1.0}.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
                Dependency path ':insight-test:unspecified' --> 'org:foo:1.+'
                Constraint path ':insight-test:unspecified' --> 'org:foo:1.1'
                Constraint path ':insight-test:unspecified' --> 'org:foo' strictly '1.0' because of the following reason: dependency was locked to version '1.0'
 
-org:foo:1.0 FAILED
+org:foo:{strictly 1.0} FAILED
 \\--- lockedConf
 
 org:foo:1.1 (by constraint) FAILED
@@ -2195,10 +2195,10 @@ org:foo:${displayVersion} -> $selected
 \\--- compileClasspath
 """
         where:
-        version                             | displayVersion | reason                                          | selected | rejected
-        "require '[1.0, 2.0)'"              | '[1.0, 2.0)'   | "foo v2+ has an incompatible API for project X" | '1.5'    | "didn't match version 2.0 because "
-        "strictly '[1.1, 1.4]'"             | '[1.1, 1.4]'   | "versions of foo verified to run on platform Y" | '1.4'    | "didn't match versions 2.0, 1.5 because "
-        "prefer '[1.0, 1.4]'; reject '1.4'" | '[1.0, 1.4]'   | "1.4 has a critical bug"                        | '1.3'    | "rejected version 1.4 because "
+        version                             | displayVersion                    | reason                                          | selected | rejected
+        "require '[1.0, 2.0)'"              | '[1.0, 2.0)'                      | "foo v2+ has an incompatible API for project X" | '1.5'    | "didn't match version 2.0 because "
+        "strictly '[1.1, 1.4]'"             | '{strictly [1.1, 1.4]}'           | "versions of foo verified to run on platform Y" | '1.4'    | "didn't match versions 2.0, 1.5 because "
+        "prefer '[1.0, 1.4]'; reject '1.4'" | '{prefer [1.0, 1.4]; reject 1.4}' | "1.4 has a critical bug"                        | '1.3'    | "rejected version 1.4 because "
     }
 
     def "doesn't report duplicate reasons"() {
@@ -2289,7 +2289,7 @@ org:foo:[1.1,1.3] -> 1.3
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
 
-org:bar:[1.0,) -> 1.0
+org:bar:{require [1.0,); reject [1.1, 1.2]} -> 1.0
 \\--- compileClasspath
 
 org:foo:1.1
@@ -2301,7 +2301,7 @@ org:foo:1.1
    Selection reasons:
       - Was requested : rejected version 1.2
 
-org:foo:[1.0,) -> 1.1
+org:foo:{require [1.0,); reject 1.2} -> 1.1
 \\--- compileClasspath
 """
     }
@@ -2370,7 +2370,7 @@ org:foo:1.1
    Selection reasons:
       - Was requested : rejected version 1.2
 
-org:foo:[1.0,) -> 1.1
+org:foo:{require [1.0,); reject 1.2} -> 1.1
 \\--- compileClasspath
 """
     }
@@ -2556,12 +2556,12 @@ org:bar: FAILED
    Selection reasons:
       - By constraint : Nope, you won't use this
    Failures:
-      - Could not resolve org:bar.:
+      - Could not resolve org:bar:{reject +}.:
           - Module 'org:bar' has been rejected:
                Dependency path ':insight-test:unspecified' --> 'org:bar:[1.0,)'
                Constraint path ':insight-test:unspecified' --> 'org:bar' rejects all versions because of the following reason: Nope, you won't use this
 
-org:bar FAILED
+org:bar:{reject +} FAILED
 \\--- compileClasspath
 
 org:bar:[1.0,) FAILED
@@ -2573,12 +2573,12 @@ org:bar:[1.0,) FAILED
 
 org:foo: (by constraint) FAILED
    Failures:
-      - Could not resolve org:foo.:
+      - Could not resolve org:foo:{reject 1.0 & 1.1 & 1.2}.:
           - Cannot find a version of 'org:foo' that satisfies the version constraints: 
                Dependency path ':insight-test:unspecified' --> 'org:foo:[1.0,)'
                Constraint path ':insight-test:unspecified' --> 'org:foo:' rejects any of "'1.0', '1.1', '1.2'"
 
-org:foo FAILED
+org:foo:{reject 1.0 & 1.1 & 1.2} FAILED
 \\--- compileClasspath
 
 org:foo:[1.0,) FAILED
@@ -2635,10 +2635,10 @@ org:foo:1.0
       - Was requested : rejected versions 1.2, 1.1
       - By constraint
 
-org:foo -> 1.0
+org:foo:{reject 1.2} -> 1.0
 \\--- compileClasspath
 
-org:foo:[1.0,) -> 1.0
+org:foo:{require [1.0,); reject 1.1} -> 1.0
 \\--- compileClasspath
 """
     }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyReportTaskIntegrationTest.groovy
@@ -956,8 +956,8 @@ conf
         output.contains """
 conf
 +--- group:moduleA:{require 1.+; prefer 1.0} -> 1.0
-+--- group:moduleB:{strictly 1.0}
-\\--- group:moduleC:{require 1.0; reject 1.1 & 1.2}
++--- group:moduleB:{strictly 1.0} -> 1.0
+\\--- group:moduleC:{require 1.0; reject 1.1 & 1.2} -> 1.0
 """
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependency.java
@@ -15,6 +15,10 @@
  */
 package org.gradle.api.tasks.diagnostics.internal.graph.nodes;
 
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
 import java.util.Collections;
@@ -55,5 +59,16 @@ public abstract class AbstractRenderableDependency implements RenderableDependen
     @Override
     public List<Section> getExtraDetails() {
         return Collections.emptyList();
+    }
+
+    protected boolean exactMatch(ComponentSelector requested, ComponentIdentifier selected) {
+        if (requested instanceof ModuleComponentSelector) {
+            VersionConstraint versionConstraint = ((ModuleComponentSelector) requested).getVersionConstraint();
+            if (!(versionConstraint.getRequiredVersion().isEmpty()
+                    || versionConstraint.getDisplayName().equals(versionConstraint.getRequiredVersion()))) {
+                return false;
+            }
+        }
+        return requested.matchesStrictly(selected);
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
@@ -31,7 +31,7 @@ public abstract class AbstractRenderableDependencyResult extends AbstractRendera
         ComponentSelector requested = getRequested();
         ComponentIdentifier selected = getActual();
 
-        if(requested.matchesStrictly(selected)) {
+        if(exactMatch(requested, selected)) {
             return getSimpleName();
         }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependencyResult.java
@@ -38,25 +38,12 @@ public abstract class AbstractRenderableDependencyResult extends AbstractRendera
         if(requested instanceof ModuleComponentSelector && selected instanceof ModuleComponentIdentifier) {
             ModuleComponentSelector requestedModuleComponentSelector = (ModuleComponentSelector)requested;
             ModuleComponentIdentifier selectedModuleComponentedIdentifier = (ModuleComponentIdentifier)selected;
-
-            if(isSameGroupAndModuleButDifferentVersion(requestedModuleComponentSelector, selectedModuleComponentedIdentifier)) {
+            if(requestedModuleComponentSelector.getModuleIdentifier().equals(selectedModuleComponentedIdentifier.getModuleIdentifier())) {
                 return getSimpleName() + " -> " + selectedModuleComponentedIdentifier.getVersion();
             }
         }
 
         return getSimpleName() + " -> " + selected.getDisplayName();
-    }
-
-    /**
-     * Checks if requested and selected module component differ by version.
-     *
-     * @param requested Requested module component selector
-     * @param selected Selected module component identifier
-     * @return Indicates whether version differs
-     */
-    private boolean isSameGroupAndModuleButDifferentVersion(ModuleComponentSelector requested, ModuleComponentIdentifier selected) {
-        return requested.getModuleIdentifier().equals(selected.getModuleIdentifier())
-            && !requested.getVersion().equals(selected.getVersion());
     }
 
     /**

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/InvertedRenderableModuleResult.java
@@ -57,7 +57,7 @@ public class InvertedRenderableModuleResult extends AbstractRenderableModuleResu
     @Override
     public String getDescription() {
         if (dependencyResult != null) {
-            if (!dependencyResult.getRequested().matchesStrictly(dependencyResult.getSelected().getId())) {
+            if (!exactMatch(dependencyResult.getRequested(), dependencyResult.getSelected().getId())) {
                 return "(requested " + dependencyResult.getRequested() + ")";
             }
         }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableUnresolvedDependencyResult.java
@@ -53,13 +53,7 @@ public class RenderableUnresolvedDependencyResult extends AbstractRenderableDepe
             if(requestedSelector.getGroup().equals(attemptedSelector.getGroup())
                 && requestedSelector.getModule().equals(attemptedSelector.getModule())) {
 
-                String requestedVersion = requestedSelector.getVersion();
-                String attemptedVersion = attemptedSelector.getVersion();
-                if (attemptedVersion.equals(requestedVersion)) {
-                    return requested.getDisplayName();
-                } else {
-                    return requested.getDisplayName() + " -> " + attemptedVersion;
-                }
+                return requested.getDisplayName() + " -> " + attemptedSelector.getVersionConstraint().getDisplayName();
             }
         }
 

--- a/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
+++ b/subprojects/version-control/src/integTest/groovy/org/gradle/vcs/internal/GitVersionSelectionIntegrationTest.groovy
@@ -435,7 +435,7 @@ Required by:
 
         then:
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':compile'.")
-        failure.assertHasCause("""Could not find any version that matches test:test (branch: release).
+        failure.assertHasCause("""Could not find any version that matches test:test:{branch release}.
 Searched in the following locations: Git repository at ${repo.url}
 Required by:
     project :""")


### PR DESCRIPTION
This PR adds a `displayName` to `VersionConstraint`, and uses this to display details of each version constraint when rending in dependency reports or error messages.