### PR TITLE
Add build scan tag when executed from IDEA

### DIFF
--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -128,6 +128,12 @@ open class BuildScanPlugin : Plugin<Project> {
             }
         } else {
             buildScan.tag("LOCAL")
+            if (listOf("idea.registered", "idea.active", "idea.paths.selector").map(System::getProperty).filterNotNull().isNotEmpty()) {
+                buildScan.tag("IDEA")
+                System.getProperty("idea.paths.selector")?.let { ideaVersion ->
+                    buildScan.value("IDEA version", ideaVersion)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
The `BuildScanPlugin` now tries to detect if the build has been
executed from IDEA. It also tries to add the version as a custom
value.

It seems like different versions of IDEA set different properties.
For example, I didn't see `idea.registered` and `idea.active` at
the same time, yet.

Fixes https://github.com/gradle/gradle-private/issues/1674.