### PR TITLE
Allow debug connections from any host

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
+import org.gradle.api.JavaVersion;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.util.GUtil;
@@ -136,7 +137,8 @@ public class JvmOptions {
             args.add("-ea");
         }
         if (debug) {
-            args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005");
+            String port = JavaVersion.current().isJava9Compatible() ? "*:5005" : "5005";
+            args.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=" + port);
         }
         return args;
     }

--- a/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JvmOptions.java
@@ -205,7 +205,13 @@ public class JvmOptions {
             } else if (extraJvmArg.toString().equals("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005")) {
                 xrunjdwpFound = true;
                 matches.add(extraJvmArg);
+            } else if (extraJvmArg.toString().equals("-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=*:5005")) {
+                xrunjdwpFound = true;
+                matches.add(extraJvmArg);
             } else if (extraJvmArg.toString().equals("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")) {
+                xagentlibJdwpFound = true;
+                matches.add(extraJvmArg);
+            } else if (extraJvmArg.toString().equals("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005")) {
                 xagentlibJdwpFound = true;
                 matches.add(extraJvmArg);
             }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -281,6 +281,13 @@ class DefaultJavaForkOptionsTest extends Specification {
         then:
         options.debug
         options.jvmArgs == []
+        
+        when:
+        options.jvmArgs('-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005')
+
+        then:
+        options.debug
+        options.jvmArgs == []
 
         when:
         options.allJvmArgs = []
@@ -302,6 +309,13 @@ class DefaultJavaForkOptionsTest extends Specification {
         then:
         !options.debug
         options.jvmArgs == ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005']
+        
+        when:
+        options.jvmArgs = ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=*:5005']
+
+        then:
+        !options.debug
+        options.jvmArgs == ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=*:5005']
 
         when:
         options.jvmArgs '-Xdebug'
@@ -325,10 +339,26 @@ class DefaultJavaForkOptionsTest extends Specification {
         then:
         options.debug
         options.jvmArgs == []
+        
+        when:
+        options.debug = false
+        options.allJvmArgs = ['-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=*:5005', '-Xdebug']
+
+        then:
+        options.debug
+        options.jvmArgs == []
 
         when:
         options.debug = false
         options.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
+
+        then:
+        options.debug
+        options.jvmArgs == []
+        
+        when:
+        options.debug = false
+        options.allJvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005']
 
         then:
         options.debug

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/util/DefaultJavaForkOptionsTest.groovy
@@ -271,7 +271,7 @@ class DefaultJavaForkOptionsTest extends Specification {
         options.debug = true
 
         then:
-        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005']
+        options.allJvmArgs == [fileEncodingProperty(), *localeProperties(), '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005']
     }
 
     def "debug is enabled when set using jvmArgs"() {

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JvmOptionsTest.groovy
@@ -203,7 +203,7 @@ class JvmOptionsTest extends Specification {
         opts.jvmArgs(fromString('-Xmx1G -Xms1G'))
         opts.debug = true
         then:
-        opts.allJvmArgs.containsAll(['-Xmx1G', '-Xms1G', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005'])
+        opts.allJvmArgs.containsAll(['-Xmx1G', '-Xms1G', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'])
     }
 
     def "can enter debug mode before setting other options"() {
@@ -212,7 +212,7 @@ class JvmOptionsTest extends Specification {
         when:
         opts.jvmArgs(fromString('-Xmx1G -Xms1G'))
         then:
-        opts.allJvmArgs.containsAll(['-Xmx1G', '-Xms1G', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005'])
+        opts.allJvmArgs.containsAll(['-Xmx1G', '-Xms1G', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005'])
     }
 
     def "options with newlines are parsed correctly"() {


### PR DESCRIPTION
### Context

Resolves #7496

This commit allows the host to debug a Gradle process run inside a container when the port 5005 is mapped from the container to the host. This was possible by default before Java 9.

When using Java 9 or above the "address" attribute of the jvmArgs is now always "*:5005" instead of the previous "5005". 

* Because Gradle can only be build using Java 9 and above, I've changed the unit tests to expect this new address. 
* For some reason the class `JvmOptions` not only sets the jvmArgs when the debug flag is set, but also the other way around. I don't know the reason behind this, but I extended the method "JvmOptions.jvmArgs(..)" to also recognize the new address format.
* Maybe someone wants to add a unit test to ensure the old address is used when running an older Java version. I am not comfortable writing unit tests in Groovy/Spock, so I don't know how to best mock the JavaVersion.

