### PR TITLE
Restore link to release notes in docs nav

### DIFF
--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -90,6 +90,7 @@
         <ul>
             <li><a href="/userguide/userguide.html">Docs Home</a></li>
             <li><a href="https://guides.gradle.org">Tutorials</a></li>
+            <li><a href="/release-notes.html">Release Notes</a></li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#gradle-api" aria-expanded="false" aria-controls="gradle-api">Gradle API</a>
                 <ul id="gradle-api">
                     <li><a href="/javadoc/">Javadoc</a></li>


### PR DESCRIPTION
This is where I would put the release notes link if we were to restore it. Not bothered about whether it comes before or after "Tutorials", but it fits nicely in the set of links at the top of the nav.