### PR TITLE
Report plugin configuration times to TAPI progress listeners

### DIFF
--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/AbstractProjectConfigurationResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/AbstractProjectConfigurationResult.java
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.events.configuration.internal;
+package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.events.configuration.ProjectConfigurationSuccessResult;
-import org.gradle.tooling.events.internal.DefaultOperationSuccessResult;
+import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult;
 
 import java.util.List;
 
-public class DefaultProjectConfigurationSuccessResult extends DefaultOperationSuccessResult implements ProjectConfigurationSuccessResult {
+public abstract class AbstractProjectConfigurationResult extends AbstractOperationResult implements InternalProjectConfigurationResult {
 
-    private final List<? extends PluginConfigurationResult> pluginConfigurationResults;
+    private final List<? extends InternalPluginConfigurationResult> pluginConfigurationResults;
 
-    public DefaultProjectConfigurationSuccessResult(long startTime, long endTime, List<? extends PluginConfigurationResult> pluginConfigurationResults) {
-        super(startTime, endTime);
+    public AbstractProjectConfigurationResult(long startTime, long endTime, String outcomeDescription, List<? extends InternalPluginConfigurationResult> pluginConfigurationResults) {
+        super(startTime, endTime, outcomeDescription);
         this.pluginConfigurationResults = pluginConfigurationResults;
     }
 
     @Override
-    public List<? extends PluginConfigurationResult> getPluginConfigurationResults() {
+    public List<? extends InternalPluginConfigurationResult> getPluginConfigurationResults() {
         return pluginConfigurationResults;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultBinaryPluginIdentifier.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultBinaryPluginIdentifier.java
@@ -27,9 +27,9 @@ public class DefaultBinaryPluginIdentifier implements InternalBinaryPluginIdenti
     private final String className;
     private final String pluginId;
 
-    public DefaultBinaryPluginIdentifier(String displayName, Class<?> pluginClass, @Nullable String pluginId) {
+    public DefaultBinaryPluginIdentifier(String displayName, String className, @Nullable String pluginId) {
         this.displayName = displayName;
-        this.className = pluginClass.getName();
+        this.className = className;
         this.pluginId = pluginId;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultBinaryPluginIdentifier.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultBinaryPluginIdentifier.java
@@ -16,19 +16,26 @@
 
 package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
+import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
 
-public class DefaultPluginIdentifier implements InternalPluginIdentifier, Serializable {
+public class DefaultBinaryPluginIdentifier implements InternalBinaryPluginIdentifier, Serializable {
 
+    private final String displayName;
     private final String className;
     private final String pluginId;
 
-    public DefaultPluginIdentifier(Class<?> pluginClass, @Nullable String pluginId) {
+    public DefaultBinaryPluginIdentifier(String displayName, Class<?> pluginClass, @Nullable String pluginId) {
+        this.displayName = displayName;
         this.className = pluginClass.getName();
         this.pluginId = pluginId;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
     }
 
     @Override
@@ -49,7 +56,7 @@ public class DefaultPluginIdentifier implements InternalPluginIdentifier, Serial
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        DefaultPluginIdentifier that = (DefaultPluginIdentifier) o;
+        DefaultBinaryPluginIdentifier that = (DefaultBinaryPluginIdentifier) o;
         return className.equals(that.className);
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultPluginConfigurationResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultPluginConfigurationResult.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.events;
+
+import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
+import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult.InternalPluginConfigurationResult;
+
+import java.io.Serializable;
+import java.time.Duration;
+
+public class DefaultPluginConfigurationResult implements InternalPluginConfigurationResult, Serializable {
+
+    private final InternalPluginIdentifier plugin;
+    private final Duration duration;
+
+    public DefaultPluginConfigurationResult(InternalPluginIdentifier plugin, Duration duration) {
+        this.plugin = plugin;
+        this.duration = duration;
+    }
+
+    @Override
+    public InternalPluginIdentifier getPlugin() {
+        return plugin;
+    }
+
+    @Override
+    public Duration getDuration() {
+        return duration;
+    }
+
+}

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultPluginIdentifier.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultPluginIdentifier.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.events;
+
+import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
+
+import javax.annotation.Nullable;
+import java.io.Serializable;
+
+public class DefaultPluginIdentifier implements InternalPluginIdentifier, Serializable {
+
+    private final String className;
+    private final String pluginId;
+
+    public DefaultPluginIdentifier(Class<?> pluginClass, @Nullable String pluginId) {
+        this.className = pluginClass.getName();
+        this.pluginId = pluginId;
+    }
+
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public String getPluginId() {
+        return pluginId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultPluginIdentifier that = (DefaultPluginIdentifier) o;
+        return className.equals(that.className);
+    }
+
+    @Override
+    public int hashCode() {
+        return className.hashCode();
+    }
+
+}

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultProjectConfigurationFailureResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultProjectConfigurationFailureResult.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.events;
+
+import org.gradle.tooling.internal.protocol.events.InternalFailureResult;
+
+import java.util.List;
+
+public class DefaultProjectConfigurationFailureResult extends AbstractProjectConfigurationResult implements InternalFailureResult {
+
+    private final List<DefaultFailure> failures;
+
+    public DefaultProjectConfigurationFailureResult(long startTime, long endTime, List<DefaultFailure> failures, List<? extends InternalPluginConfigurationResult> pluginConfigurationResults) {
+        super(startTime, endTime, "failed", pluginConfigurationResults);
+        this.failures = failures;
+    }
+
+    @Override
+    public List<DefaultFailure> getFailures() {
+        return failures;
+    }
+
+}

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultProjectConfigurationSuccessResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultProjectConfigurationSuccessResult.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.events;
+
+import org.gradle.tooling.internal.protocol.events.InternalSuccessResult;
+
+import java.util.List;
+
+public class DefaultProjectConfigurationSuccessResult extends AbstractProjectConfigurationResult implements InternalSuccessResult {
+    public DefaultProjectConfigurationSuccessResult(long startTime, long endTime, List<? extends InternalPluginConfigurationResult> pluginConfigurationResults) {
+        super(startTime, endTime, "succeeded", pluginConfigurationResults);
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultScriptPluginIdentifier.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultScriptPluginIdentifier.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.events;
+
+import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier;
+
+import java.io.Serializable;
+import java.net.URI;
+
+public class DefaultScriptPluginIdentifier implements InternalScriptPluginIdentifier, Serializable {
+
+    private final String displayName;
+    private final URI uri;
+
+    public DefaultScriptPluginIdentifier(String displayName, URI uri) {
+        this.displayName = displayName;
+        this.uri = uri;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultScriptPluginIdentifier that = (DefaultScriptPluginIdentifier) o;
+        return uri.equals(that.uri);
+    }
+
+    @Override
+    public int hashCode() {
+        return uri.hashCode();
+    }
+
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
@@ -16,21 +16,39 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
+import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType;
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType;
+import org.gradle.internal.MutableLong;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
+import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult.InternalPluginConfigurationResult;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
+import org.gradle.tooling.internal.provider.events.AbstractProjectConfigurationResult;
+import org.gradle.tooling.internal.provider.events.DefaultFailure;
 import org.gradle.tooling.internal.provider.events.DefaultOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.provider.events.DefaultOperationStartedProgressEvent;
+import org.gradle.tooling.internal.provider.events.DefaultPluginConfigurationResult;
+import org.gradle.tooling.internal.provider.events.DefaultPluginIdentifier;
 import org.gradle.tooling.internal.provider.events.DefaultProjectConfigurationDescriptor;
+import org.gradle.tooling.internal.provider.events.DefaultProjectConfigurationFailureResult;
+import org.gradle.tooling.internal.provider.events.DefaultProjectConfigurationSuccessResult;
 import org.gradle.tooling.internal.provider.events.OperationResultPostProcessor;
 
-import static org.gradle.tooling.internal.provider.runner.ClientForwardingBuildOperationListener.toOperationResult;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toCollection;
 
 /**
  * Project configuration listener that forwards all receiving events to the client via the provided {@code ProgressEventConsumer} instance.
@@ -39,18 +57,44 @@ import static org.gradle.tooling.internal.provider.runner.ClientForwardingBuildO
  */
 class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilteringBuildOperationListener<ConfigureProjectBuildOperationType.Details> {
 
+    private final Map<OperationIdentifier, ProjectConfigurationResult> results = new ConcurrentHashMap<>();
+
     ClientForwardingProjectConfigurationOperationListener(ProgressEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate, OperationResultPostProcessor operationResultPostProcessor) {
         super(eventConsumer, clientSubscriptions, delegate, OperationType.PROJECT_CONFIGURATION, ConfigureProjectBuildOperationType.Details.class);
     }
 
     @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        if (isEnabled() && buildOperation.getParentId() != null && results.containsKey(buildOperation.getParentId())) {
+            results.put(buildOperation.getId(), results.get(buildOperation.getParentId()));
+        }
+        super.started(buildOperation, startEvent);
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        super.finished(buildOperation, finishEvent);
+        if (isEnabled() && results.containsKey(buildOperation.getId())) {
+            if (buildOperation.getDetails() instanceof ApplyPluginBuildOperationType.Details) {
+                ApplyPluginBuildOperationType.Details details = (ApplyPluginBuildOperationType.Details) buildOperation.getDetails();
+                DefaultPluginIdentifier plugin = new DefaultPluginIdentifier(details.getPluginClass(), details.getPluginId());
+                long duration = finishEvent.getEndTime() - finishEvent.getStartTime();
+                results.get(buildOperation.getId()).add(plugin, duration);
+            }
+            results.remove(buildOperation.getId());
+        }
+    }
+
+    @Override
     protected InternalOperationStartedProgressEvent toStartedEvent(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent, ConfigureProjectBuildOperationType.Details details) {
+        results.put(buildOperation.getId(), new ProjectConfigurationResult());
         return new DefaultOperationStartedProgressEvent(startEvent.getStartTime(), toProjectConfigurationDescriptor(buildOperation, details));
     }
 
     @Override
     protected InternalOperationFinishedProgressEvent toFinishedEvent(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent, ConfigureProjectBuildOperationType.Details details) {
-        return new DefaultOperationFinishedProgressEvent(finishEvent.getEndTime(), toProjectConfigurationDescriptor(buildOperation, details), toOperationResult(finishEvent));
+        AbstractProjectConfigurationResult result = toProjectConfigurationOperationResult(finishEvent, results.remove(buildOperation.getId()));
+        return new DefaultOperationFinishedProgressEvent(finishEvent.getEndTime(), toProjectConfigurationDescriptor(buildOperation, details), result);
     }
 
     private DefaultProjectConfigurationDescriptor toProjectConfigurationDescriptor(BuildOperationDescriptor buildOperation, ConfigureProjectBuildOperationType.Details details) {
@@ -58,6 +102,33 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
         String displayName = buildOperation.getDisplayName();
         Object parentId = eventConsumer.findStartedParentId(buildOperation.getParentId());
         return new DefaultProjectConfigurationDescriptor(id, displayName, parentId, details.getRootDir(), details.getProjectPath());
+    }
+
+    private AbstractProjectConfigurationResult toProjectConfigurationOperationResult(OperationFinishEvent finishEvent, ProjectConfigurationResult configResult) {
+        long startTime = finishEvent.getStartTime();
+        long endTime = finishEvent.getEndTime();
+        Throwable failure = finishEvent.getFailure();
+        List<InternalPluginConfigurationResult> pluginConfigurationResults = configResult.toInternalPluginConfigurationResults();
+        if (failure != null) {
+            return new DefaultProjectConfigurationFailureResult(startTime, endTime, singletonList(DefaultFailure.fromThrowable(failure)), pluginConfigurationResults);
+        }
+        return new DefaultProjectConfigurationSuccessResult(startTime, endTime, pluginConfigurationResults);
+    }
+
+    private static class ProjectConfigurationResult {
+
+        private final Map<DefaultPluginIdentifier, MutableLong> durations = new LinkedHashMap<>();
+
+        public void add(DefaultPluginIdentifier plugin, long duration) {
+            durations.computeIfAbsent(plugin, key -> new MutableLong()).increment(duration);
+        }
+
+        public List<InternalPluginConfigurationResult> toInternalPluginConfigurationResults() {
+            return durations.entrySet().stream()
+                .map(entry -> new DefaultPluginConfigurationResult(entry.getKey(), Duration.ofMillis(entry.getValue().get())))
+                .collect(toCollection(ArrayList::new));
+        }
+
     }
 
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
@@ -16,20 +16,23 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
+import com.google.common.base.MoreObjects;
+import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType;
 import org.gradle.configuration.ApplyScriptPluginBuildOperationType;
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType;
-import org.gradle.internal.MutableLong;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationFinishEvent;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.tooling.events.OperationType;
+import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult.InternalPluginConfigurationResult;
+import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.events.AbstractProjectConfigurationResult;
 import org.gradle.tooling.internal.provider.events.DefaultBinaryPluginIdentifier;
@@ -47,12 +50,13 @@ import java.io.File;
 import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.util.Collections.singletonList;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toCollection;
 
 /**
@@ -82,10 +86,10 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
         if (isEnabled() && results.containsKey(buildOperation.getId())) {
             if (buildOperation.getDetails() instanceof ApplyPluginBuildOperationType.Details) {
                 ApplyPluginBuildOperationType.Details details = (ApplyPluginBuildOperationType.Details) buildOperation.getDetails();
-                incrementDuration(buildOperation, finishEvent, new DefaultBinaryPluginIdentifier(buildOperation.getDisplayName(), details.getPluginClass(), details.getPluginId()));
+                incrementDuration(buildOperation, details.getApplicationId(), finishEvent, toBinaryPluginIdentifier(details));
             } else if (buildOperation.getDetails() instanceof ApplyScriptPluginBuildOperationType.Details) {
                 ApplyScriptPluginBuildOperationType.Details details = (ApplyScriptPluginBuildOperationType.Details) buildOperation.getDetails();
-                incrementDuration(buildOperation, finishEvent, new DefaultScriptPluginIdentifier(buildOperation.getDisplayName(), toUri(details)));
+                incrementDuration(buildOperation, details.getApplicationId(), finishEvent, toScriptPluginIdentifier(details));
             }
             results.remove(buildOperation.getId());
         }
@@ -103,16 +107,31 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
         return new DefaultOperationFinishedProgressEvent(finishEvent.getEndTime(), toProjectConfigurationDescriptor(buildOperation, details), result);
     }
 
-    private URI toUri(ApplyScriptPluginBuildOperationType.Details details) {
-        if (details.getFile() != null) {
-            return new File(details.getFile()).toURI();
-        }
-        return URI.create(details.getUri());
+    private InternalBinaryPluginIdentifier toBinaryPluginIdentifier(ApplyPluginBuildOperationType.Details details) {
+        String className = details.getPluginClass().getName();
+        String pluginId = details.getPluginId();
+        String displayName = MoreObjects.firstNonNull(pluginId, className);
+        return new DefaultBinaryPluginIdentifier(displayName, className, pluginId);
     }
 
-    private void incrementDuration(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent, InternalPluginIdentifier plugin) {
-        long duration = finishEvent.getEndTime() - finishEvent.getStartTime();
-        results.get(buildOperation.getId()).increment(plugin, duration);
+    private InternalScriptPluginIdentifier toScriptPluginIdentifier(ApplyScriptPluginBuildOperationType.Details details) {
+        String fileString = details.getFile();
+        if (fileString != null) {
+            File file = new File(fileString);
+            return new DefaultScriptPluginIdentifier(file.getName(), file.toURI());
+        }
+        String uriString = details.getUri();
+        if (uriString != null) {
+            URI uri = URI.create(uriString);
+            return new DefaultScriptPluginIdentifier(FilenameUtils.getName(uri.getPath()), uri);
+        }
+        return null;
+    }
+
+    private void incrementDuration(BuildOperationDescriptor buildOperation, long applicationId, OperationFinishEvent finishEvent, InternalPluginIdentifier plugin) {
+        if (plugin != null) {
+            results.get(buildOperation.getId()).increment(plugin, applicationId, finishEvent.getEndTime() - finishEvent.getStartTime());
+        }
     }
 
     private DefaultProjectConfigurationDescriptor toProjectConfigurationDescriptor(BuildOperationDescriptor buildOperation, ConfigureProjectBuildOperationType.Details details) {
@@ -135,16 +154,42 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
 
     private static class ProjectConfigurationResult {
 
-        private final Map<InternalPluginIdentifier, MutableLong> durations = new LinkedHashMap<>();
+        private final Map<InternalPluginIdentifier, PluginConfigurationResult> pluginResults = new ConcurrentHashMap<>();
 
-        public void increment(InternalPluginIdentifier plugin, long duration) {
-            durations.computeIfAbsent(plugin, key -> new MutableLong()).increment(duration);
+        public void increment(InternalPluginIdentifier plugin, long applicationId, long duration) {
+            pluginResults.computeIfAbsent(plugin, key -> new PluginConfigurationResult(plugin, applicationId)).increment(duration);
         }
 
         public List<InternalPluginConfigurationResult> toInternalPluginConfigurationResults() {
-            return durations.entrySet().stream()
-                .map(entry -> new DefaultPluginConfigurationResult(entry.getKey(), Duration.ofMillis(entry.getValue().get())))
+            return pluginResults.values().stream()
+                .sorted(comparing(PluginConfigurationResult::getFirstApplicationId))
+                .map(PluginConfigurationResult::toInternalPluginConfigurationResult)
                 .collect(toCollection(ArrayList::new));
+        }
+
+    }
+
+    private static class PluginConfigurationResult {
+
+        private final InternalPluginIdentifier plugin;
+        private final long firstApplicationId;
+        private AtomicLong duration = new AtomicLong();
+
+        public PluginConfigurationResult(InternalPluginIdentifier plugin, long firstApplicationId) {
+            this.plugin = plugin;
+            this.firstApplicationId = firstApplicationId;
+        }
+
+        public long getFirstApplicationId() {
+            return firstApplicationId;
+        }
+
+        void increment(long duration) {
+            this.duration.addAndGet(duration);
+        }
+
+        public InternalPluginConfigurationResult toInternalPluginConfigurationResult() {
+            return new DefaultPluginConfigurationResult(plugin, Duration.ofMillis(duration.get()));
         }
 
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubtreeFilteringBuildOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/SubtreeFilteringBuildOperationListener.java
@@ -58,6 +58,10 @@ abstract class SubtreeFilteringBuildOperationListener<D> implements BuildOperati
         this.enabled = clientSubscriptions.isRequested(operationType);
     }
 
+    protected boolean isEnabled() {
+        return enabled;
+    }
+
     @Override
     public void graphPopulated(TaskExecutionGraph graph) {
         if (delegate instanceof TaskExecutionGraphListener) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -233,6 +233,22 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
         result.plugin.uri == scriptUri
     }
 
+    def "ignores non-project plugins"() {
+        given:
+        file("build.gradle") << """
+            apply(plugin: MyPlugin, to: gradle)
+            class MyPlugin implements Plugin<Gradle> {
+                void apply(Gradle gradle) {}
+            }
+        """
+
+        when:
+        runBuild("tasks")
+
+        then:
+        getPluginConfigurationOperationResult(":").getPluginConfigurationResults().findAll { it.plugin.displayName.contains("MyPlugin") }.empty
+    }
+
     void containsPluginConfigurationResultsForJavaPluginAndScriptPlugins(String displayName, File buildscriptDir) {
         with(containsPluginConfigurationResultsForJavaPlugin(displayName)) {
             def buildScript = pluginConfigurationResults.find { it.plugin instanceof ScriptPluginIdentifier && it.plugin.uri == new File(buildscriptDir, "build.gradle").toURI() }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/BinaryPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/BinaryPluginIdentifier.java
@@ -14,32 +14,29 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.events.internal;
+package org.gradle.tooling.events;
 
-import org.gradle.tooling.events.PluginIdentifier;
+import org.gradle.api.Incubating;
 
 import javax.annotation.Nullable;
 
-public class DefaultPluginIdentifier implements PluginIdentifier {
+/**
+ * Identifies a Gradle binary plugin.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface BinaryPluginIdentifier extends PluginIdentifier {
 
-    private final String className;
-    private final String pluginId;
+    /**
+     * Returns the fully-qualified class name of this plugin.
+     */
+    String getClassName();
 
-    public DefaultPluginIdentifier(String className, String pluginId) {
-        this.className = className;
-        this.pluginId = pluginId;
-    }
-
+    /**
+     * Returns the plugin id of this plugin, if available.
+     */
     @Nullable
-    @Override
-    public String getClassName() {
-        return className;
-    }
-
-    @Nullable
-    @Override
-    public String getPluginId() {
-        return pluginId;
-    }
+    String getPluginId();
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/PluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/PluginIdentifier.java
@@ -18,26 +18,19 @@ package org.gradle.tooling.events;
 
 import org.gradle.api.Incubating;
 
-import javax.annotation.Nullable;
-
 /**
  * Identifies a Gradle plugin.
  *
  * @since 5.1
+ * @see BinaryPluginIdentifier
+ * @see ScriptPluginIdentifier
  */
 @Incubating
 public interface PluginIdentifier {
 
     /**
-     * Returns the fully-qualified class name of this plugin.
+     * Returns a human-readable display name for this plugin.
      */
-    @Nullable
-    String getClassName();
-
-    /**
-     * Returns the plugin id of this plugin.
-     */
-    @Nullable
-    String getPluginId();
+    String getDisplayName();
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/PluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/PluginIdentifier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events;
+
+import org.gradle.api.Incubating;
+
+import javax.annotation.Nullable;
+
+/**
+ * Identifies a Gradle plugin.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface PluginIdentifier {
+
+    /**
+     * Returns the fully-qualified class name of this plugin.
+     */
+    @Nullable
+    String getClassName();
+
+    /**
+     * Returns the plugin id of this plugin.
+     */
+    @Nullable
+    String getPluginId();
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/ScriptPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/ScriptPluginIdentifier.java
@@ -14,20 +14,25 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.protocol.events;
+package org.gradle.tooling.events;
 
-import org.gradle.tooling.internal.protocol.InternalProtocolInterface;
+import org.gradle.api.Incubating;
+
+import java.net.URI;
 
 /**
- * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
+ * Identifies a Gradle script plugin.
  *
  * @since 5.1
  */
-public interface InternalPluginIdentifier extends InternalProtocolInterface {
+@Incubating
+public interface ScriptPluginIdentifier extends PluginIdentifier {
 
     /**
-     * Returns the display name of this plugin.
+     * Returns the URI of this script plugin.
+     *
+     * <p>The URI may point to the local file system or a remote server.
      */
-    String getDisplayName();
+    URI getUri();
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/configuration/internal/DefaultPluginConfigurationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/configuration/internal/DefaultPluginConfigurationResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.configuration.internal;
+
+import org.gradle.tooling.events.PluginIdentifier;
+import org.gradle.tooling.events.configuration.ProjectConfigurationOperationResult.PluginConfigurationResult;
+
+import java.time.Duration;
+
+public class DefaultPluginConfigurationResult implements PluginConfigurationResult {
+
+    private final PluginIdentifier plugin;
+    private final Duration duration;
+
+    public DefaultPluginConfigurationResult(PluginIdentifier plugin, Duration duration) {
+        this.plugin = plugin;
+        this.duration = duration;
+    }
+
+    @Override
+    public PluginIdentifier getPlugin() {
+        return plugin;
+    }
+
+    @Override
+    public Duration getDuration() {
+        return duration;
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/configuration/internal/DefaultProjectConfigurationFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/configuration/internal/DefaultProjectConfigurationFailureResult.java
@@ -24,8 +24,16 @@ import java.util.List;
 
 public class DefaultProjectConfigurationFailureResult extends DefaultOperationFailureResult implements ProjectConfigurationFailureResult {
 
-    public DefaultProjectConfigurationFailureResult(long startTime, long endTime, List<? extends Failure> failures) {
+    private final List<? extends PluginConfigurationResult> pluginConfigurationResults;
+
+    public DefaultProjectConfigurationFailureResult(long startTime, long endTime, List<? extends Failure> failures, List<? extends PluginConfigurationResult> pluginConfigurationResults) {
         super(startTime, endTime, failures);
+        this.pluginConfigurationResults = pluginConfigurationResults;
+    }
+
+    @Override
+    public List<? extends PluginConfigurationResult> getPluginConfigurationResults() {
+        return pluginConfigurationResults;
     }
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/AbstractPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/AbstractPluginIdentifier.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.protocol.events;
+package org.gradle.tooling.events.internal;
 
-import org.gradle.tooling.internal.protocol.InternalProtocolInterface;
+import org.gradle.tooling.events.PluginIdentifier;
 
-/**
- * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
- *
- * @since 5.1
- */
-public interface InternalPluginIdentifier extends InternalProtocolInterface {
+abstract class AbstractPluginIdentifier implements PluginIdentifier {
 
-    /**
-     * Returns the display name of this plugin.
-     */
-    String getDisplayName();
+    private final String displayName;
 
+    AbstractPluginIdentifier(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/DefaultBinaryPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/DefaultBinaryPluginIdentifier.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.internal;
+
+import org.gradle.tooling.events.BinaryPluginIdentifier;
+
+import javax.annotation.Nullable;
+
+public class DefaultBinaryPluginIdentifier extends AbstractPluginIdentifier implements BinaryPluginIdentifier {
+
+    private final String className;
+    private final String pluginId;
+
+    public DefaultBinaryPluginIdentifier(String displayName, String className, String pluginId) {
+        super(displayName);
+        this.className = className;
+        this.pluginId = pluginId;
+    }
+
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+    @Nullable
+    @Override
+    public String getPluginId() {
+        return pluginId;
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/DefaultPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/DefaultPluginIdentifier.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.internal;
+
+import org.gradle.tooling.events.PluginIdentifier;
+
+import javax.annotation.Nullable;
+
+public class DefaultPluginIdentifier implements PluginIdentifier {
+
+    private final String className;
+    private final String pluginId;
+
+    public DefaultPluginIdentifier(String className, String pluginId) {
+        this.className = className;
+        this.pluginId = pluginId;
+    }
+
+    @Nullable
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+    @Nullable
+    @Override
+    public String getPluginId() {
+        return pluginId;
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/DefaultScriptPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/internal/DefaultScriptPluginIdentifier.java
@@ -14,20 +14,24 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.internal.protocol.events;
+package org.gradle.tooling.events.internal;
 
-import org.gradle.tooling.internal.protocol.InternalProtocolInterface;
+import org.gradle.tooling.events.ScriptPluginIdentifier;
 
-/**
- * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
- *
- * @since 5.1
- */
-public interface InternalPluginIdentifier extends InternalProtocolInterface {
+import java.net.URI;
 
-    /**
-     * Returns the display name of this plugin.
-     */
-    String getDisplayName();
+public class DefaultScriptPluginIdentifier extends AbstractPluginIdentifier implements ScriptPluginIdentifier {
+
+    private final URI uri;
+
+    public DefaultScriptPluginIdentifier(String displayName, URI uri) {
+        super(displayName);
+        this.uri = uri;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalBinaryPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalBinaryPluginIdentifier.java
@@ -16,18 +16,24 @@
 
 package org.gradle.tooling.internal.protocol.events;
 
-import org.gradle.tooling.internal.protocol.InternalProtocolInterface;
+import javax.annotation.Nullable;
 
 /**
  * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
  *
  * @since 5.1
  */
-public interface InternalPluginIdentifier extends InternalProtocolInterface {
+public interface InternalBinaryPluginIdentifier extends InternalPluginIdentifier {
 
     /**
-     * Returns the display name of this plugin.
+     * Returns the fully-qualified class name of this plugin.
      */
-    String getDisplayName();
+    String getClassName();
+
+    /**
+     * Returns the plugin id of this plugin, if available.
+     */
+    @Nullable
+    String getPluginId();
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalPluginIdentifier.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.protocol.events;
+
+import org.gradle.tooling.internal.protocol.InternalProtocolInterface;
+
+import javax.annotation.Nullable;
+
+/**
+ * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
+ *
+ * @since 5.1
+ */
+public interface InternalPluginIdentifier extends InternalProtocolInterface {
+
+    /**
+     * Returns the fully-qualified class name of this plugin.
+     */
+    @Nullable
+    String getClassName();
+
+    /**
+     * Returns the plugin id of this plugin.
+     */
+    @Nullable
+    String getPluginId();
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalProjectConfigurationResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalProjectConfigurationResult.java
@@ -14,43 +14,32 @@
  * limitations under the License.
  */
 
-package org.gradle.tooling.events.configuration;
-
-import org.gradle.api.Incubating;
-import org.gradle.tooling.events.OperationResult;
-import org.gradle.tooling.events.PluginIdentifier;
+package org.gradle.tooling.internal.protocol.events;
 
 import java.time.Duration;
 import java.util.List;
 
 /**
- * Describes the result of running a project configuration operation.
+ * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
  *
  * @since 5.1
  */
-@Incubating
-public interface ProjectConfigurationOperationResult extends OperationResult {
+public interface InternalProjectConfigurationResult extends InternalOperationResult {
 
     /**
      * Returns the results of plugins applied as part of the configuration of this project.
-     *
-     * <p>This may include plugins applied to other projects that are part of the current build,
-     * e.g. when using {@code subprojects {}} blocks in the build script of the root project.
      */
-    List<? extends PluginConfigurationResult> getPluginConfigurationResults();
+    List<? extends InternalPluginConfigurationResult> getPluginConfigurationResults();
 
     /**
-     * Describes the result of configuring a plugin.
-     *
      * @since 5.1
      */
-    @Incubating
-    interface PluginConfigurationResult {
+    interface InternalPluginConfigurationResult {
 
         /**
          * Returns the identifier of this plugin.
          */
-        PluginIdentifier getPlugin();
+        InternalPluginIdentifier getPlugin();
 
         /**
          * Returns the total configuration time of this plugin.

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalScriptPluginIdentifier.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalScriptPluginIdentifier.java
@@ -16,18 +16,18 @@
 
 package org.gradle.tooling.internal.protocol.events;
 
-import org.gradle.tooling.internal.protocol.InternalProtocolInterface;
+import java.net.URI;
 
 /**
  * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
  *
  * @since 5.1
  */
-public interface InternalPluginIdentifier extends InternalProtocolInterface {
+public interface InternalScriptPluginIdentifier extends InternalPluginIdentifier {
 
     /**
-     * Returns the display name of this plugin.
+     * Returns the URI of the script file of this plugin.
      */
-    String getDisplayName();
+    URI getUri();
 
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForProjectConfigurationOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForProjectConfigurationOperationsTest.groovy
@@ -16,20 +16,25 @@
 
 package org.gradle.tooling.internal.consumer.parameters
 
+import org.gradle.testing.internal.util.Specification
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.configuration.ProjectConfigurationFailureResult
 import org.gradle.tooling.events.configuration.ProjectConfigurationFinishEvent
 import org.gradle.tooling.events.configuration.ProjectConfigurationStartEvent
 import org.gradle.tooling.events.configuration.ProjectConfigurationSuccessResult
-import org.gradle.tooling.events.configuration.ProjectConfigurationFailureResult
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
 import org.gradle.tooling.internal.protocol.InternalFailure
 import org.gradle.tooling.internal.protocol.events.InternalFailureResult
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent
+import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier
 import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationDescriptor
+import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult
+import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult.InternalPluginConfigurationResult
 import org.gradle.tooling.internal.protocol.events.InternalSuccessResult
-import spock.lang.Specification
+
+import java.time.Duration
 
 class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends Specification {
 
@@ -98,9 +103,17 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
         _ * startEvent.getDisplayName() >> 'Project configuration started'
         _ * startEvent.getDescriptor() >> projectConfigurationDescriptor
 
-        def projectConfigurationResult = Mock(InternalSuccessResult)
+        def pluginConfigurationResult = Stub(InternalPluginConfigurationResult)
+        _ * pluginConfigurationResult.getPlugin() >> Stub(InternalPluginIdentifier) {
+            getClassName() >> 'com.acme.SomePlugin'
+            getPluginId() >> 'com.acme.some'
+        }
+        _ * pluginConfigurationResult.getDuration() >> Duration.ofMillis(42)
+
+        def projectConfigurationResult = Mock(InternalProjectConfigurationResult, additionalInterfaces: [InternalSuccessResult])
         _ * projectConfigurationResult.getStartTime() >> 1
         _ * projectConfigurationResult.getEndTime() >> 2
+        _ * projectConfigurationResult.getPluginConfigurationResults() >> [pluginConfigurationResult]
 
         def succeededEvent = Mock(InternalOperationFinishedProgressEvent)
         _ * succeededEvent.getEventTime() >> 999
@@ -122,6 +135,12 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
             assert event.result instanceof ProjectConfigurationSuccessResult
             assert event.result.startTime == 1
             assert event.result.endTime == 2
+            with((ProjectConfigurationSuccessResult) event.result) {
+                assert pluginConfigurationResults.size() == 1
+                assert pluginConfigurationResults[0].plugin.className == 'com.acme.SomePlugin'
+                assert pluginConfigurationResults[0].plugin.pluginId == 'com.acme.some'
+                assert pluginConfigurationResults[0].duration == Duration.ofMillis(42)
+            }
         }
     }
 
@@ -144,10 +163,18 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
         _ * startEvent.getDisplayName() >> 'Project configuration started'
         _ * startEvent.getDescriptor() >> projectConfigurationDescriptor
 
-        def projectConfigurationResult = Mock(InternalFailureResult)
+        def pluginConfigurationResult = Stub(InternalPluginConfigurationResult)
+        _ * pluginConfigurationResult.getPlugin() >> Stub(InternalPluginIdentifier) {
+            getClassName() >> 'com.acme.SomePlugin'
+            getPluginId() >> 'com.acme.some'
+        }
+        _ * pluginConfigurationResult.getDuration() >> Duration.ofMillis(42)
+
+        def projectConfigurationResult = Mock(InternalProjectConfigurationResult, additionalInterfaces: [InternalFailureResult])
         _ * projectConfigurationResult.getStartTime() >> 1
         _ * projectConfigurationResult.getEndTime() >> 2
         _ * projectConfigurationResult.getFailures() >> [Stub(InternalFailure)]
+        _ * projectConfigurationResult.getPluginConfigurationResults() >> [pluginConfigurationResult]
 
         def failedEvent = Mock(InternalOperationFinishedProgressEvent)
         _ * failedEvent.getEventTime() >> 999
@@ -169,6 +196,12 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
             assert event.result.startTime == 1
             assert event.result.endTime == 2
             assert event.result.failures.size() == 1
+            with((ProjectConfigurationFailureResult) event.result) {
+                assert pluginConfigurationResults.size() == 1
+                assert pluginConfigurationResults[0].plugin.className == 'com.acme.SomePlugin'
+                assert pluginConfigurationResults[0].plugin.pluginId == 'com.acme.some'
+                assert pluginConfigurationResults[0].duration == Duration.ofMillis(42)
+            }
         }
     }
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForProjectConfigurationOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForProjectConfigurationOperationsTest.groovy
@@ -17,21 +17,24 @@
 package org.gradle.tooling.internal.consumer.parameters
 
 import org.gradle.testing.internal.util.Specification
+import org.gradle.tooling.events.BinaryPluginIdentifier
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
+import org.gradle.tooling.events.ScriptPluginIdentifier
 import org.gradle.tooling.events.configuration.ProjectConfigurationFailureResult
 import org.gradle.tooling.events.configuration.ProjectConfigurationFinishEvent
 import org.gradle.tooling.events.configuration.ProjectConfigurationStartEvent
 import org.gradle.tooling.events.configuration.ProjectConfigurationSuccessResult
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
 import org.gradle.tooling.internal.protocol.InternalFailure
+import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier
 import org.gradle.tooling.internal.protocol.events.InternalFailureResult
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent
-import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier
 import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationDescriptor
 import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult
 import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult.InternalPluginConfigurationResult
+import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier
 import org.gradle.tooling.internal.protocol.events.InternalSuccessResult
 
 import java.time.Duration
@@ -103,17 +106,23 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
         _ * startEvent.getDisplayName() >> 'Project configuration started'
         _ * startEvent.getDescriptor() >> projectConfigurationDescriptor
 
-        def pluginConfigurationResult = Stub(InternalPluginConfigurationResult)
-        _ * pluginConfigurationResult.getPlugin() >> Stub(InternalPluginIdentifier) {
+        def binaryPluginConfigurationResult = Stub(InternalPluginConfigurationResult)
+        _ * binaryPluginConfigurationResult.getPlugin() >> Stub(InternalBinaryPluginIdentifier) {
             getClassName() >> 'com.acme.SomePlugin'
             getPluginId() >> 'com.acme.some'
         }
-        _ * pluginConfigurationResult.getDuration() >> Duration.ofMillis(42)
+        _ * binaryPluginConfigurationResult.getDuration() >> Duration.ofMillis(23)
+
+        def scriptPluginConfigurationResult = Stub(InternalPluginConfigurationResult)
+        _ * scriptPluginConfigurationResult.getPlugin() >> Stub(InternalScriptPluginIdentifier) {
+            getUri() >> new File(rootDir, "build.gradle").toURI()
+        }
+        _ * scriptPluginConfigurationResult.getDuration() >> Duration.ofMillis(42)
 
         def projectConfigurationResult = Mock(InternalProjectConfigurationResult, additionalInterfaces: [InternalSuccessResult])
         _ * projectConfigurationResult.getStartTime() >> 1
         _ * projectConfigurationResult.getEndTime() >> 2
-        _ * projectConfigurationResult.getPluginConfigurationResults() >> [pluginConfigurationResult]
+        _ * projectConfigurationResult.getPluginConfigurationResults() >> [binaryPluginConfigurationResult, scriptPluginConfigurationResult]
 
         def succeededEvent = Mock(InternalOperationFinishedProgressEvent)
         _ * succeededEvent.getEventTime() >> 999
@@ -136,10 +145,14 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
             assert event.result.startTime == 1
             assert event.result.endTime == 2
             with((ProjectConfigurationSuccessResult) event.result) {
-                assert pluginConfigurationResults.size() == 1
+                assert pluginConfigurationResults.size() == 2
+                assert pluginConfigurationResults[0].plugin instanceof BinaryPluginIdentifier
                 assert pluginConfigurationResults[0].plugin.className == 'com.acme.SomePlugin'
                 assert pluginConfigurationResults[0].plugin.pluginId == 'com.acme.some'
-                assert pluginConfigurationResults[0].duration == Duration.ofMillis(42)
+                assert pluginConfigurationResults[0].duration == Duration.ofMillis(23)
+                assert pluginConfigurationResults[1].plugin instanceof ScriptPluginIdentifier
+                assert pluginConfigurationResults[1].plugin.uri == new File(rootDir, "build.gradle").toURI()
+                assert pluginConfigurationResults[1].duration == Duration.ofMillis(42)
             }
         }
     }
@@ -163,18 +176,24 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
         _ * startEvent.getDisplayName() >> 'Project configuration started'
         _ * startEvent.getDescriptor() >> projectConfigurationDescriptor
 
-        def pluginConfigurationResult = Stub(InternalPluginConfigurationResult)
-        _ * pluginConfigurationResult.getPlugin() >> Stub(InternalPluginIdentifier) {
+        def binaryPluginConfigurationResult = Stub(InternalPluginConfigurationResult)
+        _ * binaryPluginConfigurationResult.getPlugin() >> Stub(InternalBinaryPluginIdentifier) {
             getClassName() >> 'com.acme.SomePlugin'
             getPluginId() >> 'com.acme.some'
         }
-        _ * pluginConfigurationResult.getDuration() >> Duration.ofMillis(42)
+        _ * binaryPluginConfigurationResult.getDuration() >> Duration.ofMillis(23)
+
+        def scriptPluginConfigurationResult = Stub(InternalPluginConfigurationResult)
+        _ * scriptPluginConfigurationResult.getPlugin() >> Stub(InternalScriptPluginIdentifier) {
+            getUri() >> new File(rootDir, "build.gradle").toURI()
+        }
+        _ * scriptPluginConfigurationResult.getDuration() >> Duration.ofMillis(42)
 
         def projectConfigurationResult = Mock(InternalProjectConfigurationResult, additionalInterfaces: [InternalFailureResult])
         _ * projectConfigurationResult.getStartTime() >> 1
         _ * projectConfigurationResult.getEndTime() >> 2
         _ * projectConfigurationResult.getFailures() >> [Stub(InternalFailure)]
-        _ * projectConfigurationResult.getPluginConfigurationResults() >> [pluginConfigurationResult]
+        _ * projectConfigurationResult.getPluginConfigurationResults() >> [binaryPluginConfigurationResult, scriptPluginConfigurationResult]
 
         def failedEvent = Mock(InternalOperationFinishedProgressEvent)
         _ * failedEvent.getEventTime() >> 999
@@ -197,10 +216,14 @@ class BuildProgressListenerAdapterForProjectConfigurationOperationsTest extends 
             assert event.result.endTime == 2
             assert event.result.failures.size() == 1
             with((ProjectConfigurationFailureResult) event.result) {
-                assert pluginConfigurationResults.size() == 1
+                assert pluginConfigurationResults.size() == 2
+                assert pluginConfigurationResults[0].plugin instanceof BinaryPluginIdentifier
                 assert pluginConfigurationResults[0].plugin.className == 'com.acme.SomePlugin'
                 assert pluginConfigurationResults[0].plugin.pluginId == 'com.acme.some'
-                assert pluginConfigurationResults[0].duration == Duration.ofMillis(42)
+                assert pluginConfigurationResults[0].duration == Duration.ofMillis(23)
+                assert pluginConfigurationResults[1].plugin instanceof ScriptPluginIdentifier
+                assert pluginConfigurationResults[1].plugin.uri == new File(rootDir, "build.gradle").toURI()
+                assert pluginConfigurationResults[1].duration == Duration.ofMillis(42)
             }
         }
     }


### PR DESCRIPTION
This PR adds reporting for configuration times of binary and script plugins as a list of `PluginConfigurationResult` instances to `ProjectConfigurationOperationResult`. Plugins applied using cross-configuration, such as in `subprojects {}` blocks, are reported as part of the project that declared the block.