### PR TITLE
Upgrade Kotlin DSL to 1.0.1

### DIFF
--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/build-environment.kt
@@ -6,7 +6,7 @@ import org.gradle.internal.os.OperatingSystem
 
 object BuildEnvironment {
     val isCiServer = "CI" in System.getenv()
-    val gradleKotlinDslVersion = "1.0"
+    val gradleKotlinDslVersion = "1.0.1"
     val jvm = org.gradle.internal.jvm.Jvm.current()
     val javaVersion = JavaVersion.current()
     val isWindows = OperatingSystem.current().isWindows


### PR DESCRIPTION
With proper IDE support for accessors involving default package types.