### PR TITLE
Report relative path for overlapping outputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -175,7 +175,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
             task cacheableWithOverlap(type: Cacheable) {
                 outputFile = cacheable.outputFile
                 cachingEnabled = false
-                disabledReason = "Gradle does not know how file '\$outputFile' was created (output property 'outputFile'). Task output caching requires exclusive access to output paths to guarantee correctness."
+                disabledReason = "Gradle does not know how file '" + project.relativePath(outputFile) + "' was created (output property 'outputFile'). Task output caching requires exclusive access to output paths to guarantee correctness."
                 disabledReasonCategory = TaskOutputCachingDisabledReasonCategory.OVERLAPPING_OUTPUTS
             }
         """

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -28,7 +28,6 @@ import org.gradle.api.internal.changedetection.changes.ShortCircuitTaskArtifactS
 import org.gradle.api.internal.changedetection.state.CacheBackedTaskHistoryRepository;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.TaskHistoryRepository;
-import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter;
@@ -59,6 +58,7 @@ import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.execution.history.OutputFilesRepository;
 import org.gradle.internal.execution.impl.steps.UpToDateResult;
 import org.gradle.internal.file.PathToFileResolver;
+import org.gradle.internal.file.RelativeFilePathResolver;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.fingerprint.classpath.ClasspathFingerprinter;
@@ -111,7 +111,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
                                     TaskExecutionGraphInternal taskExecutionGraph,
                                     BuildInvocationScopeId buildInvocationScopeId,
                                     TaskExecutionListener taskExecutionListener,
-                                    FileOperations fileOperations,
+                                    RelativeFilePathResolver relativeFilePathResolver,
                                     WorkExecutor<UpToDateResult> workExecutor
     ) {
 
@@ -125,7 +125,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             actionListener,
             workExecutor
         );
-        executer = new ResolveTaskOutputCachingStateExecuter(buildCacheEnabled, fileOperations, executer);
+        executer = new ResolveTaskOutputCachingStateExecuter(buildCacheEnabled, relativeFilePathResolver, executer);
         if (buildCacheEnabled || scanPluginApplied) {
             executer = new ResolveBuildCacheKeyExecuter(executer, buildOperationExecutor, buildCacheController.isEmitDebugLogging());
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -28,6 +28,7 @@ import org.gradle.api.internal.changedetection.changes.ShortCircuitTaskArtifactS
 import org.gradle.api.internal.changedetection.state.CacheBackedTaskHistoryRepository;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.changedetection.state.TaskHistoryRepository;
+import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter;
@@ -110,6 +111,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
                                     TaskExecutionGraphInternal taskExecutionGraph,
                                     BuildInvocationScopeId buildInvocationScopeId,
                                     TaskExecutionListener taskExecutionListener,
+                                    FileOperations fileOperations,
                                     WorkExecutor<UpToDateResult> workExecutor
     ) {
 
@@ -123,7 +125,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
             actionListener,
             workExecutor
         );
-        executer = new ResolveTaskOutputCachingStateExecuter(buildCacheEnabled, executer);
+        executer = new ResolveTaskOutputCachingStateExecuter(buildCacheEnabled, fileOperations, executer);
         if (buildCacheEnabled || scanPluginApplied) {
             executer = new ResolveBuildCacheKeyExecuter(executer, buildOperationExecutor, buildCacheController.isEmitDebugLogging());
         }

--- a/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/CachedPlatformScalaCompileIntegrationTest.groovy
+++ b/subprojects/language-scala/src/integTest/groovy/org/gradle/language/scala/CachedPlatformScalaCompileIntegrationTest.groovy
@@ -77,7 +77,7 @@ class CachedPlatformScalaCompileIntegrationTest extends AbstractCachedCompileInt
         then:
         compiledJavaClass.exists()
         compiledScalaClass.exists()
-        output ==~ /(?s).*Caching disabled for task ':compileMainJarMainScala': Gradle does not know how file '.*build.*/
+        output.contains("Caching disabled for task ':compileMainJarMainScala': Gradle does not know how file 'build")
     }
 
     def "incremental compilation works with caching"() {


### PR DESCRIPTION
when caching has been disabled.