### PR TITLE
Set http.keepAlive=false for now

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx2500m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 systemProp.org.gradle.kotlin.dsl.caching.buildcache=true
+systemProp.http.keepAlive=false


### PR DESCRIPTION
See https://github.com/gradle/dotcom/issues/1727

With http.keepAlive, there might be memory leak when using JDK built-in
HTTP client. As a workaround, now we try to disable http.keepAlive, until
new release of Gradle Enterprise and e.grdev.net.