### PR TITLE
Move short-circuiting out of transformer invoker

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.StartParameter;
+import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
@@ -64,15 +65,19 @@ import org.gradle.api.internal.artifacts.repositories.DefaultBaseRepositoryFacto
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
-import org.gradle.api.internal.artifacts.transform.TransformerInvoker;
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener;
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransforms;
+import org.gradle.api.internal.artifacts.transform.DefaultTransformerInvoker;
 import org.gradle.api.internal.artifacts.transform.DefaultVariantTransformRegistry;
+import org.gradle.api.internal.artifacts.transform.TransformerExecutionHistoryRepository;
+import org.gradle.api.internal.artifacts.transform.TransformerInvoker;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -91,6 +96,25 @@ import org.gradle.internal.component.external.ivypublish.DefaultIvyModuleDescrip
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentAttributeMatcher;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.execution.OutputChangeListener;
+import org.gradle.internal.execution.Result;
+import org.gradle.internal.execution.WorkExecutor;
+import org.gradle.internal.execution.history.OutputFilesRepository;
+import org.gradle.internal.execution.impl.DefaultWorkExecutor;
+import org.gradle.internal.execution.impl.steps.CatchExceptionStep;
+import org.gradle.internal.execution.impl.steps.Context;
+import org.gradle.internal.execution.impl.steps.CreateOutputsStep;
+import org.gradle.internal.execution.impl.steps.CurrentSnapshotResult;
+import org.gradle.internal.execution.impl.steps.ExecuteStep;
+import org.gradle.internal.execution.impl.steps.PrepareCachingStep;
+import org.gradle.internal.execution.impl.steps.SkipUpToDateStep;
+import org.gradle.internal.execution.impl.steps.SnapshotOutputStep;
+import org.gradle.internal.execution.impl.steps.StoreSnapshotsStep;
+import org.gradle.internal.execution.impl.steps.TimeoutStep;
+import org.gradle.internal.execution.impl.steps.UpToDateResult;
+import org.gradle.internal.execution.timeout.TimeoutHandler;
+import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter;
+import org.gradle.internal.id.UniqueId;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.locking.DefaultDependencyLockingHandler;
 import org.gradle.internal.locking.DefaultDependencyLockingProvider;
@@ -104,10 +128,14 @@ import org.gradle.internal.resource.local.LocallyAvailableResourceFinder;
 import org.gradle.internal.service.DefaultServiceRegistry;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.ServiceRegistry;
+import org.gradle.internal.snapshot.FileSystemSnapshot;
+import org.gradle.internal.snapshot.FileSystemSnapshotter;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.internal.SimpleMapInterner;
 import org.gradle.vcs.internal.VcsMappingsStore;
 
+import javax.annotation.Nullable;
+import java.io.File;
 import java.util.List;
 
 public class DefaultDependencyManagementServices implements DependencyManagementServices {
@@ -124,6 +152,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         services.add(DependencyMetaDataProvider.class, dependencyMetaDataProvider);
         services.add(ProjectFinder.class, projectFinder);
         services.add(DomainObjectContext.class, domainObjectContext);
+        services.addProvider(new ArtifactTransformResolutionGradleUserHomeServices());
         services.addProvider(new DependencyResolutionScopeServices());
         return services.get(DependencyResolutionServices.class);
     }
@@ -132,10 +161,74 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         registration.addProvider(new DependencyResolutionScopeServices());
     }
 
