### PR TITLE
 Offer dependency artifacts based of `from` attributes 

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ArtifactTransformDependencies.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ArtifactTransformDependencies.java
@@ -33,14 +33,14 @@ public interface ArtifactTransformDependencies {
      * Returns the dependency artifacts of the artifact being transformed.
      * The order of the files match that of the dependencies in the source artifact view.
      */
-    Iterable<File> getDependencies();
+    Iterable<File> getFiles();
 
     /**
      * Empty dependencies.
      */
     ArtifactTransformDependencies EMPTY = new ArtifactTransformDependencies() {
         @Override
-        public Iterable<File> getDependencies() {
+        public Iterable<File> getFiles() {
             return Collections.emptySet();
         }
     };

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -100,7 +100,7 @@ class FileSizer extends ArtifactTransform {
     }
     
     List<File> transform(File input) {
-        println "Received dependencies files \${artifactDependencies.dependencies*.name} for processing \${input.name}"
+        println "Received dependencies files \${artifactDependencies.files*.name} for processing \${input.name}"
 
         assert outputDirectory.directory && outputDirectory.list().length == 0
         def output = new File(outputDirectory, input.name + ".txt")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.util.ToBeImplemented
 
 class ArtifactTransformWithDependenciesIntegrationTest extends AbstractHttpDependencyResolutionTest {
 
@@ -66,9 +65,22 @@ project(':app') {
     }
 
     dependencies {
+        // Single step transform
         registerTransform {
             from.attribute(artifactType, 'jar')
             to.attribute(artifactType, 'size')
+            artifactTransform(FileSizer)
+        }
+
+        // Multi step transform
+        registerTransform {
+            from.attribute(artifactType, 'jar')
+            to.attribute(artifactType, 'inter')
+            artifactTransform(FileSizer)
+        }
+        registerTransform {
+            from.attribute(artifactType, 'inter')
+            to.attribute(artifactType, 'final')
             artifactTransform(FileSizer)
         }
     }
@@ -109,7 +121,7 @@ class FileSizer extends ArtifactTransform {
 project(':app') {
     task resolve(type: Copy) {
         def artifacts = configurations.compileClasspath.incoming.artifactView {
-            attributes { it.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, 'size')) }
+            attributes { it.attribute(artifactType, 'size') }
         }.artifacts
         from artifacts.artifactFiles
         into "\${buildDir}/libs"
@@ -133,7 +145,40 @@ project(':app') {
         output.contains('Received dependencies files [hamcrest-core-1.3.jar] for processing junit-4.11.jar')
     }
 
-    @ToBeImplemented("See assertions")
+    def "transform can access artifact dependencies, in previous transform step, as FileCollection when using ArtifactView"() {
+
+        given:
+
+        buildFile << """
+project(':app') {
+    task resolve(type: Copy) {
+        def artifacts = configurations.compileClasspath.incoming.artifactView {
+            attributes { it.attribute(artifactType, 'final') }
+        }.artifacts
+        from artifacts.artifactFiles
+        into "\${buildDir}/libs"
+        doLast {
+            println "files: " + artifacts.collect { it.file.name }
+            println "ids: " + artifacts.collect { it.id }
+            println "components: " + artifacts.collect { it.id.componentIdentifier }
+            println "variants: " + artifacts.collect { it.variant.attributes }
+        }
+    }
+}
+
+"""
+
+        when:
+        run "resolve"
+
+        then:
+        output.count('Transforming') == 8
+        output.contains('Received dependencies files [slf4j-api-1.7.25.jar] for processing lib.jar')
+        output.contains('Received dependencies files [slf4j-api-1.7.25.jar.txt] for processing lib.jar.txt')
+        output.contains('Received dependencies files [hamcrest-core-1.3.jar] for processing junit-4.11.jar')
+        output.contains('Received dependencies files [hamcrest-core-1.3.jar.txt] for processing junit-4.11.jar.txt')
+    }
+
     def "transform can access artifact dependencies as FileCollection when using configuration attributes"() {
 
         given:
@@ -167,7 +212,7 @@ project(':app') {
         then:
         output.count("Transforming") == 4
         // The asserts below should not have the .txt part
-        output.contains('Received dependencies files [slf4j-api-1.7.25.jar.txt] for processing lib.jar')
-        output.contains('Received dependencies files [hamcrest-core-1.3.jar.txt] for processing junit-4.11.jar')
+        output.contains('Received dependencies files [slf4j-api-1.7.25.jar] for processing lib.jar')
+        output.contains('Received dependencies files [hamcrest-core-1.3.jar] for processing junit-4.11.jar')
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformDependenciesProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformDependenciesProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.ResolvableDependencies;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
+import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+class ArtifactTransformDependenciesProvider {
+
+    static final ArtifactTransformDependenciesProvider EMPTY = new ArtifactTransformDependenciesProvider(null, null) {
+        @Override
+        ArtifactTransformDependencies forAttributes(ImmutableAttributes attributes) {
+            return ArtifactTransformDependencies.EMPTY;
+        }
+    };
+
+    private final ComponentArtifactIdentifier artifactId;
+    private final ResolvableDependencies resolvableDependencies;
+
+    ArtifactTransformDependenciesProvider(ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies) {
+        this.artifactId = artifactId;
+        this.resolvableDependencies = resolvableDependencies;
+    }
+
+    ArtifactTransformDependencies forAttributes(ImmutableAttributes attributes) {
+        return new DefaultArtifactTransformDependencies(artifactId, resolvableDependencies, attributes);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependencies.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependencies.java
@@ -25,6 +25,8 @@ import org.gradle.api.artifacts.result.ResolutionResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.io.File;
 import java.util.Set;
@@ -35,10 +37,12 @@ import java.util.Set;
 public class DefaultArtifactTransformDependencies implements ArtifactTransformDependencies {
     private final ComponentArtifactIdentifier artifactId;
     private final ResolvableDependencies resolvableDependencies;
+    private final ImmutableAttributes attributes;
 
-    public DefaultArtifactTransformDependencies(ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies) {
+    public DefaultArtifactTransformDependencies(ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies, ImmutableAttributes attributes) {
         this.artifactId = artifactId;
         this.resolvableDependencies = resolvableDependencies;
+        this.attributes = attributes;
     }
 
     @Override
@@ -54,6 +58,13 @@ public class DefaultArtifactTransformDependencies implements ArtifactTransformDe
             conf.componentFilter(element -> {
                 return dependenciesIdentifiers.contains(element);
             });
+            if (!attributes.isEmpty()) {
+                conf.attributes(container -> {
+                    for (Attribute attribute : attributes.keySet()) {
+                        container.attribute(attribute, attributes.findEntry(attribute).get());
+                    }
+                });
+            }
         }).getArtifacts().getArtifactFiles().getFiles();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependencies.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependencies.java
@@ -46,7 +46,7 @@ public class DefaultArtifactTransformDependencies implements ArtifactTransformDe
     }
 
     @Override
-    public Iterable<File> getDependencies() {
+    public Iterable<File> getFiles() {
         ResolutionResult resolutionResult = resolvableDependencies.getResolutionResult();
         Set<ComponentIdentifier> dependenciesIdentifiers = Sets.newHashSet();
         for (ResolvedComponentResult component : resolutionResult.getAllComponents()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
@@ -52,7 +52,7 @@ public class DefaultTransformationRegistration implements VariantTransformRegist
 
         paramsSnapshot.appendToHasher(hasher);
 
-        Transformer transformer = new DefaultTransformer(implementation, paramsSnapshot, hasher.hash(), instantiatorFactory);
+        Transformer transformer = new DefaultTransformer(implementation, paramsSnapshot, hasher.hash(), instantiatorFactory, from);
         return new DefaultTransformationRegistration(from, to, new TransformationStep(transformer, transformerInvoker));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -20,6 +20,7 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
 import org.gradle.api.internal.InstantiatorFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -34,17 +35,19 @@ public class DefaultTransformer implements Transformer {
     private final Isolatable<Object[]> parameters;
     private final InstantiatorFactory instantiatorFactory;
     private final HashCode inputsHash;
+    private final ImmutableAttributes fromAttributes;
 
-    public DefaultTransformer(Class<? extends ArtifactTransform> implementationClass, Isolatable<Object[]> parameters, HashCode inputsHash, InstantiatorFactory instantiatorFactory) {
+    public DefaultTransformer(Class<? extends ArtifactTransform> implementationClass, Isolatable<Object[]> parameters, HashCode inputsHash, InstantiatorFactory instantiatorFactory, ImmutableAttributes fromAttributes) {
         this.implementationClass = implementationClass;
         this.parameters = parameters;
         this.instantiatorFactory = instantiatorFactory;
         this.inputsHash = inputsHash;
+        this.fromAttributes = fromAttributes;
     }
 
     @Override
-    public List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependencies dependencies) {
-        ArtifactTransform transformer = newTransformer(dependencies);
+    public List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependenciesProvider dependencies) {
+        ArtifactTransform transformer = newTransformer(dependencies.forAttributes(fromAttributes));
         transformer.setOutputDirectory(outputDir);
         List<File> outputs = transformer.transform(primaryInput);
         return validateOutputs(primaryInput, outputDir, outputs);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -100,7 +100,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         return historyRepository.withWorkspace(identity, (identityString, workspace) -> {
             return fireTransformListeners(transformer, subject, () -> {
                 CurrentFileCollectionFingerprint primaryInputFingerprint = DefaultCurrentFileCollectionFingerprint.from(ImmutableList.of(fileSystemSnapshotter.snapshot(primaryInput)), AbsolutePathFingerprintingStrategy.INCLUDE_MISSING);
-                TransformerExecution execution = new TransformerExecution(primaryInput, transformer, workspace, identityString, historyRepository, primaryInputFingerprint, subject.getDependenciesProvider());
+                TransformerExecution execution = new TransformerExecution(primaryInput, transformer, workspace, identityString, historyRepository, primaryInputFingerprint, subject.getArtifactDependenciesProvider());
                 UpToDateResult outcome = workExecutor.execute(execution);
                 return execution.getResult(outcome);
             });

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
 import org.gradle.api.artifacts.transform.TransformationException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RelativePath;
@@ -101,7 +100,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         return historyRepository.withWorkspace(identity, (identityString, workspace) -> {
             return fireTransformListeners(transformer, subject, () -> {
                 CurrentFileCollectionFingerprint primaryInputFingerprint = DefaultCurrentFileCollectionFingerprint.from(ImmutableList.of(fileSystemSnapshotter.snapshot(primaryInput)), AbsolutePathFingerprintingStrategy.INCLUDE_MISSING);
-                TransformerExecution execution = new TransformerExecution(primaryInput, transformer, workspace, identityString, historyRepository, primaryInputFingerprint, subject.getDependencies());
+                TransformerExecution execution = new TransformerExecution(primaryInput, transformer, workspace, identityString, historyRepository, primaryInputFingerprint, subject.getDependenciesProvider());
                 UpToDateResult outcome = workExecutor.execute(execution);
                 return execution.getResult(outcome);
             });
@@ -145,18 +144,18 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         private final File resultsFile;
         private final String identityString;
         private final TransformerExecutionHistoryRepository historyRepository;
-        private final ArtifactTransformDependencies dependencies;
+        private final ArtifactTransformDependenciesProvider dependenciesProvider;
         private final ImmutableSortedMap<String, ValueSnapshot> inputSnapshots;
         private final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints;
 
-        public TransformerExecution(File primaryInput, Transformer transformer, File workspace, String identityString, TransformerExecutionHistoryRepository historyRepository, CurrentFileCollectionFingerprint primaryInputFingerprint, ArtifactTransformDependencies dependencies) {
+        public TransformerExecution(File primaryInput, Transformer transformer, File workspace, String identityString, TransformerExecutionHistoryRepository historyRepository, CurrentFileCollectionFingerprint primaryInputFingerprint, ArtifactTransformDependenciesProvider dependenciesProvider) {
             this.primaryInput = primaryInput;
             this.transformer = transformer;
             this.identityString = "transform/" + identityString;
             this.historyRepository = historyRepository;
             this.outputDir = new File(workspace, "outputDirectory");
             this.resultsFile = new File(workspace,  "results.bin");
-            this.dependencies = dependencies;
+            this.dependenciesProvider = dependenciesProvider;
             this.inputSnapshots = ImmutableSortedMap.of(
                 // Emulate secondary inputs as a single property for now
                 SECONDARY_INPUTS_HASH_PROPERTY_NAME, ImplementationSnapshot.of("secondary inputs", transformer.getSecondaryInputHash())
@@ -170,7 +169,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         public boolean execute() {
             GFileUtils.cleanDirectory(outputDir);
             GFileUtils.deleteFileQuietly(resultsFile);
-            ImmutableList<File> result = ImmutableList.copyOf(transformer.transform(primaryInput, outputDir, dependencies));
+            ImmutableList<File> result = ImmutableList.copyOf(transformer.transform(primaryInput, outputDir, dependenciesProvider));
             writeResultsFile(outputDir, resultsFile, result);
             return true;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -23,7 +23,6 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.ResolvableDependencies;
 import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
 import org.gradle.api.internal.artifacts.ivyservice.DefaultLenientConfiguration;
 import org.gradle.api.internal.artifacts.ivyservice.ResolvedArtifactCollectingVisitor;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildableSingleResolvedArtifactSet;
@@ -166,7 +165,7 @@ public abstract class TransformationNode extends Node {
                     return;
                 }
                 ResolvedArtifactResult artifact = Iterables.getOnlyElement(visitor.getArtifacts());
-                ArtifactTransformDependencies dependencies = new DefaultArtifactTransformDependencies(artifact.getId(), resolvableDependencies);
+                ArtifactTransformDependenciesProvider dependencies = new ArtifactTransformDependenciesProvider(artifact.getId(), resolvableDependencies);
                 TransformationSubject initialArtifactTransformationSubject = TransformationSubject.initial(artifact.getId(), artifact.getFile(), dependencies);
 
                 this.transformedSubject = transformationStep.transform(initialArtifactTransformationSubject);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationSubject.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationSubject.java
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -37,7 +36,7 @@ public abstract class TransformationSubject implements Describable {
         return new InitialFileTransformationSubject(file);
     }
 
-    public static TransformationSubject initial(ComponentArtifactIdentifier artifactId, File file, ArtifactTransformDependencies dependencies) {
+    public static TransformationSubject initial(ComponentArtifactIdentifier artifactId, File file, ArtifactTransformDependenciesProvider dependencies) {
         return new InitialArtifactTransformationSubject(artifactId, file, dependencies);
     }
 
@@ -49,7 +48,7 @@ public abstract class TransformationSubject implements Describable {
     /**
      * Gives access to the artifacts of the dependencies of the subject of the transformation
      */
-    public abstract ArtifactTransformDependencies getDependencies();
+    public abstract ArtifactTransformDependenciesProvider getDependenciesProvider();
 
     /**
      * Records the failure to transform a previous subject.
@@ -81,7 +80,7 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependencies getDependencies() {
+        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
             throw new UnsupportedOperationException();
         }
 
@@ -137,8 +136,8 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependencies getDependencies() {
-            return ArtifactTransformDependencies.EMPTY;
+        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
+            return ArtifactTransformDependenciesProvider.EMPTY;
         }
 
         @Override
@@ -149,16 +148,16 @@ public abstract class TransformationSubject implements Describable {
 
     private static class InitialArtifactTransformationSubject extends AbstractInitialTransformationSubject {
         private final ComponentArtifactIdentifier artifactId;
-        private final ArtifactTransformDependencies dependencies;
+        private final ArtifactTransformDependenciesProvider dependencies;
 
-        public InitialArtifactTransformationSubject(ComponentArtifactIdentifier artifactId, File file, ArtifactTransformDependencies dependencies) {
+        public InitialArtifactTransformationSubject(ComponentArtifactIdentifier artifactId, File file, ArtifactTransformDependenciesProvider dependencies) {
             super(file);
             this.artifactId = artifactId;
             this.dependencies = dependencies;
         }
 
         @Override
-        public ArtifactTransformDependencies getDependencies() {
+        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
             return dependencies;
         }
 
@@ -183,8 +182,8 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependencies getDependencies() {
-            return previous.getDependencies();
+        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
+            return previous.getDependenciesProvider();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationSubject.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationSubject.java
@@ -48,7 +48,7 @@ public abstract class TransformationSubject implements Describable {
     /**
      * Gives access to the artifacts of the dependencies of the subject of the transformation
      */
-    public abstract ArtifactTransformDependenciesProvider getDependenciesProvider();
+    public abstract ArtifactTransformDependenciesProvider getArtifactDependenciesProvider();
 
     /**
      * Records the failure to transform a previous subject.
@@ -80,7 +80,7 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
+        public ArtifactTransformDependenciesProvider getArtifactDependenciesProvider() {
             throw new UnsupportedOperationException();
         }
 
@@ -136,7 +136,7 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
+        public ArtifactTransformDependenciesProvider getArtifactDependenciesProvider() {
             return ArtifactTransformDependenciesProvider.EMPTY;
         }
 
@@ -157,7 +157,7 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
+        public ArtifactTransformDependenciesProvider getArtifactDependenciesProvider() {
             return dependencies;
         }
 
@@ -182,8 +182,8 @@ public abstract class TransformationSubject implements Describable {
         }
 
         @Override
-        public ArtifactTransformDependenciesProvider getDependenciesProvider() {
-            return previous.getDependenciesProvider();
+        public ArtifactTransformDependenciesProvider getArtifactDependenciesProvider() {
+            return previous.getArtifactDependenciesProvider();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
@@ -32,7 +31,7 @@ import java.util.List;
 public interface Transformer extends Describable {
     Class<? extends ArtifactTransform> getImplementationClass();
 
-    List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependencies dependencies);
+    List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependenciesProvider dependencies);
 
     /**
      * The hash of the secondary inputs of the transformer.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -54,7 +54,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     public void artifactAvailable(ResolvableArtifact artifact) {
         ComponentArtifactIdentifier artifactId = artifact.getId();
         File file = artifact.getFile();
-        DefaultArtifactTransformDependencies dependencies = new DefaultArtifactTransformDependencies(artifactId, resolvableDependencies);
+        ArtifactTransformDependenciesProvider dependencies = new ArtifactTransformDependenciesProvider(artifactId, resolvableDependencies);
         TransformationSubject initialSubject = TransformationSubject.initial(artifactId, file, dependencies);
         initialSubjectAvailable(artifactId, initialSubject, artifactResults);
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.Buildable
 import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
@@ -171,7 +170,7 @@ class DefaultArtifactTransformsTest extends Specification {
         _ * transformation.hasCachedResult(_ as TransformationSubject) >> false
         _ * transformation.getDisplayName() >> "transform"
 
-        1 * transformation.transform({ it.files == [sourceArtifactFile]}) >> TransformationSubject.initial(sourceArtifactId, sourceArtifactFile, Mock(ArtifactTransformDependencies)).transformationSuccessful(ImmutableList.of(outFile1, outFile2))
+        1 * transformation.transform({ it.files == [sourceArtifactFile]}) >> TransformationSubject.initial(sourceArtifactId, sourceArtifactFile, Mock(ArtifactTransformDependenciesProvider)).transformationSuccessful(ImmutableList.of(outFile1, outFile2))
 
         1 * transformation.transform({ it.files == [sourceFile] }) >> TransformationSubject.initial(sourceFile).transformationSuccessful(ImmutableList.of(outFile3, outFile4))
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.artifacts.transform
 
 import org.gradle.api.artifacts.transform.ArtifactTransform
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies
 import org.gradle.api.internal.artifacts.ivyservice.CacheLayout
+import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.execution.impl.DefaultWorkExecutor
 import org.gradle.internal.execution.impl.steps.Context
@@ -217,17 +217,17 @@ class DefaultTransformerInvokerTest extends ConcurrentSpec {
     }
 
     def "multiple threads can transform files concurrently"() {
-        def transformerRegistrationA = new DefaultTransformer(ArtifactTransform.class, null, HashCode.fromInt(123), null) {
+        def transformerRegistrationA = new DefaultTransformer(ArtifactTransform.class, null, HashCode.fromInt(123), null, ImmutableAttributes.EMPTY) {
             @Override
-            List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependencies dependencies) {
+            List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependenciesProvider dependenciesProvider) {
                 instant.a
                 thread.blockUntil.b
                 instant.a_done
                 [new TestFile(outputDir, primaryInput.getName()).touch()]            }
         }
-        def transformerRegistrationB = new DefaultTransformer(ArtifactTransform.class, null, HashCode.fromInt(345), null) {
+        def transformerRegistrationB = new DefaultTransformer(ArtifactTransform.class, null, HashCode.fromInt(345), null, ImmutableAttributes.EMPTY) {
             @Override
-            List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependencies dependencies) {
+            List<File> transform(File primaryInput, File outputDir, ArtifactTransformDependenciesProvider dependenciesProvider) {
                 instant.b
                 thread.blockUntil.a
                 instant.b_done

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.transform
 
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.transform.ArtifactTransform
-import org.gradle.api.artifacts.transform.ArtifactTransformDependencies
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
@@ -321,7 +320,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
     private void runTransformer(File input) {
         1 * transformerInvoker.invoke(_ as Transformer, input, _ as TransformationSubject)  >> { Transformer transformer, File primaryInput, TransformationSubject subject ->
-            return Try.ofFailable { ImmutableList.copyOf(transformer.transform(primaryInput, outputDirectory, Mock(ArtifactTransformDependencies))) }
+            return Try.ofFailable { ImmutableList.copyOf(transformer.transform(primaryInput, outputDirectory, Mock(ArtifactTransformDependenciesProvider))) }
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformerInvokerTest.groovy
@@ -65,7 +65,7 @@ class TransformerInvokerTest extends Specification {
         1 * historyRepository.withWorkspace(_, _) >> { TransformationIdentity identity, action ->
             action.apply(identity.getIdentity(), new File("workspace"))
         }
-        1 * sourceSubject.dependencies >> null
+        1 * sourceSubject.dependenciesProvider >> null
         _ * artifactTransformListener._
         0 * _
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformerInvokerTest.groovy
@@ -65,7 +65,7 @@ class TransformerInvokerTest extends Specification {
         1 * historyRepository.withWorkspace(_, _) >> { TransformationIdentity identity, action ->
             action.apply(identity.getIdentity(), new File("workspace"))
         }
-        1 * sourceSubject.dependenciesProvider >> null
+        1 * sourceSubject.artifactDependenciesProvider >> null
         _ * artifactTransformListener._
         0 * _
     }


### PR DESCRIPTION
The transform now injects the dependencies artifacts using an
`ArtifactView` configured with the `from` attributes of the current
transform.
This effectively preserves isolation of transforms.