### PR TITLE
Report typed TAPI progress events for Worker API work items

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
@@ -38,6 +38,7 @@ import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.snapshot.FileSystemSnapshotter;
 import org.gradle.jvm.JvmLibrary;
 import org.gradle.language.java.artifact.JavadocArtifact;
+import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.SubscribableBuildActionRunnerRegistration;
 
@@ -66,7 +67,7 @@ public class JavaLanguagePluginServiceRegistry extends AbstractPluginServiceRegi
             return new SubscribableBuildActionRunnerRegistration() {
                 @Override
                 public Iterable<BuildOperationListener> createListeners(BuildClientSubscriptions clientSubscriptions, BuildEventConsumer consumer) {
-                    if (clientSubscriptions.isSendTaskProgressEvents()) {
+                    if (clientSubscriptions.isRequested(OperationType.TASK)) {
                         return Collections.<BuildOperationListener>singletonList(factory);
                     }
                     return emptyList();

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildClientSubscriptions.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/BuildClientSubscriptions.java
@@ -16,37 +16,39 @@
 
 package org.gradle.tooling.internal.provider;
 
+import org.gradle.tooling.events.OperationType;
+
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Set;
 
 /**
  * Provides information about what events the build client is interested in.
  */
 public class BuildClientSubscriptions implements Serializable {
 
-    private final boolean sendTestProgressEvents;
-    private final boolean sendTaskProgressEvents;
-    private final boolean sendBuildProgressEvents;
+    private final Set<OperationType> operationTypes;
 
-    public BuildClientSubscriptions(boolean sendTestProgressEvents, boolean sendTaskProgressEvents, boolean sendBuildProgressEvents) {
-        this.sendTestProgressEvents = sendTestProgressEvents;
-        this.sendTaskProgressEvents = sendTaskProgressEvents;
-        this.sendBuildProgressEvents = sendBuildProgressEvents;
+    public BuildClientSubscriptions(Set<OperationType> operationTypes) {
+        this.operationTypes = EnumSet.copyOf(operationTypes);
     }
 
-    public boolean isSendTestProgressEvents() {
-        return sendTestProgressEvents;
+    public boolean isRequested(OperationType workItem) {
+        return operationTypes.contains(workItem);
     }
 
-    public boolean isSendTaskProgressEvents() {
-        return sendTaskProgressEvents;
+    public boolean isAnyOperationTypeRequested() {
+        return !operationTypes.isEmpty();
     }
 
-    public boolean isSendBuildProgressEvents() {
-        return sendBuildProgressEvents;
+    public boolean isAnyRequested(OperationType... types) {
+        return !isNoneRequested(types);
     }
 
-    public boolean isSendAnyProgressEvents() {
-        return sendTestProgressEvents || sendTaskProgressEvents || sendBuildProgressEvents;
+    private boolean isNoneRequested(OperationType... types) {
+        return Collections.disjoint(operationTypes, Arrays.asList(types));
     }
 
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.provider;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.initialization.BuildCancellationToken;
@@ -42,6 +43,7 @@ import org.gradle.launcher.exec.BuildActionExecuter;
 import org.gradle.launcher.exec.BuildActionParameters;
 import org.gradle.launcher.exec.BuildActionResult;
 import org.gradle.process.internal.streams.SafeStreams;
+import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.internal.build.DefaultBuildEnvironment;
 import org.gradle.tooling.internal.consumer.parameters.FailsafeBuildProgressListenerAdapter;
 import org.gradle.tooling.internal.gradle.DefaultBuildIdentifier;
@@ -70,9 +72,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import static java.util.Collections.emptySet;
 
 public class ProviderConnection {
     private static final Logger LOGGER = LoggerFactory.getLogger(ProviderConnection.class);
@@ -305,6 +311,14 @@ public class ProviderConnection {
     }
 
     private static final class ProgressListenerConfiguration {
+
+        private static final Map<String, OperationType> OPERATION_TYPE_MAPPING = ImmutableMap.<String, OperationType>builderWithExpectedSize(OperationType.values().length)
+            .put(InternalBuildProgressListener.TEST_EXECUTION, OperationType.TEST)
+            .put(InternalBuildProgressListener.TASK_EXECUTION, OperationType.TASK)
+            .put(InternalBuildProgressListener.WORK_ITEM_EXECUTION, OperationType.WORK_ITEM)
+            .put(InternalBuildProgressListener.BUILD_EXECUTION, OperationType.GENERIC)
+            .build();
+
         private final BuildClientSubscriptions clientSubscriptions;
         private final FailsafeBuildProgressListenerAdapter failsafeWrapper;
         private final BuildEventConsumer buildEventConsumer;
@@ -317,18 +331,27 @@ public class ProviderConnection {
 
         private static ProgressListenerConfiguration from(ProviderOperationParameters providerParameters) {
             InternalBuildProgressListener buildProgressListener = providerParameters.getBuildProgressListener(null);
-            boolean listenToTestProgress = buildProgressListener != null && buildProgressListener.getSubscribedOperations().contains(InternalBuildProgressListener.TEST_EXECUTION);
-            boolean listenToTaskProgress = buildProgressListener != null && buildProgressListener.getSubscribedOperations().contains(InternalBuildProgressListener.TASK_EXECUTION);
-            boolean listenToBuildProgress = buildProgressListener != null && buildProgressListener.getSubscribedOperations().contains(InternalBuildProgressListener.BUILD_EXECUTION);
-            BuildClientSubscriptions clientSubscriptions = new BuildClientSubscriptions(listenToTestProgress, listenToTaskProgress, listenToBuildProgress);
+            Set<OperationType> operationTypes = toOperationTypes(buildProgressListener);
+            BuildClientSubscriptions clientSubscriptions = new BuildClientSubscriptions(operationTypes);
             FailsafeBuildProgressListenerAdapter wrapper = new FailsafeBuildProgressListenerAdapter(buildProgressListener);
-            BuildEventConsumer buildEventConsumer = clientSubscriptions.isSendAnyProgressEvents() ? new BuildProgressListenerInvokingBuildEventConsumer(wrapper) : new NoOpBuildEventConsumer();
+            BuildEventConsumer buildEventConsumer = clientSubscriptions.isAnyOperationTypeRequested() ? new BuildProgressListenerInvokingBuildEventConsumer(wrapper) : new NoOpBuildEventConsumer();
             if (Boolean.TRUE.equals(providerParameters.isEmbedded())) {
                 // Contract requires build events are delivered by a single thread. This is taken care of by the daemon client when not in embedded mode
                 // Need to apply some synchronization when in embedded mode
                 buildEventConsumer = new SynchronizedConsumer(buildEventConsumer);
             }
             return new ProgressListenerConfiguration(clientSubscriptions, buildEventConsumer, wrapper);
+        }
+
+        private static Set<OperationType> toOperationTypes(InternalBuildProgressListener buildProgressListener) {
+            if (buildProgressListener != null) {
+                Set<OperationType> operationTypes = EnumSet.noneOf(OperationType.class);
+                for (String operation : buildProgressListener.getSubscribedOperations()) {
+                    operationTypes.add(OPERATION_TYPE_MAPPING.get(operation));
+                }
+                return operationTypes;
+            }
+            return emptySet();
         }
 
         private static class SynchronizedConsumer implements BuildEventConsumer {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultWorkItemDescriptor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultWorkItemDescriptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.events;
+
+import org.gradle.tooling.internal.protocol.events.InternalWorkItemDescriptor;
+
+public class DefaultWorkItemDescriptor extends DefaultOperationDescriptor implements InternalWorkItemDescriptor {
+
+    private final String className;
+
+    public DefaultWorkItemDescriptor(Object id, String className, String displayName, Object parentId) {
+        super(id, displayName, displayName, parentId);
+        this.className = className;
+    }
+
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+}

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/BuildActionSerializerTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.StartParameterInternal
 import org.gradle.internal.serialize.SerializerSpec
 import org.gradle.launcher.cli.action.BuildActionSerializer
 import org.gradle.launcher.cli.action.ExecuteBuildAction
+import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions
 import org.gradle.tooling.internal.provider.BuildModelAction
 import org.gradle.tooling.internal.provider.ClientProvidedBuildAction
@@ -56,9 +57,9 @@ class BuildActionSerializerTest extends SerializerSpec {
 
         where:
         action << [
-            new ClientProvidedBuildAction(new StartParameterInternal(), new SerializedPayload(null, []), true, new BuildClientSubscriptions(true, true, true)),
-            new TestExecutionRequestAction(new BuildClientSubscriptions(true, true, true), new StartParameterInternal(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet()),
-            new BuildModelAction(new StartParameterInternal(), "model", false, new BuildClientSubscriptions(true, true, true))
+            new ClientProvidedBuildAction(new StartParameterInternal(), new SerializedPayload(null, []), true, new BuildClientSubscriptions(EnumSet.allOf(OperationType))),
+            new TestExecutionRequestAction(new BuildClientSubscriptions(EnumSet.allOf(OperationType)), new StartParameterInternal(), Collections.emptySet(), Collections.emptySet(), Collections.emptySet()),
+            new BuildModelAction(new StartParameterInternal(), "model", false, new BuildClientSubscriptions(EnumSet.allOf(OperationType)))
         ]
     }
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuterSpec.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/tooling/internal/provider/SubscribableBuildActionExecuterSpec.groovy
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.internal.provider
 
-
 import org.gradle.initialization.BuildEventConsumer
 import org.gradle.initialization.BuildRequestContext
 import org.gradle.internal.operations.BuildOperationListener
@@ -24,6 +23,7 @@ import org.gradle.internal.operations.BuildOperationListenerManager
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.launcher.exec.BuildActionExecuter
 import org.gradle.launcher.exec.BuildActionParameters
+import org.gradle.tooling.events.OperationType
 import spock.lang.Specification
 
 class SubscribableBuildActionExecuterSpec extends Specification {
@@ -59,12 +59,8 @@ class SubscribableBuildActionExecuterSpec extends Specification {
     }
 
     SubscribableBuildAction subscribableBuildAction() {
-        SubscribableBuildAction buildAction = Mock()
-        BuildClientSubscriptions clientSubscriptions = Mock()
-        _ * clientSubscriptions.isSendBuildProgressEvents() >> true
-        _ * clientSubscriptions.isSendTaskProgressEvents() >> true
-        _ * clientSubscriptions.isSendTestProgressEvents() >> true
-        _ * buildAction.getClientSubscriptions() >> clientSubscriptions
+        SubscribableBuildAction buildAction = Stub()
+        _ * buildAction.getClientSubscriptions() >> new BuildClientSubscriptions(EnumSet.allOf(OperationType))
         buildAction
     }
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildOperationParentTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/BuildOperationParentTracker.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class BuildOperationParentTracker implements BuildOperationListener {
+
+    private final Map<OperationIdentifier, OperationIdentifier> parents = new ConcurrentHashMap<>();
+
+    @Nullable
+    OperationIdentifier getParent(OperationIdentifier id) {
+        return parents.get(id);
+    }
+
+    @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        if (buildOperation.getParentId() != null) {
+            parents.put(buildOperation.getId(), buildOperation.getParentId());
+        }
+    }
+
+    @Override
+    public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        parents.remove(buildOperation.getId());
+    }
+
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingBuildOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingBuildOperationListener.java
@@ -16,7 +16,6 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
-import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationFinishEvent;
@@ -34,21 +33,21 @@ import org.gradle.tooling.internal.provider.events.DefaultSuccessResult;
 import java.util.Collections;
 
 /**
- * Build listener that forwards all receiving events to the client via the provided {@code BuildEventConsumer} instance.
+ * Build listener that forwards all receiving events to the client via the provided {@code ProgressEventConsumer} instance.
  *
  * @since 2.5
  */
 class ClientForwardingBuildOperationListener implements BuildOperationListener {
 
-    private final BuildEventConsumer eventConsumer;
+    private final ProgressEventConsumer eventConsumer;
 
-    ClientForwardingBuildOperationListener(BuildEventConsumer eventConsumer) {
+    ClientForwardingBuildOperationListener(ProgressEventConsumer eventConsumer) {
         this.eventConsumer = eventConsumer;
     }
 
     @Override
     public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-        eventConsumer.dispatch(new DefaultOperationStartedProgressEvent(startEvent.getStartTime(), toBuildOperationDescriptor(buildOperation)));
+        eventConsumer.started(new DefaultOperationStartedProgressEvent(startEvent.getStartTime(), toBuildOperationDescriptor(buildOperation)));
     }
 
     @Override
@@ -57,7 +56,7 @@ class ClientForwardingBuildOperationListener implements BuildOperationListener {
 
     @Override
     public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent result) {
-        eventConsumer.dispatch(new DefaultOperationFinishedProgressEvent(result.getEndTime(), toBuildOperationDescriptor(buildOperation), adaptResult(result)));
+        eventConsumer.finished(new DefaultOperationFinishedProgressEvent(result.getEndTime(), toBuildOperationDescriptor(buildOperation), toOperationResult(result)));
     }
 
     private DefaultOperationDescriptor toBuildOperationDescriptor(BuildOperationDescriptor buildOperation) {
@@ -68,7 +67,7 @@ class ClientForwardingBuildOperationListener implements BuildOperationListener {
         return new DefaultOperationDescriptor(id, name, displayName, parentId);
     }
 
-    private AbstractOperationResult adaptResult(OperationFinishEvent result) {
+    static AbstractOperationResult toOperationResult(OperationFinishEvent result) {
         Throwable failure = result.getFailure();
         long startTime = result.getStartTime();
         long endTime = result.getEndTime();

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
@@ -16,17 +16,16 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
-import com.google.common.collect.Sets;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationFinishEvent;
-import org.gradle.internal.operations.OperationIdentifier;
-import org.gradle.internal.operations.OperationProgressEvent;
 import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.tooling.events.OperationType;
+import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
+import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.events.AbstractTaskResult;
 import org.gradle.tooling.internal.provider.events.DefaultFailure;
@@ -39,67 +38,31 @@ import org.gradle.tooling.internal.provider.events.DefaultTaskSuccessResult;
 import org.gradle.tooling.internal.provider.events.OperationResultPostProcessor;
 
 import java.util.Collections;
-import java.util.Set;
 
 /**
  * Task listener that forwards all receiving events to the client via the provided {@code ProgressEventConsumer} instance.
  *
  * @since 2.5
  */
-class ClientForwardingTaskOperationListener implements BuildOperationListener {
-    private final ProgressEventConsumer eventConsumer;
-    private final BuildClientSubscriptions clientSubscriptions;
-    private final BuildOperationListener delegate;
+class ClientForwardingTaskOperationListener extends SubtreeFilteringBuildOperationListener<ExecuteTaskBuildOperationDetails> {
+
     private final OperationResultPostProcessor operationResultPostProcessor;
 
-    // BuildOperationListener dispatch is not serialized
-    private final Set<Object> skipEvents = Sets.newConcurrentHashSet();
-
     ClientForwardingTaskOperationListener(ProgressEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate, OperationResultPostProcessor operationResultPostProcessor) {
-        this.eventConsumer = eventConsumer;
-        this.clientSubscriptions = clientSubscriptions;
-        this.delegate = delegate;
+        super(eventConsumer, clientSubscriptions, delegate, OperationType.TASK, ExecuteTaskBuildOperationDetails.class);
         this.operationResultPostProcessor = operationResultPostProcessor;
     }
 
     @Override
-    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-        OperationIdentifier parentId = buildOperation.getParentId();
-        if (parentId != null && skipEvents.contains(parentId)) {
-            skipEvents.add(buildOperation.getId());
-            return;
-        }
-
-        if (buildOperation.getDetails() instanceof ExecuteTaskBuildOperationDetails) {
-            if (clientSubscriptions.isRequested(OperationType.TASK)) {
-                TaskInternal task = ((ExecuteTaskBuildOperationDetails) buildOperation.getDetails()).getTask();
-                eventConsumer.started(new DefaultTaskStartedProgressEvent(startEvent.getStartTime(), toTaskDescriptor(buildOperation, task)));
-            } else {
-                // Discard this operation and all children
-                skipEvents.add(buildOperation.getId());
-            }
-        } else {
-            delegate.started(buildOperation, startEvent);
-        }
+    protected InternalOperationStartedProgressEvent toStartedEvent(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent, ExecuteTaskBuildOperationDetails details) {
+        return new DefaultTaskStartedProgressEvent(startEvent.getStartTime(), toTaskDescriptor(buildOperation, details.getTask()));
     }
 
     @Override
-    public void progress(OperationIdentifier buildOperationId, OperationProgressEvent progressEvent) {
-    }
-
-    @Override
-    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
-        if (skipEvents.remove(buildOperation.getId())) {
-            return;
-        }
-
-        if (buildOperation.getDetails() instanceof ExecuteTaskBuildOperationDetails) {
-            TaskInternal task = ((ExecuteTaskBuildOperationDetails) buildOperation.getDetails()).getTask();
-            AbstractTaskResult result = operationResultPostProcessor.process(toTaskResult(task, finishEvent), buildOperation.getId());
-            eventConsumer.finished(new DefaultTaskFinishedProgressEvent(finishEvent.getEndTime(), toTaskDescriptor(buildOperation, task), result));
-        } else {
-            delegate.finished(buildOperation, finishEvent);
-        }
+    protected InternalOperationFinishedProgressEvent toFinishedEvent(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent, ExecuteTaskBuildOperationDetails details) {
+        TaskInternal task = details.getTask();
+        AbstractTaskResult result = operationResultPostProcessor.process(toTaskResult(task, finishEvent), buildOperation.getId());
+        return new DefaultTaskFinishedProgressEvent(finishEvent.getEndTime(), toTaskDescriptor(buildOperation, task), result);
     }
 
     private DefaultTaskDescriptor toTaskDescriptor(BuildOperationDescriptor buildOperation, TaskInternal task) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
@@ -20,13 +20,13 @@ import com.google.common.collect.Sets;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails;
-import org.gradle.initialization.BuildEventConsumer;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationFinishEvent;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationProgressEvent;
 import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.events.AbstractTaskResult;
 import org.gradle.tooling.internal.provider.events.DefaultFailure;
@@ -42,12 +42,12 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * Task listener that forwards all receiving events to the client via the provided {@code BuildEventConsumer} instance.
+ * Task listener that forwards all receiving events to the client via the provided {@code ProgressEventConsumer} instance.
  *
  * @since 2.5
  */
 class ClientForwardingTaskOperationListener implements BuildOperationListener {
-    private final BuildEventConsumer eventConsumer;
+    private final ProgressEventConsumer eventConsumer;
     private final BuildClientSubscriptions clientSubscriptions;
     private final BuildOperationListener delegate;
     private final OperationResultPostProcessor operationResultPostProcessor;
@@ -55,7 +55,7 @@ class ClientForwardingTaskOperationListener implements BuildOperationListener {
     // BuildOperationListener dispatch is not serialized
     private final Set<Object> skipEvents = Sets.newConcurrentHashSet();
 
-    ClientForwardingTaskOperationListener(BuildEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate, OperationResultPostProcessor operationResultPostProcessor) {
+    ClientForwardingTaskOperationListener(ProgressEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate, OperationResultPostProcessor operationResultPostProcessor) {
         this.eventConsumer = eventConsumer;
         this.clientSubscriptions = clientSubscriptions;
         this.delegate = delegate;
@@ -71,9 +71,9 @@ class ClientForwardingTaskOperationListener implements BuildOperationListener {
         }
 
         if (buildOperation.getDetails() instanceof ExecuteTaskBuildOperationDetails) {
-            if (clientSubscriptions.isSendTaskProgressEvents()) {
+            if (clientSubscriptions.isRequested(OperationType.TASK)) {
                 TaskInternal task = ((ExecuteTaskBuildOperationDetails) buildOperation.getDetails()).getTask();
-                eventConsumer.dispatch(new DefaultTaskStartedProgressEvent(startEvent.getStartTime(), toTaskDescriptor(buildOperation, task)));
+                eventConsumer.started(new DefaultTaskStartedProgressEvent(startEvent.getStartTime(), toTaskDescriptor(buildOperation, task)));
             } else {
                 // Discard this operation and all children
                 skipEvents.add(buildOperation.getId());
@@ -96,7 +96,7 @@ class ClientForwardingTaskOperationListener implements BuildOperationListener {
         if (buildOperation.getDetails() instanceof ExecuteTaskBuildOperationDetails) {
             TaskInternal task = ((ExecuteTaskBuildOperationDetails) buildOperation.getDetails()).getTask();
             AbstractTaskResult result = operationResultPostProcessor.process(toTaskResult(task, finishEvent), buildOperation.getId());
-            eventConsumer.dispatch(new DefaultTaskFinishedProgressEvent(finishEvent.getEndTime(), toTaskDescriptor(buildOperation, task), result));
+            eventConsumer.finished(new DefaultTaskFinishedProgressEvent(finishEvent.getEndTime(), toTaskDescriptor(buildOperation, task), result));
         } else {
             delegate.finished(buildOperation, finishEvent);
         }
@@ -107,13 +107,8 @@ class ClientForwardingTaskOperationListener implements BuildOperationListener {
         String taskIdentityPath = buildOperation.getName();
         String displayName = buildOperation.getDisplayName();
         String taskPath = task.getIdentityPath().toString();
-        Object parentId = getParentId(buildOperation);
+        Object parentId = eventConsumer.findStartedParentId(buildOperation.getParentId());
         return new DefaultTaskDescriptor(id, taskIdentityPath, taskPath, displayName, parentId);
-    }
-
-    private Object getParentId(BuildOperationDescriptor buildOperation) {
-        // only set the BuildOperation as the parent if the Tooling API Consumer is listening to build progress events
-        return clientSubscriptions.isSendBuildProgressEvents() ? buildOperation.getParentId() : null;
     }
 
     private static AbstractTaskResult toTaskResult(TaskInternal task, OperationFinishEvent result) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingWorkItemOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingWorkItemOperationListener.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.tooling.internal.provider.events.DefaultOperationFinishedProgressEvent;
+import org.gradle.tooling.internal.provider.events.DefaultOperationStartedProgressEvent;
+import org.gradle.tooling.internal.provider.events.DefaultWorkItemDescriptor;
+import org.gradle.workers.internal.ExecuteWorkItemBuildOperationType;
+
+import static org.gradle.tooling.internal.provider.runner.ClientForwardingBuildOperationListener.toOperationResult;
+
+/**
+ * Work item listener that forwards all receiving events to the client via the provided {@code ProgressEventConsumer} instance.
+ *
+ * @since 5.1
+ */
+class ClientForwardingWorkItemOperationListener implements BuildOperationListener {
+
+    private final ProgressEventConsumer eventConsumer;
+    private final BuildOperationListener delegate;
+
+    ClientForwardingWorkItemOperationListener(ProgressEventConsumer eventConsumer, BuildOperationListener delegate) {
+        this.eventConsumer = eventConsumer;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        if (buildOperation.getDetails() instanceof ExecuteWorkItemBuildOperationType.Details) {
+            ExecuteWorkItemBuildOperationType.Details details = (ExecuteWorkItemBuildOperationType.Details) buildOperation.getDetails();
+            eventConsumer.started(new DefaultOperationStartedProgressEvent(startEvent.getStartTime(), toWorkItemDescriptor(buildOperation, details)));
+        } else {
+            delegate.started(buildOperation, startEvent);
+        }
+    }
+
+    @Override
+    public void progress(OperationIdentifier buildOperationId, OperationProgressEvent progressEvent) {
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        if (buildOperation.getDetails() instanceof ExecuteWorkItemBuildOperationType.Details) {
+            ExecuteWorkItemBuildOperationType.Details details = (ExecuteWorkItemBuildOperationType.Details) buildOperation.getDetails();
+            eventConsumer.finished(new DefaultOperationFinishedProgressEvent(finishEvent.getEndTime(), toWorkItemDescriptor(buildOperation, details), toOperationResult(finishEvent)));
+        } else {
+            delegate.finished(buildOperation, finishEvent);
+        }
+    }
+
+    private DefaultWorkItemDescriptor toWorkItemDescriptor(BuildOperationDescriptor buildOperation, ExecuteWorkItemBuildOperationType.Details details) {
+        Object id = buildOperation.getId();
+        String className = details.getClassName();
+        String displayName = buildOperation.getDisplayName();
+        Object parentId = eventConsumer.findStartedParentId(buildOperation.getParentId());
+        return new DefaultWorkItemDescriptor(id, className, displayName, parentId);
+    }
+
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/CompositeOperationResultPostProcessor.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/CompositeOperationResultPostProcessor.java
@@ -21,7 +21,7 @@ import org.gradle.tooling.internal.provider.events.OperationResultPostProcessor;
 
 import java.util.List;
 
-public class CompositeOperationResultPostProcessor implements OperationResultPostProcessor {
+class CompositeOperationResultPostProcessor implements OperationResultPostProcessor {
 
     private final List<OperationResultPostProcessor> processors;
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import org.gradle.initialization.BuildEventConsumer;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
+import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+class ProgressEventConsumer {
+
+    private final Set<Object> startedIds = ConcurrentHashMap.newKeySet();
+    private final BuildEventConsumer delegate;
+    private final BuildOperationParentTracker parentTracker;
+
+    ProgressEventConsumer(BuildEventConsumer delegate, BuildOperationParentTracker parentTracker) {
+        this.delegate = delegate;
+        this.parentTracker = parentTracker;
+    }
+
+    Object findStartedParentId(OperationIdentifier id) {
+        if (id == null || startedIds.contains(id)) {
+            return id;
+        }
+        return findStartedParentId(parentTracker.getParent(id));
+    }
+
+    void started(InternalOperationStartedProgressEvent event) {
+        delegate.dispatch(event);
+        startedIds.add(event.getDescriptor().getId());
+    }
+
+    void finished(InternalOperationFinishedProgressEvent event) {
+        startedIds.remove(event.getDescriptor().getId());
+        delegate.dispatch(event);
+    }
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubtreeFilteringBuildOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubtreeFilteringBuildOperationListener.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import com.google.common.collect.Sets;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.tooling.events.OperationType;
+import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
+import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
+import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
+
+import java.util.Set;
+
+/**
+ * Build operation listener responsible for a certain operation type that is detected by
+ * checking for a specific details class.
+ *
+ * <p>If the operation type is not requested, all events in the corresponding subtree
+ * are skipped, i.e. neither reported to the consumer nor passed on to the delegate.
+ *
+ * @since 5.1
+ */
+abstract class SubtreeFilteringBuildOperationListener<D> implements BuildOperationListener {
+
+    protected final ProgressEventConsumer eventConsumer;
+    private final BuildOperationListener delegate;
+    private final Class<D> detailsClass;
+
+    // BuildOperationListener dispatch is not serialized
+    private final Set<Object> skipEvents = Sets.newConcurrentHashSet();
+    private final boolean enabled;
+
+    SubtreeFilteringBuildOperationListener(ProgressEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate, OperationType operationType, Class<D> detailsClass) {
+        this.eventConsumer = eventConsumer;
+        this.delegate = delegate;
+        this.detailsClass = detailsClass;
+        this.enabled = clientSubscriptions.isRequested(operationType);
+    }
+
+    @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        OperationIdentifier parentId = buildOperation.getParentId();
+        if (parentId != null && skipEvents.contains(parentId)) {
+            skipEvents.add(buildOperation.getId());
+            return;
+        }
+
+        if (detailsClass.isInstance(buildOperation.getDetails())) {
+            if (enabled) {
+                D details = detailsClass.cast(buildOperation.getDetails());
+                eventConsumer.started(toStartedEvent(buildOperation, startEvent, details));
+            } else {
+                // Discard this operation and all children
+                skipEvents.add(buildOperation.getId());
+            }
+        } else {
+            delegate.started(buildOperation, startEvent);
+        }
+    }
+
+    @Override
+    public void progress(OperationIdentifier buildOperationId, OperationProgressEvent progressEvent) {
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        if (skipEvents.remove(buildOperation.getId())) {
+            return;
+        }
+
+        if (detailsClass.isInstance(buildOperation.getDetails())) {
+            D details = detailsClass.cast(buildOperation.getDetails());
+            eventConsumer.finished(toFinishedEvent(buildOperation, finishEvent, details));
+        } else {
+            delegate.finished(buildOperation, finishEvent);
+        }
+    }
+
+    protected abstract InternalOperationStartedProgressEvent toStartedEvent(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent, D details);
+
+    protected abstract InternalOperationFinishedProgressEvent toFinishedEvent(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent, D details);
+
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiSubscribableBuildActionRunnerRegistration.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ToolingApiSubscribableBuildActionRunnerRegistration.java
@@ -53,13 +53,13 @@ public class ToolingApiSubscribableBuildActionRunnerRegistration implements Subs
         if (clientSubscriptions.isRequested(OperationType.TEST)) {
             listeners.add(new ClientForwardingTestOperationListener(progressEventConsumer, clientSubscriptions));
         }
-        if (clientSubscriptions.isAnyRequested(OperationType.GENERIC, OperationType.TASK, OperationType.WORK_ITEM)) {
+        if (clientSubscriptions.isAnyRequested(OperationType.GENERIC, OperationType.WORK_ITEM, OperationType.TASK)) {
             BuildOperationListener buildListener = NO_OP;
             if (clientSubscriptions.isRequested(OperationType.GENERIC)) {
                 buildListener = new TestIgnoringBuildOperationListener(new ClientForwardingBuildOperationListener(progressEventConsumer));
             }
-            if (clientSubscriptions.isRequested(OperationType.WORK_ITEM)) {
-                buildListener = new ClientForwardingWorkItemOperationListener(progressEventConsumer, buildListener);
+            if (clientSubscriptions.isAnyRequested(OperationType.GENERIC, OperationType.WORK_ITEM)) {
+                buildListener = new ClientForwardingWorkItemOperationListener(progressEventConsumer, clientSubscriptions, buildListener);
             }
             listeners.add(new ClientForwardingTaskOperationListener(progressEventConsumer, clientSubscriptions, buildListener, operationResultPostProcessor));
         }

--- a/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
+++ b/subprojects/tooling-api-builders/tooling-api-builders.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
     compile(project(":launcher"))
     compile(project(":toolingApi"))
     compile(project(":compositeBuilds"))
+    compile(project(":workers"))
 }
 
 gradlebuildJava {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildProgressCrossVersionSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.integtests.tooling.r35
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.gradle.test.fixtures.server.http.MavenHttpRepository
 import org.gradle.test.fixtures.server.http.RepositoryHttpServer
@@ -257,8 +258,19 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
         compileJavaActions[0].parent.descriptor.displayName == 'Task :compileJava'
     }
 
-    def "generates events for worker actions"() {
-        given:
+    @TargetGradleVersion('<5.1')
+    def "generates events for worker actions (pre 5.1)"() {
+        expect:
+        runBuildWithWorkerAction() != null
+    }
+
+    @ToolingApiVersion('>=5.1')
+    def "generates events for worker actions (post 5.1)"() {
+        expect:
+        runBuildWithWorkerAction() != null
+    }
+
+    private ProgressEvents.Operation runBuildWithWorkerAction() {
         settingsFile << "rootProject.name = 'single'"
         buildFile << """
             import org.gradle.workers.*
@@ -277,7 +289,6 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
             }
         """.stripIndent()
 
-        when:
         def events = ProgressEvents.create()
         withConnection {
             ProjectConnection connection ->
@@ -287,10 +298,7 @@ class BuildProgressCrossVersionSpec extends ToolingApiSpecification {
                     .run()
         }
 
-        then:
         events.assertIsABuild()
-
-        and:
         events.operation('Task :runInWorker').descendant('My Worker Action')
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/WorkItemProgressEventCrossVersionTest.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/WorkItemProgressEventCrossVersionTest.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r51
+
+import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.work.WorkItemOperationDescriptor
+import org.gradle.util.GradleVersion
+import org.gradle.workers.fixtures.WorkerExecutorFixture
+
+@ToolingApiVersion('>=5.1')
+@TargetGradleVersion('>=4.0')
+class WorkItemProgressEventCrossVersionTest extends ToolingApiSpecification {
+
+    def fixture = new WorkerExecutorFixture(temporaryFolder)
+
+    void setup() {
+        fixture.prepareTaskTypeUsingWorker()
+        fixture.withRunnableClassInBuildSrc()
+        buildFile << """
+            task runInWorker(type: WorkerTask) {
+                displayName = "Test Work"
+            }
+        """
+    }
+
+    def "reports work item progress events as descendants of tasks"() {
+        when:
+        def events = runBuild("runInWorker", EnumSet.allOf(OperationType))
+
+        then:
+        def taskOperation = events.operation("Task :runInWorker")
+        taskOperation.task
+        with(taskOperation.descendant("Test Work")) {
+            successful
+            if (targetVersion >= GradleVersion.version("5.1")) {
+                assert workItem
+                assert descriptor.className == "org.gradle.test.TestRunnable"
+            } else {
+                assert buildOperation
+            }
+        }
+    }
+
+    @TargetGradleVersion('>=5.1')
+    def "reports work item progress events as generic events when WORK_ITEM operations are not requested"() {
+        when:
+        def events = runBuild("runInWorker", EnumSet.complementOf(EnumSet.of(OperationType.WORK_ITEM)))
+
+        then:
+        def taskOperation = events.operation("Task :runInWorker")
+        taskOperation.isTask()
+        taskOperation.descendant("Test Work").buildOperation
+    }
+
+    @TargetGradleVersion('>=5.1')
+    def "does not report work item progress events when TASK operations are not requested"() {
+        when:
+        def events = runBuild("runInWorker", EnumSet.of(OperationType.WORK_ITEM))
+
+        then:
+        events.empty
+    }
+
+    def "does not report work item progress when neither WORK_ITEM nor GENERIC operations are requested"() {
+        when:
+        def events = runBuild("runInWorker", EnumSet.complementOf(EnumSet.of(OperationType.WORK_ITEM, OperationType.GENERIC)))
+
+        then:
+        def taskOperation = events.operation("Task :runInWorker")
+        taskOperation.task
+        taskOperation.children.empty
+    }
+
+    @TargetGradleVersion('>=5.1')
+    def "includes failure in progress event"() {
+        given:
+        buildFile << """
+            ${fixture.getRunnableThatFails(IllegalStateException, "something went horribly wrong")}
+            runInWorker {
+                displayName = null
+                runnableClass = RunnableThatFails
+            }
+        """
+
+        when:
+        def events = ProgressEvents.create()
+        runBuild("runInWorker", events, EnumSet.of(OperationType.TASK, OperationType.WORK_ITEM))
+
+        then:
+        thrown(BuildException)
+        def taskOperation = events.operation("Task :runInWorker")
+        taskOperation.task
+        with(taskOperation.child("RunnableThatFails")) {
+            !successful
+            workItem
+            descriptor instanceof WorkItemOperationDescriptor
+            descriptor.className == "RunnableThatFails"
+            failures.size() == 1
+            with (failures[0]) {
+                message == "something went horribly wrong"
+                description.startsWith("java.lang.IllegalStateException: something went horribly wrong")
+            }
+        }
+    }
+
+    private ProgressEvents runBuild(String task, Set<OperationType> operationTypes) {
+        ProgressEvents events = ProgressEvents.create()
+        runBuild(task, events, operationTypes)
+        events
+    }
+
+    private Object runBuild(String task, ProgressListener listener, Set<OperationType> operationTypes) {
+        withConnection {
+            newBuild()
+                .forTasks(task)
+                .addProgressListener(listener, operationTypes)
+                .run()
+        }
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemFailureResult.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.events.FailureResult;
+
+/**
+ * Describes how a work item operation finished with failures.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface WorkItemFailureResult extends WorkItemOperationResult, FailureResult {
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemFinishEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemFinishEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.events.FinishEvent;
+
+/**
+ * An event that informs about a work item having finished its execution.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface WorkItemFinishEvent extends WorkItemProgressEvent, FinishEvent {
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemOperationDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.events.OperationDescriptor;
+
+/**
+ * Describes a work item operation for which an event has occurred.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface WorkItemOperationDescriptor extends OperationDescriptor {
+    /**
+     * Returns the fully-qualified class name of work item's action.
+     */
+    String getClassName();
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemOperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemOperationResult.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.events.OperationResult;
+
+/**
+ * Describes the result of running a work item operation.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface WorkItemOperationResult extends OperationResult {
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemProgressEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemProgressEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,38 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.events;
+package org.gradle.tooling.events.work;
 
 import org.gradle.api.Incubating;
+import org.gradle.tooling.events.ProgressEvent;
 
 /**
- * Enumerates the different types of operations for which progress events can be received.
+ * Root interface for all events that signal progress while executing a work item.
  *
- * @see org.gradle.tooling.LongRunningOperation#addProgressListener(ProgressListener, java.util.Set)
+ * @since 5.1
  */
-public enum OperationType {
-
+@Incubating
+public interface WorkItemProgressEvent extends ProgressEvent {
     /**
-     * Flag for test operation progress events.
-     */
-    TEST,
-
-    /**
-     * Flag for task operation progress events.
-     */
-    TASK,
-
-    /**
-     * Flag for operations with no specific type.
-     */
-    GENERIC,
-
-    /**
-     * Flag for work item operation progress events.
+     * Returns the description of the work item for which progress is reported.
      *
-     * @since 5.1
+     * @return The description of the underlying work item operation.
      */
-    @Incubating
-    WORK_ITEM
-
+    @Override
+    WorkItemOperationDescriptor getDescriptor();
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemStartEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemStartEvent.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.events.StartEvent;
+
+/**
+ * An event that informs about a work item having started its execution.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface WorkItemStartEvent extends WorkItemProgressEvent, StartEvent {
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/WorkItemSuccessResult.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.events.SuccessResult;
+
+/**
+ * Describes how a work item operation finished successfully.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface WorkItemSuccessResult extends WorkItemOperationResult, SuccessResult {
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemFailureResult.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work.internal;
+
+import org.gradle.tooling.Failure;
+import org.gradle.tooling.events.internal.DefaultOperationFailureResult;
+import org.gradle.tooling.events.work.WorkItemFailureResult;
+
+import java.util.List;
+
+public class DefaultWorkItemFailureResult extends DefaultOperationFailureResult implements WorkItemFailureResult {
+
+    public DefaultWorkItemFailureResult(long startTime, long endTime, List<? extends Failure> failures) {
+        super(startTime, endTime, failures);
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemFinishEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemFinishEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work.internal;
+
+import org.gradle.tooling.events.internal.DefaultFinishEvent;
+import org.gradle.tooling.events.work.WorkItemFinishEvent;
+import org.gradle.tooling.events.work.WorkItemOperationDescriptor;
+import org.gradle.tooling.events.work.WorkItemOperationResult;
+
+public class DefaultWorkItemFinishEvent extends DefaultFinishEvent implements WorkItemFinishEvent {
+
+    public DefaultWorkItemFinishEvent(long eventTime, String displayName, WorkItemOperationDescriptor descriptor, WorkItemOperationResult result) {
+        super(eventTime, displayName, descriptor, result);
+    }
+
+    @Override
+    public WorkItemOperationDescriptor getDescriptor() {
+        return (WorkItemOperationDescriptor) super.getDescriptor();
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemOperationDescriptor.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work.internal;
+
+import org.gradle.tooling.events.OperationDescriptor;
+import org.gradle.tooling.events.internal.DefaultOperationDescriptor;
+import org.gradle.tooling.events.work.WorkItemOperationDescriptor;
+import org.gradle.tooling.internal.protocol.events.InternalWorkItemDescriptor;
+
+public class DefaultWorkItemOperationDescriptor extends DefaultOperationDescriptor implements WorkItemOperationDescriptor {
+
+    private final String className;
+
+    public DefaultWorkItemOperationDescriptor(InternalWorkItemDescriptor descriptor, OperationDescriptor parent) {
+        super(descriptor, parent);
+        this.className = descriptor.getClassName();
+    }
+
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemStartEvent.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemStartEvent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work.internal;
+
+import org.gradle.tooling.events.internal.DefaultStartEvent;
+import org.gradle.tooling.events.work.WorkItemOperationDescriptor;
+import org.gradle.tooling.events.work.WorkItemStartEvent;
+
+public class DefaultWorkItemStartEvent extends DefaultStartEvent implements WorkItemStartEvent {
+
+    public DefaultWorkItemStartEvent(long eventTime, String displayName, WorkItemOperationDescriptor descriptor) {
+        super(eventTime, displayName, descriptor);
+    }
+
+    @Override
+    public WorkItemOperationDescriptor getDescriptor() {
+        return (WorkItemOperationDescriptor) super.getDescriptor();
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/internal/DefaultWorkItemSuccessResult.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.work.internal;
+
+import org.gradle.tooling.events.internal.DefaultOperationSuccessResult;
+import org.gradle.tooling.events.work.WorkItemSuccessResult;
+
+public class DefaultWorkItemSuccessResult extends DefaultOperationSuccessResult implements WorkItemSuccessResult {
+
+    public DefaultWorkItemSuccessResult(long startTime, long endTime) {
+        super(startTime, endTime);
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/package-info.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/work/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Work item execution specific interfaces and classes related to event notifications.
+ */
+package org.gradle.tooling.events.work;

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/AbstractLongRunningOperation.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/AbstractLongRunningOperation.java
@@ -162,15 +162,7 @@ public abstract class AbstractLongRunningOperation<T extends AbstractLongRunning
 
     @Override
     public T addProgressListener(org.gradle.tooling.events.ProgressListener listener, Set<OperationType> eventTypes) {
-        if (eventTypes.contains(OperationType.TEST)) {
-            operationParamsBuilder.addTestProgressListener(listener);
-        }
-        if (eventTypes.contains(OperationType.TASK)) {
-            operationParamsBuilder.addTaskProgressListener(listener);
-        }
-        if (eventTypes.contains(OperationType.GENERIC)) {
-            operationParamsBuilder.addBuildOperationProgressListeners(listener);
-        }
+        operationParamsBuilder.addProgressListener(listener, eventTypes);
         return getThis();
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalBuildProgressListener.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/InternalBuildProgressListener.java
@@ -38,6 +38,11 @@ public interface InternalBuildProgressListener {
     String BUILD_EXECUTION = "BUILD_EXECUTION";
 
     /**
+     * The constant for the work item execution operations.
+     */
+    String WORK_ITEM_EXECUTION = "WORK_ITEM_EXECUTION";
+
+    /**
      * Invoked when a progress event happens in the build being run, and one or more listeners for the given event type have been registered.
      *
      * The event types implemented in Gradle 2.4 are:
@@ -49,7 +54,7 @@ public interface InternalBuildProgressListener {
      * The event types implemented in Gradle 2.5 are:
      *
      * <ul>
-     *     <li>{@link org.gradle.tooling.internal.protocol.events.InternalProgressEvent} - used for all operation types: task, test and generic.</li>
+     *     <li>{@link org.gradle.tooling.internal.protocol.events.InternalProgressEvent} - used for all operation types.</li>
      *     <li>{@link org.gradle.tooling.internal.protocol.events.InternalTestProgressEvent} - test events also implement these types for backwards compatibility</li>
      * </ul>
      *

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalWorkItemDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalWorkItemDescriptor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.protocol.events;
+
+/**
+ * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
+ *
+ * @since 5.1
+ */
+public interface InternalWorkItemDescriptor extends InternalOperationDescriptor {
+    /**
+     * Returns the fully-qualified class name of work item's action.
+     */
+    String getClassName();
+}

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForBuildOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForBuildOperationsTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.tooling.internal.consumer.parameters
 
 import org.gradle.tooling.events.FinishEvent
+import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.StartEvent
 import org.gradle.tooling.events.internal.DefaultFinishEvent
@@ -347,11 +348,11 @@ class BuildProgressListenerAdapterForBuildOperationsTest extends Specification {
     }
 
     private static BuildProgressListenerAdapter createAdapter() {
-        new BuildProgressListenerAdapter([], [], [])
+        new BuildProgressListenerAdapter([:])
     }
 
     private static BuildProgressListenerAdapter createAdapter(ProgressListener buildListener) {
-        new BuildProgressListenerAdapter([], [], [buildListener])
+        new BuildProgressListenerAdapter([(OperationType.GENERIC): [buildListener]])
     }
 
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTaskOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTaskOperationsTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.consumer.parameters
 
+import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.task.*
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
@@ -356,11 +357,11 @@ class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
     }
 
     private static BuildProgressListenerAdapter createAdapter() {
-        new BuildProgressListenerAdapter([], [], [])
+        new BuildProgressListenerAdapter([:])
     }
 
     private static BuildProgressListenerAdapter createAdapter(ProgressListener taskListener) {
-        new BuildProgressListenerAdapter([], [taskListener], [])
+        new BuildProgressListenerAdapter([(OperationType.TASK): [taskListener]])
     }
 
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTestOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTestOperationsTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.tooling.internal.consumer.parameters
 
+import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
 import org.gradle.tooling.events.test.*
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
@@ -523,11 +524,11 @@ class BuildProgressListenerAdapterForTestOperationsTest extends Specification {
     }
 
     private static BuildProgressListenerAdapter createAdapter() {
-        new BuildProgressListenerAdapter([], [], [])
+        new BuildProgressListenerAdapter([:])
     }
 
     private static BuildProgressListenerAdapter createAdapter(ProgressListener testListener) {
-        new BuildProgressListenerAdapter([testListener], [], [])
+        new BuildProgressListenerAdapter([(OperationType.TEST): [testListener]])
     }
 
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForWorkItemOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForWorkItemOperationsTest.groovy
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.consumer.parameters
+
+import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.work.WorkItemFailureResult
+import org.gradle.tooling.events.work.WorkItemFinishEvent
+import org.gradle.tooling.events.work.WorkItemStartEvent
+import org.gradle.tooling.events.work.WorkItemSuccessResult
+import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
+import org.gradle.tooling.internal.protocol.InternalFailure
+import org.gradle.tooling.internal.protocol.events.InternalFailureResult
+import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent
+import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent
+import org.gradle.tooling.internal.protocol.events.InternalSuccessResult
+import org.gradle.tooling.internal.protocol.events.InternalWorkItemDescriptor
+import spock.lang.Specification
+
+class BuildProgressListenerAdapterForWorkItemOperationsTest extends Specification {
+
+    def "adapter is only subscribing to test progress events if at least one test progress listener is attached"() {
+        when:
+        def adapter = createAdapter()
+
+        then:
+        adapter.subscribedOperations == []
+
+        when:
+        def listener = Mock(ProgressListener)
+        adapter = createAdapter(listener)
+
+        then:
+        adapter.subscribedOperations == [InternalBuildProgressListener.WORK_ITEM_EXECUTION]
+    }
+
+    def "convert to WorkItemStartEvent"() {
+        given:
+        def listener = Mock(ProgressListener)
+        def adapter = createAdapter(listener)
+
+        when:
+        def workItemDescriptor = Mock(InternalWorkItemDescriptor)
+        _ * workItemDescriptor.getId() >> 1
+        _ * workItemDescriptor.getName() >> 'Test Work'
+        _ * workItemDescriptor.getDisplayName() >> 'Test Work'
+        _ * workItemDescriptor.getClassName() >> 'SomeRunnable'
+
+        def startEvent = Mock(InternalOperationStartedProgressEvent)
+        _ * startEvent.getEventTime() >> 999
+        _ * startEvent.getDisplayName() >> 'Test Work started'
+        _ * startEvent.getDescriptor() >> workItemDescriptor
+
+        adapter.onEvent(startEvent)
+
+        then:
+        1 * listener.statusChanged(_ as WorkItemStartEvent) >> { WorkItemStartEvent event ->
+            assert event.eventTime == 999
+            assert event.displayName == "Test Work started"
+            assert event.descriptor.displayName == 'Test Work'
+            assert event.descriptor.className == 'SomeRunnable'
+        }
+    }
+
+    def "convert to WorkItemSuccessResult"() {
+        given:
+        def listener = Mock(ProgressListener)
+        def adapter = createAdapter(listener)
+
+        when:
+        def workItemDescriptor = Mock(InternalWorkItemDescriptor)
+        _ * workItemDescriptor.getId() >> 1
+        _ * workItemDescriptor.getName() >> 'Test Work'
+        _ * workItemDescriptor.getDisplayName() >> 'Test Work'
+        _ * workItemDescriptor.getClassName() >> 'SomeRunnable'
+
+        def startEvent = Mock(InternalOperationStartedProgressEvent)
+        _ * startEvent.getEventTime() >> 999
+        _ * startEvent.getDisplayName() >> 'Test Work started'
+        _ * startEvent.getDescriptor() >> workItemDescriptor
+
+        def workItemResult = Mock(InternalSuccessResult)
+        _ * workItemResult.getStartTime() >> 1
+        _ * workItemResult.getEndTime() >> 2
+
+        def succeededEvent = Mock(InternalOperationFinishedProgressEvent)
+        _ * succeededEvent.getEventTime() >> 999
+        _ * succeededEvent.getDisplayName() >> 'Test Work succeeded'
+        _ * succeededEvent.getDescriptor() >> workItemDescriptor
+        _ * succeededEvent.getResult() >> workItemResult
+
+        adapter.onEvent(startEvent) // succeededEvent always assumes a previous startEvent
+        adapter.onEvent(succeededEvent)
+
+        then:
+        1 * listener.statusChanged(_ as WorkItemFinishEvent) >> { WorkItemFinishEvent event ->
+            assert event.eventTime == 999
+            assert event.displayName == "Test Work succeeded"
+            assert event.descriptor.displayName == 'Test Work'
+            assert event.descriptor.className == 'SomeRunnable'
+            assert event.descriptor.parent == null
+            assert event.result instanceof WorkItemSuccessResult
+            assert event.result.startTime == 1
+            assert event.result.endTime == 2
+        }
+    }
+
+    def "convert to WorkItemFailureResult"() {
+        given:
+        def listener = Mock(ProgressListener)
+        def adapter = createAdapter(listener)
+
+        when:
+        def workItemDescriptor = Mock(InternalWorkItemDescriptor)
+        _ * workItemDescriptor.getId() >> 1
+        _ * workItemDescriptor.getName() >> 'Test Work'
+        _ * workItemDescriptor.getDisplayName() >> 'Test Work'
+        _ * workItemDescriptor.getClassName() >> 'SomeRunnable'
+
+        def startEvent = Mock(InternalOperationStartedProgressEvent)
+        _ * startEvent.getEventTime() >> 999
+        _ * startEvent.getDisplayName() >> 'Test Work started'
+        _ * startEvent.getDescriptor() >> workItemDescriptor
+
+        def workItemResult = Mock(InternalFailureResult)
+        _ * workItemResult.getStartTime() >> 1
+        _ * workItemResult.getEndTime() >> 2
+        _ * workItemResult.getFailures() >> [Stub(InternalFailure)]
+
+        def failedEvent = Mock(InternalOperationFinishedProgressEvent)
+        _ * failedEvent.getEventTime() >> 999
+        _ * failedEvent.getDisplayName() >> 'Test Work failed'
+        _ * failedEvent.getDescriptor() >> workItemDescriptor
+        _ * failedEvent.getResult() >> workItemResult
+
+        adapter.onEvent(startEvent) // failedEvent always assumes a previous startEvent
+        adapter.onEvent(failedEvent)
+
+        then:
+        1 * listener.statusChanged(_ as WorkItemFinishEvent) >> { WorkItemFinishEvent event ->
+            assert event.eventTime == 999
+            assert event.displayName == "Test Work failed"
+            assert event.descriptor.displayName == 'Test Work'
+            assert event.descriptor.className == 'SomeRunnable'
+            assert event.result instanceof WorkItemFailureResult
+            assert event.result.startTime == 1
+            assert event.result.endTime == 2
+            assert event.result.failures.size() == 1
+        }
+    }
+
+    private static BuildProgressListenerAdapter createAdapter() {
+        new BuildProgressListenerAdapter([:])
+    }
+
+    private static BuildProgressListenerAdapter createAdapter(ProgressListener testListener) {
+        new BuildProgressListenerAdapter([(OperationType.WORK_ITEM): [testListener]])
+    }
+
+}

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -317,7 +317,12 @@ class ProgressEvents implements ProgressListener {
         }
 
         boolean isWorkItem() {
-            return descriptor instanceof WorkItemOperationDescriptor
+            try {
+                // the class is not present in pre 5.1 TAPI
+                return descriptor instanceof WorkItemOperationDescriptor
+            } catch (NoClassDefFoundError ignore) {
+                false
+            }
         }
 
         boolean isBuildOperation() {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ProgressEvents.groovy
@@ -30,6 +30,7 @@ import org.gradle.tooling.events.StartEvent
 import org.gradle.tooling.events.SuccessResult
 import org.gradle.tooling.events.task.TaskOperationDescriptor
 import org.gradle.tooling.events.test.TestOperationDescriptor
+import org.gradle.tooling.events.work.WorkItemOperationDescriptor
 import org.gradle.util.GradleVersion
 
 class ProgressEvents implements ProgressListener {
@@ -315,8 +316,12 @@ class ProgressEvents implements ProgressListener {
             return descriptor instanceof TaskOperationDescriptor
         }
 
+        boolean isWorkItem() {
+            return descriptor instanceof WorkItemOperationDescriptor
+        }
+
         boolean isBuildOperation() {
-            return !test && !task
+            return !test && !task && !workItem
         }
 
         boolean isSuccessful() {

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClasspathProvider.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClasspathProvider.groovy
@@ -63,6 +63,7 @@ trait ToolingApiClasspathProvider {
         sharedSpec.allowPackage('org.gradle.test.fixtures')
         sharedSpec.allowPackage('org.gradle.nativeplatform.fixtures')
         sharedSpec.allowPackage('org.gradle.language.fixtures')
+        sharedSpec.allowPackage('org.gradle.workers.fixtures')
         sharedSpec.allowPackage('org.gradle.launcher.daemon.testing')
         sharedSpec.allowClass(OperatingSystem)
         sharedSpec.allowClass(Requires)

--- a/subprojects/tooling-api/tooling-api.gradle.kts
+++ b/subprojects/tooling-api/tooling-api.gradle.kts
@@ -70,6 +70,7 @@ testFixtures {
     from(":logging")
     from(":dependencyManagement")
     from(":ide")
+    from(":workers")
 }
 
 apply(from = "buildship.gradle")

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/AbstractWorkerExecutorIntegrationTest.groovy
@@ -17,238 +17,41 @@
 package org.gradle.workers.internal
 
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
-import org.gradle.util.TextUtil
-import org.gradle.workers.IsolationMode
-
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.workers.fixtures.WorkerExecutorFixture
 
 abstract class AbstractWorkerExecutorIntegrationTest extends AbstractIntegrationSpec {
-    public static final ISOLATION_MODES = (IsolationMode.values() - IsolationMode.AUTO).collect { "IsolationMode.${it.toString()}" }
-    def outputFileDir = file("build/workers")
-    def outputFileDirPath = TextUtil.normaliseFileSeparators(outputFileDir.absolutePath)
-    def list = [ 1, 2, 3 ]
+
+    def fixture = new WorkerExecutorFixture(temporaryFolder)
 
     def setup() {
-        buildFile << """
-            import org.gradle.workers.*
-            $taskTypeUsingWorker
-        """
+        fixture.prepareTaskTypeUsingWorker()
     }
 
     void assertRunnableExecuted(String taskName) {
-        list.each {
+        fixture.list.each {
             outputFileDir.file(taskName).file(it).assertExists()
         }
     }
 
     void assertSameDaemonWasUsed(String task1, String task2) {
-        list.each {
+        fixture.list.each {
             assert outputFileDir.file(task1).file(it).text == outputFileDir.file(task2).file(it).text
         }
     }
 
     void assertDifferentDaemonsWereUsed(String task1, String task2) {
-        list.each {
+        fixture.list.each {
             assert outputFileDir.file(task1).file(it).text != outputFileDir.file(task2).file(it).text
         }
     }
 
-    String getTaskTypeUsingWorker() {
-        withParameterClassInBuildSrc()
-        withFileHelperClassInBuildSrc()
-
-        return """
-            import javax.inject.Inject
-            import org.gradle.other.Foo
-
-            class WorkerTask extends DefaultTask {
-                def list = $list
-                def outputFileDirPath = "${outputFileDirPath}/\${name}"
-                def additionalForkOptions = {}
-                def runnableClass = TestRunnable.class
-                def additionalClasspath = project.layout.files()
-                def foo = new Foo()
-                def displayName = null
-                def isolationMode = IsolationMode.AUTO
-                def forkMode = null
-
-                @Inject
-                WorkerExecutor getWorkerExecutor() {
-                    throw new UnsupportedOperationException()
-                }
-
-                @TaskAction
-                void executeTask() {
-                    workerExecutor.submit(runnableClass) {
-                        isolationMode = this.isolationMode
-                        displayName = this.displayName
-                        if (isolationMode == IsolationMode.PROCESS) {
-                            forkOptions.maxHeapSize = "64m"
-                        }
-                        forkOptions(additionalForkOptions)
-                        classpath(additionalClasspath)
-                        params = [ list.collect { it as String }, new File(outputFileDirPath), foo ]
-                        if (this.forkMode != null) {
-                            forkMode = this.forkMode
-                        }
-                    }
-                }
-            }
-        """
+    @Override
+    protected TestFile getBuildFile() {
+        return fixture.getBuildFile()
     }
 
-    String getRunnableThatCreatesFiles() {
-        return """
-            import java.io.File;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import org.gradle.test.FileHelper;
-            import java.util.UUID;
-            import javax.inject.Inject;
-
-            public class TestRunnable implements Runnable {
-                private final List<String> files;
-                protected final File outputDir;
-                private final Foo foo;
-                private static final String id = UUID.randomUUID().toString();
-
-                @Inject
-                public TestRunnable(List<String> files, File outputDir, Foo foo) {
-                    this.files = files;
-                    this.outputDir = outputDir;
-                    this.foo = foo;
-                }
-
-                public void run() {
-                    for (String name : files) {
-                        File outputFile = new File(outputDir, name);
-                        FileHelper.write(id, outputFile);
-                    }
-                }
-            }
-        """
-    }
-
-    void withParameterClassInBuildSrc() {
-        file("buildSrc/src/main/java/org/gradle/other/Foo.java") << """
-            package org.gradle.other;
-
-            import java.io.Serializable;
-
-            public class Foo implements Serializable { }
-        """
-    }
-
-    void withFileHelperClassInBuildSrc() {
-        file("buildSrc/src/main/java/org/gradle/test/FileHelper.java") << """
-            $fileHelperClass
-        """
-    }
-
-    void withRunnableClassInBuildSrc() {
-        file("buildSrc/src/main/java/org/gradle/test/TestRunnable.java") << """
-            package org.gradle.test;
-
-            $runnableThatCreatesFiles
-        """
-
-        addImportToBuildScript("org.gradle.test.TestRunnable")
-    }
-
-    void withRunnableClassInBuildScript() {
-        buildFile << """
-            $runnableThatCreatesFiles
-        """
-    }
-
-    void withRunnableClassInExternalJar(File runnableJar) {
-        file("buildSrc").deleteDir()
-
-        def builder = artifactBuilder()
-        builder.sourceFile("org/gradle/test/TestRunnable.java") << """
-            package org.gradle.test;
-
-            $runnableThatCreatesFiles
-        """
-        builder.sourceFile("org/gradle/other/Foo.java") << """
-            $parameterClass
-        """
-        builder.sourceFile("org/gradle/test/FileHelper.java") << """
-            $fileHelperClass
-        """
-        builder.buildJar(runnableJar)
-
-        addImportToBuildScript("org.gradle.test.TestRunnable")
-    }
-
-    void withJava7CompatibleClasses() {
-        file('buildSrc/build.gradle') << """
-            tasks.withType(JavaCompile) {
-                sourceCompatibility = "1.7"
-                targetCompatibility = "1.7"
-            }
-        """
-    }
-
-    String getParameterClass() {
-        return """
-            package org.gradle.other;
-
-            import java.io.Serializable;
-
-            public class Foo implements Serializable { }
-        """
-    }
-
-    String getFileHelperClass() {
-        return """
-            package org.gradle.test;
-            
-            import java.io.File;
-            import java.io.PrintWriter;
-            import java.io.BufferedWriter;
-            import java.io.FileWriter;
-            
-            public class FileHelper {
-                static void write(String id, File outputFile) {
-                    PrintWriter out = null;
-                    try {
-                        outputFile.getParentFile().mkdirs();
-                        outputFile.createNewFile();
-                        out = new PrintWriter(new BufferedWriter(new FileWriter(outputFile)));
-                        out.print(id);
-                    } catch (Exception e) {
-                        throw new RuntimeException(e);
-                    } finally {
-                        if (out != null) {
-                            out.close();
-                        }
-                    }
-                }
-            }
-        """
-    }
-
-    void addImportToBuildScript(String className) {
-        buildFile.text = """
-            import ${className}
-            ${buildFile.text}
-        """
-    }
-
-    String getAlternateRunnable() {
-        return """
-            import java.io.File;
-            import java.util.List;
-            import org.gradle.other.Foo;
-            import java.net.URL;
-            import javax.inject.Inject;
-
-            public class AlternateRunnable extends TestRunnable {
-                @Inject
-                public AlternateRunnable(List<String> files, File outputDir, Foo foo) {
-                    super(files, outputDir, foo);
-                }
-            }
-        """
+    protected TestFile getOutputFileDir() {
+        return fixture.outputFileDir
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonIntegrationTest.groovy
@@ -33,7 +33,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
 
     def "uses the worker home directory as working directory for worker execution"() {
         def workerHomeDir = executer.gradleUserHomeDir.file("workers").getAbsolutePath()
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             import org.gradle.workers.IsolationMode
 
@@ -65,7 +65,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
     }
 
     def "setting the working directory of a worker is not supported"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             import org.gradle.workers.IsolationMode
 
@@ -88,7 +88,7 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
     @Requires(TestPrecondition.JDK_ORACLE)
     def "interesting worker daemon fork options are honored"() {
         Assume.assumeThat(Jvm.current().jre, notNullValue())
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
         outputFileDir.createDir()
 
         buildFile << """
@@ -127,8 +127,8 @@ class WorkerDaemonIntegrationTest extends AbstractWorkerExecutorIntegrationTest 
         Assume.assumeNotNull(differentJvm)
         def differentJavacExecutablePath = normaliseFileSeparators(differentJvm.getJavaExecutable().absolutePath)
 
-        withJava7CompatibleClasses()
-        withRunnableClassInBuildSrc()
+        fixture.withJava7CompatibleClasses()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             ${getExecutableVerifyingRunnable(differentJvm)}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerDaemonLifecycleTest.groovy
@@ -27,7 +27,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     String logSnapshot = ""
 
     def "worker daemons are reused across builds"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             import org.gradle.workers.internal.WorkerDaemonFactory
             
@@ -56,7 +56,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons can be restarted when daemon is stopped"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -81,7 +81,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are stopped when daemon is stopped"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -104,7 +104,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are stopped and not reused when log level is changed"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -134,7 +134,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "worker daemons are not reused when classpath changes"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             task runInWorker1(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS
@@ -200,7 +200,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
     }
 
     def "only compiler daemons are stopped with the build session"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         file('src/main/java').createDir()
         file('src/main/java/Test.java') << "public class Test {}"
         buildFile << """
@@ -234,7 +234,7 @@ class WorkerDaemonLifecycleTest extends AbstractDaemonWorkerExecutorIntegrationS
 
     @Requires(TestPrecondition.UNIX)
     def "worker daemons exit when the parent build daemon is killed"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.PROCESS

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -21,11 +21,13 @@ import org.gradle.internal.jvm.Jvm
 import org.gradle.workers.IsolationMode
 import spock.lang.Unroll
 
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
 @IntegrationTestTimeout(120)
 class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
     @Unroll
     def "produces a sensible error when there is a failure in the worker runnable in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             $runnableThatFails
@@ -51,7 +53,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when there is a failure in the worker runnable and work completes before the task in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             $runnableThatFails
@@ -78,7 +80,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     def "produces a sensible error when there is a failure starting a worker daemon"() {
         executer.withStackTraceChecksDisabled()
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask) {
@@ -104,11 +106,11 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when a parameter can't be serialized to the worker in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
         withParameterMemberThatFailsSerialization()
 
         buildFile << """
-            $alternateRunnable
+            ${fixture.alternateRunnable}
 
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
@@ -141,11 +143,11 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
     @Unroll
     def "produces a sensible error when a parameter can't be de-serialized in the worker in #isolationMode"() {
         def parameterJar = file("parameter.jar")
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
         withParameterMemberThatFailsDeserialization()
 
         buildFile << """  
-            $alternateRunnable
+            ${fixture.alternateRunnable}
 
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = IsolationMode.$isolationMode
@@ -178,10 +180,10 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error even if the action failure cannot be fully serialized in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
-            $alternateRunnable
+            ${fixture.alternateRunnable}
 
             task runAgainInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
@@ -214,7 +216,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when the runnable cannot be instantiated in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             $runnableThatFailsInstantiation
@@ -239,7 +241,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when parameters are incorrect in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             $runnableWithDifferentConstructor
@@ -264,7 +266,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
 
     @Unroll
     def "produces a sensible error when worker configuration is incorrect in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             $runnableWithDifferentConstructor
@@ -425,7 +427,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
             $parameterClassWithUnserializableMember
         """
 
-        addImportToBuildScript("org.gradle.other.FooWithUnserializableBar")
+        fixture.addImportToBuildScript("org.gradle.other.FooWithUnserializableBar")
     }
 
     void withParameterMemberThatFailsDeserialization() {
@@ -439,7 +441,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
             $classThatFailsDeserialization
         """
 
-        addImportToBuildScript("org.gradle.other.FooWithUnserializableBar")
+        fixture.addImportToBuildScript("org.gradle.other.FooWithUnserializableBar")
     }
 
     String getRunnableWithDifferentConstructor() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorErrorHandlingIntegrationTest.groovy
@@ -30,7 +30,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
-            $runnableThatFails
+            ${fixture.runnableThatFails}
 
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
@@ -56,7 +56,7 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
-            $runnableThatFails
+            ${fixture.runnableThatFails}
             $workerTaskThatWaits
 
             task runInWorker(type: WorkerTaskThatWaits) {
@@ -296,28 +296,6 @@ class WorkerExecutorErrorHandlingIntegrationTest extends AbstractWorkerExecutorI
         } else {
             return "Unrecognized option: -foo"
         }
-    }
-
-    String getRunnableThatFails() {
-        return """
-            public class RunnableThatFails implements Runnable {
-                private final File outputDir;
-                
-                @javax.inject.Inject
-                public RunnableThatFails(List<String> files, File outputDir, Foo foo) { 
-                    this.outputDir = outputDir;
-                }
-
-                public void run() {
-                    try {
-                        throw new RuntimeException("Failure from runnable");
-                    } finally {
-                        outputDir.mkdirs();
-                        new File(outputDir, "finished").createNewFile();
-                    }                    
-                }
-            }
-        """
     }
 
     String getWorkerTaskThatWaits() {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -22,6 +22,8 @@ import org.gradle.test.fixtures.server.http.BlockingHttpServer
 import org.junit.Rule
 import spock.lang.Unroll
 
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
 @IntegrationTestTimeout(120)
 @Unroll
 class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
@@ -32,7 +34,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
     def "can create and use a worker runnable defined in buildSrc in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -51,7 +53,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "can create and use a worker runnable defined in build script in #isolationMode"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -97,7 +99,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "re-uses an existing idle worker daemon"() {
         executer.withWorkerDaemonsExpirationDisabled()
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask) {
@@ -118,7 +120,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "starts a new worker daemon when existing worker daemons are incompatible"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             task runInDaemon(type: WorkerTask)
@@ -145,7 +147,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         blockingServer.start()
         blockingServer.expectConcurrent("runInDaemon", "startNewDaemon")
 
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
         withBlockingRunnableClassInBuildSrc("http://localhost:${blockingServer.port}")
 
         buildFile << """
@@ -174,7 +176,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "re-uses an existing compatible worker daemon when a different runnable is executed"() {
         executer.withWorkerDaemonsExpirationDisabled()
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
         withAlternateRunnableClassInBuildSrc()
 
         buildFile << """
@@ -198,7 +200,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "throws if worker used from a thread with no current build operation in #isolationMode"() {
         given:
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         and:
         buildFile << """
@@ -246,14 +248,14 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "can set a custom display name for work items in #isolationMode"() {
-        withRunnableClassInBuildSrc()
-
+        given:
+        fixture.withRunnableClassInBuildSrc()
         buildFile << """
             task runInWorker(type: WorkerTask) {
                 isolationMode = $isolationMode
                 displayName = "Test Work"
             }
-        """.stripIndent()
+        """
 
         when:
         succeeds("runInWorker")
@@ -271,7 +273,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "can use a parameter that references classes in other packages in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
         withParameterClassReferencingClassInAnotherPackage()
 
         buildFile << """
@@ -289,7 +291,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
 
     def "can set isolation mode using fork mode"() {
         executer.withWorkerDaemonsExpirationDisabled()
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {
@@ -311,7 +313,7 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
     }
 
     def "classloader is not isolated when using IsolationMode.NONE"() {
-        withRunnableClassInBuildScript()
+        fixture.withRunnableClassInBuildScript()
 
         buildFile << """
             class MutableItem {
@@ -421,16 +423,36 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
             ${getBlockingRunnableThatCreatesFiles(url)}
         """
 
-        addImportToBuildScript("org.gradle.test.BlockingRunnable")
+        fixture.addImportToBuildScript("org.gradle.test.BlockingRunnable")
     }
 
     void withAlternateRunnableClassInBuildSrc() {
         file("buildSrc/src/main/java/org/gradle/test/AlternateRunnable.java") << """
             package org.gradle.test;
 
-            $alternateRunnable
+            ${fixture.alternateRunnable}
         """
 
-        addImportToBuildScript("org.gradle.test.AlternateRunnable")
+        fixture.addImportToBuildScript("org.gradle.test.AlternateRunnable")
+    }
+
+    void withRunnableClassInExternalJar(File runnableJar) {
+        file("buildSrc").deleteDir()
+
+        def builder = artifactBuilder()
+        builder.sourceFile("org/gradle/test/TestRunnable.java") << """
+            package org.gradle.test;
+
+            $fixture.runnableThatCreatesFiles
+        """
+        builder.sourceFile("org/gradle/other/Foo.java") << """
+            $fixture.parameterClass
+        """
+        builder.sourceFile("org/gradle/test/FileHelper.java") << """
+            $fixture.fileHelperClass
+        """
+        builder.buildJar(runnableJar)
+
+        fixture.addImportToBuildScript("org.gradle.test.TestRunnable")
     }
 }

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorIntegrationTest.groovy
@@ -259,7 +259,12 @@ class WorkerExecutorIntegrationTest extends AbstractWorkerExecutorIntegrationTes
         succeeds("runInWorker")
 
         then:
-        buildOperations.hasOperation("Test Work")
+        def operation = buildOperations.only(ExecuteWorkItemBuildOperationType)
+        operation.displayName == "Test Work"
+        with (operation.details) {
+            className == "org.gradle.test.TestRunnable"
+            displayName == "Test Work"
+        }
 
         where:
         isolationMode << ISOLATION_MODES

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorLoggingIntegrationTest.groovy
@@ -19,12 +19,14 @@ package org.gradle.workers.internal
 import spock.lang.Timeout
 import spock.lang.Unroll
 
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
 @Timeout(120)
 class WorkerExecutorLoggingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 
     @Unroll
     def "worker lifecycle is logged in #isolationMode"() {
-        withRunnableClassInBuildSrc()
+        fixture.withRunnableClassInBuildSrc()
 
         buildFile << """
             task runInWorker(type: WorkerTask) {

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorNestingIntegrationTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import org.gradle.internal.work.DefaultConditionalExecutionQueue
 import spock.lang.Unroll
 
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
 @IntegrationTestTimeout(120)
 class WorkerExecutorNestingIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
 

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorParallelIntegrationTest.groovy
@@ -23,6 +23,8 @@ import org.junit.Rule
 import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
+import static org.gradle.workers.fixtures.WorkerExecutorFixture.ISOLATION_MODES
+
 @IntegrationTestTimeout(120)
 @IgnoreIf({ GradleContextualExecuter.parallel })
 class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegrationTest {
@@ -813,7 +815,7 @@ class WorkerExecutorParallelIntegrationTest extends AbstractWorkerExecutorIntegr
                 public void run() {
                     System.out.println("Running \${itemName}...")
                     new URI("http", null, "localhost", ${blockingHttpServer.getPort()}, "/\${itemName}", null, null).toURL().text
-                    File outputDir = new File("${outputFileDirPath}")
+                    File outputDir = new File("${fixture.outputFileDirPath}")
                     File outputFile = new File(outputDir, itemName)
                     FileHelper.write(id, outputFile)
                 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.BuildOperationRef;
+import org.gradle.internal.operations.CallableBuildOperation;
+
+public abstract class AbstractWorker implements Worker {
+
+    public static final Result RESULT = new Result();
+
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    AbstractWorker(BuildOperationExecutor buildOperationExecutor) {
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public DefaultWorkResult execute(ActionExecutionSpec spec) {
+        return execute(spec, buildOperationExecutor.getCurrentOperation());
+    }
+
+    DefaultWorkResult executeWrappedInBuildOperation(final ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation, final Work work) {
+        return buildOperationExecutor.call(new CallableBuildOperation<DefaultWorkResult>() {
+            @Override
+            public DefaultWorkResult call(BuildOperationContext context) {
+                DefaultWorkResult result = work.execute(spec);
+                context.setResult(RESULT);
+                return result;
+            }
+
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                return BuildOperationDescriptor.displayName(spec.getDisplayName())
+                    .parent(parentBuildOperation)
+                    .details(new Details(spec.getImplementationClass().getName(), spec.getDisplayName()));
+            }
+        });
+    }
+
+    interface Work {
+        DefaultWorkResult execute(ActionExecutionSpec spec);
+    }
+
+    static class Details implements ExecuteWorkItemBuildOperationType.Details {
+
+        private final String className;
+        private final String displayName;
+
+        public Details(String className, String displayName) {
+            this.className = className;
+            this.displayName = displayName;
+        }
+
+        @Override
+        public String getClassName() {
+            return className;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return displayName;
+        }
+
+    }
+
+    static class Result implements ExecuteWorkItemBuildOperationType.Result {
+    }
+
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/AbstractWorker.java
@@ -43,6 +43,7 @@ public abstract class AbstractWorker implements Worker {
             public DefaultWorkResult call(BuildOperationContext context) {
                 DefaultWorkResult result = work.execute(spec);
                 context.setResult(RESULT);
+                context.failed(result.getException());
                 return result;
             }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ExecuteWorkItemBuildOperationType.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ExecuteWorkItemBuildOperationType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+/**
+ * @since 5.1
+ */
+public interface ExecuteWorkItemBuildOperationType extends BuildOperationType<ExecuteWorkItemBuildOperationType.Details, ExecuteWorkItemBuildOperationType.Result> {
+
+    interface Details {
+        /**
+         * Returns the fully-qualified class name of work item's action.
+         */
+        String getClassName();
+
+        /**
+         * Returns the display name of the work item.
+         */
+        String getDisplayName();
+    }
+
+    interface Result {
+    }
+
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/NoIsolationWorkerFactory.java
@@ -17,10 +17,7 @@
 package org.gradle.workers.internal;
 
 import org.gradle.api.internal.InstantiatorFactory;
-import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationExecutor;
-import org.gradle.internal.operations.CallableBuildOperation;
-import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.DefaultServiceRegistry;
@@ -52,17 +49,12 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
     @Override
     public Worker getWorker(final DaemonForkOptions forkOptions) {
         final WorkerExecutor workerExecutor = this.workerExecutor;
-        return new Worker() {
+        return new AbstractWorker(buildOperationExecutor) {
             @Override
-            public DefaultWorkResult execute(ActionExecutionSpec spec) {
-                return execute(spec, buildOperationExecutor.getCurrentOperation());
-            }
-
-            @Override
-            public DefaultWorkResult execute(final ActionExecutionSpec spec, final BuildOperationRef parentBuildOperation) {
-                return buildOperationExecutor.call(new CallableBuildOperation<DefaultWorkResult>() {
+            public DefaultWorkResult execute(ActionExecutionSpec spec, BuildOperationRef parentBuildOperation) {
+                return executeWrappedInBuildOperation(spec, parentBuildOperation, new Work() {
                     @Override
-                    public DefaultWorkResult call(BuildOperationContext context) {
+                    public DefaultWorkResult execute(ActionExecutionSpec spec) {
                         DefaultWorkResult result;
                         try {
                             WorkerProtocol workerServer = new DefaultWorkerServer(actionInstantiator);
@@ -73,11 +65,6 @@ public class NoIsolationWorkerFactory implements WorkerFactory {
                             workerExecutor.await();
                         }
                         return result;
-                    }
-
-                    @Override
-                    public BuildOperationDescriptor.Builder description() {
-                        return BuildOperationDescriptor.displayName(spec.getDisplayName()).parent(parentBuildOperation);
                     }
                 });
             }

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/WorkerDaemonFactoryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.workers.internal
 
+import org.gradle.internal.operations.BuildOperationContext
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationRef
 import spock.lang.Specification
@@ -57,8 +58,8 @@ class WorkerDaemonFactoryTest extends Specification {
         1 * clientsManager.reserveNewClient(WorkerDaemonServer.class, options) >> client
 
         then:
-        1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
-        1 * client.execute(spec)
+        1 * buildOperationExecutor.call(_) >> { args -> args[0].call(Stub(BuildOperationContext)) }
+        1 * client.execute(spec) >> new DefaultWorkResult(true, null)
 
         then:
         1 * clientsManager.release(client)
@@ -72,8 +73,8 @@ class WorkerDaemonFactoryTest extends Specification {
         1 * clientsManager.reserveIdleClient(options) >> client
 
         then:
-        1 * buildOperationExecutor.call(_) >> { args -> args[0].call() }
-        1 * client.execute(spec)
+        1 * buildOperationExecutor.call(_) >> { args -> args[0].call(Stub(BuildOperationContext)) }
+        1 * client.execute(spec) >> new DefaultWorkResult(true, null)
 
         then:
         1 * clientsManager.release(client)

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -116,6 +116,28 @@ class WorkerExecutorFixture {
         """
     }
 
+    String getRunnableThatFails(Class<? extends RuntimeException> exceptionClass = RuntimeException.class, String message = "Failure from runnable") {
+        return """
+            public class RunnableThatFails implements Runnable {
+                private final File outputDir;
+                
+                @javax.inject.Inject
+                public RunnableThatFails(List<String> files, File outputDir, Foo foo) { 
+                    this.outputDir = outputDir;
+                }
+
+                public void run() {
+                    try {
+                        throw new ${exceptionClass.name}("$message");
+                    } finally {
+                        outputDir.mkdirs();
+                        new File(outputDir, "finished").createNewFile();
+                    }                    
+                }
+            }
+        """
+    }
+
     void withParameterClassInBuildSrc() {
         file("buildSrc/src/main/java/org/gradle/other/Foo.java") << """
             package org.gradle.other;

--- a/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
+++ b/subprojects/workers/src/testFixtures/groovy/org/gradle/workers/fixtures/WorkerExecutorFixture.groovy
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.fixtures
+
+import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
+import org.gradle.util.TextUtil
+import org.gradle.workers.IsolationMode
+
+class WorkerExecutorFixture {
+    public static final ISOLATION_MODES = (IsolationMode.values() - IsolationMode.AUTO).collect { "IsolationMode.${it.toString()}" }
+    def outputFileDir
+    def outputFileDirPath
+    def list = [ 1, 2, 3 ]
+    private final TestNameTestDirectoryProvider temporaryFolder
+
+    WorkerExecutorFixture(TestNameTestDirectoryProvider temporaryFolder) {
+        this.temporaryFolder = temporaryFolder
+        this.outputFileDir = temporaryFolder.file("build/workers")
+        outputFileDirPath = TextUtil.normaliseFileSeparators(outputFileDir.absolutePath)
+    }
+
+    def prepareTaskTypeUsingWorker() {
+        buildFile << """
+            import org.gradle.workers.*
+            $taskTypeUsingWorker
+        """
+    }
+
+    String getTaskTypeUsingWorker() {
+        withParameterClassInBuildSrc()
+        withFileHelperClassInBuildSrc()
+
+        return """
+            import javax.inject.Inject
+            import org.gradle.other.Foo
+
+            class WorkerTask extends DefaultTask {
+                def list = $list
+                def outputFileDirPath = "${outputFileDirPath}/\${name}"
+                def additionalForkOptions = {}
+                def runnableClass = TestRunnable.class
+                def additionalClasspath = project.layout.files()
+                def foo = new Foo()
+                def displayName = null
+                def isolationMode = IsolationMode.AUTO
+                def forkMode = null
+
+                @Inject
+                WorkerExecutor getWorkerExecutor() {
+                    throw new UnsupportedOperationException()
+                }
+
+                @TaskAction
+                void executeTask() {
+                    workerExecutor.submit(runnableClass) {
+                        isolationMode = this.isolationMode
+                        displayName = this.displayName
+                        if (isolationMode == IsolationMode.PROCESS) {
+                            forkOptions.maxHeapSize = "64m"
+                        }
+                        forkOptions(additionalForkOptions)
+                        classpath(additionalClasspath)
+                        params = [ list.collect { it as String }, new File(outputFileDirPath), foo ]
+                        if (this.forkMode != null) {
+                            forkMode = this.forkMode
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    String getRunnableThatCreatesFiles() {
+        return """
+            import java.io.File;
+            import java.util.List;
+            import org.gradle.other.Foo;
+            import org.gradle.test.FileHelper;
+            import java.util.UUID;
+            import javax.inject.Inject;
+
+            public class TestRunnable implements Runnable {
+                private final List<String> files;
+                protected final File outputDir;
+                private final Foo foo;
+                private static final String id = UUID.randomUUID().toString();
+
+                @Inject
+                public TestRunnable(List<String> files, File outputDir, Foo foo) {
+                    this.files = files;
+                    this.outputDir = outputDir;
+                    this.foo = foo;
+                }
+
+                public void run() {
+                    for (String name : files) {
+                        File outputFile = new File(outputDir, name);
+                        FileHelper.write(id, outputFile);
+                    }
+                }
+            }
+        """
+    }
+
+    void withParameterClassInBuildSrc() {
+        file("buildSrc/src/main/java/org/gradle/other/Foo.java") << """
+            package org.gradle.other;
+
+            import java.io.Serializable;
+
+            public class Foo implements Serializable { }
+        """
+    }
+
+    void withFileHelperClassInBuildSrc() {
+        file("buildSrc/src/main/java/org/gradle/test/FileHelper.java") << """
+            $fileHelperClass
+        """
+    }
+
+    void withRunnableClassInBuildSrc() {
+        file("buildSrc/src/main/java/org/gradle/test/TestRunnable.java") << """
+            package org.gradle.test;
+
+            $runnableThatCreatesFiles
+        """
+
+        addImportToBuildScript("org.gradle.test.TestRunnable")
+    }
+
+    void withRunnableClassInBuildScript() {
+        buildFile << """
+            $runnableThatCreatesFiles
+        """
+    }
+
+    void withJava7CompatibleClasses() {
+        file('buildSrc/build.gradle') << """
+            tasks.withType(JavaCompile) {
+                sourceCompatibility = "1.7"
+                targetCompatibility = "1.7"
+            }
+        """
+    }
+
+    String getParameterClass() {
+        return """
+            package org.gradle.other;
+
+            import java.io.Serializable;
+
+            public class Foo implements Serializable { }
+        """
+    }
+
+    String getFileHelperClass() {
+        return """
+            package org.gradle.test;
+            
+            import java.io.File;
+            import java.io.PrintWriter;
+            import java.io.BufferedWriter;
+            import java.io.FileWriter;
+            
+            public class FileHelper {
+                static void write(String id, File outputFile) {
+                    PrintWriter out = null;
+                    try {
+                        outputFile.getParentFile().mkdirs();
+                        outputFile.createNewFile();
+                        out = new PrintWriter(new BufferedWriter(new FileWriter(outputFile)));
+                        out.print(id);
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        if (out != null) {
+                            out.close();
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+    void addImportToBuildScript(String className) {
+        buildFile.text = """
+            import ${className}
+            ${buildFile.text}
+        """
+    }
+
+    String getAlternateRunnable() {
+        return """
+            import java.io.File;
+            import java.util.List;
+            import org.gradle.other.Foo;
+            import java.net.URL;
+            import javax.inject.Inject;
+
+            public class AlternateRunnable extends TestRunnable {
+                @Inject
+                public AlternateRunnable(List<String> files, File outputDir, Foo foo) {
+                    super(files, outputDir, foo);
+                }
+            }
+        """
+    }
+
+    def getBuildFile() {
+        return file("build.gradle")
+    }
+
+    private def file(Object... path) {
+        temporaryFolder.file(path)
+    }
+}

--- a/subprojects/workers/workers.gradle.kts
+++ b/subprojects/workers/workers.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     compile(library("jcip"))
 
     integTestCompile(project(":internalIntegTesting"))
+    testFixturesApi(project(":internalTesting"))
 }
 
 gradlebuildJava {


### PR DESCRIPTION
This PR introduces a new `OperationType.WORK_ITEM` and adds specific `ProgressEvent` implementations. For backwards compatibility, if the new `OperationType` is not requested but `OperationType.GENERIC` is, we continue to report such operations as a generic build operations.

Moreover, worker executions now use their own `BuildOperationType` and report failures as part of the build operation.

/cc @ldaley @ghale 