### PR TITLE
Fix list rendering in release notes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -163,6 +163,7 @@ An important feature of the `Provider` API is that `Provider` instances can trac
 When a `Provider` that represents an output of a task is connected to a `Property` instance that represents a task input, Gradle automatically adds task dependencies between the tasks. This eliminates a class of configuration problems where the location of a task input and the producing task dependencies are not kept in sync as configuration changes are made.
 
 In this release, more `Provider` implementations track the tasks that produces the value of the provider:
+
 - Any provider returned by `TaskContainer`
 - Any property marked with `@OutputFile`, `@OutputDirectory`, `@OutputFiles` or `@OutputDirectories`.
 - Any `List` or `Set` property whose elements match these criteria.


### PR DESCRIPTION
Add missing newline before the list, otherwise the whole list is shown
as a single line.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
