### PR TITLE
Prefer loopback bind address if available for build daemon communications

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonInitialCommunicationFailureIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonInitialCommunicationFailureIntegrationSpec.groovy
@@ -18,6 +18,7 @@ package org.gradle.launcher.daemon
 
 import org.gradle.integtests.fixtures.KillProcessAvailability
 import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.internal.remote.internal.inet.InetAddressFactory
 import org.gradle.launcher.daemon.logging.DaemonMessages
 import org.junit.Rule
 import org.junit.rules.ExternalResource
@@ -157,7 +158,7 @@ class DaemonInitialCommunicationFailureIntegrationSpec extends DaemonIntegration
         daemon.assertIdle()
 
         when:
-        def socket = new Socket(InetAddress.getByName(null), daemon.port)
+        def socket = new Socket(new InetAddressFactory().localBindingAddress, daemon.port)
         socket.outputStream.write("GET / HTTP/1.0\n\n".getBytes())
         socket.outputStream.flush()
 

--- a/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/remote/internal/inet/InetAddressFactory.java
@@ -32,6 +32,7 @@ public class InetAddressFactory {
     private final Object lock = new Object();
     private List<InetAddress> communicationAddresses;
     private InetAddress localBindingAddress;
+    private InetAddress wildcardBindingAddress;
     private InetAddresses inetAddresses;
     private boolean initialized;
     private String hostName;
@@ -90,6 +91,17 @@ public class InetAddressFactory {
         }
     }
 
+    public InetAddress getWildcardBindingAddress() {
+        try {
+            synchronized (lock) {
+                init();
+                return wildcardBindingAddress;
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not determine a usable wildcard IP for this machine.", e);
+        }
+    }
+
     private void init() throws Exception {
         if (initialized) {
             return;
@@ -99,11 +111,26 @@ public class InetAddressFactory {
         if (inetAddresses == null) { // For testing
             inetAddresses = new InetAddresses();
         }
-        localBindingAddress = new InetSocketAddress(0).getAddress();
+
+        wildcardBindingAddress = new InetSocketAddress(0).getAddress();
+
+        findLocalBindingAddress();
 
         findCommunicationAddresses();
 
         handleOpenshift();
+    }
+
+    /**
+     * Prefer first loopback address if available, otherwise use the wildcard address.
+     */
+    private void findLocalBindingAddress() {
+        if (inetAddresses.getLoopback().isEmpty()) {
+            logger.debug("No loopback address for local binding, using fallback {}", wildcardBindingAddress);
+            localBindingAddress = wildcardBindingAddress;
+        } else {
+            localBindingAddress = inetAddresses.getLoopback().get(0);
+        }
     }
 
     private void handleOpenshift() {
@@ -135,10 +162,10 @@ public class InetAddressFactory {
         if (inetAddresses.getLoopback().isEmpty()) {
             if (inetAddresses.getRemote().isEmpty()) {
                 InetAddress fallback = InetAddress.getByName(null);
-                logger.debug("No loopback addresses, using fallback {}", fallback);
+                logger.debug("No loopback addresses for communication, using fallback {}", fallback);
                 communicationAddresses.add(fallback);
             } else {
-                logger.debug("No loopback addresses, using remote addresses instead.");
+                logger.debug("No loopback addresses for communication, using remote addresses instead.");
                 communicationAddresses.addAll(inetAddresses.getRemote());
             }
         } else {

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/InetAddressFactoryTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/InetAddressFactoryTest.groovy
@@ -68,9 +68,27 @@ class InetAddressFactoryTest extends Specification {
         !factory.isCommunicationAddress(ip(127, 0, 0, 3))
     }
 
-    def "0.0.0.0 is used as bind address by default"() {
+    def "wildcard address is always present"() {
+
         when:
         defaultAddresses()
+
+        then:
+        factory.wildcardBindingAddress == new InetSocketAddress(0).address
+    }
+
+    def "loopback is used as bind address if available"() {
+        when:
+        defaultAddresses()
+
+        then:
+        factory.localBindingAddress == ip(127, 0, 0, 1)
+    }
+
+    def "wildcard address is used as bind address if no loopback available"() {
+        when:
+        loopbackAddresses([])
+        remoteAddresses([ip(192, 168, 18, 256)])
 
         then:
         factory.localBindingAddress == new InetSocketAddress(0).address

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/TcpConnectorTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/TcpConnectorTest.groovy
@@ -284,7 +284,7 @@ class TcpConnectorTest extends ConcurrentSpec {
     def "detects self connect when outgoing connection binds to same port"() {
         given:
         def socketChannel = SocketChannel.open()
-        def communicationAddress = addressFactory.getCommunicationAddresses().find { it instanceof Inet6Address }
+        def communicationAddress = addressFactory.getLocalBindingAddress()
         def bindAnyPort = new InetSocketAddress(communicationAddress, 0)
         socketChannel.socket().bind(bindAnyPort)
         def selfConnect = new InetSocketAddress(communicationAddress, socketChannel.socket().getLocalPort())
@@ -305,7 +305,7 @@ class TcpConnectorTest extends ConcurrentSpec {
         def action = Mock(Action)
         def socketChannel = SocketChannel.open()
         def acceptor = incomingConnector.accept(action, false)
-        def communicationAddress = addressFactory.getCommunicationAddresses().find { it instanceof Inet6Address }
+        def communicationAddress = addressFactory.getLocalBindingAddress()
         def bindAnyPort = new InetSocketAddress(communicationAddress, 0)
         def connectAddress = new InetSocketAddress(communicationAddress, acceptor.address.port)
 

--- a/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
+++ b/subprojects/persistent-cache/src/integTest/groovy/org/gradle/cache/internal/DefaultFileLockManagerContentionIntegrationTest.groovy
@@ -89,7 +89,7 @@ class DefaultFileLockManagerContentionIntegrationTest extends AbstractIntegratio
         poll { assert requestReceived }
 
         // simulate additional requests
-        def socket = new DatagramSocket(0, addressFactory.localBindingAddress)
+        def socket = new DatagramSocket(0, addressFactory.wildcardBindingAddress)
         (1..500).each {
             addressFactory.communicationAddresses.each { address ->
                 byte[] bytes = [1, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockCommunicatorTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/locklistener/FileLockCommunicatorTest.groovy
@@ -36,7 +36,7 @@ class FileLockCommunicatorTest extends ConcurrentSpecification {
         communicator.getPort() != -1
     }
 
-    def "knows port after stopping"() {
+    def "does not know port after stopping"() {
         when:
         communicator.stop()
 
@@ -79,7 +79,7 @@ class FileLockCommunicatorTest extends ConcurrentSpecification {
         }
 
         when:
-        def socket = new DatagramSocket(0, addressFactory.getLocalBindingAddress())
+        def socket = new DatagramSocket(0, addressFactory.getWildcardBindingAddress())
         def bytes = [1, 0, 0, 0, 0, 0, 0, 0, 155] as byte[]
         addressFactory.getCommunicationAddresses().each { address ->
             socket.send(new DatagramPacket(bytes, bytes.length, new InetSocketAddress(address, communicator.port)))


### PR DESCRIPTION
in order to limit build daemon visibility on the network.

Keep file lock communicator bound to wildcard address.
