### PR TITLE
Reintroduce `-nostdinc` for all system expect macOS

### DIFF
--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal.gcc;
 
 import org.gradle.internal.Transformers;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext;
@@ -33,7 +34,7 @@ class CCompiler extends GccCompatibleNativeCompiler<CCompileSpec> {
     private static class CCompileArgsTransformer extends GccCompilerArgsTransformer<CCompileSpec> {
         @Override
         protected boolean isNoStandardIncludes() {
-            return false;
+            return !OperatingSystem.current().isMacOsX();
         }
 
         @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CPCHCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CPCHCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal.gcc;
 
 import org.gradle.internal.Transformers;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext;
@@ -32,7 +33,7 @@ public class CPCHCompiler extends GccCompatibleNativeCompiler<CPCHCompileSpec> {
     private static class CPCHCompileArgsTransformer extends GccCompilerArgsTransformer<CPCHCompileSpec> {
         @Override
         protected boolean isNoStandardIncludes() {
-            return false;
+            return !OperatingSystem.current().isMacOsX();
         }
 
         @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CppCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CppCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal.gcc;
 
 import org.gradle.internal.Transformers;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext;
@@ -33,7 +34,7 @@ class CppCompiler extends GccCompatibleNativeCompiler<CppCompileSpec>  {
     private static class CppCompileArgsTransformer extends GccCompilerArgsTransformer<CppCompileSpec> {
         @Override
         protected boolean isNoStandardIncludes() {
-            return false;
+            return !OperatingSystem.current().isMacOsX();
         }
 
         @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CppPCHCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/gcc/CppPCHCompiler.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.toolchain.internal.gcc;
 
 import org.gradle.internal.Transformers;
 import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.work.WorkerLeaseService;
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory;
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext;
@@ -32,7 +33,7 @@ public class CppPCHCompiler extends GccCompatibleNativeCompiler<CppPCHCompileSpe
     private static class CppPCHCompileArgsTransformer extends GccCompilerArgsTransformer<CppPCHCompileSpec> {
         @Override
         protected boolean isNoStandardIncludes() {
-            return false;
+            return !OperatingSystem.current().isMacOsX();
         }
 
         @Override

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CCompilerTest.groovy
@@ -15,6 +15,8 @@
  */
 
 package org.gradle.nativeplatform.toolchain.internal.gcc
+
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext
 import org.gradle.nativeplatform.toolchain.internal.NativeCompiler
 import org.gradle.nativeplatform.toolchain.internal.compilespec.CCompileSpec
@@ -34,7 +36,9 @@ class CCompilerTest extends GccCompatibleNativeCompilerTest {
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
         def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
-        arguments.remove('-nostdinc')
+        if (OperatingSystem.current().macOsX) {
+            arguments.remove('-nostdinc')
+        }
         [ '-x', 'c' ] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CPCHCompilerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain.internal.gcc
 
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec
 import org.gradle.nativeplatform.toolchain.internal.NativeCompiler
@@ -35,7 +36,9 @@ class CPCHCompilerTest extends GccCompatibleNativeCompilerTest {
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
         def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
-        arguments.remove('-nostdinc')
+        if (OperatingSystem.current().macOsX) {
+            arguments.remove('-nostdinc')
+        }
         return [ '-x', 'c-header' ] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppCompilerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain.internal.gcc
 
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext
 import org.gradle.nativeplatform.toolchain.internal.NativeCompiler
 import org.gradle.nativeplatform.toolchain.internal.compilespec.CppCompileSpec
@@ -35,7 +36,9 @@ class CppCompilerTest extends GccCompatibleNativeCompilerTest {
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
         def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
-        arguments.remove('-nostdinc')
+        if (OperatingSystem.current().macOsX) {
+            arguments.remove('-nostdinc')
+        }
         [ '-x', 'c++' ] + arguments
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppPCHCompilerTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/gcc/CppPCHCompilerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.toolchain.internal.gcc
 
+import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.toolchain.internal.CommandLineToolContext
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec
 import org.gradle.nativeplatform.toolchain.internal.NativeCompiler
@@ -35,7 +36,9 @@ class CppPCHCompilerTest extends GccCompatibleNativeCompilerTest {
     @Override
     protected List<String> getCompilerSpecificArguments(File includeDir, File systemIncludeDir) {
         def arguments = super.getCompilerSpecificArguments(includeDir, systemIncludeDir)
-        arguments.remove('-nostdinc')
+        if (OperatingSystem.current().macOsX) {
+            arguments.remove('-nostdinc')
+        }
         return [ '-x', 'c++-header' ] + arguments
     }
 }


### PR DESCRIPTION
macOS won't have `-nostdinc` until we support properly framework search
path discovery.

### Context
Fixes https://github.com/gradle/gradle-native/issues/925

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fnostdinc-linux)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
