### PR TITLE
Update single-page user manual

### DIFF
--- a/subprojects/docs/src/docs/userguide/getting_started.adoc
+++ b/subprojects/docs/src/docs/userguide/getting_started.adoc
@@ -23,6 +23,7 @@ In order to use Gradle effectively, you need to know what it is and understand s
 
 Even if you're experienced with using Gradle, we suggest you read the section <<five_things#five_things,5 things you need to know about Gradle>> as it clears up some common misconceptions.
 
+[[gs:installation]]
 == Installation
 
 If all you want to do is run an existing Gradle build, then you don't need to install Gradle if the build has a <<gradle_wrapper#gradle_wrapper,Gradle Wrapper>>, identifiable via the _gradlew_ and/or _gradlew.bat_ files in the root of the build. You just need to make sure your system <<installation#sec:prerequisites,satisfies Gradle's prerequisites>>.

--- a/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
@@ -36,7 +36,7 @@ If you are looking into migrating an existing build to the Gradle Kotlin DSL, pl
 ====
 
 
-[[sec:prerequisites]]
+[[kotdsl:prerequisites]]
 == Prerequisites
 
 * The embedded Kotlin compiler is known to work on Linux, macOS, Windows, Cygwin, FreeBSD and Solaris on x86-64 architectures.
