### PR TITLE
Fix issue with leading zero in version numbers

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/StaticVersionComparator.java
@@ -66,7 +66,11 @@ class StaticVersionComparator implements Comparator<Version> {
                 return -1;
             }
             if (is1Number && is2Number) {
-                return numericPart1.compareTo(numericPart2);
+                int result = numericPart1.compareTo(numericPart2);
+                if (result == 0) {
+                    continue;
+                }
+                return result;
             }
             // both are strings, we compare them taking into account special meaning
             Integer sm1 = SPECIAL_MEANINGS.get(part1.toLowerCase(Locale.US));

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/strategy/DefaultVersionComparatorTest.groovy
@@ -161,6 +161,43 @@ class DefaultVersionComparatorTest extends Specification {
         compare("1.a.2", "1a2") == 0 // number-word and word-number boundaries are considered separators
     }
 
+    def "compares versions that differ only in leading zeros equal"() {
+        expect:
+        compare("01.0", "1.0") == 0
+        compare("1.0", "01.0") == 0
+        compare("001.2.003", "0001.02.3") == 0
+    }
+
+    def "compares different versions that also differ in leading zeros"() {
+        expect:
+        compare(smaller, larger) < 0
+        compare(larger, smaller) > 0
+        compare(smaller, smaller) == 0
+        compare(larger, larger) == 0
+
+        where:
+        smaller        | larger
+        "1.01"         | "1.2"
+        "1.1"          | "1.02"
+        "01.0"         | "2.0"
+        "1.0"          | "02.0"
+    }
+
+    def "compares versions where earlier version parts differ only in leading zeros"() {
+        expect:
+        compare(smaller, larger) < 0
+        compare(larger, smaller) > 0
+        compare(smaller, smaller) == 0
+        compare(larger, larger) == 0
+
+        where:
+        smaller        | larger
+        "01.1"         | "1.2"
+        "1.1"          | "01.2"
+        "1.01.1"       | "1.1.2"
+        "1.1.1"        | "1.01.2"
+    }
+
     def "compares unrelated versions unequal"() {
         expect:
         compare("1.0", "") != 0


### PR DESCRIPTION
If the numeric parts of either of two dependencies' version strings has
a differing number of leading zeroes, but parse as the same numerical
value, the comparison algorithm breaks out too early.

Signed-off-by: Kim Brouer <kim@baudwalk.com>

Example:
```
V08.02.07.00001
V8.04.00.00091
V8.04.00.00093
V08.04.00.00138
V08.04.00.00139
```
The V08 and V8 mix causes problems.

Only a problem for people with the habit of putting leading zeros in their version numbers, of course.


### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
