### PR TITLE
ProgressLogEventGenerator gives NoSuchElementException #3465

### DIFF
--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/ProgressLogEventGenerator.java
@@ -69,9 +69,10 @@ public class ProgressLogEventGenerator implements OutputEventListener {
     }
 
     private void onComplete(ProgressCompleteEvent progressCompleteEvent) {
-        assert !operations.isEmpty();
         Operation operation = operations.remove(progressCompleteEvent.getProgressOperationId());
-        completeOperation(progressCompleteEvent, operation);
+        if(operation != null) {
+            completeOperation(progressCompleteEvent, operation);
+        }
     }
 
     private void completeOperation(ProgressCompleteEvent progressCompleteEvent, Operation operation) {


### PR DESCRIPTION
Guards the progress logger against NPEs if an operation is not found in its local cache. Various people reported for that particular code to crash. And having to disable the parallel built severely impacts performance. The source of the cache inconsistency is not fixed with this commit and still uknown, but at least does not let Gradle crash. Most likely the entire code base in the area needs to be hardened against multi-threading (see comments in ticket).