### PR TITLE
Handle duplicate target machines

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
@@ -110,6 +110,26 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
         result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinaryWithArchitecture(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
     }
 
+    // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
+    def "ignores duplicate target machines"() {
+        assumeFalse(toolChain.meets(WINDOWS_GCC))
+
+        given:
+        makeSingleProject()
+        componentUnderTest.writeToProject(testDirectory)
+
+        and:
+        buildFile << """
+            ${componentUnderTestDsl} {
+                targetMachines = [machines.host().architecture('foo'), machines.host()${currentHostArchitectureDsl}, machines.host()${currentHostArchitectureDsl}]
+            }
+        """
+
+        expect:
+        succeeds taskNameToAssembleDevelopmentBinary
+        result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinaryWithArchitecture(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
+    }
+
     protected abstract String getDevelopmentBinaryCompileTask()
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
@@ -126,6 +126,25 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
         result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinaryWithArchitecture(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
     }
 
+    // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
+    def "ignores duplicate target machines"() {
+        given:
+        makeSingleProject()
+        settingsFile << "rootProject.name = '${componentUnderTest.projectName}'"
+        componentUnderTest.writeToProject(testDirectory)
+
+        and:
+        buildFile << """
+            ${componentUnderTestDsl} {
+                targetMachines = [machines.os('${currentOsFamilyName}').architecture('foo'), machines.os('${currentOsFamilyName}'), machines.os('${currentOsFamilyName}')]
+            }
+        """
+
+        expect:
+        succeeds taskNameToAssembleDevelopmentBinary
+        result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinaryWithArchitecture(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
+    }
+
     protected abstract List<String> getTasksToAssembleDevelopmentBinary()
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultTargetMachineFactory.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultTargetMachineFactory.java
@@ -23,6 +23,8 @@ import org.gradle.nativeplatform.TargetMachine;
 import org.gradle.nativeplatform.TargetMachineFactory;
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform;
 
+import java.util.Objects;
+
 public class DefaultTargetMachineFactory implements TargetMachineFactory {
     private final ObjectFactory objectFactory;
 
@@ -93,6 +95,24 @@ public class DefaultTargetMachineFactory implements TargetMachineFactory {
         @Override
         public TargetMachine architecture(String architecture) {
             return new TargetMachineImpl(operatingSystemFamily, objectFactory.named(MachineArchitecture.class, architecture));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TargetMachineImpl that = (TargetMachineImpl) o;
+            return Objects.equals(operatingSystemFamily, that.operatingSystemFamily) &&
+                    Objects.equals(architecture, that.architecture);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(operatingSystemFamily, architecture);
         }
     }
 }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultTargetMachineFactoryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultTargetMachineFactoryTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.nativeplatform.internal
+
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+
+class DefaultTargetMachineFactoryTest extends Specification {
+    def factory = new DefaultTargetMachineFactory(TestUtil.objectFactory())
+
+    def "can use created target machines in Set"() {
+        def windows1 = factory.windows()
+        def windows2 = factory.windows()
+        def linux1 = factory.linux().x86_64()
+        def linux2 = factory.linux().x86_64()
+
+        expect:
+        def targetMachines = [windows1, windows2, linux1, linux2] as Set
+        targetMachines.size() == 2
+        targetMachines == [windows1, linux1] as Set
+    }
+
+    def "same target machine are equals"() {
+        expect:
+        factory.windows() == factory.windows()
+        factory.linux() == factory.linux()
+        factory.macOS() == factory.macOS()
+        factory.windows().x86() == factory.windows().x86()
+        factory.linux().x86_64() == factory.linux().x86_64()
+        factory.windows().architecture("arm") == factory.windows().architecture("arm")
+        factory.os("fushia").architecture("arm") == factory.os("fushia").architecture("arm")
+    }
+
+    def "different target machine are not equals"() {
+        expect:
+        factory.windows() != factory.linux()
+        factory.linux() != factory.macOS()
+        factory.macOS() != factory.windows()
+        factory.windows().x86() != factory.windows().x86_64()
+        factory.linux().x86() != factory.windows().x86()
+        factory.windows().architecture("arm") != factory.windows().architecture("leg")
+        factory.os("fushia").architecture("arm") != factory.os("helenOS").architecture("arm")
+    }
+}


### PR DESCRIPTION
The `TargetMachine` implementation didn't implement `hashCode` and
`equals` which cause duplicate in the `SetProperty<TargetMachine>`.

### Context
Fixes https://github.com/gradle/gradle-native/issues/944

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fallow-duplicate-target-machines)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
