### PR TITLE
[WIP] Report task dependencies to TAPI listeners

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskDescriptor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskDescriptor.java
@@ -16,23 +16,26 @@
 
 package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.internal.protocol.events.InternalTaskDescriptor;
+import org.gradle.tooling.internal.protocol.events.InternalTaskWithDependenciesDescriptor;
 
 import java.io.Serializable;
+import java.util.Set;
 
-public class DefaultTaskDescriptor implements Serializable, InternalTaskDescriptor {
+public class DefaultTaskDescriptor implements Serializable, InternalTaskWithDependenciesDescriptor {
 
     private final Object id;
     private final String taskIdentityPath;
     private final String displayName;
     private final String taskPath;
     private final Object parentId;
+    private final Set<DefaultTaskDescriptor> dependencies;
 
-    public DefaultTaskDescriptor(Object id, String taskIdentityPath, String taskPath, String displayName, Object parentId) {
+    public DefaultTaskDescriptor(Object id, String taskIdentityPath, String taskPath, String displayName, Object parentId, Set<DefaultTaskDescriptor> dependencies) {
         this.id = id;
         this.taskIdentityPath = taskIdentityPath;
         this.displayName = displayName;
         this.taskPath = taskPath;
+        this.dependencies = dependencies;
         this.parentId = parentId;
     }
 
@@ -59,6 +62,11 @@ public class DefaultTaskDescriptor implements Serializable, InternalTaskDescript
     @Override
     public Object getParentId() {
         return parentId;
+    }
+
+    @Override
+    public Set<DefaultTaskDescriptor> getDependencies() {
+        return dependencies;
     }
 
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskDependenciesCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskDependenciesCrossVersionSpec.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r51
+
+import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.events.task.TaskOperationDescriptor
+
+@ToolingApiVersion('>=5.1')
+class TaskDependenciesCrossVersionSpec extends ToolingApiSpecification {
+
+    def events = ProgressEvents.create()
+
+    void setup() {
+        buildFile << """
+            task a { enabled = false }
+            task b { dependsOn(a) }
+            task c { finalizedBy(b) }
+            task d { shouldRunAfter(c) }
+            task e { mustRunAfter(d) }
+        """
+    }
+
+    @TargetGradleVersion('>=5.1')
+    def "reports task dependencies when target version supports it"() {
+        when:
+        runBuild('a', 'b', 'c', 'd', 'e')
+
+        then:
+        task('a').dependencies.empty
+        task('b').dependencies == [task('a')] as Set
+        task('c').dependencies.empty
+        task('d').dependencies.empty
+        task('e').dependencies.empty
+    }
+
+    @TargetGradleVersion('<5.1')
+    def "returns null for unknown task dependencies when target version does not support it"() {
+        when:
+        runBuild('b')
+
+        then:
+        task('a').dependencies == null
+        task('b').dependencies == null
+    }
+
+    private void runBuild(String... tasks) {
+        withConnection {
+            ProjectConnection connection ->
+                connection.newBuild()
+                    .forTasks(tasks)
+                    .addProgressListener(events, EnumSet.of(OperationType.TASK))
+                    .run()
+        }
+    }
+
+    private TaskOperationDescriptor task(String name) {
+        events.operation("Task :$name").descriptor as TaskOperationDescriptor
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationDescriptor.java
@@ -15,7 +15,11 @@
  */
 package org.gradle.tooling.events.task;
 
+import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationDescriptor;
+
+import javax.annotation.Nullable;
+import java.util.Set;
 
 /**
  * Describes a task operation for which an event has occurred.
@@ -23,8 +27,22 @@ import org.gradle.tooling.events.OperationDescriptor;
  * @since 2.5
  */
 public interface TaskOperationDescriptor extends OperationDescriptor {
+
     /**
      * Returns the path of the task.
      */
     String getTaskPath();
+
+    /**
+     * Returns the dependencies of the task, if available.
+     *
+     * <p>The dependencies are only available for builds that use Gradle 5.1 or later.
+     *
+     * @return The dependencies of the task, if available; otherwise, {@code null}.
+     * @since 5.1
+     */
+    @Nullable
+    @Incubating
+    Set<? extends OperationDescriptor> getDependencies();
+
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskOperationDescriptor.java
@@ -21,21 +21,32 @@ import org.gradle.tooling.events.internal.DefaultOperationDescriptor;
 import org.gradle.tooling.events.task.TaskOperationDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalTaskDescriptor;
 
+import javax.annotation.Nullable;
+import java.util.Set;
+
 /**
  * Implementation of the {@code TaskOperationDescriptor} interface.
  */
 public final class DefaultTaskOperationDescriptor extends DefaultOperationDescriptor implements TaskOperationDescriptor {
 
     private final String taskPath;
+    private final Set<OperationDescriptor> dependencies;
 
-    public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, String taskPath, OperationDescriptor parent) {
+    public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath, Set<OperationDescriptor> dependencies) {
         super(descriptor, parent);
         this.taskPath = taskPath;
+        this.dependencies = dependencies;
     }
 
     @Override
     public String getTaskPath() {
         return taskPath;
+    }
+
+    @Nullable
+    @Override
+    public Set<? extends OperationDescriptor> getDependencies() {
+        return dependencies;
     }
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalTaskWithDependenciesDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalTaskWithDependenciesDescriptor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.protocol.events;
+
+import java.util.Set;
+
+/**
+ * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
+ *
+ * @since 5.1
+ */
+public interface InternalTaskWithDependenciesDescriptor extends InternalTaskDescriptor {
+    /**
+     * Returns the dependencies of the task.
+     *
+     * @return The dependencies of the task
+     */
+    Set<? extends InternalOperationDescriptor> getDependencies();
+}

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTaskOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTaskOperationsTest.groovy
@@ -355,6 +355,72 @@ class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
         }
     }
 
+    def "convert task dependencies"() {
+        given:
+        def listener = Mock(ProgressListener)
+        def adapter = createAdapter(listener)
+
+        def dependencyTaskDescriptor = Stub(InternalTaskWithDependenciesDescriptor)
+        _ * dependencyTaskDescriptor.getId() >> ':dependency'
+        _ * dependencyTaskDescriptor.getName() >> 'dependency task'
+        _ * dependencyTaskDescriptor.getParentId() >> null
+        _ * dependencyTaskDescriptor.getTaskPath() >> ':dependency:path'
+        _ * dependencyTaskDescriptor.getDependencies() >> []
+
+        def dependencyStartEvent = Stub(InternalOperationStartedProgressEvent)
+        _ * dependencyStartEvent.getEventTime() >> 800
+        _ * dependencyStartEvent.getDisplayName() >> 'task started'
+        _ * dependencyStartEvent.getDescriptor() >> dependencyTaskDescriptor
+
+        def dependencyTaskResult = Stub(InternalTaskSuccessResult)
+        _ * dependencyTaskResult.getStartTime() >> 1
+        _ * dependencyTaskResult.getEndTime() >> 2
+
+        def dependencyFinishEvent = Stub(InternalOperationFinishedProgressEvent)
+        _ * dependencyFinishEvent.getEventTime() >> 900
+        _ * dependencyFinishEvent.getDisplayName() >> 'task finished'
+        _ * dependencyFinishEvent.getDescriptor() >> dependencyTaskDescriptor
+        _ * dependencyFinishEvent.getResult() >> dependencyTaskResult
+
+        def taskDescriptor = Stub(InternalTaskWithDependenciesDescriptor)
+        _ * taskDescriptor.getId() >> ':dummy'
+        _ * taskDescriptor.getName() >> 'some task'
+        _ * taskDescriptor.getParentId() >> null
+        _ * taskDescriptor.getTaskPath() >> ':some:path'
+        _ * taskDescriptor.getDependencies() >> [dependencyTaskDescriptor]
+
+        def startEvent = Stub(InternalOperationStartedProgressEvent)
+        _ * startEvent.getEventTime() >> 1000
+        _ * startEvent.getDisplayName() >> 'task started'
+        _ * startEvent.getDescriptor() >> taskDescriptor
+
+        when:
+        adapter.onEvent(dependencyStartEvent)
+        adapter.onEvent(dependencyFinishEvent)
+
+        then:
+        2 * listener.statusChanged(_)
+
+        when:
+        adapter.onEvent(startEvent)
+
+        then:
+        1 * listener.statusChanged(_ as TaskStartEvent) >> { TaskStartEvent event ->
+            assert event.eventTime == 1000
+            assert event.displayName == "task started"
+            assert event.descriptor.name == 'some task'
+            assert event.descriptor.taskPath == ':some:path'
+            assert event.descriptor.parent == null
+            assert event.descriptor.dependencies.size() == 1
+            with(event.descriptor.dependencies[0]) {
+                assert it.name == 'dependency task'
+                assert it.taskPath == ':dependency:path'
+                assert it.parent == null
+                assert it.dependencies.empty
+            }
+        }
+    }
+
     private static BuildProgressListenerAdapter createAdapter() {
         new BuildProgressListenerAdapter([], [], [])
     }


### PR DESCRIPTION
The basic plumbing works, but there are a few things I'd like to clarify.

First, I'm not sure which tasks to consider as task dependencies for TAPI listeners. Currently, I've only included those returned by `Task.getTaskDependencies()`. Should we report finalizers/finalizing successors etc. separately or not at all?

Is it ok to call `Task.getTaskDependencies().getDependencies(task)` directly, or should I rather use `TaskExecutionGraph.getDependencies(task)`?