### PR TITLE
Report task execution reasons and incrementality

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/scan/NotUsedByScanPlugin.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/scan/NotUsedByScanPlugin.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.scan;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Documents that the type or method is <em>not</em> referenced by the build scan plugin,
+ * and therefore can be changed or removed without breaking it.
+ *
+ * @since 5.1
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface NotUsedByScanPlugin {
+
+    /**
+     * Any clarifying comments about why it isn't used by the build scan plugin or how it is used instead.
+     */
+    String value() default "";
+
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.project.taskfactory;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.reflect.Instantiator;
@@ -47,8 +46,6 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
 
     private <S extends Task> S process(S task) {
         TaskClassInfo taskClassInfo = taskClassInfoStore.getTaskClassInfo(task.getClass());
-
-        ((TaskStateInternal) task.getState()).setIncremental(taskClassInfo.isIncremental());
 
         if (taskClassInfo.isIncremental()) {
             // Add a dummy upToDateWhen spec: this will force TaskOutputs.hasOutputs() to be true.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.project.taskfactory;
 import org.gradle.api.Task;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.internal.reflect.Instantiator;
@@ -46,6 +47,8 @@ public class AnnotationProcessingTaskFactory implements ITaskFactory {
 
     private <S extends Task> S process(S task) {
         TaskClassInfo taskClassInfo = taskClassInfoStore.getTaskClassInfo(task.getClass());
+
+        ((TaskStateInternal) task.getState()).setIncremental(taskClassInfo.isIncremental());
 
         if (taskClassInfo.isIncremental()) {
             // Add a dummy upToDateWhen spec: this will force TaskOutputs.hasOutputs() to be true.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.internal.changedetection.TaskArtifactState;
 import org.gradle.api.internal.tasks.execution.TaskProperties;
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 
@@ -74,4 +75,13 @@ public interface TaskExecutionContext {
     boolean isTaskCachingEnabled();
 
     void setTaskCachingEnabled(boolean enabled);
+
+    /**
+     * Returns if this task was executed incrementally.
+     *
+     * @see IncrementalTaskInputs#isIncremental()
+     */
+    boolean isTaskExecutedIncrementally();
+
+    void setTaskExecutedIncrementally(boolean taskExecutedIncrementally);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -32,6 +32,7 @@ public class TaskStateInternal implements TaskState {
     private RuntimeException failure;
     private TaskOutputCachingState taskOutputCaching = DefaultTaskOutputCachingState.disabled(TaskOutputCachingDisabledReasonCategory.UNKNOWN, "Cacheability was not determined");
     private TaskExecutionOutcome outcome;
+    private boolean incremental = false;
 
     public boolean getDidWork() {
         return didWork;
@@ -138,5 +139,13 @@ public class TaskStateInternal implements TaskState {
 
     public void setActionable(boolean actionable) {
         this.actionable = actionable;
+    }
+
+    public boolean isIncremental() {
+        return incremental;
+    }
+
+    public void setIncremental(boolean incremental) {
+        this.incremental = incremental;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskStateInternal.java
@@ -32,7 +32,6 @@ public class TaskStateInternal implements TaskState {
     private RuntimeException failure;
     private TaskOutputCachingState taskOutputCaching = DefaultTaskOutputCachingState.disabled(TaskOutputCachingDisabledReasonCategory.UNKNOWN, "Cacheability was not determined");
     private TaskExecutionOutcome outcome;
-    private boolean incremental = false;
 
     public boolean getDidWork() {
         return didWork;
@@ -139,13 +138,5 @@ public class TaskStateInternal implements TaskState {
 
     public void setActionable(boolean actionable) {
         this.actionable = actionable;
-    }
-
-    public boolean isIncremental() {
-        return incremental;
-    }
-
-    public void setIncremental(boolean incremental) {
-        this.incremental = incremental;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -36,6 +36,7 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
     private Long executionTime;
 
     private final Timer executionTimer;
+    private boolean taskExecutedIncrementally;
 
     public DefaultTaskExecutionContext() {
         this.executionTimer = Time.startTimer();
@@ -118,5 +119,15 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
     @Override
     public void setTaskCachingEnabled(boolean taskCachingEnabled) {
         this.taskCachingEnabled = taskCachingEnabled;
+    }
+
+    @Override
+    public boolean isTaskExecutedIncrementally() {
+        return taskExecutedIncrementally;
+    }
+
+    @Override
+    public void setTaskExecutedIncrementally(boolean taskExecutedIncrementally) {
+        this.taskExecutedIncrementally = taskExecutedIncrementally;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationResult.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationResult.java
@@ -84,4 +84,9 @@ public class ExecuteTaskBuildOperationResult implements ExecuteTaskBuildOperatio
         return ctx.getUpToDateMessages();
     }
 
+    @Override
+    public boolean isIncremental() {
+        return ctx.isTaskExecutedIncrementally();
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.execution;
 
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.NotUsedByScanPlugin;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
@@ -125,6 +126,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
          *
          * @see IncrementalTaskInputs#isIncremental()
          */
+        @NotUsedByScanPlugin("used to report incrementality to TAPI progress listeners")
         boolean isIncremental();
 
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.tasks.execution;
 
+import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
@@ -118,6 +119,13 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
          */
         @Nullable
         List<String> getUpToDateMessages();
+
+        /**
+         * Returns if this task was executed incrementally.
+         *
+         * @see IncrementalTaskInputs#isIncremental()
+         */
+        boolean isIncremental();
 
     }
 

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -63,6 +63,22 @@
            "member": "Method org.gradle.api.tasks.bundling.AbstractArchiveTask.getDestinationDirectory()",
            "acceptation": "Replacing existing properties with Provider API",
            "changes": []
+       },
+       {
+           "type": "org.gradle.tooling.events.task.TaskFailureResult",
+           "member": "Class org.gradle.tooling.events.task.TaskFailureResult",
+           "acceptation": "Adding methods to both TaskFailureResult and TaskSuccessResult via a new common super-interface",
+           "changes": [
+               "org.gradle.tooling.events.task.TaskExecutionResult"
+           ]
+       },
+       {
+           "type": "org.gradle.tooling.events.task.TaskSuccessResult",
+           "member": "Class org.gradle.tooling.events.task.TaskSuccessResult",
+           "acceptation": "Adding methods to both TaskFailureResult and TaskSuccessResult via a new common super-interface",
+           "changes": [
+               "org.gradle.tooling.events.task.TaskExecutionResult"
+           ]
        }
    ]
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompileJavaBuildOperationType.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/CompileJavaBuildOperationType.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.tasks.compile;
 
 import org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType;
 import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.NotUsedByScanPlugin;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.List;
 /**
  * @since 5.1
  */
+@NotUsedByScanPlugin("used to report annotation processor execution times to TAPI progress listeners")
 public class CompileJavaBuildOperationType implements BuildOperationType<CompileJavaBuildOperationType.Details, CompileJavaBuildOperationType.Result> {
 
     public interface Details {

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/AbstractTaskResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/AbstractTaskResult.java
@@ -16,10 +16,29 @@
 
 package org.gradle.tooling.internal.provider.events;
 
-import org.gradle.tooling.internal.protocol.events.InternalTaskResult;
+import org.gradle.tooling.internal.protocol.events.InternalIncrementalTaskResult;
 
-public abstract class AbstractTaskResult extends AbstractResult implements InternalTaskResult {
-    protected AbstractTaskResult(long startTime, long endTime, String outcomeDescription) {
+import java.util.List;
+
+public abstract class AbstractTaskResult extends AbstractResult implements InternalIncrementalTaskResult {
+
+    private final boolean incremental;
+    private final List<String> executionReasons;
+
+    protected AbstractTaskResult(long startTime, long endTime, String outcomeDescription, boolean incremental, List<String> executionReasons) {
         super(startTime, endTime, outcomeDescription);
+        this.incremental = incremental;
+        this.executionReasons = executionReasons;
     }
+
+    @Override
+    public boolean isIncremental() {
+        return incremental;
+    }
+
+    @Override
+    public List<String> getExecutionReasons() {
+        return executionReasons;
+    }
+
 }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultJavaCompileTaskSuccessResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultJavaCompileTaskSuccessResult.java
@@ -26,7 +26,7 @@ public class DefaultJavaCompileTaskSuccessResult extends DefaultTaskSuccessResul
     private final List<InternalAnnotationProcessorResult> annotationProcessorResults;
 
     public DefaultJavaCompileTaskSuccessResult(DefaultTaskSuccessResult delegate, List<InternalAnnotationProcessorResult> annotationProcessorResults) {
-        super(delegate.getStartTime(), delegate.getEndTime(), delegate.isUpToDate(), delegate.isFromCache(), delegate.getOutcomeDescription());
+        super(delegate.getStartTime(), delegate.getEndTime(), delegate.isUpToDate(), delegate.isFromCache(), delegate.getOutcomeDescription(), delegate.isIncremental(), delegate.getExecutionReasons());
         this.annotationProcessorResults = annotationProcessorResults;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskFailureResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskFailureResult.java
@@ -23,8 +23,8 @@ import java.util.List;
 public class DefaultTaskFailureResult extends AbstractTaskResult implements InternalTaskFailureResult {
     private final List<DefaultFailure> failures;
 
-    public DefaultTaskFailureResult(long startTime, long endTime, List<DefaultFailure> failures) {
-        super(startTime, endTime, "failed");
+    public DefaultTaskFailureResult(long startTime, long endTime, List<DefaultFailure> failures, boolean incremental, List<String> executionReasons) {
+        super(startTime, endTime, "failed", incremental, executionReasons);
         this.failures = failures;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskSkippedResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskSkippedResult.java
@@ -21,8 +21,8 @@ import org.gradle.tooling.internal.protocol.events.InternalTaskSkippedResult;
 public class DefaultTaskSkippedResult extends AbstractTaskResult implements InternalTaskSkippedResult {
     private final String skipMessage;
 
-    public DefaultTaskSkippedResult(long startTime, long endTime, String skipMessage) {
-        super(startTime, endTime, "skipped");
+    public DefaultTaskSkippedResult(long startTime, long endTime, String skipMessage, boolean incremental) {
+        super(startTime, endTime, "skipped", incremental, null);
         this.skipMessage = skipMessage;
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskSuccessResult.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/events/DefaultTaskSuccessResult.java
@@ -16,15 +16,19 @@
 
 package org.gradle.tooling.internal.provider.events;
 
+import org.gradle.tooling.internal.protocol.events.InternalIncrementalTaskResult;
 import org.gradle.tooling.internal.protocol.events.InternalTaskCachedResult;
 import org.gradle.tooling.internal.protocol.events.InternalTaskSuccessResult;
 
-public class DefaultTaskSuccessResult extends AbstractTaskResult implements InternalTaskSuccessResult, InternalTaskCachedResult {
+import java.util.List;
+
+public class DefaultTaskSuccessResult extends AbstractTaskResult implements InternalTaskSuccessResult, InternalTaskCachedResult, InternalIncrementalTaskResult {
+
     private final boolean upToDate;
     private final boolean fromCache;
 
-    public DefaultTaskSuccessResult(long startTime, long endTime, boolean upToDate, boolean fromCache, String outcomeDescription) {
-        super(startTime, endTime, outcomeDescription);
+    public DefaultTaskSuccessResult(long startTime, long endTime, boolean upToDate, boolean fromCache, String outcomeDescription, boolean incremental, List<String> executionReasons) {
+        super(startTime, endTime, outcomeDescription, incremental, executionReasons);
         this.upToDate = upToDate;
         this.fromCache = fromCache;
     }
@@ -38,4 +42,5 @@ public class DefaultTaskSuccessResult extends AbstractTaskResult implements Inte
     public boolean isFromCache() {
         return fromCache;
     }
+
 }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
@@ -105,19 +105,20 @@ class ClientForwardingTaskOperationListener extends SubtreeFilteringBuildOperati
         TaskStateInternal state = task.getState();
         long startTime = finishEvent.getStartTime();
         long endTime = finishEvent.getEndTime();
+        ExecuteTaskBuildOperationType.Result result = (ExecuteTaskBuildOperationType.Result) finishEvent.getResult();
+        boolean incremental = result != null && result.isIncremental();
 
         if (state.getUpToDate()) {
-            return new DefaultTaskSuccessResult(startTime, endTime, true, state.isFromCache(), state.getSkipMessage(), state.isIncremental(), Collections.emptyList());
+            return new DefaultTaskSuccessResult(startTime, endTime, true, state.isFromCache(), state.getSkipMessage(), incremental, Collections.emptyList());
         } else if (state.getSkipped()) {
-            return new DefaultTaskSkippedResult(startTime, endTime, state.getSkipMessage(), state.isIncremental());
+            return new DefaultTaskSkippedResult(startTime, endTime, state.getSkipMessage(), incremental);
         } else {
-            ExecuteTaskBuildOperationType.Result result = (ExecuteTaskBuildOperationType.Result) finishEvent.getResult();
             List<String> executionReasons = result != null ? result.getUpToDateMessages() : null;
             Throwable failure = finishEvent.getFailure();
             if (failure == null) {
-                return new DefaultTaskSuccessResult(startTime, endTime, false, state.isFromCache(), "SUCCESS", state.isIncremental(), executionReasons);
+                return new DefaultTaskSuccessResult(startTime, endTime, false, state.isFromCache(), "SUCCESS", incremental, executionReasons);
             } else {
-                return new DefaultTaskFailureResult(startTime, endTime, singletonList(DefaultFailure.fromThrowable(failure)), state.isIncremental(), executionReasons);
+                return new DefaultTaskFailureResult(startTime, endTime, singletonList(DefaultFailure.fromThrowable(failure)), incremental, executionReasons);
             }
         }
     }

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingTaskOperationListener.java
@@ -22,6 +22,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationDetails;
+import org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType;
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationListener;
@@ -46,11 +47,13 @@ import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toCollection;
 
 /**
@@ -83,8 +86,8 @@ class ClientForwardingTaskOperationListener extends SubtreeFilteringBuildOperati
     @Override
     protected InternalOperationFinishedProgressEvent toFinishedEvent(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent, ExecuteTaskBuildOperationDetails details) {
         TaskInternal task = details.getTask();
-        AbstractTaskResult result = operationResultPostProcessor.process(toTaskResult(task, finishEvent), buildOperation.getId());
-        return new DefaultTaskFinishedProgressEvent(finishEvent.getEndTime(), toTaskDescriptor(buildOperation, task), result);
+        AbstractTaskResult taskResult = operationResultPostProcessor.process(toTaskResult(task, finishEvent), buildOperation.getId());
+        return new DefaultTaskFinishedProgressEvent(finishEvent.getEndTime(), toTaskDescriptor(buildOperation, task), taskResult);
     }
 
     private DefaultTaskDescriptor toTaskDescriptor(BuildOperationDescriptor buildOperation, TaskInternal task) {
@@ -98,21 +101,23 @@ class ClientForwardingTaskOperationListener extends SubtreeFilteringBuildOperati
         });
     }
 
-    private static AbstractTaskResult toTaskResult(TaskInternal task, OperationFinishEvent result) {
+    private static AbstractTaskResult toTaskResult(TaskInternal task, OperationFinishEvent finishEvent) {
         TaskStateInternal state = task.getState();
-        long startTime = result.getStartTime();
-        long endTime = result.getEndTime();
+        long startTime = finishEvent.getStartTime();
+        long endTime = finishEvent.getEndTime();
 
         if (state.getUpToDate()) {
-            return new DefaultTaskSuccessResult(startTime, endTime, true, state.isFromCache(), state.getSkipMessage());
+            return new DefaultTaskSuccessResult(startTime, endTime, true, state.isFromCache(), state.getSkipMessage(), state.isIncremental(), Collections.emptyList());
         } else if (state.getSkipped()) {
-            return new DefaultTaskSkippedResult(startTime, endTime, state.getSkipMessage());
+            return new DefaultTaskSkippedResult(startTime, endTime, state.getSkipMessage(), state.isIncremental());
         } else {
-            Throwable failure = result.getFailure();
+            ExecuteTaskBuildOperationType.Result result = (ExecuteTaskBuildOperationType.Result) finishEvent.getResult();
+            List<String> executionReasons = result != null ? result.getUpToDateMessages() : null;
+            Throwable failure = finishEvent.getFailure();
             if (failure == null) {
-                return new DefaultTaskSuccessResult(startTime, endTime, false, state.isFromCache(), "SUCCESS");
+                return new DefaultTaskSuccessResult(startTime, endTime, false, state.isFromCache(), "SUCCESS", state.isIncremental(), executionReasons);
             } else {
-                return new DefaultTaskFailureResult(startTime, endTime, Collections.singletonList(DefaultFailure.fromThrowable(failure)));
+                return new DefaultTaskFailureResult(startTime, endTime, singletonList(DefaultFailure.fromThrowable(failure)), state.isIncremental(), executionReasons);
             }
         }
     }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskExecutionResultCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskExecutionResultCrossVersionSpec.groovy
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r51
+
+import org.gradle.integtests.tooling.fixture.ProgressEvents
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.BuildException
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.events.OperationType
+import org.gradle.tooling.events.task.TaskFailureResult
+import org.gradle.tooling.events.task.TaskOperationResult
+import org.gradle.tooling.events.task.TaskSkippedResult
+import org.gradle.tooling.events.task.TaskSuccessResult
+import org.gradle.tooling.model.UnsupportedMethodException
+
+@ToolingApiVersion('>=5.1')
+@TargetGradleVersion('>=5.1')
+class TaskExecutionResultCrossVersionSpec extends ToolingApiSpecification {
+
+    def events = ProgressEvents.create()
+
+    def "reports no execution reasons for skipped tasks"() {
+        given:
+        buildFile << """
+            task disabledTask {
+                enabled = false
+            }
+        """
+
+        when:
+        runBuild('disabledTask')
+
+        then:
+        taskSkippedResult(':disabledTask')
+    }
+
+    def "reports execution reason for executed task without declared outputs"() {
+        given:
+        buildFile << """
+            task helloWorld {
+                doFirst { println "Hello, World!" }
+            }
+        """
+
+        when:
+        runBuild('helloWorld')
+
+        then:
+        with (taskSuccessResult(':helloWorld')) {
+            !incremental
+            executionReasons == ["Task has not declared any outputs despite executing actions."]
+        }
+    }
+
+    def "reports empty list of execution reasons for up-to-date tasks"() {
+        given:
+        buildFile << """
+            task writeFile {
+                def file = file("\$buildDir/test.txt")
+                outputs.file(file)
+                doFirst {
+                    file.createNewFile()
+                    file.text == "Hello, World!"
+                }
+            }
+        """
+
+        when:
+        runBuild('writeFile')
+
+        then:
+        with (taskSuccessResult(':writeFile')) {
+            !upToDate
+            !executionReasons.empty
+        }
+
+        when:
+        runBuild('writeFile')
+
+        then:
+        with (taskSuccessResult(':writeFile')) {
+            upToDate
+            executionReasons.empty
+        }
+    }
+
+    def "reports execution reasons for failed tasks"() {
+        given:
+        buildFile << """
+            task failingTask {
+                doFirst {
+                    throw new GradleException('task failed intentionally')
+                }
+            }
+        """
+
+        when:
+        runBuild('failingTask')
+
+        then:
+        thrown(BuildException)
+        with (taskFailureResult(':failingTask')) {
+            !executionReasons.empty
+            failures[0].description.contains("task failed intentionally")
+        }
+    }
+
+    def "reports incremental task as incremental"() {
+        given:
+        file('src').mkdir()
+        buildFile << """
+            task incrementalTask(type: MyIncrementalTask) {
+                inputDir = file('src')
+            }
+            
+            class MyIncrementalTask extends DefaultTask {
+                @InputDirectory
+                def File inputDir
+                @TaskAction
+                void doSomething(IncrementalTaskInputs inputs) {}
+            }
+        """
+
+        when:
+        runBuild('incrementalTask')
+
+        then:
+        taskSuccessResult(':incrementalTask').incremental
+    }
+
+    @TargetGradleVersion('>=2.6 <5.1')
+    def "throws UnsupportedMethodException for execution reasons when target version does not support it"() {
+        when:
+        runBuild('tasks')
+
+        and:
+        taskSuccessResult(':tasks').executionReasons
+
+        then:
+        def e = thrown(UnsupportedMethodException)
+        e.message.startsWith("Unsupported method: TaskExecutionResult.getExecutionReasons().")
+    }
+
+    @TargetGradleVersion('>=2.6 <5.1')
+    def "throws UnsupportedMethodException for incremental property when target version does not support it"() {
+        when:
+        runBuild('tasks')
+
+        and:
+        taskSuccessResult(':tasks').incremental
+
+        then:
+        def e = thrown(UnsupportedMethodException)
+        e.message.startsWith("Unsupported method: TaskExecutionResult.isIncremental().")
+    }
+
+    private void runBuild(String... tasks) {
+        events.clear()
+        withConnection {
+            ProjectConnection connection ->
+                connection.newBuild()
+                    .forTasks(tasks)
+                    .addProgressListener(events, EnumSet.of(OperationType.TASK))
+                    .run()
+        }
+    }
+
+    private TaskSkippedResult taskSkippedResult(String path) {
+        taskResult(path) as TaskSkippedResult
+    }
+
+    private TaskSuccessResult taskSuccessResult(String path) {
+        taskResult(path) as TaskSuccessResult
+    }
+
+    private TaskFailureResult taskFailureResult(String path) {
+        taskResult(path) as TaskFailureResult
+    }
+
+    private TaskOperationResult taskResult(String path) {
+        events.operation("Task $path").result as TaskOperationResult
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskExecutionResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskExecutionResult.java
@@ -31,9 +31,9 @@ import java.util.List;
 public interface TaskExecutionResult extends TaskOperationResult {
 
     /**
-     * Returns whether this task was incremental.
+     * Returns whether this task was executed incrementally.
      *
-     * @return {@code true} if this task was incremental
+     * @return {@code true} if this task was executed incrementally
      * @throws UnsupportedMethodException For Gradle versions older than 5.1, where this method is not supported.
      */
     boolean isIncremental();

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskExecutionResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskExecutionResult.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.task;
+
+import org.gradle.api.Incubating;
+import org.gradle.tooling.model.UnsupportedMethodException;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+/**
+ * Describes the result of a non-skipped task.
+ *
+ * @since 5.1
+ */
+@Incubating
+public interface TaskExecutionResult extends TaskOperationResult {
+
+    /**
+     * Returns whether this task was incremental.
+     *
+     * @return {@code true} if this task was incremental
+     * @throws UnsupportedMethodException For Gradle versions older than 5.1, where this method is not supported.
+     */
+    boolean isIncremental();
+
+    /**
+     * Returns the reasons why this task was executed.
+     *
+     * @return the reasons why this task was executed; an empty list indicates the task was up-to-date;
+     *         {@code null} that it failed before up-to-date checks had been performed.
+     * @throws UnsupportedMethodException For Gradle versions older than 5.1, where this method is not supported.
+     */
+    @Nullable
+    List<String> getExecutionReasons();
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskFailureResult.java
@@ -23,5 +23,5 @@ import org.gradle.tooling.events.FailureResult;
  *
  * @since 2.5
  */
-public interface TaskFailureResult extends TaskOperationResult, FailureResult {
+public interface TaskFailureResult extends TaskExecutionResult, FailureResult {
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/TaskSuccessResult.java
@@ -23,7 +23,7 @@ import org.gradle.tooling.events.SuccessResult;
  *
  * @since 2.5
  */
-public interface TaskSuccessResult extends TaskOperationResult, SuccessResult {
+public interface TaskSuccessResult extends TaskExecutionResult, SuccessResult {
     /**
      * Returns whether this task was up-to-date.
      *

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskFailureResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskFailureResult.java
@@ -20,6 +20,7 @@ import org.gradle.tooling.Failure;
 import org.gradle.tooling.events.internal.DefaultOperationFailureResult;
 import org.gradle.tooling.events.task.TaskFailureResult;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 /**
@@ -27,8 +28,22 @@ import java.util.List;
  */
 public final class DefaultTaskFailureResult extends DefaultOperationFailureResult implements TaskFailureResult {
 
-    public DefaultTaskFailureResult(long startTime, long endTime, List<? extends Failure> failures) {
+    private final TaskExecutionDetails taskExecutionDetails;
+
+    public DefaultTaskFailureResult(long startTime, long endTime, List<? extends Failure> failures, TaskExecutionDetails taskExecutionDetails) {
         super(startTime, endTime, failures);
+        this.taskExecutionDetails = taskExecutionDetails;
+    }
+
+    @Override
+    public boolean isIncremental() {
+        return taskExecutionDetails.isIncremental();
+    }
+
+    @Override
+    @Nullable
+    public List<String> getExecutionReasons() {
+        return taskExecutionDetails.getExecutionReasons();
     }
 
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/DefaultTaskSuccessResult.java
@@ -19,6 +19,9 @@ package org.gradle.tooling.events.task.internal;
 import org.gradle.tooling.events.internal.DefaultOperationSuccessResult;
 import org.gradle.tooling.events.task.TaskSuccessResult;
 
+import javax.annotation.Nullable;
+import java.util.List;
+
 /**
  * Implementation of the {@code TaskSuccessResult} interface.
  */
@@ -26,11 +29,13 @@ public class DefaultTaskSuccessResult extends DefaultOperationSuccessResult impl
 
     private final boolean upToDate;
     private final boolean fromCache;
+    private final TaskExecutionDetails taskExecutionDetails;
 
-    public DefaultTaskSuccessResult(long startTime, long endTime, boolean upToDate, boolean fromCache) {
+    public DefaultTaskSuccessResult(long startTime, long endTime, boolean upToDate, boolean fromCache, TaskExecutionDetails taskExecutionDetails) {
         super(startTime, endTime);
         this.upToDate = upToDate;
         this.fromCache = fromCache;
+        this.taskExecutionDetails = taskExecutionDetails;
     }
 
     @Override
@@ -42,4 +47,16 @@ public class DefaultTaskSuccessResult extends DefaultOperationSuccessResult impl
     public boolean isFromCache() {
         return fromCache;
     }
+
+    @Override
+    public boolean isIncremental() {
+        return taskExecutionDetails.isIncremental();
+    }
+
+    @Override
+    @Nullable
+    public List<String> getExecutionReasons() {
+        return taskExecutionDetails.getExecutionReasons();
+    }
+
 }

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/TaskExecutionDetails.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/TaskExecutionDetails.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.events.task.internal;
+
+import org.gradle.tooling.events.task.TaskExecutionResult;
+import org.gradle.tooling.model.internal.Exceptions;
+
+import javax.annotation.Nullable;
+import java.util.List;
+
+public abstract class TaskExecutionDetails {
+
+    private static final TaskExecutionDetails UNSUPPORTED = new TaskExecutionDetails() {
+        @Override
+        public boolean isIncremental() {
+            throw Exceptions.unsupportedMethod(TaskExecutionResult.class.getSimpleName() + ".isIncremental()");
+        }
+
+        @Override
+        public List<String> getExecutionReasons() {
+            throw Exceptions.unsupportedMethod(TaskExecutionResult.class.getSimpleName() + ".getExecutionReasons()");
+        }
+    };
+
+    abstract boolean isIncremental();
+
+    @Nullable
+    abstract List<String> getExecutionReasons();
+
+    public static TaskExecutionDetails of(final boolean incremental, final List<String> executionReasons) {
+        return new TaskExecutionDetails() {
+            @Override
+            public boolean isIncremental() {
+                return incremental;
+            }
+
+            @Override
+            public List<String> getExecutionReasons() {
+                return executionReasons;
+            }
+        };
+    }
+
+    public static TaskExecutionDetails unsupported() {
+        return UNSUPPORTED;
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/java/DefaultJavaCompileTaskSuccessResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/events/task/internal/java/DefaultJavaCompileTaskSuccessResult.java
@@ -17,6 +17,7 @@
 package org.gradle.tooling.events.task.internal.java;
 
 import org.gradle.tooling.events.task.internal.DefaultTaskSuccessResult;
+import org.gradle.tooling.events.task.internal.TaskExecutionDetails;
 import org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult;
 
 import javax.annotation.Nullable;
@@ -26,8 +27,8 @@ public class DefaultJavaCompileTaskSuccessResult extends DefaultTaskSuccessResul
 
     private final List<AnnotationProcessorResult> annotationProcessorResults;
 
-    public DefaultJavaCompileTaskSuccessResult(long startTime, long endTime, boolean upToDate, boolean fromCache, List<AnnotationProcessorResult> annotationProcessorResults) {
-        super(startTime, endTime, upToDate, fromCache);
+    public DefaultJavaCompileTaskSuccessResult(long startTime, long endTime, boolean upToDate, boolean fromCache, TaskExecutionDetails taskExecutionDetails, List<AnnotationProcessorResult> annotationProcessorResults) {
+        super(startTime, endTime, upToDate, fromCache, taskExecutionDetails);
         this.annotationProcessorResults = annotationProcessorResults;
     }
 

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/parameters/BuildProgressListenerAdapter.java
@@ -55,6 +55,7 @@ import org.gradle.tooling.events.task.internal.DefaultTaskOperationDescriptor;
 import org.gradle.tooling.events.task.internal.DefaultTaskSkippedResult;
 import org.gradle.tooling.events.task.internal.DefaultTaskStartEvent;
 import org.gradle.tooling.events.task.internal.DefaultTaskSuccessResult;
+import org.gradle.tooling.events.task.internal.TaskExecutionDetails;
 import org.gradle.tooling.events.task.internal.java.DefaultAnnotationProcessorResult;
 import org.gradle.tooling.events.task.internal.java.DefaultJavaCompileTaskSuccessResult;
 import org.gradle.tooling.events.task.java.JavaCompileTaskOperationResult.AnnotationProcessorResult;
@@ -86,6 +87,7 @@ import org.gradle.tooling.internal.protocol.InternalBuildProgressListener;
 import org.gradle.tooling.internal.protocol.InternalFailure;
 import org.gradle.tooling.internal.protocol.events.InternalBinaryPluginIdentifier;
 import org.gradle.tooling.internal.protocol.events.InternalFailureResult;
+import org.gradle.tooling.internal.protocol.events.InternalIncrementalTaskResult;
 import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult;
 import org.gradle.tooling.internal.protocol.events.InternalJavaCompileTaskOperationResult.InternalAnnotationProcessorResult;
 import org.gradle.tooling.internal.protocol.events.InternalJvmTestDescriptor;
@@ -450,24 +452,35 @@ public class BuildProgressListenerAdapter implements InternalBuildProgressListen
     }
 
     private static TaskOperationResult toTaskResult(InternalTaskResult result) {
-        boolean fromCache = false;
-        if (result instanceof InternalTaskCachedResult) {
-            fromCache = ((InternalTaskCachedResult)result).isFromCache();
-        }
-
         if (result instanceof InternalTaskSuccessResult) {
+            InternalTaskSuccessResult successResult = (InternalTaskSuccessResult) result;
             if (result instanceof InternalJavaCompileTaskOperationResult) {
                 List<AnnotationProcessorResult> annotationProcessorResults = toAnnotationProcessorResults(((InternalJavaCompileTaskOperationResult) result).getAnnotationProcessorResults());
-                return new DefaultJavaCompileTaskSuccessResult(result.getStartTime(), result.getEndTime(), ((InternalTaskSuccessResult) result).isUpToDate(), fromCache, annotationProcessorResults);
+                return new DefaultJavaCompileTaskSuccessResult(result.getStartTime(), result.getEndTime(), successResult.isUpToDate(), isFromCache(result), toTaskExecutionDetails(result), annotationProcessorResults);
             }
-            return new DefaultTaskSuccessResult(result.getStartTime(), result.getEndTime(), ((InternalTaskSuccessResult) result).isUpToDate(), fromCache);
+            return new DefaultTaskSuccessResult(result.getStartTime(), result.getEndTime(), successResult.isUpToDate(), isFromCache(result), toTaskExecutionDetails(result));
         } else if (result instanceof InternalTaskSkippedResult) {
             return new DefaultTaskSkippedResult(result.getStartTime(), result.getEndTime(), ((InternalTaskSkippedResult) result).getSkipMessage());
         } else if (result instanceof InternalTaskFailureResult) {
-            return new DefaultTaskFailureResult(result.getStartTime(), result.getEndTime(), toFailures(result.getFailures()));
+            return new DefaultTaskFailureResult(result.getStartTime(), result.getEndTime(), toFailures(result.getFailures()), toTaskExecutionDetails(result));
         } else {
             return null;
         }
+    }
+
+    private static boolean isFromCache(InternalTaskResult result) {
+        if (result instanceof InternalTaskCachedResult) {
+            return ((InternalTaskCachedResult)result).isFromCache();
+        }
+        return false;
+    }
+
+    private static TaskExecutionDetails toTaskExecutionDetails(InternalTaskResult result) {
+        if (result instanceof InternalIncrementalTaskResult) {
+            InternalIncrementalTaskResult taskResult = (InternalIncrementalTaskResult) result;
+            return TaskExecutionDetails.of(taskResult.isIncremental(), taskResult.getExecutionReasons());
+        }
+        return TaskExecutionDetails.unsupported();
     }
 
     private static WorkItemOperationResult toWorkItemResult(InternalOperationResult result) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalIncrementalTaskResult.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/protocol/events/InternalIncrementalTaskResult.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.internal.protocol.events;
+
+import java.util.List;
+
+/**
+ * DO NOT CHANGE THIS INTERFACE. It is part of the cross-version protocol.
+ *
+ * @since 5.1
+ */
+public interface InternalIncrementalTaskResult extends InternalTaskResult {
+
+    /**
+     * Returns whether this task is incremental.
+     */
+    boolean isIncremental();
+
+    /**
+     * Returns the reasons for executing this task.
+     *
+     * @return the list of reasons; {@code null} if undetermined (e.g. if the task was skipped).
+     */
+    List<String> getExecutionReasons();
+
+}


### PR DESCRIPTION
For non-skipped tasks, the list of execution reasons and whether the
task was incremental is now reported to TAPI progress listeners as
part of the operation result.

Tasks are considered incremental if their `@TaskAction` method takes an `IncrementalTaskInputs` parameter and `IncrementalTaskInputs.isIncremental()` returns `true`.