### PR TITLE
Catch `Exception` instead of `Throwable` in dependency-management

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolvedArtifact.java
@@ -154,7 +154,7 @@ public class DefaultResolvedArtifact implements ResolvedArtifact, ResolvableArti
             try {
                 f = artifactSource.create();
                 file = f;
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 err = e;
                 failure = err;
                 throw UncheckedException.throwAsUncheckedException(err);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ErrorHandlingConfigurationResolver.java
@@ -60,7 +60,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults results) {
         try {
             delegate.resolveBuildDependencies(configuration, results);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             results.failed(wrapException(e, configuration));
             BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, configuration);
             results.artifactsResolved(broken, broken);
@@ -71,7 +71,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
     public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
         try {
             delegate.resolveGraph(configuration, results);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             results.failed(wrapException(e, configuration));
             BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, configuration);
             results.artifactsResolved(broken, broken);
@@ -86,7 +86,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
     public void resolveArtifacts(ConfigurationInternal configuration, ResolverResults results) throws ResolveException {
         try {
             delegate.resolveArtifacts(configuration, results);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             BrokenResolvedConfiguration broken = new BrokenResolvedConfiguration(e, configuration);
             results.artifactsResolved(broken, broken);
             return;
@@ -125,7 +125,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedArtifact> getArtifacts(Spec<? super Dependency> dependencySpec) {
             try {
                 return lenientConfiguration.getArtifacts(dependencySpec);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -134,7 +134,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedDependency> getFirstLevelModuleDependencies() {
             try {
                 return lenientConfiguration.getFirstLevelModuleDependencies();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -143,7 +143,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedDependency> getFirstLevelModuleDependencies(Spec<? super Dependency> dependencySpec) {
             try {
                 return lenientConfiguration.getFirstLevelModuleDependencies(dependencySpec);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -152,7 +152,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedDependency> getAllModuleDependencies() {
             try {
                 return lenientConfiguration.getAllModuleDependencies();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -161,7 +161,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<UnresolvedDependency> getUnresolvedModuleDependencies() {
             try {
                 return lenientConfiguration.getUnresolvedModuleDependencies();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -179,7 +179,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<File> getFiles(Spec<? super Dependency> dependencySpec) {
             try {
                 return lenientConfiguration.getFiles(dependencySpec);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -197,7 +197,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public ResolvedComponentResult getRoot() {
             try {
                 return resolutionResult.getRoot();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -209,7 +209,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<? extends DependencyResult> getAllDependencies() {
             try {
                 return resolutionResult.getAllDependencies();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -221,7 +221,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedComponentResult> getAllComponents() {
             try {
                 return resolutionResult.getAllComponents();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, resolveContext);
             }
         }
@@ -252,7 +252,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public LenientConfiguration getLenientConfiguration() {
             try {
                 return new ErrorHandlingLenientConfiguration(resolvedConfiguration.getLenientConfiguration(), configuration);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, configuration);
             }
         }
@@ -260,7 +260,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public void rethrowFailure() throws ResolveException {
             try {
                 resolvedConfiguration.rethrowFailure();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, configuration);
             }
         }
@@ -277,7 +277,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<File> getFiles(Spec<? super Dependency> dependencySpec) throws ResolveException {
             try {
                 return resolvedConfiguration.getFiles(dependencySpec);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, configuration);
             }
         }
@@ -285,7 +285,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedDependency> getFirstLevelModuleDependencies() throws ResolveException {
             try {
                 return resolvedConfiguration.getFirstLevelModuleDependencies();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, configuration);
             }
         }
@@ -293,7 +293,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedDependency> getFirstLevelModuleDependencies(Spec<? super Dependency> dependencySpec) throws ResolveException {
             try {
                 return resolvedConfiguration.getFirstLevelModuleDependencies(dependencySpec);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, configuration);
             }
         }
@@ -301,7 +301,7 @@ public class ErrorHandlingConfigurationResolver implements ConfigurationResolver
         public Set<ResolvedArtifact> getResolvedArtifacts() throws ResolveException {
             try {
                 return resolvedConfiguration.getResolvedArtifacts();
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 throw wrapException(e, configuration);
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedArtifactCollectingVisitor.java
@@ -48,7 +48,7 @@ public class ResolvedArtifactCollectingVisitor implements ArtifactVisitor {
                 File file = artifact.getFile();
                 this.artifacts.add(new DefaultResolvedArtifactResult(artifact.getId(), variantAttributes, variantName, Artifact.class, file));
             }
-        } catch (Throwable t) {
+        } catch (Exception t) {
             failures.add(t);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ResolvedFilesCollectingVisitor.java
@@ -36,7 +36,7 @@ public class ResolvedFilesCollectingVisitor implements ArtifactVisitor {
         try {
             File file = artifact.getFile(); // triggering file resolve
             this.files.add(file);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             failures.add(t);
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionApplicator.java
@@ -32,7 +32,7 @@ public class DefaultDependencySubstitutionApplicator implements DependencySubsti
         DependencySubstitutionInternal details = new DefaultDependencySubstitution(dependency.getSelector(), dependency.getReason());
         try {
             rule.execute(details);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             return SubstitutionResult.failed(e);
         }
         return SubstitutionResult.of(details);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/DynamicVersionResolver.java
@@ -175,7 +175,7 @@ public class DynamicVersionResolver {
             RepositoryResolveState request = queue.removeFirst();
             try {
                 request.resolve();
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 failures.add(t);
                 if (isCriticalFailure(t)) {
                     queue.clear();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingArtifactResolver.java
@@ -35,7 +35,7 @@ public class ErrorHandlingArtifactResolver implements ArtifactResolver {
     public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
         try {
             resolver.resolveArtifactsWithType(component, artifactType, result);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             result.failed(new ArtifactResolveException(component.getId(), t));
         }
     }
@@ -44,7 +44,7 @@ public class ErrorHandlingArtifactResolver implements ArtifactResolver {
     public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
         try {
             resolver.resolveArtifact(artifact, moduleSource, result);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             result.failed(new ArtifactResolveException(artifact.getId(), t));
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -62,8 +62,8 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
 
     public ErrorHandlingModuleComponentRepository(ModuleComponentRepository delegate, RepositoryBlacklister remoteRepositoryBlacklister) {
         this.delegate = delegate;
-        local = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getLocalAccess(), getId(), RepositoryBlacklister.NoOpBlacklister.INSTANCE);
-        remote = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getRemoteAccess(), getId(), remoteRepositoryBlacklister);
+        local = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getLocalAccess(), getId(), RepositoryBlacklister.NoOpBlacklister.INSTANCE, getName());
+        remote = new ErrorHandlingModuleComponentRepositoryAccess(delegate.getRemoteAccess(), getId(), remoteRepositoryBlacklister, getName());
     }
 
     @Override
@@ -113,12 +113,14 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         private final RepositoryBlacklister repositoryBlacklister;
         private final int maxTentativesCount;
         private final int initialBackOff;
+        private final String repositoryName;
 
-        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate, String repositoryId, RepositoryBlacklister repositoryBlacklister) {
-            this(delegate, repositoryId, repositoryBlacklister, Integer.getInteger(MAX_TENTATIVES_BEFORE_BLACKLISTING, 3), Integer.getInteger(INITIAL_BACKOFF_MS, 1000));
+        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate, String repositoryId, RepositoryBlacklister repositoryBlacklister, String repositoryName) {
+            this(delegate, repositoryId, repositoryBlacklister, Integer.getInteger(MAX_TENTATIVES_BEFORE_BLACKLISTING, 3), Integer.getInteger(INITIAL_BACKOFF_MS, 1000), repositoryName);
         }
 
-        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate, String repositoryId, RepositoryBlacklister repositoryBlacklister, int maxTentativesCount, int initialBackoff) {
+        private ErrorHandlingModuleComponentRepositoryAccess(ModuleComponentRepositoryAccess delegate, String repositoryId, RepositoryBlacklister repositoryBlacklister, int maxTentativesCount, int initialBackoff, String repositoryName) {
+            this.repositoryName = repositoryName;
             assert maxTentativesCount > 0 : "Max tentatives must be > 0";
             assert initialBackoff >= 0 : "Initial backoff must be >= 0";
             this.delegate = delegate;
@@ -249,7 +251,7 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
                     result.failed(failure);
                     break;
                 } else {
-                    LOGGER.debug("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", repositoryId, backoff, maxTentativesCount - retries);
+                    LOGGER.debug("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", repositoryName, backoff, maxTentativesCount - retries, failure);
                     try {
                         Thread.sleep(backoff);
                         backoff *= 2;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -240,7 +240,7 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
                         }
                         return;
                     }
-                } catch (Throwable throwable) {
+                } catch (Exception throwable) {
                     unexpectedFailure = throwable;
                     failure = onError.transform(throwable);
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ArtifactBackedResolvedVariant.java
@@ -151,7 +151,7 @@ class ArtifactBackedResolvedVariant implements ResolvedVariant {
                 if (context != null) {
                     context.setResult(DownloadArtifactBuildOperationType.RESULT);
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 owner.failure = t;
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -68,7 +68,7 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         Set<File> files;
         try {
             files = dependencyMetadata.getFiles().getFiles();
-        } catch (Throwable throwable) {
+        } catch (Exception throwable) {
             return new BrokenResolvedArtifactSet(throwable);
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -182,7 +182,7 @@ class EdgeState implements DependencyGraphEdge {
             ImmutableAttributes attributes = resolveState.getRoot().getMetadata().getAttributes();
             attributes = resolveState.getAttributesFactory().concat(attributes, getAttributes());
             targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema());
-        } catch (Throwable t) {
+        } catch (Exception t) {
             // Failure to select the target variant/configurations from this component, given the dependency attributes/metadata.
             targetNodeSelectionFailure = new ModuleVersionResolveException(dependencyState.getRequested(), t);
             return;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/query/DefaultArtifactResolutionQuery.java
@@ -140,7 +140,7 @@ public class DefaultArtifactResolutionQuery implements ArtifactResolutionQuery {
             try {
                 ComponentIdentifier validId = validateComponentIdentifier(componentId);
                 componentResults.add(buildComponentResult(validId, componentMetaDataResolver, artifactResolver));
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 componentResults.add(new DefaultUnresolvedComponentResult(componentId, t));
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/ExternalResourceResolver.java
@@ -480,7 +480,7 @@ public abstract class ExternalResourceResolver<T extends ModuleComponentResolveM
                 } else {
                     result.resolved(artifactResource.getFile());
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 result.failed(new ArtifactResolveException(artifact.getId(), e));
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -68,7 +68,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             return doSelect(producer);
         } catch (VariantSelectionException t) {
             return new BrokenResolvedArtifactSet(t);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             return new BrokenResolvedArtifactSet(VariantSelectionException.selectionFailed(producer, t));
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformArtifactOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformArtifactOperation.java
@@ -55,7 +55,7 @@ class TransformArtifactOperation implements RunnableBuildOperation {
                 LOGGER.info("Executing transform {} on artifact {}", transform.getDisplayName(), artifactId.getDisplayName());
             }
             result = transform.transform(file);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             failure = t;
         }
         if (!hasCachedResult) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformFileOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformFileOperation.java
@@ -52,7 +52,7 @@ class TransformFileOperation implements RunnableBuildOperation {
                 LOGGER.info("Executing transform {} on file {}", transform.getDisplayName(), file);
             }
             result = transform.transform(file);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             failure = t;
         }
         if (!hasCachedResult) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UserCodeBackedTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UserCodeBackedTransformer.java
@@ -87,7 +87,7 @@ class UserCodeBackedTransformer implements VariantTransformRegistry.Registration
         try {
             File absoluteFile = input.getAbsoluteFile();
             return transformedFileCache.getResult(absoluteFile, inputsHash, transformer);
-        } catch (Throwable t) {
+        } catch (Exception t) {
             throw new ArtifactTransformException(input, to, transformer.getImplementationClass(), t);
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -50,7 +50,7 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
     ErrorHandlingModuleComponentRepository.ErrorHandlingModuleComponentRepositoryAccess access
 
     private ErrorHandlingModuleComponentRepository.ErrorHandlingModuleComponentRepositoryAccess createAccess(int maxRetries = 1, int backoff = 0) {
-        new ErrorHandlingModuleComponentRepository.ErrorHandlingModuleComponentRepositoryAccess(delegate, 'abc', repositoryBlacklister, maxRetries, backoff)
+        new ErrorHandlingModuleComponentRepository.ErrorHandlingModuleComponentRepositoryAccess(delegate, 'abc', repositoryBlacklister, maxRetries, backoff, 'abc')
     }
 
     @Unroll("can list module versions (max retries = #retries)")

--- a/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
@@ -27,6 +27,7 @@ image::deprecations.png[Deprecations View of a Gradle Build Scan]
 This is so that you can see any deprecation warnings that apply to your build. Gradle 5.x will generate (potentially less obvious) errors if you try to upgrade directly to it.
 +
 Alternatively, you could run `gradle help --warning-mode=all` to see the deprecations in the console, though it may not report as much detailed information.
+. If you are using Android Studio, you need to move to version 3.3 or higher.
 . Update your plugins.
 +
 Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed. The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.


### PR DESCRIPTION
This PR changes error handling in dependency management and also enables better debugging for HTTP retries.
It also clarifies that Gradle 5.0 will required Android Studio 3.3 or higher.