### PR TITLE
Switch build JDK to OpenJDK 11 in Gradle

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -65,7 +65,7 @@ for (project in rootProject.children) {
 
 fun remoteBuildCacheEnabled(settings: Settings) = settings.buildCache.remote?.isEnabled == true
 
-fun getBuildJavaVendor() = System.getProperty("java.vendor")
+fun isOpenJDK() = true == System.getProperty("java.vm.name")?.contains("OpenJDK")
 
 fun getBuildJavaHome() = System.getProperty("java.home")
 
@@ -74,12 +74,12 @@ gradle.settingsEvaluated {
         return@settingsEvaluated
     }
 
-    if (remoteBuildCacheEnabled(this) && !getBuildJavaVendor().contains("Oracle") && !JavaVersion.current().isJava9()) {
-        throw GradleException("Remote cache is enabled, which requires Oracle JDK 9 to perform this build. It's currently ${getBuildJavaVendor()} at ${getBuildJavaHome()}.")
+    if (remoteBuildCacheEnabled(this) && !(isOpenJDK() && JavaVersion.current().isJava11)) {
+        throw GradleException("Remote cache is enabled, which requires OpenJDK 11 to perform this build. It's currently ${isOpenJDK()} at ${getBuildJavaHome()}.")
     }
 
-    if (!JavaVersion.current().isJava9Compatible()) {
-        throw GradleException("JDK 9 is required to perform this build. It's currently ${getBuildJavaVendor()} at ${getBuildJavaHome()}.")
+    if (!JavaVersion.current().isJava9Compatible) {
+        throw GradleException("JDK 9+ is required to perform this build. It's currently ${getBuildJavaHome()}.")
     }
 }
 

--- a/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
+++ b/buildSrc/subprojects/configuration/src/main/kotlin/org/gradle/gradlebuild/java/AvailableJavaInstallations.kt
@@ -54,7 +54,7 @@ const val testJavaHomePropertyName = "testJavaHome"
 
 
 private
-const val oracleJdk9 = "Oracle JDK 9"
+const val openjdk11 = "OpenJDK 11"
 
 
 open class AvailableJavaInstallations(private val project: Project, private val javaInstallationProbe: JavaInstallationProbe, private val jvmVersionDetector: JvmVersionDetector) {
@@ -106,8 +106,8 @@ open class AvailableJavaInstallations(private val project: Project, private val 
     private
     fun validateProductionJdks(): Map<String, Boolean> =
         mapOf(
-            "Must use Oracle JDK 9 to perform this build. Is currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
-                (currentJavaInstallation.vendorAndMajorVersion != oracleJdk9)
+            "Must use OpenJDK 11 to perform this build. Is currently ${currentJavaInstallation.vendorAndMajorVersion} at ${currentJavaInstallation.javaHome}." to
+                (currentJavaInstallation.vendorAndMajorVersion != openjdk11)
         )
 
     private


### PR DESCRIPTION
### Context

Previously we have the following checks:

- The JDK used in `packageBuild` and `promoteBuild` must be Oracle JDK 9.
- If remote cache is enabled, the build JDK must be Oracle JDK 9 (same as TC).

Now we're going to switch to OpenJDK 11 on TC https://github.com/gradle/gradle/pull/7809 , correspondingly, we change these checks to OpenJDK 11.