### PR TITLE
Test that constraining a virtual platform aligns its components

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -764,8 +764,8 @@ include 'other'
     }
 
 
-    @Unroll("can constrain a virtual platform's components by adding the platform itself via a constraint")
-    def "can constrain a virtual platform's components by adding the platform itself via a constraint"() {
+    @Unroll("can constrain a virtual platforms components by adding the platform itself via a constraint")
+    def "can constrain a virtual platforms components by adding the platform itself via a constraint"() {
         repository {
             ['2.7.9', '2.9.4', '2.9.4.1'].each {
                 path "databind:$it -> core:$it"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -764,6 +764,69 @@ include 'other'
     }
 
 
+    @Unroll("can force a virtual platform version by adding the platform itself via a constraint")
+    def "can force a virtual platform version by adding the platform itself via a constraint"() {
+        repository {
+            ['2.7.9', '2.9.4', '2.9.4.1'].each {
+                path "databind:$it -> core:$it"
+                path "databind:$it -> annotations:$it"
+                path "kotlin:$it -> core:$it"
+                path "kotlin:$it -> annotations:$it"
+            }
+        }
+
+        given:
+        buildFile << """
+            dependencies {
+                $dependencies
+            }
+        """
+
+        and:
+        "a rule which infers module set from group and version"()
+
+        when:
+        allowAllRepositoryInteractions()
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("org:core:2.7.9", "org:core:2.9.4.1") {
+                    forced()
+                }
+                module("org:databind:2.9.4.1") {
+                    module('org:annotations:2.9.4.1')
+                    module('org:core:2.9.4.1')
+                }
+                edge("org:kotlin:2.9.4", "org:kotlin:2.9.4.1") {
+                    forced()
+                    module('org:core:2.9.4.1')
+                    module('org:annotations:2.9.4.1')
+                }
+                constraint('org:platform:2.9.4.1', 'org:platform:2.9.4.1') {
+                    noArtifacts()
+                    byConstraint("belongs to platform org:platform:2.9.4.1")
+                    forced()
+                    constraint('org:core:2.9.4.1')
+                    constraint('org:databind:2.9.4.1')
+                    constraint('org:annotations:2.9.4.1')
+                    constraint('org:kotlin:2.9.4.1')
+                }
+            }
+            virtualConfiguration('org:platform:2.9.4.1')
+        }
+
+        where: "order of dependencies doesn't matter"
+        dependencies << [
+            'conf("org:core:2.7.9")',
+            'conf("org:databind:2.7.9")',
+            'conf("org:kotlin:2.9.4")',
+            'constraints { conf platform("org:platform:2.9.4.1") }'
+        ].permutations()*.join("\n")
+    }
+
+
     @Unroll("can force a published platform version by forcing the platform itself via a dependency")
     @RequiredFeatures([
         @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven"),

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -792,22 +792,18 @@ include 'other'
         then:
         resolve.expectGraph {
             root(":", ":test:") {
-                edge("org:core:2.7.9", "org:core:2.9.4.1") {
-                    forced()
-                }
+                edge("org:core:2.7.9", "org:core:2.9.4.1")
                 module("org:databind:2.9.4.1") {
                     module('org:annotations:2.9.4.1')
                     module('org:core:2.9.4.1')
                 }
                 edge("org:kotlin:2.9.4", "org:kotlin:2.9.4.1") {
-                    forced()
                     module('org:core:2.9.4.1')
                     module('org:annotations:2.9.4.1')
                 }
                 constraint('org:platform:2.9.4.1', 'org:platform:2.9.4.1') {
                     noArtifacts()
                     byConstraint("belongs to platform org:platform:2.9.4.1")
-                    forced()
                     constraint('org:core:2.9.4.1')
                     constraint('org:databind:2.9.4.1')
                     constraint('org:annotations:2.9.4.1')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -764,8 +764,8 @@ include 'other'
     }
 
 
-    @Unroll("can force a virtual platform version by adding the platform itself via a constraint")
-    def "can force a virtual platform version by adding the platform itself via a constraint"() {
+    @Unroll("can constrain a virtual platform's components by adding the platform itself via a constraint")
+    def "can constrain a virtual platform's components by adding the platform itself via a constraint"() {
         repository {
             ['2.7.9', '2.9.4', '2.9.4.1'].each {
                 path "databind:$it -> core:$it"


### PR DESCRIPTION
### Context

Currently, we test that adding a constraint for a virtual platform (using `enforcedPlatform`) works: https://github.com/gradle/gradle/blob/master/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy

However, if we use `platform()` instead, constraining a virtual platform doesn't work, and gradle tries to resolve it as if it were a published platform.

This is a test that should pass but doesn't.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
