### PR TITLE
Fix for starting a single-use daemon when client has low memory

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/SingleUseDaemonIntegrationTest.groovy
@@ -49,6 +49,21 @@ class SingleUseDaemonIntegrationTest extends AbstractIntegrationSpec {
         daemons.daemon.stops()
     }
 
+    def "forks build when default client VM memory is used and user didn't specify a different limit"() {
+        executer.withCommandLineGradleOpts('-Xmx64m')
+        executer.useOnlyRequestedJvmOpts()
+        executer.requireGradleDistribution()
+
+        when:
+        succeeds()
+
+        then:
+        wasForked()
+
+        and:
+        daemons.daemon.stops()
+    }
+
     def "stops single use daemon when build fails"() {
         requireJvmArg('-Xmx64m')
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/BuildProcess.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/BuildProcess.java
@@ -20,7 +20,6 @@ import org.gradle.internal.jvm.JavaInfo;
 import org.gradle.process.internal.CurrentProcess;
 import org.gradle.process.internal.JvmOptions;
 
-import java.util.List;
 import java.util.Properties;
 
 public class BuildProcess extends CurrentProcess {
@@ -45,7 +44,7 @@ public class BuildProcess extends CurrentProcess {
         if (requiredBuildParameters.hasUserDefinedImmutableJvmArgs()) {
             immutableJvmArgsMatch = getJvmOptions().getAllImmutableJvmArgs().equals(requiredBuildParameters.getEffectiveSingleUseJvmArgs());
         }
-        if (javaHomeMatch && immutableJvmArgsMatch && !isLowDefaultMemory(requiredBuildParameters.getEffectiveSingleUseJvmArgs())) {
+        if (javaHomeMatch && immutableJvmArgsMatch && !isLowDefaultMemory(requiredBuildParameters)) {
             // Set the system properties and use this process
             Properties properties = new Properties();
             properties.putAll(requiredBuildParameters.getEffectiveSystemProperties());
@@ -58,10 +57,12 @@ public class BuildProcess extends CurrentProcess {
     /**
      * Checks whether the current process is using the default client VM setting of 64m, which is too low to run the majority of builds.
      */
-    private boolean isLowDefaultMemory(List<String> effectiveSingleUseJvmArgs) {
-        for (String arg : effectiveSingleUseJvmArgs) {
-            if (arg.startsWith("-Xmx")) {
-                return false;
+    private boolean isLowDefaultMemory(DaemonParameters daemonParameters) {
+        if (daemonParameters.hasUserDefinedImmutableJvmArgs()) {
+            for (String arg : daemonParameters.getEffectiveSingleUseJvmArgs()) {
+                if (arg.startsWith("-Xmx")) {
+                    return false;
+                }
             }
         }
         return "64m".equals(getJvmOptions().getMaxHeapSize());

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/configuration/BuildProcessTest.groovy
@@ -113,13 +113,13 @@ class BuildProcessTest extends Specification {
         given:
         def currentJvmOptions = new JvmOptions(fileResolver)
         currentJvmOptions.maxHeapSize = "64m"
-        def emptyRequest = buildParameters([])
+        def defaultRequest = buildParameters(null as Iterable)
 
         when:
         def buildProcess = new BuildProcess(currentJvm, currentJvmOptions)
 
         then:
-        !buildProcess.configureForBuild(emptyRequest)
+        !buildProcess.configureForBuild(defaultRequest)
     }
 
     def "current and requested build vm match if no arguments are requested even if the daemon defaults are applied"() {


### PR DESCRIPTION
The previous logic was testing whether the daemon parameters had
a memory setting, but not whether that setting was the default or
whether it actually came from the user. The default settings are
ignored for the purpose of forking a single-use daemon, so they
also need to be ignored in the decision whether the current VM
has enough memory.