+    private static class ArtifactTransformResolutionGradleUserHomeServices {
+
+        ArtifactTransformListener createArtifactTransformListener() {
+            return new ArtifactTransformListener() {
+                @Override
+                public void beforeTransformerInvocation(Describable transformer, Describable subject) {
+                }
+
+                @Override
+                public void afterTransformerInvocation(Describable transformer, Describable subject) {
+                }
+            };
+        }
+
+        OutputFileCollectionFingerprinter createOutputFingerprinter(FileSystemSnapshotter fileSystemSnapshotter, StringInterner stringInterner) {
+            return new OutputFileCollectionFingerprinter(stringInterner, fileSystemSnapshotter);
+        }
+
+        /**
+         * Work executer for usage above Gradle scope
+         *
+         * Currently used for running artifact transformations in buildscript blocks.
+         */
+        WorkExecutor<UpToDateResult> createWorkExecutor(
+            TimeoutHandler timeoutHandler, ListenerManager listenerManager
+        ) {
+            OutputChangeListener outputChangeListener = listenerManager.getBroadcaster(OutputChangeListener.class);
+            OutputFilesRepository noopOutputFilesRepository = new OutputFilesRepository() {
+                @Override
+                public boolean isGeneratedByGradle(File file) {
+                    return true;
+                }
+
+                @Override
+                public void recordOutputs(Iterable<? extends FileSystemSnapshot> outputFileFingerprints) {
+                }
+            };
+            // TODO: Figure out how to get rid of origin scope id in snapshot outputs step
+            UniqueId fixedUniqueId = UniqueId.from("dhwwyv4tqrd43cbxmdsf24wquu");
+            return new DefaultWorkExecutor<UpToDateResult>(
+                new SkipUpToDateStep<Context>(
+                    new StoreSnapshotsStep<Context>(noopOutputFilesRepository,
+                        new PrepareCachingStep<Context, CurrentSnapshotResult>(
+                            new SnapshotOutputStep<Context>(fixedUniqueId,
+                                new CreateOutputsStep<Context, Result>(
+                                    new CatchExceptionStep<Context>(
+                                        new TimeoutStep<Context>(timeoutHandler,
+                                            new ExecuteStep(outputChangeListener)
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            );
+        }
+    }
+
     private static class DependencyResolutionScopeServices {
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory) {
             return instantiatorFactory.decorate().newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher(), instantiatorFactory, isolatableFactory);
+        }
+
+        TransformerInvoker createTransformerInvoker(WorkExecutor<UpToDateResult> workExecutor,
+                                                    FileSystemSnapshotter fileSystemSnapshotter, TransformerExecutionHistoryRepository historyRepository, ArtifactTransformListener artifactTransformListener, OutputFileCollectionFingerprinter outputFileCollectionFingerprinter) {
+            return new DefaultTransformerInvoker(workExecutor, fileSystemSnapshotter, artifactTransformListener, historyRepository, outputFileCollectionFingerprinter);
         }
 
         VariantTransformRegistry createVariantTransforms(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, TransformerInvoker transformerInvoker) {
@@ -218,6 +311,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             );
         }
 
+        @Nullable
         private TaskResolver taskResolverFor(DomainObjectContext domainObjectContext) {
             if (domainObjectContext instanceof ProjectInternal) {
                 return ((ProjectInternal) domainObjectContext).getTasks();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGradleUserHomeScopeServices.java
@@ -16,18 +16,13 @@
 
 package org.gradle.api.internal.artifacts;
 
-import org.gradle.api.Describable;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultArtifactCacheMetadata;
-import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformerExecutionHistoryRepository;
-import org.gradle.api.internal.artifacts.transform.DefaultTransformerInvoker;
 import org.gradle.api.internal.artifacts.transform.GradleUserHomeWorkspaceProvider;
 import org.gradle.api.internal.artifacts.transform.TransformerExecutionHistoryRepository;
-import org.gradle.api.internal.artifacts.transform.TransformerInvoker;
-import org.gradle.api.internal.artifacts.transform.TransformerWorkspaceProvider;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.changedetection.state.DefaultExecutionHistoryCacheAccess;
 import org.gradle.cache.CacheRepository;
@@ -36,14 +31,10 @@ import org.gradle.cache.internal.InMemoryCacheDecoratorFactory;
 import org.gradle.cache.internal.UsedGradleVersions;
 import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.impl.DefaultExecutionHistoryStore;
-import org.gradle.internal.execution.impl.steps.UpToDateResult;
-import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter;
 import org.gradle.internal.resource.local.FileAccessTimeJournal;
-import org.gradle.internal.snapshot.FileSystemSnapshotter;
 
 public class DependencyManagementGradleUserHomeScopeServices {
     DefaultArtifactCacheMetadata createArtifactCacheMetaData(CacheScopeMapping cacheScopeMapping) {
@@ -63,29 +54,12 @@ public class DependencyManagementGradleUserHomeScopeServices {
         return new DefaultExecutionHistoryStore(executionHistoryCacheAccess, stringInterner);
     }
 
-    TransformerWorkspaceProvider createTransformerWorkspaceProvider(ArtifactCacheMetadata artifactCacheMetadata, CacheRepository cacheRepository, FileAccessTimeJournal fileAccessTimeJournal) {
+    GradleUserHomeWorkspaceProvider createTransformerWorkspaceProvider(ArtifactCacheMetadata artifactCacheMetadata, CacheRepository cacheRepository, FileAccessTimeJournal fileAccessTimeJournal) {
         return new GradleUserHomeWorkspaceProvider(artifactCacheMetadata.getTransformsStoreDirectory(), cacheRepository, fileAccessTimeJournal);
     }
 
-    TransformerExecutionHistoryRepository createTransformerExecutionHistoryRepository(TransformerWorkspaceProvider transformerWorkspaceProvider, ExecutionHistoryStore executionHistoryStore) {
-        return new DefaultTransformerExecutionHistoryRepository(transformerWorkspaceProvider, executionHistoryStore);
-    }
-
-    OutputFileCollectionFingerprinter createOutputFingerprinter(FileSystemSnapshotter fileSystemSnapshotter, StringInterner stringInterner) {
-        return new OutputFileCollectionFingerprinter(stringInterner, fileSystemSnapshotter);
-    }
-
-    TransformerInvoker createTransformerInvoker(WorkExecutor<UpToDateResult> workExecutor,
-                                                FileSystemSnapshotter fileSystemSnapshotter, ListenerManager listenerManager, TransformerExecutionHistoryRepository historyRepository, OutputFileCollectionFingerprinter outputFileCollectionFingerprinter) {
-        DefaultTransformerInvoker transformerInvoker = new DefaultTransformerInvoker(workExecutor, fileSystemSnapshotter, new ArtifactTransformListener() {
-            @Override
-            public void beforeTransformerInvocation(Describable transformer, Describable subject) {
-            }
-
-            @Override
-            public void afterTransformerInvocation(Describable transformer, Describable subject) {
-            }
-        }, historyRepository, outputFileCollectionFingerprinter);
+    TransformerExecutionHistoryRepository createTransformerExecutionHistoryRepository(GradleUserHomeWorkspaceProvider transformerWorkspaceProvider, ExecutionHistoryStore executionHistoryStore, ListenerManager listenerManager) {
+        DefaultTransformerExecutionHistoryRepository executionHistoryRepository = new DefaultTransformerExecutionHistoryRepository(transformerWorkspaceProvider, executionHistoryStore);
         listenerManager.addListener(new RootBuildLifecycleListener() {
             @Override
             public void afterStart() {
@@ -93,9 +67,9 @@ public class DependencyManagementGradleUserHomeScopeServices {
 
             @Override
             public void beforeComplete() {
-                transformerInvoker.clearInMemoryCache();
+                executionHistoryRepository.clearInMemoryCache();
             }
         });
-        return transformerInvoker;
+        return executionHistoryRepository;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyServices.java
@@ -18,21 +18,13 @@ package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformationNodeFactory;
-import org.gradle.api.internal.artifacts.transform.DefaultTransformerInvoker;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeDependencyResolver;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeExecutor;
 import org.gradle.api.internal.artifacts.transform.TransformationNodeFactory;
-import org.gradle.api.internal.artifacts.transform.TransformerExecutionHistoryRepository;
-import org.gradle.api.internal.artifacts.transform.TransformerInvoker;
-import org.gradle.initialization.RootBuildLifecycleListener;
 import org.gradle.internal.event.ListenerManager;
-import org.gradle.internal.execution.WorkExecutor;
-import org.gradle.internal.execution.impl.steps.UpToDateResult;
-import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
-import org.gradle.internal.snapshot.FileSystemSnapshotter;
 
 public class DependencyServices extends AbstractPluginServiceRegistry {
     public void registerGlobalServices(ServiceRegistration registration) {
@@ -74,22 +66,6 @@ public class DependencyServices extends AbstractPluginServiceRegistry {
 
         TransformationNodeExecutor createTransformationNodeExecutor(BuildOperationExecutor buildOperationExecutor, ArtifactTransformListener transformListener) {
             return new TransformationNodeExecutor(buildOperationExecutor, transformListener);
-        }
-
-        TransformerInvoker createTransformerInvoker(WorkExecutor<UpToDateResult> workExecutor,
-                                                    FileSystemSnapshotter fileSystemSnapshotter, TransformerExecutionHistoryRepository historyRepository, ListenerManager listenerManager, ArtifactTransformListener artifactTransformListener, OutputFileCollectionFingerprinter outputFileCollectionFingerprinter) {
-            DefaultTransformerInvoker transformerInvoker = new DefaultTransformerInvoker(workExecutor, fileSystemSnapshotter, artifactTransformListener, historyRepository, outputFileCollectionFingerprinter);
-            listenerManager.addListener(new RootBuildLifecycleListener() {
-                @Override
-                public void afterStart() {
-                }
-
-                @Override
-                public void beforeComplete() {
-                    transformerInvoker.clearInMemoryCache();
-                }
-            });
-            return transformerInvoker;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/package-info.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/package-info.java
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.artifacts.transform;
+@NonNullApi
+package org.gradle.api.internal.artifacts;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.internal.Try;
-
-import java.io.File;
-import java.util.function.BiFunction;
-
-public interface TransformerWorkspaceProvider {
-    /**
-     * Provides a workspace for executing the transformation.
-     */
-    Try<ImmutableList<File>> withWorkspace(TransformationIdentity identity, BiFunction<String, File, Try<ImmutableList<File>>> useWorkspace);
-}
+import org.gradle.api.NonNullApi;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -23,23 +23,26 @@ import org.gradle.api.artifacts.transform.TransformInvocationException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.file.collections.ImmutableFileCollection;
-import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.internal.Try;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.change.Change;
 import org.gradle.internal.change.ChangeVisitor;
+import org.gradle.internal.change.SummarizingChangeContainer;
 import org.gradle.internal.execution.CacheHandler;
 import org.gradle.internal.execution.UnitOfWork;
 import org.gradle.internal.execution.WorkExecutor;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 import org.gradle.internal.execution.history.changes.AbstractFingerprintChanges;
 import org.gradle.internal.execution.history.changes.ExecutionStateChanges;
+import org.gradle.internal.execution.history.changes.InputFileChanges;
 import org.gradle.internal.execution.impl.steps.UpToDateResult;
 import org.gradle.internal.file.TreeType;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
@@ -55,9 +58,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -67,8 +68,6 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
 
     private final FileSystemSnapshotter fileSystemSnapshotter;
     private final WorkExecutor<UpToDateResult> workExecutor;
-    private final ProducerGuard<CacheKey> producing = ProducerGuard.adaptive();
-    private final Map<CacheKey, ImmutableList<File>> resultHashToResult = new ConcurrentHashMap<CacheKey, ImmutableList<File>>();
     private final ArtifactTransformListener artifactTransformListener;
     private final TransformerExecutionHistoryRepository historyRepository;
     private final OutputFileCollectionFingerprinter outputFileCollectionFingerprinter;
@@ -84,19 +83,15 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         this.outputFileCollectionFingerprinter = outputFileCollectionFingerprinter;
     }
 
-    public void clearInMemoryCache() {
-        resultHashToResult.clear();
-    }
-
     @Override
     public boolean hasCachedResult(File primaryInput, Transformer transformer) {
-        return resultHashToResult.containsKey(getCacheKey(primaryInput.getAbsoluteFile(), transformer.getSecondaryInputHash()));
+        return historyRepository.hasCachedResult(getImmutableTransformationIdentity(primaryInput, transformer));
     }
 
     @Override
     public Try<ImmutableList<File>> invoke(TransformerInvocation invocation) {
         return Try.ofFailable(() ->
-            invoke(invocation.getPrimaryInput(), invocation.getTransformer(), invocation.getSubjectBeingTransformed()).get()
+            doInvoke(invocation.getPrimaryInput(), invocation.getTransformer(), invocation.getSubjectBeingTransformed()).get()
         ).mapFailure(e -> wrapInTransformInvocationException(invocation, e));
     }
 
@@ -104,21 +99,25 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         return new TransformInvocationException(invocation.getPrimaryInput().getAbsoluteFile(), invocation.getTransformer().getImplementationClass(), originalFailure);
     }
 
-    private Try<ImmutableList<File>> invoke(File primaryInput, Transformer transformer, Describable subject) {
-        CacheKey cacheKey = getCacheKey(primaryInput, transformer);
-        ImmutableList<File> results = resultHashToResult.get(cacheKey);
-        if (results != null) {
-            return Try.successful(results);
-        }
-        return fireTransformListeners(transformer, subject, () -> {
-            HashCode persistentCacheKey = cacheKey.getPersistentCacheKey();
-            File workspace = historyRepository.getWorkspace(primaryInput, persistentCacheKey);
-            TransformerExecution execution = new TransformerExecution(primaryInput, transformer, persistentCacheKey, workspace);
-            UpToDateResult outcome = producing.guardByKey(cacheKey, () -> workExecutor.execute(execution));
-            Try<ImmutableList<File>> result = execution.getResult(outcome);
-            result.ifSuccessful(transformerResult -> resultHashToResult.put(cacheKey, transformerResult));
-            return result;
+    private Try<ImmutableList<File>> doInvoke(File primaryInput, Transformer transformer, TransformationSubject subject) {
+        TransformationIdentity identity = getImmutableTransformationIdentity(primaryInput, transformer);
+        return historyRepository.withWorkspace(identity, (identityString, workspace) -> {
+            return fireTransformListeners(transformer, subject, () -> {
+                TransformerExecution execution = new TransformerExecution(primaryInput, transformer, workspace, identityString, historyRepository);
+                UpToDateResult outcome = workExecutor.execute(execution);
+                return execution.getResult(outcome);
+            });
         });
+    }
+
+    private TransformationIdentity getImmutableTransformationIdentity(File primaryInput, Transformer transformer) {
+        FileSystemLocationSnapshot snapshot = fileSystemSnapshotter.snapshot(primaryInput);
+        return new ImmutableTransformationIdentity(
+            primaryInput.getName(),
+            snapshot.getAbsolutePath(),
+            snapshot.getHash(),
+            transformer.getSecondaryInputHash()
+        );
     }
 
     private Try<ImmutableList<File>> fireTransformListeners(Transformer transformer, Describable subject, Supplier<Try<ImmutableList<File>>> execution) {
@@ -130,69 +129,8 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         }
     }
 
-    private CacheKey getCacheKey(File primaryInput, Transformer transformer) {
-        return getCacheKey(primaryInput, transformer.getSecondaryInputHash());
-    }
-
-    private CacheKey getCacheKey(File inputFile, HashCode inputsHash) {
-        FileSystemLocationSnapshot snapshot = fileSystemSnapshotter.snapshot(inputFile);
-        return new CacheKey(inputsHash, snapshot.getAbsolutePath(), snapshot.getHash());
-    }
-
-    /**
-     * A lightweight key for in-memory caching of transformation results.
-     * Computing the hash key for the persistent cache is a rather expensive
-     * operation, so we only calculate it when we have a cache miss in memory.
-     */
-    private static class CacheKey {
-        private final String absolutePath;
-        private final HashCode fileContentHash;
-        private final HashCode inputHash;
-
-        public CacheKey(HashCode inputHash, String absolutePath, HashCode fileContentHash) {
-            this.absolutePath = absolutePath;
-            this.fileContentHash = fileContentHash;
-            this.inputHash = inputHash;
-        }
-
-        public HashCode getPersistentCacheKey() {
-            Hasher hasher = Hashing.newHasher();
-            hasher.putHash(inputHash);
-            hasher.putString(absolutePath);
-            hasher.putHash(fileContentHash);
-            return hasher.hash();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) {
-                return true;
-            }
-            if (o == null || getClass() != o.getClass()) {
-                return false;
-            }
-
-            CacheKey cacheKey = (CacheKey) o;
-
-            if (!fileContentHash.equals(cacheKey.fileContentHash)) {
-                return false;
-            }
-            if (!inputHash.equals(cacheKey.inputHash)) {
-                return false;
-            }
-            return absolutePath.equals(cacheKey.absolutePath);
-        }
-
-        @Override
-        public int hashCode() {
-            int result = fileContentHash.hashCode();
-            result = 31 * result + absolutePath.hashCode();
-            result = 31 * result + inputHash.hashCode();
-            return result;
-        }
-    }
-
     private class TransformerExecution implements UnitOfWork {
+        private static final String PRIMARY_INPUT_PROPERTY_NAME = "primaryInput";
         private static final String OUTPUT_DIRECTORY_PROPERTY_NAME = "outputDirectory";
         private static final String RESULTS_FILE_PROPERTY_NAME = "resultsFile";
         private static final String INPUT_FILE_PATH_PREFIX = "i/";
@@ -202,14 +140,21 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         private final Transformer transformer;
         private final File outputDir;
         private final File resultsFile;
-        private final HashCode persistentCacheKey;
+        private final String identityString;
+        private final TransformerExecutionHistoryRepository historyRepository;
+        private final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints;
 
-        public TransformerExecution(File primaryInput, Transformer transformer, HashCode persistentCacheKey, File workspace) {
+        public TransformerExecution(File primaryInput, Transformer transformer, File workspace, String identityString, TransformerExecutionHistoryRepository historyRepository) {
             this.primaryInput = primaryInput;
             this.transformer = transformer;
-            this.persistentCacheKey = persistentCacheKey;
+            this.identityString = "transform/" + identityString;
+            this.historyRepository = historyRepository;
             this.outputDir = new File(workspace, "outputDirectory");
             this.resultsFile = new File(workspace,  "results.bin");
+            CurrentFileCollectionFingerprint primaryInputFingerprint = DefaultCurrentFileCollectionFingerprint.from(ImmutableList.of(fileSystemSnapshotter.snapshot(primaryInput)), AbsolutePathFingerprintingStrategy.INCLUDE_MISSING);
+            this.inputFileFingerprints = ImmutableSortedMap.<String, CurrentFileCollectionFingerprint>naturalOrder()
+                .put(PRIMARY_INPUT_PROPERTY_NAME, primaryInputFingerprint)
+                .build();
         }
 
         @Override
@@ -308,10 +253,11 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         @Override
         public void persistResult(ImmutableSortedMap<String, CurrentFileCollectionFingerprint> finalOutputs, boolean successful, OriginMetadata originMetadata) {
             if (successful) {
-                historyRepository.persist(persistentCacheKey,
+                historyRepository.persist(identityString,
                     originMetadata,
                     // TODO: only use implementation hash
                     ImplementationSnapshot.of(transformer.getImplementationClass().getName(), transformer.getSecondaryInputHash()),
+                    inputFileFingerprints,
                     finalOutputs,
                     successful
                 );
@@ -320,11 +266,12 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
 
         @Override
         public Optional<ExecutionStateChanges> getChangesSincePreviousExecution() {
-            Optional<AfterPreviousExecutionState> previousExecution = historyRepository.getPreviousExecution(persistentCacheKey);
+            Optional<AfterPreviousExecutionState> previousExecution = historyRepository.getPreviousExecution(identityString);
             return previousExecution.map(previous -> {
                 ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsBeforeExecution = snapshotOutputs();
+                InputFileChanges inputFileChanges = new InputFileChanges(previous.getInputFileProperties(), inputFileFingerprints);
                 AllOutputFileChanges outputFileChanges = new AllOutputFileChanges(previous.getOutputFileProperties(), outputsBeforeExecution);
-                return new TransformerExecutionStateChanges(outputFileChanges, previous);
+                return new TransformerExecutionStateChanges(inputFileChanges, outputFileChanges, previous);
                 }
             );
         }
@@ -350,7 +297,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
 
         @Override
         public String getIdentity() {
-            return "fake";
+            return identityString;
         }
 
         @Override
@@ -364,10 +311,12 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         }
 
         private class TransformerExecutionStateChanges implements ExecutionStateChanges {
+            private final InputFileChanges inputFileChanges;
             private final AllOutputFileChanges outputFileChanges;
             private final AfterPreviousExecutionState afterPreviousExecutionState;
 
-            public TransformerExecutionStateChanges(AllOutputFileChanges outputFileChanges, AfterPreviousExecutionState afterPreviousExecutionState) {
+            public TransformerExecutionStateChanges(InputFileChanges inputFileChanges, AllOutputFileChanges outputFileChanges, AfterPreviousExecutionState afterPreviousExecutionState) {
+                this.inputFileChanges = inputFileChanges;
                 this.outputFileChanges = outputFileChanges;
                 this.afterPreviousExecutionState = afterPreviousExecutionState;
             }
@@ -379,7 +328,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
 
             @Override
             public void visitAllChanges(ChangeVisitor visitor) {
-                outputFileChanges.accept(visitor);
+                new SummarizingChangeContainer(inputFileChanges, outputFileChanges).accept(visitor);
             }
 
             @Override
@@ -403,6 +352,64 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         @Override
         public boolean accept(ChangeVisitor visitor) {
             return accept(visitor, true);
+        }
+    }
+
+    public static class ImmutableTransformationIdentity implements TransformationIdentity {
+        private final String initialSubjectFileName;
+        private final String primaryInputAbsolutePath;
+        private final HashCode primaryInputHash;
+        private final HashCode secondaryInputHash;
+
+        public ImmutableTransformationIdentity(String initialSubjectFileName, String primaryInputAbsolutePath, HashCode primaryInputHash, HashCode secondaryInputHash) {
+            this.initialSubjectFileName = initialSubjectFileName;
+            this.primaryInputAbsolutePath = primaryInputAbsolutePath;
+            this.primaryInputHash = primaryInputHash;
+            this.secondaryInputHash = secondaryInputHash;
+        }
+
+        @Override
+        public String getInitialSubjectFileName() {
+            return initialSubjectFileName;
+        }
+
+        @Override
+        public String getIdentity() {
+            Hasher hasher = Hashing.newHasher();
+            hasher.putHash(secondaryInputHash);
+            hasher.putString(primaryInputAbsolutePath);
+            hasher.putHash(primaryInputHash);
+            return hasher.hash().toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            ImmutableTransformationIdentity that = (ImmutableTransformationIdentity) o;
+
+            if (!primaryInputHash.equals(that.primaryInputHash)) {
+                return false;
+            }
+            if (!secondaryInputHash.equals(that.secondaryInputHash)) {
+                return false;
+            }
+            if (!initialSubjectFileName.equals(that.initialSubjectFileName)) {
+                return false;
+            }
+            return primaryInputAbsolutePath.equals(that.primaryInputAbsolutePath);
+        }
+
+        @Override
+        public int hashCode() {
+            int result = primaryInputHash.hashCode();
+            result = 31 * result + secondaryInputHash.hashCode();
+            return result;
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/GradleUserHomeWorkspaceProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/GradleUserHomeWorkspaceProvider.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.cache.CacheBuilder;
 import org.gradle.cache.CacheRepository;
 import org.gradle.cache.CleanupAction;
@@ -23,14 +24,16 @@ import org.gradle.cache.FileLockManager;
 import org.gradle.cache.PersistentCache;
 import org.gradle.cache.internal.CompositeCleanupAction;
 import org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup;
+import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.cache.internal.SingleDepthFilesFinder;
-import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.Try;
 import org.gradle.internal.resource.local.FileAccessTimeJournal;
 import org.gradle.internal.resource.local.SingleDepthFileAccessTracker;
 
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.function.BiFunction;
 
 import static org.gradle.api.internal.artifacts.ivyservice.CacheLayout.TRANSFORMS_STORE;
 import static org.gradle.cache.internal.LeastRecentlyUsedCacheCleanup.DEFAULT_MAX_AGE_IN_DAYS_FOR_RECREATABLE_CACHE_ENTRIES;
@@ -42,6 +45,7 @@ public class GradleUserHomeWorkspaceProvider implements TransformerWorkspaceProv
     private final SingleDepthFileAccessTracker fileAccessTracker;
     private final File filesOutputDirectory;
     private final PersistentCache cache;
+    private final ProducerGuard<TransformationIdentity> producing = ProducerGuard.adaptive();
 
     public GradleUserHomeWorkspaceProvider(File transformsStoreDirectory, CacheRepository cacheRepository, FileAccessTimeJournal fileAccessTimeJournal) {
         filesOutputDirectory = new File(transformsStoreDirectory, TRANSFORMS_STORE.getKey());
@@ -62,10 +66,13 @@ public class GradleUserHomeWorkspaceProvider implements TransformerWorkspaceProv
     }
 
     @Override
-    public File getWorkspace(File toBeTransformed, HashCode cacheKey) {
-        File workspace = new File(filesOutputDirectory, toBeTransformed.getName() + "/" + cacheKey);
-        fileAccessTracker.markAccessed(workspace);
-        return workspace;
+    public Try<ImmutableList<File>> withWorkspace(TransformationIdentity identity, BiFunction<String, File, Try<ImmutableList<File>>> useWorkspace) {
+        return producing.guardByKey(identity, () -> {
+            String identityString = identity.getIdentity();
+            File workspace = new File(filesOutputDirectory, identity.getInitialSubjectFileName() + "/" + identityString);
+            fileAccessTracker.markAccessed(workspace);
+            return useWorkspace.apply(identityString, workspace);
+        });
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationIdentity.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationIdentity.java
@@ -16,15 +16,7 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import com.google.common.collect.ImmutableList;
-import org.gradle.internal.Try;
-
-import java.io.File;
-import java.util.function.BiFunction;
-
-public interface TransformerWorkspaceProvider {
-    /**
-     * Provides a workspace for executing the transformation.
-     */
-    Try<ImmutableList<File>> withWorkspace(TransformationIdentity identity, BiFunction<String, File, Try<ImmutableList<File>>> useWorkspace);
+public interface TransformationIdentity {
+    String getInitialSubjectFileName();
+    String getIdentity();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformerExecutionHistoryRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformerExecutionHistoryRepository.java
@@ -20,14 +20,12 @@ import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.caching.internal.origin.OriginMetadata;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
-import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.snapshot.impl.ImplementationSnapshot;
 
-import java.io.File;
 import java.util.Optional;
 
-public interface TransformerExecutionHistoryRepository {
-    Optional<AfterPreviousExecutionState> getPreviousExecution(HashCode cacheKey);
-    File getWorkspace(File toBeTransformed, HashCode cacheKey);
-    void persist(HashCode cacheKey, OriginMetadata originMetadata, ImplementationSnapshot implementationSnapshot, ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFingerprints, boolean successful);
+public interface TransformerExecutionHistoryRepository extends TransformerWorkspaceProvider {
+    Optional<AfterPreviousExecutionState> getPreviousExecution(String identity);
+    void persist(String identity, OriginMetadata originMetadata, ImplementationSnapshot implementationSnapshot, ImmutableSortedMap<String, CurrentFileCollectionFingerprint> primaryInputFingerprints, ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFingerprints, boolean successful);
+    boolean hasCachedResult(TransformationIdentity identity);
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -16,22 +16,16 @@
 
 package org.gradle.api.internal.artifacts.transform
 
-
-import com.google.common.collect.ImmutableSortedMap
 import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
-import org.gradle.caching.internal.origin.OriginMetadata
-import org.gradle.internal.execution.history.AfterPreviousExecutionState
 import org.gradle.internal.execution.impl.DefaultWorkExecutor
 import org.gradle.internal.execution.impl.steps.Context
 import org.gradle.internal.execution.impl.steps.CreateOutputsStep
 import org.gradle.internal.execution.impl.steps.Step
 import org.gradle.internal.execution.impl.steps.UpToDateResult
-import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.snapshot.FileSystemSnapshotter
 import org.gradle.internal.snapshot.RegularFileSnapshot
-import org.gradle.internal.snapshot.impl.ImplementationSnapshot
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -56,24 +50,7 @@ class DefaultTransformerInvokerTest extends ConcurrentSpec {
         }
     }
     def workExecutor = new DefaultWorkExecutor(new CreateOutputsStep(executeStep))
-    Map<HashCode, List<File>> history = [:]
-    def historyRepository = new TransformerExecutionHistoryRepository() {
-
-        @Override
-        Optional<AfterPreviousExecutionState> getPreviousExecution(HashCode cacheKey) {
-            return Optional.ofNullable(history.get(cacheKey))
-        }
-
-        @Override
-        File getWorkspace(File toBeTransformed, HashCode cacheKey) {
-            return new File(transformsStoreDirectory, toBeTransformed.getName() + "/" + cacheKey)
-        }
-
-        @Override
-        void persist(HashCode cacheKey, OriginMetadata originMetadata, ImplementationSnapshot implementationSnapshot, ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFingerprints, boolean successful) {
-            // TODO
-        }
-    }
+    def historyRepository = Mock(TransformerExecutionHistoryRepository)
     DefaultTransformerInvoker transformerInvoker
 
     def setup() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformerInvokerTest.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.transform
 
-
 import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.artifacts.transform.TransformInvocationException
 import org.gradle.api.internal.cache.StringInterner
@@ -61,7 +60,9 @@ class TransformerInvokerTest extends Specification {
         1 * workExecutor.execute(_) >> { throw failure }
         1 * transformer.implementationClass >> ArtifactTransform
         1 * transformer.getSecondaryInputHash() >> HashCode.fromInt(1234)
-        1 * historyRepository.getWorkspace(_, _) >> new File("workspace")
+        1 * historyRepository.withWorkspace(_, _) >> { TransformationIdentity identity, action ->
+            action.apply(identity.getIdentity(), new File("workspace"))
+        }
         _ * artifactTransformListener._
         0 * _
     }


### PR DESCRIPTION
Instead of doing the locking and short circuting in the transformer
invoker we move it to a Gradle user home service.

A transformer identity is used for identifying what to lock on.

The transformer invoker is now project scoped. More precisely
it is dependency dsl services scoped.