### PR TITLE
Use main build for tagging

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -178,7 +178,7 @@ fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTas
                 executionMode = BuildStep.ExecutionMode.ALWAYS
                 tasks = "tagBuild"
                 gradleParams = "$gradleParameterString -PteamCityUsername=%teamcity.username.restbot% -PteamCityPassword=%teamcity.password.restbot% -PteamCityBuildId=%teamcity.build.id% -PgithubToken=%github.ci.oauth.token%"
-                buildFile = "gradle/buildTagging.gradle"
+                buildFile = "build.gradle.kts"
             }
         }
     }


### PR DESCRIPTION
When this is merged, the `gradle/settings.gradle` and
`gradle/buildTagging.gradle` can be removed.
