### PR TITLE
Handle deferred values uniformly via `DeferredUtil`

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/WritePropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/WritePropertiesIntegrationTest.groovy
@@ -19,6 +19,8 @@ package org.gradle.api.tasks
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
+import static org.gradle.util.GUtil.loadProperties
+
 class WritePropertiesIntegrationTest extends AbstractIntegrationSpec {
     def "empty properties are written properly"() {
         given:
@@ -156,6 +158,20 @@ class WritePropertiesIntegrationTest extends AbstractIntegrationSpec {
         failure.assertHasCause("Property 'someProp' is not allowed to have a null value.")
         where:
         propValue << [ "null", "{ null }" ]
+    }
+
+    def "value can be provided"() {
+        given:
+        buildFile << """
+            task props(type: WriteProperties) {
+                property "provided", provider { "42" }
+                outputFile = file("output.properties")
+            }
+        """
+        when:
+        succeeds "props"
+        then:
+        loadProperties(file('output.properties'))['provided'] == '42'
     }
 
     private static String normalize(String text) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/PathNotationConverter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/PathNotationConverter.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.file.copy;
 
-import groovy.lang.Closure;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
 import org.gradle.internal.typeconversion.*;
 
@@ -55,17 +54,10 @@ public class PathNotationConverter implements NotationConverter<Object, String> 
                 || notation instanceof Number
                 || notation instanceof Boolean) {
             result.converted(notation.toString());
-        } else if (notation instanceof Closure) {
-            final Closure closure = (Closure) notation;
-            final Object called = closure.call();
-            convert(called, result);
         } else if (notation instanceof Callable) {
             final Callable callableNotation = (Callable) notation;
             final Object called = uncheckedCall(callableNotation);
             convert(called, result);
-            if (!result.hasResult()) {
-                throw new TypeConversionException("Couldn't convert " + notation);
-            }
         }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -23,6 +23,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.util.PropertiesUtils;
+import org.gradle.util.DeferredUtil;
 
 import javax.annotation.Nullable;
 import java.io.BufferedOutputStream;
@@ -105,11 +106,11 @@ public class WriteProperties extends DefaultTask {
      */
     public void property(final String name, final Object value) {
         checkForNullValue(name, value);
-        if (value instanceof Callable) {
+        if (DeferredUtil.isDeferred(value)) {
             deferredProperties.put(name, new Callable<String>() {
                 @Override
                 public String call() throws Exception {
-                    Object futureValue = ((Callable) value).call();
+                    Object futureValue = DeferredUtil.unpack(value);
                     checkForNullValue(name, futureValue);
                     return String.valueOf(futureValue);
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/PathNotationConverterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/copy/PathNotationConverterTest.groovy
@@ -86,6 +86,16 @@ class PathNotationConverterTest extends Specification {
         null == pathNotationParser.parseNotation({ null });
     }
 
+    def "with Callable of unsupported return value"() {
+        def customObj = new DefaultExcludeRule()
+
+        when:
+        pathNotationParser.parseNotation({ customObj } as Callable);
+
+        then:
+        thrown(UnsupportedNotationException)
+    }
+
     def "with closure of unsupported return value"() {
         def customObj = new DefaultExcludeRule()
 

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/BuildDependenciesOnlyFileCollectionResolveContext.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.file.collections;
 
-import groovy.lang.Closure;
 import org.gradle.api.Buildable;
 import org.gradle.api.Task;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -61,17 +60,10 @@ public class BuildDependenciesOnlyFileCollectionResolveContext implements FileCo
         } else if (element instanceof TaskOutputs) {
             TaskOutputs outputs = (TaskOutputs) element;
             taskContext.add(outputs.getFiles());
-        } else if (element instanceof Closure) {
-            Closure closure = (Closure) element;
-            Object closureResult = closure.call();
-            if (closureResult != null) {
-                add(closureResult);
-            }
         } else if (element instanceof Callable) {
-            Callable callable = (Callable) element;
-            Object callableResult = uncheckedCall(callable);
-            if (callableResult != null) {
-                add(callableResult);
+            Object deferredResult = uncheckedCall((Callable) element);
+            if (deferredResult != null) {
+                add(deferredResult);
             }
         } else if (element instanceof Iterable && !(element instanceof Path)) {
             // Ignore Path

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
@@ -21,7 +21,6 @@ import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.FileTreeInternal;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskOutputs;
 import org.gradle.api.tasks.util.PatternSet;

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/DefaultFileCollectionResolveContext.java
@@ -119,10 +119,6 @@ public class DefaultFileCollectionResolveContext implements ResolvableFileCollec
             } else if (element instanceof TaskOutputs) {
                 TaskOutputs outputs = (TaskOutputs) element;
                 queue.add(0, outputs.getFiles());
-            } else if (element instanceof Provider) {
-                Provider provider = (Provider) element;
-                Object providerResult = provider.get();
-                queue.add(0, providerResult);
             } else if (DeferredUtil.isDeferred(element)) {
                 Object deferredResult = DeferredUtil.unpack(element);
                 if (deferredResult != null) {

--- a/subprojects/model-core/src/main/java/org/gradle/util/DeferredUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/DeferredUtil.java
@@ -45,4 +45,10 @@ public class DeferredUtil {
         }
         return null;
     }
+
+    public static boolean isDeferred(Object value) {
+        return value instanceof Callable
+            || value instanceof Provider
+            || value instanceof Factory;
+    }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/util/DeferredUtil.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/DeferredUtil.java
@@ -25,30 +25,38 @@ import java.util.concurrent.Callable;
 import static org.gradle.util.GUtil.uncheckedCall;
 
 public class DeferredUtil {
+
     /**
-     * Successively unpacks a path that may be deferred by a Callable or Factory
-     * until it's resolved to null or something other than a Callable or Factory.
+     * Successively unpacks a deferred value until it is resolved to null or something other than Callable
+     * then unpacks the remaining Provider or Factory.
      */
     @Nullable
-    public static Object unpack(@Nullable Object path) {
-        Object current = path;
-        while (current != null) {
-            if (current instanceof Callable) {
-                current = uncheckedCall((Callable) current);
-            } else if (current instanceof Provider) {
-                return ((Provider<?>) current).get();
-            } else if (current instanceof Factory) {
-                return ((Factory) current).create();
-            } else {
-                return current;
-            }
+    public static Object unpack(@Nullable Object deferred) {
+        if (deferred == null) {
+            return null;
         }
-        return null;
+        Object value = unpackCallables(deferred);
+        if (value instanceof Provider) {
+            return ((Provider<?>) value).get();
+        }
+        if (value instanceof Factory) {
+            return ((Factory<?>) value).create();
+        }
+        return value;
     }
 
     public static boolean isDeferred(Object value) {
         return value instanceof Callable
             || value instanceof Provider
             || value instanceof Factory;
+    }
+
+    @Nullable
+    private static Object unpackCallables(Object deferred) {
+        Object current = deferred;
+        while (current instanceof Callable) {
+            current = uncheckedCall((Callable<?>) current);
+        }
+        return current;
     }
 }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/SigningExtension.java
@@ -42,6 +42,7 @@ import org.gradle.plugins.signing.signatory.pgp.PgpSignatoryProvider;
 import org.gradle.plugins.signing.type.DefaultSignatureTypeProvider;
 import org.gradle.plugins.signing.type.SignatureType;
 import org.gradle.plugins.signing.type.SignatureTypeProvider;
+import org.gradle.util.DeferredUtil;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -52,7 +53,6 @@ import java.util.concurrent.Callable;
 
 import static org.codehaus.groovy.runtime.StringGroovyMethods.capitalize;
 import static org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation.castToBoolean;
-import static org.gradle.util.GUtil.uncheckedCall;
 
 /**
  * The global signing configuration for a project.
@@ -589,8 +589,6 @@ public class SigningExtension {
     }
 
     private Object force(Object maybeCallable) {
-        return maybeCallable instanceof Callable
-            ? uncheckedCall((Callable) maybeCallable)
-            : maybeCallable;
+        return DeferredUtil.unpack(maybeCallable);
     }
 }


### PR DESCRIPTION
In preparation to also accept Kotlin lambdas as deferred computations, this PR makes their handling more uniform across the board by:
- Treating deferred computation represented by `Callable` instances the same as `Closure` instances (`Closure` is `Callable`), this makes the code simpler and the error handling more uniform;
- Reuse `DeferredUtil.unpack` for code that handles `Callable`s as deferred computations, this extends their reach to `Factory` and `Provider` and later to Kotlin's `Function0` (lambda expressions)