### PR TITLE
Do not invoke included build for already-executed task

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildPluginDevelopmentIntegrationTest.groovy
@@ -29,7 +29,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
     def setup() {
         pluginDependencyA = singleProjectBuild("pluginDependencyA") {
             buildFile << """
-                apply plugin: 'java'
+                apply plugin: 'java-library'
                 version "2.0"
             """
         }
@@ -67,7 +67,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
             }
         """
         pluginDependencyA.buildFile << """
-            tasks.jar.dependsOn(tasks.taskFromPluginBuild)
+            tasks.compileJava.dependsOn(tasks.taskFromPluginBuild)
         """
 
         includeBuild pluginBuild
@@ -77,7 +77,7 @@ class CompositeBuildPluginDevelopmentIntegrationTest extends AbstractCompositeBu
         execute(buildA, "assemble")
 
         then:
-        executed ":pluginBuild:jar", ":pluginDependencyA:taskFromPluginBuild", ":pluginDependencyA:jar", ":jar"
+        executed ":pluginBuild:jar", ":pluginDependencyA:taskFromPluginBuild", ":pluginDependencyA:compileJava", ":jar"
     }
 
     @Issue("https://github.com/gradle/gradle/issues/5234")

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildController.java
@@ -206,6 +206,10 @@ class DefaultIncludedBuildController implements Runnable, Stoppable, IncludedBui
         lock.lock();
         try {
             TaskState taskState = tasks.get(task);
+            if (taskState == null) {
+                taskState = new TaskState();
+                tasks.put(task, taskState);
+            }
             taskState.status = failure == null ? TaskStatus.SUCCESS : TaskStatus.FAILED;
         } finally {
             lock.unlock();
@@ -316,9 +320,7 @@ class DefaultIncludedBuildController implements Runnable, Stoppable, IncludedBui
         public void afterExecute(Task task, org.gradle.api.tasks.TaskState state) {
             String taskPath = task.getPath();
             Throwable failure = state.getFailure();
-            if (tasksToExecute.contains(taskPath)) {
-                taskCompleted(taskPath, failure);
-            }
+            taskCompleted(taskPath, failure);
         }
     }
 }


### PR DESCRIPTION
Previously, we were only tracking the tasks that had been _requested_ for execution. With this change, we track any task is actually executed in the included build, and avoid re-executing when any of these tasks are requested

This will make composite builds work in cases where the included build provides a `:jar` to the classpath of an including build, and the `:compileJava` classes directory to the implementation configuration of the same build. Note that we still ignore task requests that would require a 2nd execution in an included build.

Fixes #7650
