### PR TITLE
Add crossVersionTests from languageJava

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -117,7 +117,7 @@ data class CIBuildModel (
             GradleSubproject("javascript"),
             GradleSubproject("jvmServices", functionalTests = false),
             GradleSubproject("languageGroovy"),
-            GradleSubproject("languageJava"),
+            GradleSubproject("languageJava", crossVersionTests = true),
             GradleSubproject("languageJvm"),
             GradleSubproject("languageNative"),
             GradleSubproject("languageScala"),


### PR DESCRIPTION
Cross-version tests were added to `languageJava` in #7744.