### PR TITLE
update note about min android studio version

### DIFF
--- a/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
@@ -17,6 +17,8 @@
 
 This chapter provides the information you need to migrate your older Gradle 4.x builds to Gradle 5.0. In most cases, you will need to apply the changes from all versions that come after the one you're upgrading from. For example, if you're upgrading from Gradle 4.3, you will also need to apply the changes since 4.4, 4.5, etc.
 
+TIP: If you are using Gradle for Android, you need to move to version 3.4 or higher of both the Android Gradle Plugin and Android Studio.
+
 We recommend the following steps for all users:
 
  . If you are not already on version 4.10.2, read the sections <<#changes_5.0,below>> for help upgrading your project to 4.10.2.
@@ -27,7 +29,6 @@ image::deprecations.png[Deprecations View of a Gradle Build Scan]
 This is so that you can see any deprecation warnings that apply to your build. Gradle 5.x will generate (potentially less obvious) errors if you try to upgrade directly to it.
 +
 Alternatively, you could run `gradle help --warning-mode=all` to see the deprecations in the console, though it may not report as much detailed information.
-. If you are using Android Studio, you need to move to version 3.3 or higher.
 . Update your plugins.
 +
 Some plugins will break with this new version of Gradle, for example because they use internal APIs that have been removed or changed. The previous step will help you identify potential problems by issuing deprecation warnings when a plugin does try to use a deprecated part of the API.


### PR DESCRIPTION
Move the Android Studio information into a callout and add that the minimum version is for both Android Studio and the Android Gradle Plugin