### PR TITLE
Include task origin plugin in TaskOperationDescriptor

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/CollectionCallbackActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CollectionCallbackActionDecorator.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 
 public interface CollectionCallbackActionDecorator {
 
+    // TODO when removing this feature toggle, also remove this class from the allowed
+    //      classes in org.gradle.integtests.tooling.fixture.ToolingApiClasspathProvider
     String CALLBACK_EXECUTION_BUILD_OPS_TOGGLE = "org.gradle.internal.domain-collection-callback-ops";
 
     @Nullable

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskDescriptor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskDescriptor.java
@@ -16,12 +16,13 @@
 
 package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.internal.protocol.events.InternalTaskWithDependenciesDescriptor;
+import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
+import org.gradle.tooling.internal.protocol.events.InternalTaskWithExtraInfoDescriptor;
 
 import java.io.Serializable;
 import java.util.Set;
 
-public class DefaultTaskDescriptor implements Serializable, InternalTaskWithDependenciesDescriptor {
+public class DefaultTaskDescriptor implements Serializable, InternalTaskWithExtraInfoDescriptor {
 
     private final Object id;
     private final String taskIdentityPath;
@@ -29,14 +30,16 @@ public class DefaultTaskDescriptor implements Serializable, InternalTaskWithDepe
     private final String taskPath;
     private final Object parentId;
     private final Set<DefaultTaskDescriptor> dependencies;
+    private final InternalPluginIdentifier originPlugin;
 
-    public DefaultTaskDescriptor(Object id, String taskIdentityPath, String taskPath, String displayName, Object parentId, Set<DefaultTaskDescriptor> dependencies) {
+    public DefaultTaskDescriptor(Object id, String taskIdentityPath, String taskPath, String displayName, Object parentId, Set<DefaultTaskDescriptor> dependencies, InternalPluginIdentifier originPlugin) {
         this.id = id;
         this.taskIdentityPath = taskIdentityPath;
         this.displayName = displayName;
         this.taskPath = taskPath;
         this.dependencies = dependencies;
         this.parentId = parentId;
+        this.originPlugin = originPlugin;
     }
 
     @Override
@@ -67,6 +70,11 @@ public class DefaultTaskDescriptor implements Serializable, InternalTaskWithDepe
     @Override
     public Set<DefaultTaskDescriptor> getDependencies() {
         return dependencies;
+    }
+
+    @Override
+    public InternalPluginIdentifier getOriginPlugin() {
+        return originPlugin;
     }
 
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
@@ -16,10 +16,6 @@
 
 package org.gradle.tooling.internal.provider.runner;
 
-import com.google.common.base.MoreObjects;
-import org.apache.commons.io.FilenameUtils;
-import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType;
-import org.gradle.configuration.ApplyScriptPluginBuildOperationType;
 import org.gradle.configuration.project.ConfigureProjectBuildOperationType;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
@@ -27,15 +23,12 @@ import org.gradle.internal.operations.OperationFinishEvent;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationStartEvent;
 import org.gradle.tooling.events.OperationType;
-import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalProjectConfigurationResult.InternalPluginConfigurationResult;
-import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.events.AbstractProjectConfigurationResult;
-import org.gradle.tooling.internal.provider.events.DefaultBinaryPluginIdentifier;
 import org.gradle.tooling.internal.provider.events.DefaultFailure;
 import org.gradle.tooling.internal.provider.events.DefaultOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.provider.events.DefaultOperationStartedProgressEvent;
@@ -43,18 +36,14 @@ import org.gradle.tooling.internal.provider.events.DefaultPluginConfigurationRes
 import org.gradle.tooling.internal.provider.events.DefaultProjectConfigurationDescriptor;
 import org.gradle.tooling.internal.provider.events.DefaultProjectConfigurationFailureResult;
 import org.gradle.tooling.internal.provider.events.DefaultProjectConfigurationSuccessResult;
-import org.gradle.tooling.internal.provider.events.DefaultScriptPluginIdentifier;
-import org.gradle.tooling.internal.provider.events.OperationResultPostProcessor;
+import org.gradle.tooling.internal.provider.runner.PluginApplicationTracker.PluginApplication;
 
-import java.io.File;
-import java.net.URI;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
 import static java.util.Comparator.comparing;
@@ -67,34 +56,28 @@ import static java.util.stream.Collectors.toCollection;
  */
 class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilteringBuildOperationListener<ConfigureProjectBuildOperationType.Details> {
 
-    private static final String PROJECT_TARGET_TYPE = "project";
-
     private final Map<OperationIdentifier, ProjectConfigurationResult> results = new ConcurrentHashMap<>();
+    private final BuildOperationParentTracker parentTracker;
+    private final PluginApplicationTracker pluginApplicationTracker;
 
-    ClientForwardingProjectConfigurationOperationListener(ProgressEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate, OperationResultPostProcessor operationResultPostProcessor) {
+    ClientForwardingProjectConfigurationOperationListener(ProgressEventConsumer eventConsumer, BuildClientSubscriptions clientSubscriptions, BuildOperationListener delegate,
+                                                          BuildOperationParentTracker parentTracker, PluginApplicationTracker pluginApplicationTracker) {
         super(eventConsumer, clientSubscriptions, delegate, OperationType.PROJECT_CONFIGURATION, ConfigureProjectBuildOperationType.Details.class);
-    }
-
-    @Override
-    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
-        if (isEnabled() && buildOperation.getParentId() != null && results.containsKey(buildOperation.getParentId())) {
-            results.put(buildOperation.getId(), results.get(buildOperation.getParentId()));
-        }
-        super.started(buildOperation, startEvent);
+        this.parentTracker = parentTracker;
+        this.pluginApplicationTracker = pluginApplicationTracker;
     }
 
     @Override
     public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
         super.finished(buildOperation, finishEvent);
-        if (isEnabled() && results.containsKey(buildOperation.getId())) {
-            if (buildOperation.getDetails() instanceof ApplyPluginBuildOperationType.Details) {
-                ApplyPluginBuildOperationType.Details details = (ApplyPluginBuildOperationType.Details) buildOperation.getDetails();
-                incrementDuration(buildOperation, details.getTargetType(), details.getApplicationId(), finishEvent, () -> toBinaryPluginIdentifier(details));
-            } else if (buildOperation.getDetails() instanceof ApplyScriptPluginBuildOperationType.Details) {
-                ApplyScriptPluginBuildOperationType.Details details = (ApplyScriptPluginBuildOperationType.Details) buildOperation.getDetails();
-                incrementDuration(buildOperation, details.getTargetType(), details.getApplicationId(), finishEvent, () -> toScriptPluginIdentifier(details));
+        if (isEnabled()) {
+            PluginApplication pluginApplication = pluginApplicationTracker.getPluginApplication(buildOperation.getId());
+            if (pluginApplication != null) {
+                ProjectConfigurationResult result = parentTracker.findClosestExistingAncestor(buildOperation.getParentId(), results::get);
+                if (result != null) {
+                    result.increment(pluginApplication, finishEvent.getEndTime() - finishEvent.getStartTime());
+                }
             }
-            results.remove(buildOperation.getId());
         }
     }
 
@@ -110,40 +93,10 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
         return new DefaultOperationFinishedProgressEvent(finishEvent.getEndTime(), toProjectConfigurationDescriptor(buildOperation, details), result);
     }
 
-    private InternalBinaryPluginIdentifier toBinaryPluginIdentifier(ApplyPluginBuildOperationType.Details details) {
-        String className = details.getPluginClass().getName();
-        String pluginId = details.getPluginId();
-        String displayName = MoreObjects.firstNonNull(pluginId, className);
-        return new DefaultBinaryPluginIdentifier(displayName, className, pluginId);
-    }
-
-    private InternalScriptPluginIdentifier toScriptPluginIdentifier(ApplyScriptPluginBuildOperationType.Details details) {
-        String fileString = details.getFile();
-        if (fileString != null) {
-            File file = new File(fileString);
-            return new DefaultScriptPluginIdentifier(file.getName(), file.toURI());
-        }
-        String uriString = details.getUri();
-        if (uriString != null) {
-            URI uri = URI.create(uriString);
-            return new DefaultScriptPluginIdentifier(FilenameUtils.getName(uri.getPath()), uri);
-        }
-        return null;
-    }
-
-    private void incrementDuration(BuildOperationDescriptor buildOperation, String targetType, long applicationId, OperationFinishEvent finishEvent, Supplier<? extends InternalPluginIdentifier> pluginSupplier) {
-        if (PROJECT_TARGET_TYPE.equals(targetType)) {
-            InternalPluginIdentifier plugin = pluginSupplier.get();
-            if (plugin != null) {
-                results.get(buildOperation.getId()).increment(plugin, applicationId, finishEvent.getEndTime() - finishEvent.getStartTime());
-            }
-        }
-    }
-
     private DefaultProjectConfigurationDescriptor toProjectConfigurationDescriptor(BuildOperationDescriptor buildOperation, ConfigureProjectBuildOperationType.Details details) {
         Object id = buildOperation.getId();
         String displayName = buildOperation.getDisplayName();
-        Object parentId = eventConsumer.findStartedParentId(buildOperation.getParentId());
+        Object parentId = eventConsumer.findStartedParentId(buildOperation);
         return new DefaultProjectConfigurationDescriptor(id, displayName, parentId, details.getRootDir(), details.getProjectPath());
     }
 
@@ -162,11 +115,14 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
 
         private final Map<InternalPluginIdentifier, PluginConfigurationResult> pluginResults = new ConcurrentHashMap<>();
 
-        public void increment(InternalPluginIdentifier plugin, long applicationId, long duration) {
-            pluginResults.computeIfAbsent(plugin, key -> new PluginConfigurationResult(plugin, applicationId)).increment(duration);
+        void increment(PluginApplication pluginApplication, long duration) {
+            InternalPluginIdentifier plugin = pluginApplication.getPlugin();
+            pluginResults
+                .computeIfAbsent(plugin, key -> new PluginConfigurationResult(plugin, pluginApplication.getApplicationId()))
+                .increment(duration);
         }
 
-        public List<InternalPluginConfigurationResult> toInternalPluginConfigurationResults() {
+        List<InternalPluginConfigurationResult> toInternalPluginConfigurationResults() {
             return pluginResults.values().stream()
                 .sorted(comparing(PluginConfigurationResult::getFirstApplicationId))
                 .map(PluginConfigurationResult::toInternalPluginConfigurationResult)
@@ -177,16 +133,16 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
 
     private static class PluginConfigurationResult {
 
+        private AtomicLong duration = new AtomicLong();
         private final InternalPluginIdentifier plugin;
         private final long firstApplicationId;
-        private AtomicLong duration = new AtomicLong();
 
-        public PluginConfigurationResult(InternalPluginIdentifier plugin, long firstApplicationId) {
+        PluginConfigurationResult(InternalPluginIdentifier plugin, long firstApplicationId) {
             this.plugin = plugin;
             this.firstApplicationId = firstApplicationId;
         }
 
-        public long getFirstApplicationId() {
+        long getFirstApplicationId() {
             return firstApplicationId;
         }
 
@@ -194,7 +150,7 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
             this.duration.addAndGet(duration);
         }
 
-        public InternalPluginConfigurationResult toInternalPluginConfigurationResult() {
+        InternalPluginConfigurationResult toInternalPluginConfigurationResult() {
             return new DefaultPluginConfigurationResult(plugin, Duration.ofMillis(duration.get()));
         }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingWorkItemOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingWorkItemOperationListener.java
@@ -56,7 +56,7 @@ class ClientForwardingWorkItemOperationListener extends SubtreeFilteringBuildOpe
         Object id = buildOperation.getId();
         String className = details.getClassName();
         String displayName = buildOperation.getDisplayName();
-        Object parentId = eventConsumer.findStartedParentId(buildOperation.getParentId());
+        Object parentId = eventConsumer.findStartedParentId(buildOperation);
         return new DefaultWorkItemDescriptor(id, className, displayName, parentId);
     }
 

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/PluginApplicationTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/PluginApplicationTracker.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import com.google.common.base.MoreObjects;
+import org.apache.commons.io.FilenameUtils;
+import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType;
+import org.gradle.configuration.ApplyScriptPluginBuildOperationType;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier;
+import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
+import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier;
+import org.gradle.tooling.internal.provider.events.DefaultBinaryPluginIdentifier;
+import org.gradle.tooling.internal.provider.events.DefaultScriptPluginIdentifier;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+class PluginApplicationTracker implements BuildOperationListener {
+
+    private static final String PROJECT_TARGET_TYPE = "project";
+
+    private final Map<OperationIdentifier, PluginApplication> pluginApplications = new ConcurrentHashMap<>();
+    private final BuildOperationParentTracker parentTracker;
+
+    PluginApplicationTracker(BuildOperationParentTracker parentTracker) {
+        this.parentTracker = parentTracker;
+    }
+
+    @Nullable
+    public PluginApplication getPluginApplication(OperationIdentifier id) {
+        return pluginApplications.get(id);
+    }
+
+    @Nullable
+    public PluginApplication findCurrentPluginApplication(OperationIdentifier id) {
+        return parentTracker.findClosestExistingAncestor(id, pluginApplications::get);
+    }
+
+    @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        if (buildOperation.getDetails() instanceof ApplyPluginBuildOperationType.Details) {
+            ApplyPluginBuildOperationType.Details details = (ApplyPluginBuildOperationType.Details) buildOperation.getDetails();
+            add(buildOperation, details.getTargetType(), details.getApplicationId(), () -> toBinaryPluginIdentifier(details));
+        } else if (buildOperation.getDetails() instanceof ApplyScriptPluginBuildOperationType.Details) {
+            ApplyScriptPluginBuildOperationType.Details details = (ApplyScriptPluginBuildOperationType.Details) buildOperation.getDetails();
+            add(buildOperation, details.getTargetType(), details.getApplicationId(), () -> toScriptPluginIdentifier(details));
+        }
+    }
+
+    private void add(BuildOperationDescriptor buildOperation, String targetType, long applicationId, Supplier<InternalPluginIdentifier> pluginSupplier) {
+        if (PROJECT_TARGET_TYPE.equals(targetType)) {
+            InternalPluginIdentifier plugin = pluginSupplier.get();
+            if (plugin != null) {
+                pluginApplications.put(buildOperation.getId(), new PluginApplication(applicationId, plugin));
+            }
+        }
+    }
+
+    @Override
+    public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        pluginApplications.remove(buildOperation.getId());
+    }
+
+    private InternalBinaryPluginIdentifier toBinaryPluginIdentifier(ApplyPluginBuildOperationType.Details details) {
+        String className = details.getPluginClass().getName();
+        String pluginId = details.getPluginId();
+        String displayName = MoreObjects.firstNonNull(pluginId, className);
+        return new DefaultBinaryPluginIdentifier(displayName, className, pluginId);
+    }
+
+    private InternalScriptPluginIdentifier toScriptPluginIdentifier(ApplyScriptPluginBuildOperationType.Details details) {
+        String fileString = details.getFile();
+        if (fileString != null) {
+            File file = new File(fileString);
+            return new DefaultScriptPluginIdentifier(file.getName(), file.toURI());
+        }
+        String uriString = details.getUri();
+        if (uriString != null) {
+            URI uri = URI.create(uriString);
+            return new DefaultScriptPluginIdentifier(FilenameUtils.getName(uri.getPath()), uri);
+        }
+        return null;
+    }
+
+    static class PluginApplication {
+
+        private final long applicationId;
+        private final InternalPluginIdentifier plugin;
+
+        PluginApplication(long applicationId, InternalPluginIdentifier plugin) {
+            this.applicationId = applicationId;
+            this.plugin = plugin;
+        }
+
+        public long getApplicationId() {
+            return applicationId;
+        }
+
+        public InternalPluginIdentifier getPlugin() {
+            return plugin;
+        }
+
+    }
+
+}

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ProgressEventConsumer.java
@@ -17,7 +17,7 @@
 package org.gradle.tooling.internal.provider.runner;
 
 import org.gradle.initialization.BuildEventConsumer;
-import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent;
 import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent;
 
@@ -35,11 +35,8 @@ class ProgressEventConsumer {
         this.parentTracker = parentTracker;
     }
 
-    Object findStartedParentId(OperationIdentifier id) {
-        if (id == null || startedIds.contains(id)) {
-            return id;
-        }
-        return findStartedParentId(parentTracker.getParent(id));
+    Object findStartedParentId(BuildOperationDescriptor operation) {
+        return parentTracker.findClosestMatchingAncestor(operation.getParentId(), startedIds::contains);
     }
 
     void started(InternalOperationStartedProgressEvent event) {

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOriginTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOriginTracker.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.provider.runner;
+
+import org.gradle.api.internal.project.taskfactory.TaskIdentity;
+import org.gradle.api.internal.tasks.RealizeTaskBuildOperationType;
+import org.gradle.api.internal.tasks.RegisterTaskBuildOperationType;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationListener;
+import org.gradle.internal.operations.OperationFinishEvent;
+import org.gradle.internal.operations.OperationIdentifier;
+import org.gradle.internal.operations.OperationProgressEvent;
+import org.gradle.internal.operations.OperationStartEvent;
+import org.gradle.tooling.internal.protocol.events.InternalPluginIdentifier;
+import org.gradle.tooling.internal.provider.runner.PluginApplicationTracker.PluginApplication;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class TaskOriginTracker implements BuildOperationListener {
+
+    private final Map<Long, InternalPluginIdentifier> origins = new ConcurrentHashMap<>();
+    private final PluginApplicationTracker pluginApplicationTracker;
+
+    TaskOriginTracker(PluginApplicationTracker pluginApplicationTracker) {
+        this.pluginApplicationTracker = pluginApplicationTracker;
+    }
+
+    @Nullable
+    InternalPluginIdentifier getOriginPlugin(TaskIdentity<?> taskIdentity) {
+        return origins.get(taskIdentity.uniqueId);
+    }
+
+    @Override
+    public void started(BuildOperationDescriptor buildOperation, OperationStartEvent startEvent) {
+        if (buildOperation.getDetails() instanceof RealizeTaskBuildOperationType.Details) {
+            RealizeTaskBuildOperationType.Details details = (RealizeTaskBuildOperationType.Details) buildOperation.getDetails();
+            storeOrigin(buildOperation, details.getTaskId());
+        } else if (buildOperation.getDetails() instanceof RegisterTaskBuildOperationType.Details) {
+            RegisterTaskBuildOperationType.Details details = (RegisterTaskBuildOperationType.Details) buildOperation.getDetails();
+            storeOrigin(buildOperation, details.getTaskId());
+        }
+    }
+
+    private void storeOrigin(BuildOperationDescriptor buildOperation, long taskId) {
+        origins.computeIfAbsent(taskId, key -> {
+            PluginApplication pluginApplication = pluginApplicationTracker.findCurrentPluginApplication(buildOperation.getParentId());
+            return pluginApplication == null ? null : pluginApplication.getPlugin();
+        });
+    }
+
+    @Override
+    public void progress(OperationIdentifier operationIdentifier, OperationProgressEvent progressEvent) {
+    }
+
+    @Override
+    public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
+        // origins have to be stored until the end of the build
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskOriginCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskOriginCrossVersionSpec.groovy
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r51
+
+import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.events.task.TaskOperationDescriptor
+import org.gradle.tooling.model.UnsupportedMethodException
+
+@ToolingApiVersion('>=5.1')
+@TargetGradleVersion('>=5.1')
+class TaskOriginCrossVersionSpec extends ToolingApiSpecification {
+
+    def events = ProgressEvents.create()
+
+    def "reports task origin for script plugins"() {
+        given:
+        file("script.gradle") << """
+            task b { dependsOn('a') }
+        """
+        buildFile << """
+            apply from: 'script.gradle'
+            task a {}
+        """
+
+        when:
+        runBuild('b')
+
+        then:
+        task(':a').originPlugin.displayName == "build.gradle"
+        task(':b').originPlugin.displayName == "script.gradle"
+    }
+
+    def "reports task origin for binary plugins"() {
+        given:
+        buildFile << """
+            apply plugin: 'java'
+        """
+
+        when:
+        runBuild('build')
+
+        then:
+        task(':classes').originPlugin.displayName == "org.gradle.java"
+        task(':jar').originPlugin.displayName == "org.gradle.java"
+        task(':assemble').originPlugin.displayName == "org.gradle.language.base.plugins.LifecycleBasePlugin"
+        task(':test').originPlugin.displayName == "org.gradle.java"
+        task(':check').originPlugin.displayName == "org.gradle.language.base.plugins.LifecycleBasePlugin"
+        task(':build').originPlugin.displayName == "org.gradle.language.base.plugins.LifecycleBasePlugin"
+    }
+
+    def "reports task origin for lazily realized tasks"() {
+        given:
+        buildFile << """
+            tasks.register('lazyTask') {
+                doLast { println 'nothing to see here' }
+            }
+        """
+
+        when:
+        runBuild('lazyTask')
+
+        then:
+        task(':lazyTask').originPlugin.displayName == "build.gradle"
+    }
+
+    @TargetGradleVersion('>=2.6 <5.1')
+    def "throws UnsupportedMethodException for task origin when target version does not support it"() {
+        when:
+        runBuild('tasks')
+
+        and:
+        task(':tasks').originPlugin
+
+        then:
+        def e = thrown(UnsupportedMethodException)
+        e.message.startsWith("Unsupported method: TaskOperationDescriptor.getOriginPlugin()")
+    }
+
+    private void runBuild(String... tasks) {
+        withConnection {
+            ProjectConnection connection ->
+                connection.newBuild()
+                    .forTasks(tasks)
+                    .addProgressListener(events, EnumSet.of(OperationType.TASK))
+                    .run()
+        }
+    }
+
+    private TaskOperationDescriptor task(String path) {
+        events.operation("Task $path").descriptor as TaskOperationDescriptor
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskOriginCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskOriginCrossVersionSpec.groovy
@@ -16,11 +16,13 @@
 
 package org.gradle.integtests.tooling.r51
 
+import org.gradle.api.Action
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.BuildLauncher
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.task.TaskOperationDescriptor
 import org.gradle.tooling.model.UnsupportedMethodException
@@ -95,13 +97,70 @@ class TaskOriginCrossVersionSpec extends ToolingApiSpecification {
         e.message.startsWith("Unsupported method: TaskOperationDescriptor.getOriginPlugin()")
     }
 
-    private void runBuild(String... tasks) {
+    def "reports task origin for tasks defined in project evaluation listener callbacks"() {
+        given:
+        buildFile << """
+            apply plugin: MyPlugin
+            afterEvaluate {
+                task a {}
+            }
+            class MyPlugin implements Plugin<Project> {
+                void apply(Project project) {
+                    project.afterEvaluate {
+                        project.tasks.create('b') {
+                            dependsOn('a')
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        runBuild('b')
+
+        then:
+        task(':a').originPlugin.displayName == "build.gradle"
+        task(':b').originPlugin.displayName == "MyPlugin"
+    }
+
+    def "reports task origin for tasks defined in configuration callbacks"() {
+        given:
+        buildFile << """
+            apply plugin: MyPlugin
+
+            configurations {
+                foo
+            }
+
+            class MyPlugin implements Plugin<Project> {
+                void apply(Project project) {
+                    project.configurations.all {
+                        project.tasks.create("print\${it.name.capitalize()}") {
+                            doLast {
+                                println it.name
+                            }
+                        }
+                    }
+                }
+            }
+        """
+
+        when:
+        runBuild('printFoo') {
+            it.withArguments("-D${CollectionCallbackActionDecorator.CALLBACK_EXECUTION_BUILD_OPS_TOGGLE}=true")
+        }
+
+        then:
+        task(':printFoo').originPlugin.displayName == "MyPlugin"
+    }
+
+    private void runBuild(String task, Action<BuildLauncher> config = {}) {
         withConnection {
-            ProjectConnection connection ->
-                connection.newBuild()
-                    .forTasks(tasks)
+                def launcher = newBuild()
+                    .forTasks(task)
                     .addProgressListener(events, EnumSet.of(OperationType.TASK))
-                    .run()
+                config.execute(launcher)
+                launcher.run()
         }
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskOperationDescriptor.java
@@ -17,8 +17,10 @@ package org.gradle.tooling.events.task;
 
 import org.gradle.api.Incubating;
 import org.gradle.tooling.events.OperationDescriptor;
+import org.gradle.tooling.events.PluginIdentifier;
 import org.gradle.tooling.model.UnsupportedMethodException;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -36,11 +38,21 @@ public interface TaskOperationDescriptor extends OperationDescriptor {
     /**
      * Returns the dependencies of the task, if available.
      *
-     * @return The dependencies of the task
      * @throws UnsupportedMethodException For Gradle versions older than 5.1, where this method is not supported.
      * @since 5.1
      */
     @Incubating
     Set<? extends OperationDescriptor> getDependencies() throws UnsupportedMethodException;
+
+    /**
+     * Returns the identifier of the plugin that registered this task, if available.
+     *
+     * @throws UnsupportedMethodException For Gradle versions older than 5.1, where this method is not supported.
+     * @since 5.1
+     * @return the origin plugin; {@code null} if unknown
+     */
+    @Nullable
+    @Incubating
+    PluginIdentifier getOriginPlugin();
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskOperationDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskOperationDescriptor.java
@@ -16,12 +16,16 @@
 
 package org.gradle.tooling.events.task.internal;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.gradle.tooling.events.OperationDescriptor;
+import org.gradle.tooling.events.PluginIdentifier;
 import org.gradle.tooling.events.internal.DefaultOperationDescriptor;
 import org.gradle.tooling.events.task.TaskOperationDescriptor;
 import org.gradle.tooling.internal.protocol.events.InternalTaskDescriptor;
 import org.gradle.tooling.model.internal.Exceptions;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -29,13 +33,25 @@ import java.util.Set;
  */
 public final class DefaultTaskOperationDescriptor extends DefaultOperationDescriptor implements TaskOperationDescriptor {
 
-    private final String taskPath;
-    private final Set<OperationDescriptor> dependencies;
+    private static final String DEPENDENCIES_METHOD = TaskOperationDescriptor.class.getSimpleName() + ".getDependencies()";
+    private static final String ORIGIN_PLUGIN_METHOD = TaskOperationDescriptor.class.getSimpleName() + ".getOriginPlugin()";
 
-    public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath, Set<OperationDescriptor> dependencies) {
+    private final String taskPath;
+    private final Supplier<Set<OperationDescriptor>> dependencies;
+    private final Supplier<PluginIdentifier> originPlugin;
+
+    public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath) {
         super(descriptor, parent);
         this.taskPath = taskPath;
-        this.dependencies = dependencies;
+        this.dependencies = unsupportedMethodExceptionThrowingSupplier(DEPENDENCIES_METHOD);
+        this.originPlugin = unsupportedMethodExceptionThrowingSupplier(ORIGIN_PLUGIN_METHOD);
+    }
+
+    public DefaultTaskOperationDescriptor(InternalTaskDescriptor descriptor, OperationDescriptor parent, String taskPath, Set<OperationDescriptor> dependencies, @Nullable PluginIdentifier originPlugin) {
+        super(descriptor, parent);
+        this.taskPath = taskPath;
+        this.dependencies = Suppliers.ofInstance(dependencies);
+        this.originPlugin = Suppliers.ofInstance(originPlugin);
     }
 
     @Override
@@ -45,10 +61,22 @@ public final class DefaultTaskOperationDescriptor extends DefaultOperationDescri
 
     @Override
     public Set<? extends OperationDescriptor> getDependencies() {
-        if (dependencies == null) {
-            throw Exceptions.unsupportedMethod(TaskOperationDescriptor.class.getSimpleName() + ".getDependencies()");
-        }
-        return dependencies;
+        return dependencies.get();
+    }
+
+    @Override
+    @Nullable
+    public PluginIdentifier getOriginPlugin() {
+        return originPlugin.get();
+    }
+
+    private static <T> Supplier<T> unsupportedMethodExceptionThrowingSupplier(final String method) {
+        return new Supplier<T>() {
+            @Override
+            public T get() {
+                throw Exceptions.unsupportedMethod(method);
+            }
+        };
     }
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalTaskWithExtraInfoDescriptor.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalTaskWithExtraInfoDescriptor.java
@@ -23,11 +23,16 @@ import java.util.Set;
  *
  * @since 5.1
  */
-public interface InternalTaskWithDependenciesDescriptor extends InternalTaskDescriptor {
+public interface InternalTaskWithExtraInfoDescriptor extends InternalTaskDescriptor {
+
     /**
      * Returns the dependencies of the task.
-     *
-     * @return The dependencies of the task
      */
     Set<? extends InternalOperationDescriptor> getDependencies();
+
+    /**
+     * Returns the plugin that registered this task.
+     */
+    InternalPluginIdentifier getOriginPlugin();
+
 }

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTaskOperationsTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapterForTaskOperationsTest.groovy
@@ -16,13 +16,29 @@
 
 package org.gradle.tooling.internal.consumer.parameters
 
+import org.gradle.testing.internal.util.Specification
+import org.gradle.tooling.events.BinaryPluginIdentifier
 import org.gradle.tooling.events.OperationType
 import org.gradle.tooling.events.ProgressListener
-import org.gradle.tooling.events.task.*
+import org.gradle.tooling.events.ScriptPluginIdentifier
+import org.gradle.tooling.events.task.TaskFailureResult
+import org.gradle.tooling.events.task.TaskFinishEvent
+import org.gradle.tooling.events.task.TaskSkippedResult
+import org.gradle.tooling.events.task.TaskStartEvent
+import org.gradle.tooling.events.task.TaskSuccessResult
 import org.gradle.tooling.internal.protocol.InternalBuildProgressListener
 import org.gradle.tooling.internal.protocol.InternalFailure
-import org.gradle.tooling.internal.protocol.events.*
-import spock.lang.Specification
+import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier
+import org.gradle.tooling.internal.protocol.events.InternalOperationDescriptor
+import org.gradle.tooling.internal.protocol.events.InternalOperationFinishedProgressEvent
+import org.gradle.tooling.internal.protocol.events.InternalOperationStartedProgressEvent
+import org.gradle.tooling.internal.protocol.events.InternalProgressEvent
+import org.gradle.tooling.internal.protocol.events.InternalScriptPluginIdentifier
+import org.gradle.tooling.internal.protocol.events.InternalTaskDescriptor
+import org.gradle.tooling.internal.protocol.events.InternalTaskFailureResult
+import org.gradle.tooling.internal.protocol.events.InternalTaskSkippedResult
+import org.gradle.tooling.internal.protocol.events.InternalTaskSuccessResult
+import org.gradle.tooling.internal.protocol.events.InternalTaskWithExtraInfoDescriptor
 
 class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
 
@@ -361,7 +377,7 @@ class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
         def listener = Mock(ProgressListener)
         def adapter = createAdapter(listener)
 
-        def dependencyTaskDescriptor = Stub(InternalTaskWithDependenciesDescriptor)
+        def dependencyTaskDescriptor = Stub(InternalTaskWithExtraInfoDescriptor)
         _ * dependencyTaskDescriptor.getId() >> ':dependency'
         _ * dependencyTaskDescriptor.getName() >> 'dependency task'
         _ * dependencyTaskDescriptor.getParentId() >> null
@@ -383,12 +399,13 @@ class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
         _ * dependencyFinishEvent.getDescriptor() >> dependencyTaskDescriptor
         _ * dependencyFinishEvent.getResult() >> dependencyTaskResult
 
-        def taskDescriptor = Stub(InternalTaskWithDependenciesDescriptor)
+        def taskDescriptor = Stub(InternalTaskWithExtraInfoDescriptor)
         _ * taskDescriptor.getId() >> ':dummy'
         _ * taskDescriptor.getName() >> 'some task'
         _ * taskDescriptor.getParentId() >> null
         _ * taskDescriptor.getTaskPath() >> ':some:path'
         _ * taskDescriptor.getDependencies() >> [dependencyTaskDescriptor]
+        _ * taskDescriptor.getOriginPlugin() >> null
 
         def startEvent = Stub(InternalOperationStartedProgressEvent)
         _ * startEvent.getEventTime() >> 1000
@@ -413,6 +430,7 @@ class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
             assert event.descriptor.taskPath == ':some:path'
             assert event.descriptor.parent == null
             assert event.descriptor.dependencies.size() == 1
+            assert event.descriptor.originPlugin == null
             with(event.descriptor.dependencies[0]) {
                 assert it.name == 'dependency task'
                 assert it.taskPath == ':dependency:path'
@@ -422,12 +440,68 @@ class BuildProgressListenerAdapterForTaskOperationsTest extends Specification {
         }
     }
 
+    def "convert task origin for script plugin"() {
+        given:
+        def listener = Mock(ProgressListener)
+        def adapter = createAdapter(listener)
+
+        def taskOrigin = Stub(InternalScriptPluginIdentifier)
+        _ * taskOrigin.getDisplayName() >> "build.gradle"
+        _ * taskOrigin.getUri() >> URI.create("http://example.com/build.gradle")
+
+        def taskDescriptor = Stub(InternalTaskWithExtraInfoDescriptor)
+        _ * taskDescriptor.getParentId() >> null
+        _ * taskDescriptor.getOriginPlugin() >> taskOrigin
+
+        def startEvent = Stub(InternalOperationStartedProgressEvent)
+        _ * startEvent.getDescriptor() >> taskDescriptor
+
+        when:
+        adapter.onEvent(startEvent)
+
+        then:
+        1 * listener.statusChanged(_ as TaskStartEvent) >> { TaskStartEvent event ->
+            assert event.descriptor.originPlugin instanceof ScriptPluginIdentifier
+            assert event.descriptor.originPlugin.displayName == 'build.gradle'
+            assert event.descriptor.originPlugin.uri == URI.create("http://example.com/build.gradle")
+        }
+    }
+
+    def "convert task origin for binary plugin"() {
+        given:
+        def listener = Mock(ProgressListener)
+        def adapter = createAdapter(listener)
+
+        def taskOrigin = Stub(InternalBinaryPluginIdentifier)
+        _ * taskOrigin.getDisplayName() >> "org.example"
+        _ * taskOrigin.getClassName() >> "org.example.MyPlugin"
+        _ * taskOrigin.getPluginId() >> "org.example"
+
+        def taskDescriptor = Stub(InternalTaskWithExtraInfoDescriptor)
+        _ * taskDescriptor.getParentId() >> null
+        _ * taskDescriptor.getOriginPlugin() >> taskOrigin
+
+        def startEvent = Stub(InternalOperationStartedProgressEvent)
+        _ * startEvent.getDescriptor() >> taskDescriptor
+
+        when:
+        adapter.onEvent(startEvent)
+
+        then:
+        1 * listener.statusChanged(_ as TaskStartEvent) >> { TaskStartEvent event ->
+            assert event.descriptor.originPlugin instanceof BinaryPluginIdentifier
+            assert event.descriptor.originPlugin.displayName == 'org.example'
+            assert event.descriptor.originPlugin.className == 'org.example.MyPlugin'
+            assert event.descriptor.originPlugin.pluginId == 'org.example'
+        }
+    }
+
     def "ignores unknown dependencies"() {
         given:
         def listener = Mock(ProgressListener)
         def adapter = createAdapter(listener)
 
-        def taskDescriptor = Stub(InternalTaskWithDependenciesDescriptor)
+        def taskDescriptor = Stub(InternalTaskWithExtraInfoDescriptor)
         _ * taskDescriptor.getId() >> ':dummy'
         _ * taskDescriptor.getName() >> 'some task'
         _ * taskDescriptor.getParentId() >> null

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClasspathProvider.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClasspathProvider.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.tooling.fixture
 
 import org.apache.commons.io.output.TeeOutputStream
 import org.gradle.api.Action
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.internal.classloader.DefaultClassLoaderFactory
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.classloader.MultiParentClassLoader
@@ -72,6 +73,7 @@ trait ToolingApiClasspathProvider {
         sharedSpec.allowClass(ToolingApiVersion)
         sharedSpec.allowClass(TeeOutputStream)
         sharedSpec.allowClass(ClassLoaderFixture)
+        sharedSpec.allowClass(CollectionCallbackActionDecorator) // TODO remove this class when the CALLBACK_EXECUTION_BUILD_OPS_TOGGLE feature toggle is removed
         classpathConfigurer.execute(sharedSpec)
         def sharedClassLoader = classLoaderFactory.createFilteringClassLoader(getClass().classLoader, sharedSpec)
 


### PR DESCRIPTION
The plugin that registered a task is now reported to TAPI progress
listeners as a `PluginIdentifier` returned from
`TaskOperationDescriptor.getOriginPlugin()`.