### PR TITLE
Fix attribute disambiguation ignoring attributes of different types

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionUtils.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeSelectionUtils.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Sets;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
+import java.util.Iterator;
 import java.util.Set;
 
 public class AttributeSelectionUtils {
@@ -27,7 +28,7 @@ public class AttributeSelectionUtils {
         for (ImmutableAttributes attributes : candidateAttributeSets) {
             extraAttributes.addAll(attributes.keySet());
         }
-        extraAttributes.removeAll(requested.keySet());
+        removeSameAttributes(requested, extraAttributes);
         Attribute<?>[] extraAttributesArray = extraAttributes.toArray(new Attribute[0]);
         for (int i = 0; i < extraAttributesArray.length; i++) {
             Attribute<?> extraAttribute = extraAttributesArray[i];
@@ -37,5 +38,18 @@ public class AttributeSelectionUtils {
             }
         }
         return extraAttributesArray;
+    }
+
+    private static void removeSameAttributes(ImmutableAttributes requested, Set<Attribute<?>> extraAttributes) {
+        for (Attribute<?> attribute : requested.keySet()) {
+            Iterator<Attribute<?>> it = extraAttributes.iterator();
+            while (it.hasNext()) {
+                Attribute<?> next = it.next();
+                if (next.getName().equals(attribute.getName())) {
+                    it.remove();
+                    break;
+                }
+            }
+        }
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -77,7 +77,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(androidGradle3x)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of('1.2.21', '1.2.31', '1.2.41', '1.2.51', '1.2.61', '1.2.71', '1.3.10')
+        static kotlin = Versions.of('1.2.21', '1.2.31', '1.2.41', '1.2.51', '1.2.61', '1.2.71', '1.3.0', '1.3.10')
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "2.2.0"

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/AbstractSmokeTest.groovy
@@ -77,7 +77,7 @@ abstract class AbstractSmokeTest extends Specification {
         static androidGradle = Versions.of(androidGradle3x)
 
         // https://search.maven.org/search?q=g:org.jetbrains.kotlin%20AND%20a:kotlin-project&core=gav
-        static kotlin = Versions.of('1.2.21', '1.2.31', '1.2.41', '1.2.51', '1.2.61', '1.2.71')
+        static kotlin = Versions.of('1.2.21', '1.2.31', '1.2.41', '1.2.51', '1.2.61', '1.2.71', '1.3.10')
 
         // https://plugins.gradle.org/plugin/org.gretty
         static gretty = "2.2.0"
@@ -133,6 +133,10 @@ abstract class AbstractSmokeTest extends Specification {
 
     protected String getDefaultBuildFileName() {
         'build.gradle'
+    }
+
+    void withKotlinBuildFile() {
+        buildFile = new File(testProjectDir.root, "${getDefaultBuildFileName()}.kts")
     }
 
     File file(String filename) {

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/KotlinPluginSmokeTest.groovy
@@ -16,10 +16,11 @@
 
 package org.gradle.smoketests
 
+import org.gradle.util.Requires
 import spock.lang.Unroll
 
-import static org.gradle.smoketests.AndroidPluginsSmokeTest.assertAndroidHomeSet
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
 
 class KotlinPluginSmokeTest extends AbstractSmokeTest {
     @Unroll
@@ -56,5 +57,23 @@ class KotlinPluginSmokeTest extends AbstractSmokeTest {
 
         where:
         androidPluginVersion << TestedVersions.androidGradle
+    }
+
+    @Unroll
+    @Requires(KOTLIN_SCRIPT)
+    def 'kotlin js #version plugin'() {
+        given:
+        useSample("kotlin-js-sample")
+        withKotlinBuildFile()
+        replaceVariablesInBuildFile(kotlinVersion: version)
+
+        when:
+        def result = runner('compileKotlin2Js').forwardOutput().build()
+
+        then:
+        result.task(':compileKotlin2Js').outcome == SUCCESS
+
+        where:
+        version << TestedVersions.kotlin
     }
 }

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-js-sample/build.gradle.kts
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-js-sample/build.gradle.kts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
+
+plugins {
+    id("kotlin2js") version "$kotlinVersion"
+}
+
+dependencies {
+    compile(kotlin("stdlib-js"))
+}
+
+repositories {
+    jcenter()
+}
+
+tasks {
+    compileKotlin2Js {
+        kotlinOptions {
+            outputFile = "${sourceSets.main.get().output.resourcesDir}/output.js"
+            sourceMap = true
+        }
+    }
+    val unpackKotlinJsStdlib by registering {
+        group = "build"
+        description = "Unpack the Kotlin JavaScript standard library"
+        val outputDir = file("$buildDir/$name")
+        inputs.property("compileClasspath", configurations.compileClasspath.get())
+        outputs.dir(outputDir)
+        doLast {
+            val kotlinStdLibJar = configurations.compileClasspath.get().single {
+                it.name.matches(Regex("kotlin-stdlib-js-.+\\.jar"))
+            }
+            copy {
+                includeEmptyDirs = false
+                from(zipTree(kotlinStdLibJar))
+                into(outputDir)
+                include("**/*.js")
+                exclude("META-INF/**")
+            }
+        }
+    }
+    val assembleWeb by registering(Copy::class) {
+        group = "build"
+        description = "Assemble the web application"
+        includeEmptyDirs = false
+        from(unpackKotlinJsStdlib)
+        from(sourceSets.main.get().output) {
+            exclude("**/*.kjsm")
+        }
+        into("$buildDir/web")
+    }
+    assemble {
+        dependsOn(assembleWeb)
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-js-sample/settings.gradle.kts
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-js-sample/settings.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "kotlin-js-sample"
+
+pluginManagement {
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "kotlin2js") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:${requested.version}")
+            }
+        }
+    }
+}

--- a/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-js-sample/src/main/kotlin/samples/HelloWorld.kt
+++ b/subprojects/smoke-test/src/smokeTest/resources/org/gradle/smoketests/kotlin-js-sample/src/main/kotlin/samples/HelloWorld.kt
@@ -1,0 +1,5 @@
+package samples
+
+fun main(args: Array<String>) {
+    println("Hello, world!")
+}


### PR DESCRIPTION
### Context

This is a hotfix for [KT-28203](https://youtrack.jetbrains.com/issue/KT-28203), which is about the Kotlin2Js plugin
failing with 5.0 because of extra attributes disambiguation. What
happens is that we have 2 sets of attributes, but one is using the
coercing `Usage` attribute while the other is not. As a consequence,
the attribute is not removed from the list of extra attributes,
and we fail disambiguation.

Ideally this should come with a (unit|integration) test that proves
it works independently of the smoke test, but there's a bit of urgency
so it can be added later.

Creating the PR early so that we can check the impact on performance.