@@ -412,7 +412,7 @@ include::sample[dir="kotlinDsl/sourceSetConvention",files="build.gradle.kts[tags
 ====
 
 
-[[sec:multi_project_builds]]
+[[kotdsl:multi_project_builds]]
 == Multi-project builds (e.g. Android)
 
 Multi-project builds are very common.
@@ -483,7 +483,7 @@ See the <<sec:configuring_plugins>> section above for a detailed explanation.
 Plugins fetched from a source other than the link:https://plugins.gradle.org/[Gradle Plugin Portal] may or may not be usable with the `plugins {}` block.
 It depends on how they have been published.
 
-If your build is a multi-project build and you don't need to apply such a plugin to your root project, see the <<kotlin_dsl#sec:multi_project_builds_applying_plugins,dedicated section>> above.
+If your build is a multi-project build and you don't need to apply such a plugin to your root project, see the <<kotlin_dsl#kotdsl:multi_project_builds_applying_plugins,dedicated section>> above.
 Otherwise, keep reading.
 
 The Android Plugin for Gradle, for example, is not published to the Gradle Plugin Portal and at least up to version 3.2.0 of the plugin, the metadata required to resolve the artifacts for a given plugin identifier is not published to the Google repository.

--- a/subprojects/docs/src/docs/userguide/migrating_from_ant.adoc
+++ b/subprojects/docs/src/docs/userguide/migrating_from_ant.adoc
@@ -319,6 +319,7 @@ The first option is usually quick and easy, but not always. And if you want to i
 
 The second option is preferable in the long term, if you have the time. Gradle task types tend to be simpler than Ant tasks because they don't have to work with an XML-based interface. You also gain access to Gradle's rich APIs. Lastly, this approach can make use of the <<more_about_tasks#sec:task_input_output_annotations,type-safe incremental build API>> based on typed properties.
 
+[[migant:working_with_files]]
 == Working with files
 
 Ant has many tasks for working with files, most of which have Gradle equivalents. As with other areas of Ant to Gradle migration, you can <<ant#sec:using_ant_tasks,use those Ant tasks>> from within your Gradle build. However, we strongly recommend migrating to native Gradle constructs where possible so that the build benefits from:

--- a/subprojects/docs/src/docs/userguide/userguide_single.adoc
+++ b/subprojects/docs/src/docs/userguide/userguide_single.adoc
@@ -25,29 +25,33 @@
 
 toc::[]
 
+[[part:about_gradle]]
 == About Gradle
 
 include::overview.adoc[leveloffset=+2]
 
 include::what_is_gradle.adoc[leveloffset=+2]
 
+[[part:getting_started]]
 == Getting Started
 
 include::getting_started.adoc[leveloffset=2]
 
 include::installation.adoc[leveloffset=+2]
 
-include::kotlin_dsl.adoc[leveloffset=+2]
+include::troubleshooting.adoc[leveloffset=+2]
+
+[[part:upgrading_and_migrating]]
+== Upgrading and Migrating
 
 include::upgrading_version_4.adoc[leveloffset=+2]
 
-== Using Gradle Builds
+include::migrating_from_ant.adoc[leveloffset=+2]
 
-include::command_line_interface.adoc[leveloffset=+2]
+[[part:running_builds]]
+== Running Gradle Builds
 
 include::build_environment.adoc[leveloffset=+2]
-
-include::directory_layout.adoc[leveloffset=+2]
 
 include::gradle_daemon.adoc[leveloffset=+2]
 
@@ -55,50 +59,42 @@ include::init_scripts.adoc[leveloffset=+2]
 
 include::intro_multi_project_builds.adoc[leveloffset=+2]
 
-include::gradle_wrapper.adoc[leveloffset=+2]
-
-include::troubleshooting.adoc[leveloffset=+2]
-
-
-== Authoring Gradle Builds
-
-include::feature_lifecycle.adoc[leveloffset=+2]
-
-include::authoring_maintainable_build_scripts.adoc[leveloffset=+2]
-
-include::organizing_gradle_projects.adoc[leveloffset=+2]
-
 include::build_cache.adoc[leveloffset=+2]
-
-include::build_init_plugin.adoc[leveloffset=+2]
-
-include::build_lifecycle.adoc[leveloffset=+2]
-
-include::tutorial_using_tasks.adoc[leveloffset=+2]
 
 include::composite_builds.adoc[leveloffset=+2]
 
-include::multi_project_builds.adoc[leveloffset=+2]
+[[part:authoring_builds]]
+== Authoring Gradle Builds
+
+include::tutorial_using_tasks.adoc[leveloffset=+2]
 
 include::more_about_tasks.adoc[leveloffset=+2]
 
-include::logging.adoc[leveloffset=+2]
-
-include::standard_plugins.adoc[leveloffset=+2]
-
-include::test_kit.adoc[leveloffset=+2]
-
-include::plugins.adoc[leveloffset=+2]
+include::writing_build_scripts.adoc[leveloffset=+2]
 
 include::working_with_files.adoc[leveloffset=+2]
 
-include::writing_build_scripts.adoc[leveloffset=+2]
-
 include::custom_tasks.adoc[leveloffset=+2]
 
-include::base_plugin.adoc[leveloffset=+2]
+include::plugins.adoc[leveloffset=+2]
 
+include::build_lifecycle.adoc[leveloffset=+2]
 
+include::logging.adoc[leveloffset=+2]
+
+include::multi_project_builds.adoc[leveloffset=+2]
+
+include::organizing_gradle_projects.adoc[leveloffset=+2]
+
+include::authoring_maintainable_build_scripts.adoc[leveloffset=+2]
+
+include::lazy_configuration.adoc[leveloffset=+2]
+
+include::test_kit.adoc[leveloffset=+2]
+
+include::ant.adoc[leveloffset=+2]
+
+[[part:dependency_management]]
 == Dependency Management
 
 include::introduction_dependency_management.adoc[leveloffset=+2]
@@ -131,24 +127,23 @@ include::working_with_dependencies.adoc[leveloffset=+2]
 
 include::dependency_management_attribute_based_matching.adoc[leveloffset=+2]
 
-
+[[part:publishing]]
 == Publishing Artifacts
 
 include::publishing_overview.adoc[leveloffset=+2]
 
-include::publishing_maven.adoc[leveloffset=+2]
-
-include::publishing_ivy.adoc[leveloffset=+2]
-
 include::artifact_management.adoc[leveloffset=+2]
 
-include::maven_plugin.adoc[leveloffset=+2]
+[[part:jvm_projects]]
+== Java & Other JVM Projects
 
-include::signing_plugin.adoc[leveloffset=+2]
+include::building_java_projects.adoc[leveloffset=+2]
 
-include::distribution_plugin.adoc[leveloffset=+2]
+include::java_testing.adoc[leveloffset=+2]
 
+include::dependency_management_for_java_projects.adoc[leveloffset=+2]
 
+[[part:native_projects]]
 == Native Projects
 
 include::native_software.adoc[leveloffset=+2]
@@ -161,23 +156,62 @@ include::rule_source.adoc[leveloffset=+2]
 
 include::software_model_extend.adoc[leveloffset=+2]
 
+[[part:extending_gradle]]
+== Extending Gradle
 
-== Groovy Projects
+include::custom_plugins.adoc[leveloffset=+2]
 
-include::tutorial_groovy_projects.adoc[leveloffset=+2]
+include::java_gradle_plugin.adoc[leveloffset=+2]
 
-include::groovy_plugin.adoc[leveloffset=+2]
+include::embedding.adoc[leveloffset=+2]
+
+[[part:reference]]
+== Reference
+
+include::groovy_build_script_primer.adoc[leveloffset=+2]
+
+include::kotlin_dsl.adoc[leveloffset=+2]
+
+include::plugin_reference.adoc[leveloffset=2]
+
+include::command_line_interface.adoc[leveloffset=+2]
+
+include::third_party_integration.adoc[leveloffset=2]
+
+include::gradle_wrapper.adoc[leveloffset=+2]
+
+include::directory_layout.adoc[leveloffset=+2]
+
+[[part:plugins]]
+== Plugins
+
+include::antlr_plugin.adoc[leveloffset=+2]
+
+include::application_plugin.adoc[leveloffset=+2]
+
+include::base_plugin.adoc[leveloffset=+2]
+
+include::build_init_plugin.adoc[leveloffset=+2]
+
+include::checkstyle_plugin.adoc[leveloffset=+2]
 
 include::codenarc_plugin.adoc[leveloffset=+2]
 
+include::distribution_plugin.adoc[leveloffset=+2]
 
-== Java Projects
+include::ear_plugin.adoc[leveloffset=+2]
 
-include::tutorial_java_projects.adoc[leveloffset=+2]
+include::eclipse_plugin.adoc[leveloffset=+2]
 
-include::building_java_projects.adoc[leveloffset=+2]
+include::findbugs_plugin.adoc[leveloffset=+2]
 
-include::java_testing.adoc[leveloffset=+2]
+include::groovy_plugin.adoc[leveloffset=+2]
+
+include::idea_plugin.adoc[leveloffset=+2]
+
+include::publishing_ivy.adoc[leveloffset=+2]
+
+include::jacoco_plugin.adoc[leveloffset=+2]
 
 include::java_plugin.adoc[leveloffset=+2]
 
@@ -185,64 +219,22 @@ include::java_library_plugin.adoc[leveloffset=+2]
 
 include::java_library_distribution_plugin.adoc[leveloffset=+2]
 
-include::dependency_management_for_java_projects.adoc[leveloffset=+2]
-
-include::ant.adoc[leveloffset=+2]
-
-include::antlr_plugin.adoc[leveloffset=+2]
-
-include::application_plugin.adoc[leveloffset=+2]
-
-include::checkstyle_plugin.adoc[leveloffset=+2]
-
-include::findbugs_plugin.adoc[leveloffset=+2]
-
-include::jacoco_plugin.adoc[leveloffset=+2]
-
 include::jdepend_plugin.adoc[leveloffset=+2]
+
+include::publishing_maven.adoc[leveloffset=+2]
+
+include::maven_plugin.adoc[leveloffset=+2]
 
 include::osgi_plugin.adoc[leveloffset=+2]
 
-include::pmd_plugin.adoc[leveloffset=+2]
-
-
-== Java Web Projects
-
-include::war_plugin.adoc[leveloffset=+2]
-
-include::ear_plugin.adoc[leveloffset=+2]
-
 include::play_plugin.adoc[leveloffset=+2]
 
-
-== Scala Projects
+include::pmd_plugin.adoc[leveloffset=+2]
 
 include::scala_plugin.adoc[leveloffset=+2]
 
+include::signing_plugin.adoc[leveloffset=+2]
 
-== Integrating Gradle
-
-include::eclipse_plugin.adoc[leveloffset=+2]
-
-include::idea_plugin.adoc[leveloffset=+2]
-
-include::embedding.adoc[leveloffset=+2]
-
-
-== Extending Gradle
-
-include::custom_plugins.adoc[leveloffset=+2]
-
-include::java_gradle_plugin.adoc[leveloffset=+2]
-
-include::lazy_configuration.adoc[leveloffset=+2]
-
-== Reference
-
-include::plugin_reference.adoc[leveloffset=2]
-
-include::third_party_integration.adoc[leveloffset=2]
-
-== Licenses
+include::war_plugin.adoc[leveloffset=+2]
 
 include::licenses.adoc[leveloffset=+1]

--- a/subprojects/docs/src/samples/userguide/antMigration/multiProject/groovy/web/build.xml
+++ b/subprojects/docs/src/samples/userguide/antMigration/multiProject/groovy/web/build.xml
@@ -7,7 +7,7 @@
 
     <!-- tag::build-required[] -->
     <target name="buildRequiredProjects">
-        <ant dir="${root.dir}/util" target="build"/>
+        <ant dir="${root.dir}/util" target="build"/>  // <1>
     </target>
     <!-- end::build-required[] -->
 


### PR DESCRIPTION
I have tried to bring the TOC for the single-page user manual into line with
the current navigation on the docs website.

I have also fixed some ambiguities in anchors and a missing sample callout.

It would be nice to get this into 5.0.GA!