### PR TITLE
Let integration tests not opt-in to in-process kotlin compiler

### DIFF
--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinApplicationInitIntegrationTest.groovy
@@ -17,21 +17,16 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
 
+@LeaksFileHandles
 class KotlinApplicationInitIntegrationTest extends AbstractInitIntegrationSpec {
 
     public static final String SAMPLE_APP_CLASS = "some/thing/App.kt"
     public static final String SAMPLE_APP_TEST_CLASS = "some/thing/AppTest.kt"
-
-    def setup() {
-        executer.beforeExecute {
-            // Run Kotlin compiler in-process to avoid file locking issues
-            executer.withArgument("-Dkotlin.compiler.execution.strategy=in-process")
-        }
-    }
 
     def "defaults to kotlin build scripts"() {
         when:

--- a/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
+++ b/subprojects/build-init/src/integTest/groovy/org/gradle/buildinit/plugins/KotlinLibraryInitIntegrationTest.groovy
@@ -17,21 +17,16 @@
 package org.gradle.buildinit.plugins
 
 import org.gradle.buildinit.plugins.fixtures.ScriptDslFixture
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import spock.lang.Unroll
 
 import static org.gradle.buildinit.plugins.internal.modifiers.BuildInitDsl.KOTLIN
 
+@LeaksFileHandles
 class KotlinLibraryInitIntegrationTest extends AbstractInitIntegrationSpec {
 
     public static final String SAMPLE_LIBRARY_CLASS = "some/thing/Library.kt"
     public static final String SAMPLE_LIBRARY_TEST_CLASS = "some/thing/LibraryTest.kt"
-
-    def setup() {
-        executer.beforeExecute {
-            // Run Kotlin compiler in-process to avoid file locking issues
-            executer.withArgument("-Dkotlin.compiler.execution.strategy=in-process")
-        }
-    }
 
     def "defaults to kotlin build scripts"() {
         when:

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/AbstractPropertyLanguageInterOpIntegrationTest.groovy
@@ -40,8 +40,6 @@ abstract class AbstractPropertyLanguageInterOpIntegrationTest extends AbstractIn
         if (!hasKotlin) {
             executer.beforeExecute {
                 expectDeprecationWarning()
-                // Run Kotlin compiler in-process to avoid file locking issues
-                executer.withArgument("-Dkotlin.compiler.execution.strategy=in-process")
             }
             hasKotlin = true
         }

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyKotlinInterOpIntegrationTest.groovy
@@ -21,11 +21,13 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.TaskAction
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import javax.inject.Inject
 
+@LeaksFileHandles
 @Requires(TestPrecondition.KOTLIN_SCRIPT)
 class PropertyKotlinInterOpIntegrationTest extends AbstractPropertyLanguageInterOpIntegrationTest {
     def setup() {


### PR DESCRIPTION
when using the `kotlin-gradle-plugin`
by not setting `-Dkotlin.compiler.execution.strategy=in-process`
to prevent metaspace leak in the Gradle daemon process

See https://github.com/gradle/kotlin-dsl/issues/1228
