### PR TITLE
Remove short circuiting cached execution of transforms

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerExecutionHistoryRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerExecutionHistoryRepository.java
@@ -62,11 +62,6 @@ public class DefaultTransformerExecutionHistoryRepository implements Transformer
     }
 
     @Override
-    public boolean hasCachedResult(TransformationIdentity identity) {
-        return inMemoryResultCache.containsKey(identity);
-    }
-
-    @Override
     public Try<ImmutableList<File>> withWorkspace(TransformationIdentity identity, BiFunction<String, File, Try<ImmutableList<File>>> useWorkspace) {
         ImmutableList<File> resultFromCache = inMemoryResultCache.get(identity);
         if (resultFromCache != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -90,11 +90,6 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
     }
 
     @Override
-    public boolean hasCachedResult(File primaryInput, Transformer transformer) {
-        return historyRepository.hasCachedResult(getImmutableTransformationIdentity(primaryInput, transformer));
-    }
-
-    @Override
     public Try<ImmutableList<File>> invoke(Transformer transformer, File primaryInput, TransformationSubject subject) {
         TransformationIdentity identity = getImmutableTransformationIdentity(primaryInput, transformer);
         return historyRepository.withWorkspace(identity, (identityString, workspace) -> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
@@ -37,11 +37,6 @@ public interface Transformation extends Describable {
     boolean requiresDependencies();
 
     /**
-     * Returns true if there is a cached result in memory, meaning that a call to {@link #transform(TransformationSubject)} will be fast.
-     */
-    boolean hasCachedResult(TransformationSubject subject);
-
-    /**
      * Extract the transformation steps from this transformation.
      */
     void visitTransformationSteps(Action<? super TransformationStep> action);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChain.java
@@ -43,15 +43,6 @@ public class TransformationChain implements Transformation {
     }
 
     @Override
-    public boolean hasCachedResult(TransformationSubject subject) {
-        if (first.hasCachedResult(subject)) {
-            TransformationSubject intermediate = first.transform(subject);
-            return second.hasCachedResult(intermediate);
-        }
-        return false;
-    }
-
-    @Override
     public String getDisplayName() {
         return first.getDisplayName() + " -> " + second.getDisplayName();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -68,19 +68,6 @@ public class TransformationStep implements Transformation {
     }
 
     @Override
-    public boolean hasCachedResult(TransformationSubject subject) {
-        if (subject.getFailure() != null) {
-            return true;
-        }
-        for (File file : subject.getFiles()) {
-            if (!transformerInvoker.hasCachedResult(file, transformer)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    @Override
     public String getDisplayName() {
         return transformer.getDisplayName();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformerExecutionHistoryRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformerExecutionHistoryRepository.java
@@ -36,5 +36,4 @@ public interface TransformerExecutionHistoryRepository extends TransformerWorksp
         ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputFingerprints,
         boolean successful
     );
-    boolean hasCachedResult(TransformationIdentity identity);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformerInvoker.java
@@ -28,6 +28,4 @@ public interface TransformerInvoker {
      * Returns the result of applying the given transformer to the given file.
      */
     Try<ImmutableList<File>> invoke(Transformer transformer, File primaryInput, TransformationSubject subject);
-
-    boolean hasCachedResult(File primaryInput, Transformer transformer);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -81,10 +81,6 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     private <T> void initialSubjectAvailable(T key, TransformationSubject initialSubject, Map<T, TransformationOperation> results) {
         TransformationOperation operation = new TransformationOperation(transformation, initialSubject);
         results.put(key, operation);
-        if (transformation.hasCachedResult(initialSubject)) {
-            operation.run(null);
-        } else {
-            actions.add(operation);
-        }
+        actions.add(operation);
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ChainedTransformerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ChainedTransformerTest.groovy
@@ -23,30 +23,6 @@ import spock.lang.Specification
 class ChainedTransformerTest extends Specification {
     private TransformationSubject initialSubject = TransformationSubject.initial(new File("foo"))
 
-    def "is cached if all parts are cached"() {
-        given:
-        def chain = new TransformationChain(new CachingTransformation(), new CachingTransformation())
-
-        expect:
-        chain.hasCachedResult(initialSubject)
-    }
-
-    def "is not cached if first part is not cached"() {
-        given:
-        def chain = new TransformationChain(new NonCachingTransformation(), new CachingTransformation())
-
-        expect:
-        !chain.hasCachedResult(initialSubject)
-    }
-
-    def "is not cached if second part is not cached"() {
-        given:
-        def chain = new TransformationChain(new CachingTransformation(), new NonCachingTransformation())
-
-        expect:
-        !chain.hasCachedResult(initialSubject)
-    }
-
     def "applies second transform on the result of the first"() {
         given:
         def chain = new TransformationChain(new CachingTransformation(), new NonCachingTransformation())
@@ -68,10 +44,6 @@ class ChainedTransformerTest extends Specification {
             return false
         }
 
-        @Override
-        boolean hasCachedResult(TransformationSubject subject) {
-            return true
-        }
 
         @Override
         String getDisplayName() {
@@ -95,10 +67,6 @@ class ChainedTransformerTest extends Specification {
             return false
         }
 
-        @Override
-        boolean hasCachedResult(TransformationSubject subject) {
-            return false
-        }
 
         @Override
         String getDisplayName() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -167,7 +167,6 @@ class DefaultArtifactTransformsTest extends Specification {
                 }
             }
         }
-        _ * transformation.hasCachedResult(_ as TransformationSubject) >> false
         _ * transformation.getDisplayName() >> "transform"
         _ * transformation.requiresDependencies() >> false
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -36,10 +36,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         getArtifactFile() >> artifactFile
     }
 
-    def "runs transforms in parallel if no cached result is available"() {
-        given:
-        transformation.hasCachedResult(_ as TransformationSubject) >> false
-
+    def "runs transforms in parallel"() {
         when:
         listener.artifactAvailable(artifact)
 
@@ -51,22 +48,5 @@ class TransformingAsyncArtifactListenerTest extends Specification {
 
         then:
         1 * operationQueue.add(_ as BuildOperation)
-    }
-
-    def "runs transforms immediately if the result is already cached"() {
-        given:
-        transformation.hasCachedResult(_ as TransformationSubject) >> true
-
-        when:
-        listener.artifactAvailable(artifact)
-
-        then:
-        1 * transformation.transform({ it.files == [artifactFile] })
-
-        when:
-        listener.fileAvailable(file)
-
-        then:
-        1 * transformation.transform({ it.files == [file] })
     }
 }


### PR DESCRIPTION
This PR removes the short circuit code path where we avoided executing a transform via the `BuildOperationExecutor` if we knew already that it would be served from the in-memory cache. This was a change to reduce the overhead of the executor, but this approach does not work well with more complex inputs used for artifact transforms.