### PR TITLE
Let init use the same Kotlin version as embedded for Kotlin DSL

### DIFF
--- a/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
+++ b/subprojects/build-init/src/main/resources/org/gradle/buildinit/tasks/templates/library-versions.properties
@@ -2,7 +2,7 @@
 junit=4.12
 slf4j=1.7.25
 scala=2.12
-kotlin=1.2.71
+kotlin=1.3.10
 scala-library=2.12.7
 commons-math=3.6.1
 groovy=2.4.15


### PR DESCRIPTION
See #7793 