### PR TITLE
Change the tooling API to write error logging to the stderr stream provided by the client

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/DefaultGradleDistribution.java
@@ -215,14 +215,23 @@ public class DefaultGradleDistribution implements GradleDistribution {
     }
 
     @Override
+    public boolean isToolingApiHasCauseOnPhasedActionFail() {
+        return isSameOrNewer("5.1");
+    }
+
+    @Override
+    public boolean isToolingApiMergesStderrIntoStdout() {
+        return isSameOrNewer("4.7") && isSameOrOlder("5.0");
+    }
+
+    @Override
     public boolean isToolingApiLogsConfigureSummary() {
         return isSameOrNewer("2.14");
     }
 
     @Override
     public <T> T selectOutputWithFailureLogging(T stdout, T stderr) {
-        if (isSameOrNewer("4.0") && isSameOrOlder("4.6")) {
-            // This only worked as expected for a while
+        if (isSameOrNewer("4.0") && isSameOrOlder("4.6") || isSameOrNewer("5.1")) {
             return stderr;
         }
         return stdout;

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/GradleDistribution.java
@@ -132,6 +132,16 @@ public interface GradleDistribution {
     boolean isToolingApiLogsFailureOnCancel();
 
     /**
+     * Returns true if this version retains the original exception as cause on phased action fail.
+     */
+    boolean isToolingApiHasCauseOnPhasedActionFail();
+
+    /**
+     * Returns true if this version logs errors to stdout instead of stderr.
+     */
+    boolean isToolingApiMergesStderrIntoStdout();
+
+    /**
      * Returns the logging output stream that this version logs build failures to when invoked via the tooling API.
      */
     <T> T selectOutputWithFailureLogging(T stdout, T stderr);

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfOptionalRequestHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfOptionalRequestHandler.java
@@ -22,7 +22,7 @@ import java.util.concurrent.locks.Lock;
 /**
  * A cyclic barrier for {@link BlockingHttpServer} where expectations are optional.
  */
-public class CyclicBarrierAnyOfOptionalRequestHandler extends CyclicBarrierAnyOfRequestHandler {
+class CyclicBarrierAnyOfOptionalRequestHandler extends CyclicBarrierAnyOfRequestHandler {
     private final Lock lock;
 
     CyclicBarrierAnyOfOptionalRequestHandler(Lock lock, int testId, int timeoutMs, int maxConcurrent, WaitPrecondition previous, Collection<? extends ResourceExpectation> expectedRequests) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/HttpServer.groovy
@@ -44,6 +44,9 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.zip.GZIPOutputStream
 
+/**
+ * Due to be replaced by {@link BlockingHttpServer}. You should prefer using that class where possible, however there is a bunch of stuff on this fixture that is missing from {@link BlockingHttpServer}.
+ */
 class HttpServer extends ServerWithExpectations implements HttpServerFixture {
 
     private final static Logger logger = LoggerFactory.getLogger(HttpServer.class)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ResourceHandlerWrapper.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ResourceHandlerWrapper.java
@@ -27,7 +27,7 @@ class ResourceHandlerWrapper implements ResourceHandler, WaitPrecondition {
     private boolean started;
     private boolean received;
 
-    public ResourceHandlerWrapper(Lock lock, ResourceExpectation expectation) {
+    ResourceHandlerWrapper(Lock lock, ResourceExpectation expectation) {
         this.lock = lock;
         handler = expectation.create(this);
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ResponseProducer.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ResponseProducer.java
@@ -20,7 +20,7 @@ import com.sun.net.httpserver.HttpExchange;
 
 import java.io.IOException;
 
-public interface ResponseProducer {
+interface ResponseProducer {
     /**
      * Called to handle a request. Is *not* called under lock.
      */

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/LoggingOutputInternal.java
@@ -22,6 +22,7 @@ import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
+import javax.annotation.Nullable;
 import java.io.OutputStream;
 
 /**
@@ -64,7 +65,7 @@ public interface LoggingOutputInternal extends LoggingOutput {
      * @param consoleMetadata The metadata associated with this console
      * @param consoleOutput The output format.
      */
-    void attachConsole(OutputStream outputStream, OutputStream errorStream, ConsoleOutput consoleOutput, ConsoleMetaData consoleMetadata);
+    void attachConsole(OutputStream outputStream, OutputStream errorStream, ConsoleOutput consoleOutput, @Nullable ConsoleMetaData consoleMetadata);
 
     /**
      * Adds the given {@link java.io.OutputStream} as a logging destination. The stream receives stdout logging formatted according to the current logging settings and

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/services/DefaultLoggingManager.java
@@ -29,7 +29,6 @@ import org.gradle.internal.logging.config.LoggingSystem;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.text.StreamBackedStandardOutputListener;
 import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
-import org.gradle.internal.nativeintegration.console.FallbackConsoleMetaData;
 
 import java.io.Closeable;
 import java.io.OutputStream;
@@ -219,7 +218,7 @@ public class DefaultLoggingManager implements LoggingManagerInternal, Closeable 
 
     @Override
     public void attachConsole(OutputStream outputStream, OutputStream errorStream, ConsoleOutput consoleOutput) {
-        loggingRouter.attachConsole(outputStream, errorStream, consoleOutput, FallbackConsoleMetaData.INSTANCE);
+        loggingRouter.attachConsole(outputStream, errorStream, consoleOutput, null);
     }
 
     @Override

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ConsoleConfigureAction.java
@@ -25,6 +25,7 @@ import org.gradle.internal.nativeintegration.console.FallbackConsoleMetaData;
 import org.gradle.internal.nativeintegration.console.TestConsoleMetadata;
 import org.gradle.internal.nativeintegration.services.NativeServices;
 
+import javax.annotation.Nullable;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 
@@ -78,21 +79,23 @@ public class ConsoleConfigureAction {
         renderer.addPlainConsole(consoleMetaData != null && consoleMetaData.isStdOut() && consoleMetaData.isStdErr());
     }
 
-    private static void configureRichConsole(OutputEventRenderer renderer, ConsoleMetaData consoleMetaData, boolean force, boolean verbose) {
-        consoleMetaData = consoleMetaData == null ? FallbackConsoleMetaData.INSTANCE : consoleMetaData;
+    private static void configureRichConsole(OutputEventRenderer renderer, @Nullable ConsoleMetaData consoleMetaData, boolean force, boolean verbose) {
+        if (consoleMetaData == null) {
+            consoleMetaData = FallbackConsoleMetaData.ATTACHED;
+        }
         if (consoleMetaData.isStdOut()) {
             OutputStream originalStdOut = renderer.getOriginalStdOut();
             OutputStreamWriter outStr = new OutputStreamWriter(force ? originalStdOut : AnsiConsoleUtil.wrapOutputStream(originalStdOut));
             Console console = new AnsiConsole(outStr, outStr, renderer.getColourMap(), consoleMetaData, force);
-            renderer.addRichConsole(console, true, consoleMetaData.isStdErr(), consoleMetaData, verbose);
+            renderer.addRichConsole(console, consoleMetaData, verbose);
         } else if (consoleMetaData.isStdErr()) {
             // Only stderr is connected to a terminal
             OutputStream originalStdErr = renderer.getOriginalStdErr();
             OutputStreamWriter errStr = new OutputStreamWriter(force ? originalStdErr : AnsiConsoleUtil.wrapOutputStream(originalStdErr));
             Console console = new AnsiConsole(errStr, errStr, renderer.getColourMap(), consoleMetaData, force);
-            renderer.addRichConsole(console, false, true, consoleMetaData, verbose);
+            renderer.addRichConsole(console, consoleMetaData, verbose);
         } else {
-            renderer.addRichConsole(null, false, false, consoleMetaData, verbose);
+            renderer.addRichConsole(null, consoleMetaData, verbose);
         }
     }
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventRenderer.java
@@ -52,6 +52,7 @@ import org.gradle.internal.nativeintegration.console.ConsoleMetaData;
 import org.gradle.internal.nativeintegration.console.FallbackConsoleMetaData;
 import org.gradle.internal.time.Clock;
 
+import javax.annotation.Nullable;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.concurrent.atomic.AtomicReference;
@@ -150,31 +151,31 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
 
     @Override
     public void attachConsole(OutputStream outputStream, OutputStream errorStream, ConsoleOutput consoleOutput) {
-        attachConsole(outputStream, errorStream, consoleOutput, FallbackConsoleMetaData.INSTANCE);
+        attachConsole(outputStream, errorStream, consoleOutput, null);
     }
 
     @Override
-    public void attachConsole(OutputStream outputStream, OutputStream errorStream, ConsoleOutput consoleOutput, ConsoleMetaData consoleMetadata) {
+    public void attachConsole(OutputStream outputStream, OutputStream errorStream, ConsoleOutput consoleOutput, @Nullable ConsoleMetaData consoleMetadata) {
         synchronized (lock) {
+            if (consoleMetadata == null) {
+                consoleMetadata = consoleOutput == ConsoleOutput.Plain ? FallbackConsoleMetaData.NOT_ATTACHED : FallbackConsoleMetaData.ATTACHED;
+            }
             StandardOutputListener outputListener = new StreamBackedStandardOutputListener(outputStream);
             StandardOutputListener errorListener = new StreamBackedStandardOutputListener(errorStream);
             if (consoleOutput == ConsoleOutput.Plain) {
-                addPlainConsole(outputListener, errorListener, consoleMetadata != null && (consoleMetadata.isStdErr() && consoleMetadata.isStdOut()));
+                addPlainConsole(outputListener, errorListener, consoleMetadata.isStdOut() && consoleMetadata.isStdErr());
             } else {
-                if (consoleMetadata == null) {
-                    consoleMetadata = FallbackConsoleMetaData.INSTANCE;
-                }
                 Console console;
                 if (consoleMetadata.isStdOut()) {
                     OutputStreamWriter writer = new OutputStreamWriter(outputStream);
-                    console =new AnsiConsole(writer, writer, getColourMap(), consoleMetadata, true);
+                    console = new AnsiConsole(writer, writer, getColourMap(), consoleMetadata, true);
                 } else if (consoleMetadata.isStdErr()) {
                     OutputStreamWriter writer = new OutputStreamWriter(errorStream);
-                    console =new AnsiConsole(writer, writer, getColourMap(), consoleMetadata, true);
+                    console = new AnsiConsole(writer, writer, getColourMap(), consoleMetadata, true);
                 } else {
                     console = null;
                 }
-                addRichConsole(console, consoleMetadata.isStdOut(), consoleMetadata.isStdErr(), outputListener, errorListener, consoleMetadata, consoleOutput == ConsoleOutput.Verbose);
+                addRichConsole(console, outputListener, errorListener, consoleMetadata, consoleOutput == ConsoleOutput.Verbose);
             }
         }
     }
@@ -246,16 +247,18 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
         }
     }
 
-    public OutputEventRenderer addRichConsole(Console console, boolean stdoutAttachedToConsole, boolean stderrAttachedToConsole, ConsoleMetaData consoleMetaData) {
-        return addRichConsole(console, stdoutAttachedToConsole, stderrAttachedToConsole, consoleMetaData, false);
+    public OutputEventRenderer addRichConsole(Console console, ConsoleMetaData consoleMetaData) {
+        return addRichConsole(console, consoleMetaData, false);
     }
 
-    public OutputEventRenderer addRichConsole(Console console, boolean stdoutAttachedToConsole, boolean stderrAttachedToConsole, ConsoleMetaData consoleMetaData, boolean verbose) {
-        return addRichConsole(console, stdoutAttachedToConsole, stderrAttachedToConsole, new StreamBackedStandardOutputListener((Appendable) originalStdOut), new StreamBackedStandardOutputListener((Appendable)originalStdErr), consoleMetaData, verbose);
+    public OutputEventRenderer addRichConsole(Console console, ConsoleMetaData consoleMetaData, boolean verbose) {
+        return addRichConsole(console, new StreamBackedStandardOutputListener((Appendable) originalStdOut), new StreamBackedStandardOutputListener((Appendable) originalStdErr), consoleMetaData, verbose);
     }
 
-    private OutputEventRenderer addRichConsole(Console console, boolean stdoutAttachedToConsole, boolean stderrAttachedToConsole, StandardOutputListener outputListener, StandardOutputListener errorListener, ConsoleMetaData consoleMetaData, boolean verbose) {
+    private OutputEventRenderer addRichConsole(Console console, StandardOutputListener outputListener, StandardOutputListener errorListener, ConsoleMetaData consoleMetaData, boolean verbose) {
         OutputEventListener consoleChain;
+        boolean stdoutAttachedToConsole = consoleMetaData.isStdOut();
+        boolean stderrAttachedToConsole = consoleMetaData.isStdErr();
         if (stdoutAttachedToConsole && stderrAttachedToConsole) {
             OutputEventListener consoleListener = new StyledTextOutputBackedRenderer(console.getBuildOutputArea());
             consoleChain = getRichConsoleChain(console, consoleMetaData, verbose, consoleListener);
@@ -300,7 +303,7 @@ public class OutputEventRenderer implements OutputEventListener, LoggingRouter {
     }
 
     private OutputEventListener getPlainConsoleChain(boolean redirectStderr) {
-        return getPlainConsoleChain(new StreamBackedStandardOutputListener((Appendable) originalStdOut), new StreamBackedStandardOutputListener((Appendable)originalStdErr), redirectStderr, true);
+        return getPlainConsoleChain(new StreamBackedStandardOutputListener((Appendable) originalStdOut), new StreamBackedStandardOutputListener((Appendable) originalStdErr), redirectStderr, true);
     }
 
     private OutputEventListener getPlainConsoleChain(StandardOutputListener outputListener, StandardOutputListener errorListener, boolean redirectStderr, boolean verbose) {

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/services/DefaultLoggingManagerTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/services/DefaultLoggingManagerTest.groovy
@@ -22,12 +22,11 @@ import org.gradle.internal.logging.config.LoggingRouter
 import org.gradle.internal.logging.config.LoggingSourceSystem
 import org.gradle.internal.logging.config.LoggingSystem
 import org.gradle.internal.logging.events.OutputEventListener
-import org.gradle.internal.nativeintegration.console.FallbackConsoleMetaData
 import org.gradle.util.RedirectStdOutAndErr
 import org.junit.Rule
 import spock.lang.Specification
 
-public class DefaultLoggingManagerTest extends Specification {
+class DefaultLoggingManagerTest extends Specification {
     @Rule
     public final RedirectStdOutAndErr outputs = new RedirectStdOutAndErr();
     private final def slf4jLoggingSystem = Mock(LoggingSourceSystem)
@@ -490,7 +489,7 @@ public class DefaultLoggingManagerTest extends Specification {
 
         then:
         1 * loggingRouter.snapshot() >> snapshot
-        1 * loggingRouter.attachConsole(output, error, ConsoleOutput.Verbose, FallbackConsoleMetaData.INSTANCE)
+        1 * loggingRouter.attachConsole(output, error, ConsoleOutput.Verbose, null)
         0 * loggingRouter._
 
         when:
@@ -517,7 +516,7 @@ public class DefaultLoggingManagerTest extends Specification {
         loggingManager.attachConsole(output, error, ConsoleOutput.Verbose)
 
         then:
-        1 * loggingRouter.attachConsole(output, error, ConsoleOutput.Verbose, FallbackConsoleMetaData.INSTANCE)
+        1 * loggingRouter.attachConsole(output, error, ConsoleOutput.Verbose, null)
         0 * loggingRouter._
 
         when:

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/sink/OutputEventRendererTest.groovy
@@ -286,7 +286,9 @@ class OutputEventRendererTest extends OutputSpecification {
 
     def rendersLogEventsWhenStdOutAndStdErrAreConsole() {
         def snapshot = renderer.snapshot()
-        renderer.addRichConsole(console, true, true, metaData)
+        metaData.stdOut >> true
+        metaData.stdErr >> true
+        renderer.addRichConsole(console, metaData)
 
         when:
         renderer.onOutput(start(description: 'description', buildOperationStart: true, id: 1L, buildOperationId: 1L, buildOperationCategory: BuildOperationCategory.TASK))
@@ -301,8 +303,10 @@ class OutputEventRendererTest extends OutputSpecification {
 
     def rendersLogEventsWhenOnlyStdOutIsConsole() {
         def snapshot = renderer.snapshot()
+        metaData.stdOut >> true
+        metaData.stdErr >> false
         renderer.attachSystemOutAndErr()
-        renderer.addRichConsole(console, true, false, metaData)
+        renderer.addRichConsole(console, metaData)
 
         when:
         renderer.onOutput(start(description: 'description', buildOperationStart: true, id: 1L, buildOperationId: 1L, buildOperationCategory: BuildOperationCategory.TASK))
@@ -317,8 +321,10 @@ class OutputEventRendererTest extends OutputSpecification {
 
     def rendersLogEventsWhenOnlyStdErrIsConsole() {
         def snapshot = renderer.snapshot()
+        metaData.stdOut >> false
+        metaData.stdErr >> true
         renderer.attachSystemOutAndErr()
-        renderer.addRichConsole(console, false, true, metaData)
+        renderer.addRichConsole(console, metaData)
 
         when:
         renderer.onOutput(start('description'))
@@ -334,7 +340,9 @@ class OutputEventRendererTest extends OutputSpecification {
     def rendersLogEventsInConsoleWhenLogLevelIsDebug() {
         renderer.configure(LogLevel.DEBUG)
         def snapshot = renderer.snapshot()
-        renderer.addRichConsole(console, true, true, metaData)
+        metaData.stdOut >> true
+        metaData.stdErr >> true
+        renderer.addRichConsole(console, metaData)
 
         when:
         renderer.onOutput(event(tenAm, 'info', LogLevel.INFO))
@@ -349,7 +357,9 @@ class OutputEventRendererTest extends OutputSpecification {
         when:
         renderer.attachSystemOutAndErr()
         def snapshot = renderer.snapshot()
-        renderer.addRichConsole(console, true, true, metaData)
+        metaData.stdOut >> true
+        metaData.stdErr >> true
+        renderer.addRichConsole(console, metaData)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
         renderer.restore(snapshot) // close console to flush
@@ -364,7 +374,9 @@ class OutputEventRendererTest extends OutputSpecification {
         when:
         renderer.attachSystemOutAndErr()
         def snapshot = renderer.snapshot()
-        renderer.addRichConsole(console, true, false, metaData)
+        metaData.stdOut >> true
+        metaData.stdErr >> false
+        renderer.addRichConsole(console, metaData)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
         renderer.restore(snapshot) // close console to flush
@@ -379,7 +391,9 @@ class OutputEventRendererTest extends OutputSpecification {
         when:
         renderer.attachSystemOutAndErr()
         def snapshot = renderer.snapshot()
-        renderer.addRichConsole(console, false, true, metaData)
+        metaData.stdOut >> false
+        metaData.stdErr >> true
+        renderer.addRichConsole(console, metaData)
         renderer.onOutput(event('info', LogLevel.INFO))
         renderer.onOutput(event('error', LogLevel.ERROR))
         renderer.restore(snapshot) // close console to flush
@@ -405,8 +419,8 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        output.toString().readLines() == ['un-grouped error', '', '> description status', 'info', 'error']
-        error.toString().empty
+        output.toString().readLines() == ['', '> description status', 'info']
+        error.toString().readLines() == ['un-grouped error', 'error']
     }
 
     def "renders log events in plain console when log level is debug"() {
@@ -422,8 +436,8 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        output.toString().readLines() == ['10:00:00.000 [INFO] [category] info', '10:00:00.000 [ERROR] [category] error']
-        error.toString().empty
+        output.toString().readLines() == ['10:00:00.000 [INFO] [category] info']
+        error.toString().readLines() == ['10:00:00.000 [ERROR] [category] error']
     }
 
     def "attaches plain console when stdout and stderr are attached"() {
@@ -438,8 +452,8 @@ class OutputEventRendererTest extends OutputSpecification {
         renderer.restore(snapshot) // close console to flush
 
         then:
-        output.toString().readLines() == ['info', 'error']
-        error.toString().empty
+        output.toString().readLines() == ['info']
+        error.toString().readLines() == ['error']
         outputs.stdOut == ''
         outputs.stdErr == ''
     }

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/FallbackConsoleMetaData.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/FallbackConsoleMetaData.java
@@ -17,16 +17,23 @@
 package org.gradle.internal.nativeintegration.console;
 
 public enum FallbackConsoleMetaData implements ConsoleMetaData {
-    INSTANCE;
+    ATTACHED(true),
+    NOT_ATTACHED(false);
+
+    private final boolean attached;
+
+    FallbackConsoleMetaData(boolean attached) {
+        this.attached = attached;
+    }
 
     @Override
     public boolean isStdOut() {
-        return true;
+        return attached;
     }
 
     @Override
     public boolean isStdErr() {
-        return true;
+        return attached;
     }
 
     @Override

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/console/WindowsConsoleDetector.java
@@ -27,7 +27,7 @@ public class WindowsConsoleDetector implements ConsoleDetector {
         // Use Jansi's detection mechanism
         try {
             new WindowsAnsiOutputStream(new ByteArrayOutputStream());
-            return FallbackConsoleMetaData.INSTANCE;
+            return FallbackConsoleMetaData.ATTACHED;
         } catch (IOException ignore) {
             // Not attached to a console
             return null;

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r48/PhasedBuildActionCrossVersionSpec.groovy
@@ -162,8 +162,11 @@ class PhasedBuildActionCrossVersionSpec extends ToolingApiSpecification {
 
         and:
         def failure = OutputScrapingExecutionFailure.from(stdout.toString(), stderr.toString())
-        // <5.1 would log an intermediate exception with the actual exception as its cause, >=5.1 log just the actual exception
-        failure.assertRawOutputContains('actionFailure')
+        if (targetDist.toolingApiHasCauseOnPhasedActionFail) {
+            failure.assertHasDescription('actionFailure')
+        } else {
+            failure.assertHasCause('actionFailure')
+        }
         assertHasConfigureFailedLogging()
     }
 

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ConcurrentToolingApiIntegrationSpec.groovy
@@ -134,8 +134,8 @@ project.description = text
                     assert operation.standardOutput.contains("out=hasta la vista $idx")
                     assert operation.standardOutput.count("out=hasta la vista") == 1
 
-                    assert operation.standardOutput.contains("err=hasta la vista $idx")
-                    assert operation.standardOutput.count("err=hasta la vista") == 1
+                    assert operation.standardError.contains("err=hasta la vista $idx")
+                    assert operation.standardError.count("err=hasta la vista") == 1
                 }
             }
             concurrent.finished()
@@ -315,13 +315,11 @@ logger.lifecycle 'this is lifecycle: $idx'
                     assert operation.standardOutput.contains("this is stdout: $idx")
                     assert operation.standardOutput.count("this is stdout") == 1
 
-                    assert operation.standardOutput.contains("this is stderr: $idx")
-                    assert operation.standardOutput.count("this is stderr") == 1
+                    assert operation.standardError.contains("this is stderr: $idx")
+                    assert operation.standardError.count("this is stderr") == 1
 
                     assert operation.standardOutput.contains("this is lifecycle: $idx")
                     assert operation.standardOutput.count("this is lifecycle") == 1
-
-                    assert operation.standardError.empty
                 }
             }
         }
@@ -351,13 +349,11 @@ logger.lifecycle 'this is lifecycle: $idx'
                     assert operation.standardOutput.contains("this is stdout: $idx")
                     assert operation.standardOutput.count("this is stdout") == 1
 
-                    assert operation.standardOutput.contains("this is stderr: $idx")
-                    assert operation.standardOutput.count("this is stderr") == 1
+                    assert operation.standardError.contains("this is stderr: $idx")
+                    assert operation.standardError.count("this is stderr") == 1
 
                     assert operation.standardOutput.contains("this is lifecycle: $idx")
                     assert operation.standardOutput.count("this is lifecycle") == 1
-
-                    assert operation.standardError.empty
                 }
             }
         }


### PR DESCRIPTION
### Context

When the plain console was initially introduced, both the console and tooling API changed to write errors to the stdout stream. Subsequently, the plain console was changed to write errors to the stderr stream again, but the tooling API was not.

The PR changes the tooling API so that it writes error logging to the stderr stream again.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
