### PR TITLE
WIP - Support creation of providers with default values

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -28,6 +28,7 @@ import org.gradle.api.reflect.ObjectInstantiationException;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * A factory for creating various kinds of model objects.
@@ -103,6 +104,25 @@ public interface ObjectFactory {
      * @since 4.3
      */
     <T> Property<T> property(Class<T> valueType);
+
+    /**
+     * Creates a {@link Property} implementation to hold values of the given type. If nothing else
+     * sets this property value, it will be computed from the supplied callable.
+     *
+     * <p>For certain types, there are more specialized property factory methods available:</p>
+     * <ul>
+     * <li>For {@link List} properties, you should use {@link #listProperty(Class)}.</li>
+     * <li>For {@link Set} properties, you should use {@link #setProperty(Class)}.</li>
+     * <li>For {@link org.gradle.api.file.Directory} properties, you should use {@link #directoryProperty()}.</li>
+     * <li>For {@link org.gradle.api.file.RegularFile} properties, you should use {@link #fileProperty()}.</li>
+     * </ul>
+     *
+     * @param valueType The type of the property.
+     * @param defaultValue the default value generator
+     * @return The property. Never returns null.
+     * @since 5.1
+     */
+    <T> Property<T> property(Class<T> valueType, Callable<? extends T> defaultValue);
 
     /**
      * Creates a {@link ListProperty} implementation to hold a {@link List} of the given element type {@code T}. The property has no initial value.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.file.collections.FileCollectionAdapter;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.internal.model.InstantiatorBackedObjectFactory;
+import org.gradle.api.internal.provider.DefaultProviderFactory;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -76,7 +77,7 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
     // Used by the Javascript plugins
     @Deprecated
     public DefaultSourceDirectorySet(String name, String displayName, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
-        this(name, displayName, fileResolver, directoryFileTreeFactory, new InstantiatorBackedObjectFactory(DirectInstantiator.INSTANCE));
+        this(name, displayName, fileResolver, directoryFileTreeFactory, new InstantiatorBackedObjectFactory(DirectInstantiator.INSTANCE, new DefaultProviderFactory()));
     }
 
     // Used by the Kotlin plugin

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -32,6 +32,7 @@ import org.gradle.api.internal.provider.DefaultSetProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.Cast;
@@ -43,6 +44,7 @@ import org.gradle.util.DeprecationLogger;
 import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 public class DefaultObjectFactory implements ObjectFactory {
     private final Instantiator instantiator;
@@ -50,13 +52,15 @@ public class DefaultObjectFactory implements ObjectFactory {
     private final FileResolver fileResolver;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
     private final FilePropertyFactory filePropertyFactory;
+    private final ProviderFactory providerFactory;
 
-    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory) {
+    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, ProviderFactory providerFactory) {
         this.instantiator = instantiator;
         this.namedObjectInstantiator = namedObjectInstantiator;
         this.fileResolver = fileResolver;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         this.filePropertyFactory = filePropertyFactory;
+        this.providerFactory = providerFactory;
     }
 
     @Override
@@ -111,6 +115,13 @@ public class DefaultObjectFactory implements ObjectFactory {
         }
 
         return new DefaultPropertyState<T>(valueType);
+    }
+
+    @Override
+    public <T> Property<T> property(Class<T> valueType, Callable<? extends T> defaultValue) {
+        Property<T> property = property(valueType);
+        property.set(providerFactory.provider(defaultValue));
+        return property;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -23,15 +23,20 @@ import org.gradle.api.internal.provider.DefaultPropertyState;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.reflect.Instantiator;
 
+import java.util.concurrent.Callable;
+
 public class InstantiatorBackedObjectFactory implements ObjectFactory {
     private final Instantiator instantiator;
+    private final ProviderFactory providerFactory;
 
-    public InstantiatorBackedObjectFactory(Instantiator instantiator) {
+    public InstantiatorBackedObjectFactory(Instantiator instantiator, ProviderFactory providerFactory) {
         this.instantiator = instantiator;
+        this.providerFactory = providerFactory;
     }
 
     @Override
@@ -47,6 +52,13 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     @Override
     public <T> Property<T> property(Class<T> valueType) {
         return new DefaultPropertyState<T>(valueType);
+    }
+
+    @Override
+    public <T> Property<T> property(Class<T> valueType, Callable<? extends T> defaultValue) {
+        Property<T> property = property(valueType);
+        property.set(providerFactory.provider(defaultValue));
+        return property;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -320,13 +320,13 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultMemoryManager(osMemoryInfo, jvmMemoryInfo, listenerManager, executorFactory);
     }
 
-    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, ProviderFactory providerFactory) {
         return new DefaultObjectFactory(
             instantiatorFactory.injectAndDecorate(services),
             NamedObjectInstantiator.INSTANCE,
             fileResolver,
             directoryFileTreeFactory,
-            new DefaultFilePropertyFactory(fileResolver));
+            new DefaultFilePropertyFactory(fileResolver), providerFactory);
     }
 
     ProviderFactory createProviderFactory() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -62,6 +62,7 @@ import org.gradle.api.internal.tasks.DefaultTaskContainerFactory;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.tasks.TaskStatistics;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
@@ -300,9 +301,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return ConfigurationTargetIdentifier.of(project);
     }
 
-    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory) {
+    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, ProviderFactory providerFactory) {
         Instantiator instantiator = instantiatorFactory.injectAndDecorate(ProjectScopeServices.this);
-        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory);
+        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory, providerFactory);
     }
 
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -19,13 +19,13 @@ package org.gradle.api.internal.model
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
+import org.gradle.api.internal.provider.DefaultProviderFactory
 import org.gradle.internal.reflect.Instantiator
 import spock.lang.Specification
 import spock.lang.Unroll
 
-
 class DefaultObjectFactoryTest extends Specification {
-    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory))
+    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory), new DefaultProviderFactory())
 
     def "can create a property"() {
         expect:
@@ -87,6 +87,29 @@ class DefaultObjectFactoryTest extends Specification {
         def property = factory.setProperty(String)
         !property.present
         property.getOrNull() == null
+    }
+
+    def "can create a property with a default value"() {
+        given:
+        def property = factory.property(String) {
+            "foo"
+        }
+
+        expect:
+        property.present
+        property.get() == "foo"
+    }
+
+    def "doesn't call the default value provider if overridden"() {
+        given:
+        def property = factory.property(String) {
+            throw new AssertionError("this should never be called")
+        }
+        property.set("foo")
+
+        expect:
+        property.present
+        property.get() == "foo"
     }
 
 }

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -71,7 +71,7 @@ class TestUtil {
     private static ObjectFactory objFactory(FileResolver fileResolver) {
         DefaultServiceRegistry services = new DefaultServiceRegistry()
         services.add(ProviderFactory, new DefaultProviderFactory())
-        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver))
+        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver), new DefaultProviderFactory())
     }
 
 


### PR DESCRIPTION
### Context

This commit improves the provider API by allowing to set
a default value provider when creating the property instance.
This leads to more idiomatic code in plugins, in particular
when they need to provide a default value.

