### PR TITLE
TAPI: Make JavaCompile result orthogonal to task outcome

### DIFF
--- a/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
+++ b/subprojects/language-java/src/crossVersionTest/groovy/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskOperationResultCrossVersionTest.groovy
@@ -23,14 +23,14 @@ import org.gradle.integtests.tooling.fixture.ToolingApiVersion
 import org.gradle.language.fixtures.HelperProcessorFixture
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.task.TaskSuccessResult
-import org.gradle.tooling.events.task.java.JavaCompileTaskSuccessResult
+import org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult
 
 import java.time.Duration
 
-import static org.gradle.tooling.events.task.java.JavaCompileTaskSuccessResult.AnnotationProcessorResult.Type.ISOLATING
+import static org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult.AnnotationProcessorResult.Type.ISOLATING
 
 @ToolingApiVersion('>=5.1')
-class JavaCompileTaskSuccessResultCrossVersionTest extends ToolingApiSpecification {
+class JavaCompileTaskOperationResultCrossVersionTest extends ToolingApiSpecification {
 
     void setup() {
         settingsFile << """
@@ -63,8 +63,8 @@ class JavaCompileTaskSuccessResultCrossVersionTest extends ToolingApiSpecificati
         then:
         def operation = events.operation("Task :compileJava")
         operation.task
-        operation.result instanceof JavaCompileTaskSuccessResult
-        with((JavaCompileTaskSuccessResult) operation.result) {
+        operation.result instanceof JavaCompileTaskOperationResult
+        with((JavaCompileTaskOperationResult) operation.result) {
             annotationProcessorResults.size() == 1
             with(annotationProcessorResults.first()) {
                 className == 'HelperProcessor'
@@ -76,8 +76,8 @@ class JavaCompileTaskSuccessResultCrossVersionTest extends ToolingApiSpecificati
         and:
         def processorOperation = events.operation("Task :processor:compileJava")
         processorOperation.task
-        processorOperation.result instanceof JavaCompileTaskSuccessResult
-        ((JavaCompileTaskSuccessResult) processorOperation.result).annotationProcessorResults.empty
+        processorOperation.result instanceof JavaCompileTaskOperationResult
+        ((JavaCompileTaskOperationResult) processorOperation.result).annotationProcessorResults.empty
     }
 
     @TargetGradleVersion("<5.1")
@@ -89,7 +89,7 @@ class JavaCompileTaskSuccessResultCrossVersionTest extends ToolingApiSpecificati
         def operation = events.operation("Task :compileJava")
         operation.task
         operation.result instanceof TaskSuccessResult
-        !(operation.result instanceof JavaCompileTaskSuccessResult)
+        !(operation.result instanceof JavaCompileTaskOperationResult)
     }
 
     private ProgressEvents runBuild(task) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskSuccessResultPostProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/tooling/JavaCompileTaskSuccessResultPostProcessor.java
@@ -25,7 +25,7 @@ import org.gradle.internal.operations.OperationFinishEvent;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationProgressEvent;
 import org.gradle.internal.operations.OperationStartEvent;
-import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskSuccessResult.InternalAnnotationProcessorResult;
+import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult.InternalAnnotationProcessorResult;
 import org.gradle.tooling.internal.provider.events.AbstractTaskResult;
 import org.gradle.tooling.internal.provider.events.DefaultAnnotationProcessorResult;
 import org.gradle.tooling.internal.provider.events.DefaultJavaCompileTaskSuccessResult;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultAnnotationProcessorResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultAnnotationProcessorResult.java
@@ -16,7 +16,7 @@
 
 package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskSuccessResult.InternalAnnotationProcessorResult;
+import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult.InternalAnnotationProcessorResult;
 
 import java.io.Serializable;
 import java.time.Duration;

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultJavaCompileTaskSuccessResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultJavaCompileTaskSuccessResult.java
@@ -16,12 +16,12 @@
 
 package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskSuccessResult;
+import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class DefaultJavaCompileTaskSuccessResult extends DefaultTaskSuccessResult implements InternalJavaCompileTaskSuccessResult {
+public class DefaultJavaCompileTaskSuccessResult extends DefaultTaskSuccessResult implements InternalJavaCompileTaskOperationResult {
 
     private final List<InternalAnnotationProcessorResult> annotationProcessorResults;
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/java/DefaultAnnotationProcessorResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/java/DefaultAnnotationProcessorResult.java
@@ -16,7 +16,7 @@
 
 package org.gradle.tooling.events.task.internal.java;
 
-import org.gradle.tooling.events.task.java.JavaCompileTaskSuccessResult.AnnotationProcessorResult;
+import org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult.AnnotationProcessorResult;
 
 import java.time.Duration;
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/java/DefaultJavaCompileTaskSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/java/DefaultJavaCompileTaskSuccessResult.java
@@ -17,12 +17,12 @@
 package org.gradle.tooling.events.task.internal.java;
 
 import org.gradle.tooling.events.task.internal.DefaultTaskSuccessResult;
-import org.gradle.tooling.events.task.java.JavaCompileTaskSuccessResult;
+import org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult;
 
 import javax.annotation.Nullable;
 import java.util.List;
 
-public class DefaultJavaCompileTaskSuccessResult extends DefaultTaskSuccessResult implements JavaCompileTaskSuccessResult {
+public class DefaultJavaCompileTaskSuccessResult extends DefaultTaskSuccessResult implements JavaCompileTaskOperationResult {
 
     private final List<AnnotationProcessorResult> annotationProcessorResults;
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/java/JavaCompileTaskOperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/java/JavaCompileTaskOperationResult.java
@@ -17,19 +17,21 @@
 package org.gradle.tooling.events.task.java;
 
 import org.gradle.api.Incubating;
-import org.gradle.tooling.events.task.TaskSuccessResult;
+import org.gradle.tooling.events.task.TaskOperationResult;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.List;
 
 /**
- * Describes the successful result of a {@code JavaCompile} task.
+ * Describes the result of a {@code JavaCompile} task.
+ *
+ * <p>Currently, this result is only reported for successful tasks.
  *
  * @since 5.1
  */
 @Incubating
-public interface JavaCompileTaskSuccessResult extends TaskSuccessResult {
+public interface JavaCompileTaskOperationResult extends TaskOperationResult {
 
     /**
      * Returns results of used annotation processors, if available.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -41,7 +41,7 @@ import org.gradle.tooling.events.task.internal.DefaultTaskStartEvent;
 import org.gradle.tooling.events.task.internal.DefaultTaskSuccessResult;
 import org.gradle.tooling.events.task.internal.java.DefaultAnnotationProcessorResult;
 import org.gradle.tooling.events.task.internal.java.DefaultJavaCompileTaskSuccessResult;
-import org.gradle.tooling.events.task.java.JavaCompileTaskSuccessResult.AnnotationProcessorResult;
+import org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult.AnnotationProcessorResult;
 import org.gradle.tooling.events.test.JvmTestKind;
 import org.gradle.tooling.events.test.TestFinishEvent;
 import org.gradle.tooling.events.test.TestOperationDescriptor;
@@ -59,8 +59,8 @@ import org.gradle.tooling.internal.consumer.DefaultFailure;
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 import org.gradle.tooling.internal.protocol.InternalFailure;
 import org.gradle.tooling.internal.protocol.events.InternalFailureResult;
-import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskSuccessResult;
-import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskSuccessResult.InternalAnnotationProcessorResult;
+import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult;
+import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult.InternalAnnotationProcessorResult;
 import org.gradle.tooling.internal.protocol.events.InternalJvmTestDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalOperationDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
@@ -325,8 +325,8 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
         }
 
         if (result instanceof InternalTaskSuccessResult) {
-            if (result instanceof InternalJavaCompileTaskSuccessResult) {
-                List<AnnotationProcessorResult> annotationProcessorResults = toAnnotationProcessorResults(((InternalJavaCompileTaskSuccessResult) result).getAnnotationProcessorResults());
+            if (result instanceof InternalJavaCompileTaskOperationResult) {
+                List<AnnotationProcessorResult> annotationProcessorResults = toAnnotationProcessorResults(((InternalJavaCompileTaskOperationResult) result).getAnnotationProcessorResults());
                 return new DefaultJavaCompileTaskSuccessResult(result.getStartTime(), result.getEndTime(), ((InternalTaskSuccessResult) result).isUpToDate(), fromCache, annotationProcessorResults);
             }
             return new DefaultTaskSuccessResult(result.getStartTime(), result.getEndTime(), ((InternalTaskSuccessResult) result).isUpToDate(), fromCache);

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalJavaCompileTaskOperationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalJavaCompileTaskOperationResult.java
@@ -27,7 +27,7 @@ import java.util.List;
  *
  * @since 5.1
  */
-public interface InternalJavaCompileTaskSuccessResult extends InternalTaskSuccessResult {
+public interface InternalJavaCompileTaskOperationResult extends InternalTaskResult {
 
     @Nullable
     List<InternalAnnotationProcessorResult> getAnnotationProcessorResults();


### PR DESCRIPTION
While we currently only report rich results for successful `JavaCompile`
tasks, we might change that in the future. Therefore, this commit
renames `JavaCompileTaskSuccessResult` to
`JavaCompileTaskOperationResult` so we won't have to change the API
when we start reporting rich results for failed tasks as well.
There are only implementations that also implement `TaskSuccessResult`
and `InternalTaskSuccessResult`, respectively, though.