### PR TITLE
Ignore operating system dimension from output path and task name when unambiguous

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/LanguageTaskNames.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/LanguageTaskNames.groovy
@@ -17,7 +17,6 @@
 package org.gradle.language
 
 import org.gradle.nativeplatform.fixtures.AvailableToolChains
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
 abstract trait LanguageTaskNames {
     private static final String DEBUG = 'Debug'
@@ -124,6 +123,7 @@ abstract trait LanguageTaskNames {
         private final AvailableToolChains.InstalledToolChain toolChainUnderTest
         private final String languageTaskSuffix
         private String architecture = null
+        private String operatingSystemFamily = null
 
         ProjectTasks(String project, AvailableToolChains.InstalledToolChain toolChainUnderTest, String languageTaskSuffix) {
             this.toolChainUnderTest = toolChainUnderTest
@@ -148,21 +148,26 @@ abstract trait LanguageTaskNames {
             project + ":" + t
         }
 
+        ProjectTasks withOperatingSystemFamily(String operatingSystemFamily) {
+            this.operatingSystemFamily = operatingSystemFamily
+            return this
+        }
+
         class DebugTasks {
             String getCompile() {
-                return withProject("compileDebug${variant(architecture)}${languageTaskSuffix}")
+                return withProject("compileDebug${variant}${languageTaskSuffix}")
             }
 
             String getLink() {
-                return withProject("linkDebug${variant(architecture)}")
+                return withProject("linkDebug${variant}")
             }
 
             String getInstall() {
-                return withProject("installDebug${variant(architecture)}")
+                return withProject("installDebug${variant}")
             }
 
             String getAssemble() {
-                return withProject("assembleDebug${variant(architecture)}")
+                return withProject("assembleDebug${variant}")
             }
 
             List<String> getAllToLink() {
@@ -176,26 +181,26 @@ abstract trait LanguageTaskNames {
 
         class ReleaseTasks {
             String getCompile() {
-                return withProject("compileRelease${variant(architecture)}${languageTaskSuffix}")
+                return withProject("compileRelease${variant}${languageTaskSuffix}")
             }
 
             String getLink() {
-                return withProject("linkRelease${variant(architecture)}")
+                return withProject("linkRelease${variant}")
             }
 
             String getInstall() {
-                return withProject("installRelease${variant(architecture)}")
+                return withProject("installRelease${variant}")
             }
 
             String getAssemble() {
-                return withProject("assembleRelease${variant(architecture)}")
+                return withProject("assembleRelease${variant}")
             }
 
             List<String> getExtract() {
                 if (toolChainUnderTest.visualCpp) {
                     return []
                 } else {
-                    return [withProject("extractSymbolsRelease${variant(architecture)}")]
+                    return [withProject("extractSymbolsRelease${variant}")]
                 }
             }
 
@@ -203,7 +208,7 @@ abstract trait LanguageTaskNames {
                 if (toolChainUnderTest.visualCpp) {
                     return []
                 } else {
-                    return [withProject("stripSymbolsRelease${variant(architecture)}")]
+                    return [withProject("stripSymbolsRelease${variant}")]
                 }
             }
 
@@ -216,12 +221,15 @@ abstract trait LanguageTaskNames {
             }
         }
 
-        protected String variant(String architecture) {
-            if (architecture == null) {
-                return ''
+        protected String getVariant() {
+            String result = ""
+            if (operatingSystemFamily != null) {
+                result += operatingSystemFamily.toLowerCase().capitalize()
             }
-            String operatingSystemFamily = DefaultNativePlatform.currentOperatingSystem.toFamilyName()
-            return operatingSystemFamily.toLowerCase().capitalize() + architecture.toLowerCase().capitalize()
+            if (architecture != null) {
+                result += architecture.toLowerCase().capitalize()
+            }
+            return result
         }
     }
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -44,14 +44,8 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugCpp", ":linkDebug", ":installDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        String variantSuffix = getVariantSuffix(architecture)
-        return [":compileDebug${variantSuffix}Cpp", ":linkDebug${variantSuffix}", ":installDebug${variantSuffix}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Cpp", ":linkDebug${variant.capitalize()}", ":installDebug${variant.capitalize()}"]
     }
 
     @Override
@@ -409,7 +403,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             project(':app') {
                 apply plugin: 'cpp-application'
                 application {
-                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.os('host-family')]
+                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.os('host-family')${currentHostArchitectureDsl}]
                 }
                 dependencies {
                     implementation project(':hello')
@@ -418,7 +412,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             project(':hello') {
                 apply plugin: 'cpp-library'
                 library {
-                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.os('host-family')]
+                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.os('host-family')${currentHostArchitectureDsl}]
                 }
             }
         """
@@ -428,10 +422,10 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         expect:
         succeeds ":app:assemble"
 
-        result.assertTasksExecuted(tasks(':hello').withArchitecture(currentArchitecture).debug.allToLink, tasks(':app').withArchitecture(currentArchitecture).debug.allToInstall, ":app:assemble")
-        executable("app/build/exe/main/debug/${currentOsFamilyName.toLowerCase()}/${currentArchitecture}/app").assertExists()
-        sharedLibrary("hello/build/lib/main/debug/${currentOsFamilyName.toLowerCase()}/${currentArchitecture}/hello").assertExists()
-        def installation = installation("app/build/install/main/debug/${currentOsFamilyName.toLowerCase()}/${currentArchitecture}")
+        result.assertTasksExecuted(tasks(':hello').withOperatingSystemFamily(currentOsFamilyName).debug.allToLink, tasks(':app').withOperatingSystemFamily(currentOsFamilyName).debug.allToInstall, ":app:assemble")
+        executable("app/build/exe/main/debug/${currentOsFamilyName.toLowerCase()}/app").assertExists()
+        sharedLibrary("hello/build/lib/main/debug/${currentOsFamilyName.toLowerCase()}/hello").assertExists()
+        def installation = installation("app/build/install/main/debug/${currentOsFamilyName.toLowerCase()}")
         installation.exec().out == app.expectedOutput
         installation.assertIncludesLibraries("hello")
     }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -439,7 +439,7 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
 
         then:
         assertMainModuleIsPublished('some.group', 'test', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'test', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'test', '1.2', ['debug', 'release'], targetMachines)
 
         when:
         consumer.file("build.gradle") << """
@@ -528,9 +528,9 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
     }
 
     @Override
-    TestFile getVariantSourceFile(String module, String buildType, Map<String, String> targetMachine) {
-        def executable = executable("build/exe/main/${buildType}/${targetMachine.os.toLowerCase()}/${targetMachine.architecture}/${module}")
-        return buildType == 'release' ? executable.strippedRuntimeFile : executable.file
+    TestFile getVariantSourceFile(String module, Map<String, VariantDimension> variantContext) {
+        def executable = executable("build/exe/main${variantContext.buildType.asPath}${variantContext.os.asPath}${variantContext.architecture.asPath}/${module}")
+        return variantContext.buildType.name == 'release' ? executable.strippedRuntimeFile : executable.file
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBothLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppBothLibraryLinkageIntegrationTest.groovy
@@ -21,18 +21,13 @@ import org.gradle.nativeplatform.fixtures.app.SourceElement
 
 class CppBothLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest {
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugSharedCpp", ":linkDebugShared"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebugShared${getVariantSuffix(architecture)}Cpp", ":linkDebugShared${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebugShared${variant.capitalize()}Cpp", ":linkDebugShared${variant.capitalize()}"]
     }
 
     @Override
     protected String getTaskNameToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return ":assembleDebugShared${getVariantSuffix(architecture)}"
+        return ":assembleDebugShared${architecture.toLowerCase().capitalize()}"
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryIntegrationTest.groovy
@@ -35,13 +35,8 @@ class CppLibraryIntegrationTest extends AbstractCppIntegrationTest implements Cp
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugCpp", ":linkDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebug${getVariantSuffix(architecture)}Cpp", ":linkDebug${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Cpp", ":linkDebug${variant.capitalize()}"]
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -772,15 +772,15 @@ dependencies { implementation 'some.group:greeter:1.2' }
 
         then:
         assertMainModuleIsPublished('some.group', 'deck', '1.2', targetMachines, ["some.group:card:1.2"])
-        assertVariantsArePublished('some.group', 'deck', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName }, ["some.group:shuffle:1.2", "some.group:card:1.2"])
+        assertVariantsArePublished('some.group', 'deck', '1.2', ['debug', 'release'], targetMachines, ["some.group:shuffle:1.2", "some.group:card:1.2"])
 
         and:
         assertMainModuleIsPublished('some.group', 'card', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'card', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'card', '1.2', ['debug', 'release'], targetMachines)
 
         and:
         assertMainModuleIsPublished('some.group', 'shuffle', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines)
 
         when:
         def consumer = file("consumer").createDir()
@@ -947,9 +947,9 @@ dependencies { implementation 'some.group:greeter:1.2' }
     }
 
     @Override
-    TestFile getVariantSourceFile(String module, String buildType, Map<String, String> targetMachine) {
-        def library = sharedLibrary("${module}/build/lib/main/${buildType}/${targetMachine.os.toLowerCase()}/${targetMachine.architecture}/${module}")
-        return buildType == 'release' ? library.strippedRuntimeFile : library.file
+    TestFile getVariantSourceFile(String module, Map<String, VariantDimension> variantContext) {
+        def library = sharedLibrary("${module}/build/lib/main${variantContext.buildType.asPath}${variantContext.os.asPath}${variantContext.architecture.asPath}/${module}")
+        return variantContext.buildType.name == 'release' ? library.strippedRuntimeFile : library.file
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSharedLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppSharedLibraryLinkageIntegrationTest.groovy
@@ -34,13 +34,8 @@ class CppSharedLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugCpp", ":linkDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebug${getVariantSuffix(architecture)}Cpp", ":linkDebug${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Cpp", ":linkDebug${variant.capitalize()}"]
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryLinkageIntegrationTest.groovy
@@ -34,13 +34,8 @@ class CppStaticLibraryLinkageIntegrationTest extends AbstractCppIntegrationTest 
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugCpp", ":createDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebug${getVariantSuffix(architecture)}Cpp", ":createDebug${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Cpp", ":createDebug${variant.capitalize()}"]
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
@@ -63,15 +63,15 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
 
         then:
         assertMainModuleIsPublished('some.group', 'deck', '1.2', targetMachines, ["some.group:card:1.2"])
-        assertVariantsArePublished('some.group', 'deck', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName }, ["some.group:shuffle:1.2", "some.group:card:1.2"])
+        assertVariantsArePublished('some.group', 'deck', '1.2', ['debug', 'release'], targetMachines, ["some.group:shuffle:1.2", "some.group:card:1.2"])
 
         and:
         assertMainModuleIsPublished('some.group', 'card', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'card', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'card', '1.2', ['debug', 'release'], targetMachines)
 
         and:
         assertMainModuleIsPublished('some.group', 'shuffle', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines)
 
         when:
         def consumer = file("consumer").createDir()
@@ -131,15 +131,15 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
 
         then:
         assertMainModuleIsPublished('some.group', 'deck', '1.2', targetMachines, ["some.group:card:1.2"])
-        assertVariantsArePublished('some.group', 'deck', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName }, ["some.group:shuffle:1.2", "some.group:card:1.2"])
+        assertVariantsArePublished('some.group', 'deck', '1.2', ['debug', 'release'], targetMachines, ["some.group:shuffle:1.2", "some.group:card:1.2"])
 
         and:
         assertMainModuleIsPublished('some.group', 'card', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'card', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'card', '1.2', ['debug', 'release'], targetMachines)
 
         and:
         assertMainModuleIsPublished('some.group', 'shuffle', '1.2', targetMachines)
-        assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines.findAll { it.os == currentOsFamilyName })
+        assertVariantsArePublished('some.group', 'shuffle', '1.2', ['debug', 'release'], targetMachines)
 
         when:
         def consumer = file("consumer").createDir()
@@ -180,8 +180,8 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
     }
 
     @Override
-    TestFile getVariantSourceFile(String module, String buildType, Map<String, String> targetMachine) {
-        return staticLibrary("${module}/build/lib/main/${buildType}/${targetMachine.os.toLowerCase()}/${targetMachine.architecture}/${module}").file
+    TestFile getVariantSourceFile(String module, Map<String, VariantDimension> variantContext) {
+        return staticLibrary("${module}/build/lib/main${variantContext.buildType.asPath}${variantContext.os.asPath}${variantContext.architecture.asPath}/${module}").file
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppTaskNames.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppTaskNames.groovy
@@ -23,4 +23,88 @@ abstract trait CppTaskNames extends LanguageTaskNames {
     String getLanguageTaskSuffix() {
         return 'Cpp'
     }
+
+    static Map<String, VariantDimension> toVariantContext(Object[] collections) {
+        def result = new HashMap<String, VariantDimension>().withDefault { VariantDimension.missing(it) }
+        def dimensions = GroovyCollections.combinations(collections)
+        dimensions.eachWithIndex { item, idx ->
+            if (item instanceof VariantDimension) {
+                assert collections[idx] instanceof Iterable
+                if (collections[idx].size() > 1) {
+                    result.put(item.dimensionName, item)
+                }
+            } else if (item instanceof Map) {
+                item.each { key, value ->
+                    assert key instanceof String
+                    assert value instanceof String
+                    if (collections[idx].collect { it.get(key) }.unique().size() > 1) {
+                        result.put(key, VariantDimension.of(key, value))
+                    }
+                }
+            }
+        }
+
+        return result
+    }
+
+    static abstract class VariantDimension {
+        final String dimensionName
+
+        protected VariantDimension(String dimensionName) {
+            this.dimensionName = dimensionName
+        }
+
+        abstract String getAsPath()
+        abstract String getAsPublishingName()
+        abstract String getAsVariantName()
+        abstract String getName()
+
+        static VariantDimension missing(String dimensionName) {
+            return new MissingVariantDimension(dimensionName)
+        }
+
+        static VariantDimension of(String dimensionName, String dimensionValue) {
+            return new DefaultVariantDimension(dimensionName, dimensionValue.toLowerCase())
+        }
+
+        static class DefaultVariantDimension extends VariantDimension {
+            private final String normalizedDimensionValue
+
+            private DefaultVariantDimension(String dimensionName, String normalizedDimensionValue) {
+                super(dimensionName)
+                this.normalizedDimensionValue = normalizedDimensionValue
+            }
+
+            @Override
+            String getAsPath() {
+                return "/${normalizedDimensionValue}"
+            }
+
+            @Override
+            String getAsPublishingName() {
+                return "_${normalizedDimensionValue.replace("-", "_")}"
+            }
+
+            @Override
+            String getAsVariantName() {
+                return normalizedDimensionValue.capitalize()
+            }
+
+            @Override
+            String getName() {
+                return normalizedDimensionValue
+            }
+        }
+
+        static class MissingVariantDimension extends VariantDimension {
+            final String asPath = ""
+            final String asPublishingName = ""
+            final String asVariantName = ""
+            final String name = ""
+
+            private MissingVariantDimension(String dimensionName) {
+                super(dimensionName)
+            }
+        }
+    }
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
@@ -16,13 +16,11 @@
 
 package org.gradle.language.swift
 
-import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.fixtures.app.Swift3
 import org.gradle.nativeplatform.fixtures.app.Swift4
-import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.util.Matchers
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
@@ -68,7 +66,7 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
 
         expect:
         succeeds taskNameToAssembleDevelopmentBinary
-        result.assertTasksExecutedAndNotSkipped getTasksToAssembleDevelopmentBinaryWithArchitecture(MachineArchitecture.X86_64), ":${taskNameToAssembleDevelopmentBinary}"
+        result.assertTasksExecutedAndNotSkipped getTasksToAssembleDevelopmentBinary(currentOsFamilyName.toLowerCase()), ":${taskNameToAssembleDevelopmentBinary}"
     }
 
     // TODO Move this to AbstractSwiftComponentIntegrationTest when xcode test works properly with architecture
@@ -123,7 +121,7 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
 
         expect:
         succeeds taskNameToAssembleDevelopmentBinary
-        result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinaryWithArchitecture(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
+        result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinary(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
     }
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
@@ -142,10 +140,10 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
 
         expect:
         succeeds taskNameToAssembleDevelopmentBinary
-        result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinaryWithArchitecture(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
+        result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinary(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
     }
 
-    protected abstract List<String> getTasksToAssembleDevelopmentBinary()
+    protected abstract List<String> getTasksToAssembleDevelopmentBinary(String variant = "")
 
     @Override
     SourceElement getSwift3Component() {
@@ -171,13 +169,6 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
     List<String> getTasksToAssembleDevelopmentBinaryOfComponentUnderTest() {
         return getTasksToAssembleDevelopmentBinary()
     }
-
-    protected String getVariantSuffix(String architecture) {
-        String operatingSystemFamily = DefaultNativePlatform.currentOperatingSystem.toFamilyName()
-        return operatingSystemFamily.toLowerCase().capitalize() + architecture.toLowerCase().capitalize()
-    }
-
-    protected abstract List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture)
 
     protected abstract SourceElement getComponentUnderTest()
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
@@ -29,13 +29,8 @@ import org.gradle.nativeplatform.fixtures.app.SwiftCompilerDetectingApp
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest implements SwiftTaskNames {
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugSwift", ":linkDebug", ":installDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebug${getVariantSuffix(architecture)}Swift", ":linkDebug${getVariantSuffix(architecture)}", ":installDebug${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Swift", ":linkDebug${variant.capitalize()}", ":installDebug${variant.capitalize()}"]
     }
 
     @Override
@@ -463,11 +458,11 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
 
         expect:
         succeeds ":app:assemble"
-        result.assertTasksExecuted(tasks(':greeter').withArchitecture(currentArchitecture).debug.allToLink, tasks(':app').withArchitecture(currentArchitecture).debug.allToInstall, ":app:assemble")
+        result.assertTasksExecuted(tasks(':greeter').withOperatingSystemFamily(currentOsFamilyName).debug.allToLink, tasks(':app').withOperatingSystemFamily(currentOsFamilyName).debug.allToInstall, ":app:assemble")
 
-        executable("app/build/exe/main/debug/${currentOsFamilyName}/${currentArchitecture}/App").assertExists()
-        sharedLibrary("greeter/build/lib/main/debug/${currentOsFamilyName}/${currentArchitecture}/Greeter").assertExists()
-        def installation = installation("app/build/install/main/debug/${currentOsFamilyName}/${currentArchitecture}")
+        executable("app/build/exe/main/debug/${currentOsFamilyName}/App").assertExists()
+        sharedLibrary("greeter/build/lib/main/debug/${currentOsFamilyName}/Greeter").assertExists()
+        def installation = installation("app/build/install/main/debug/${currentOsFamilyName}")
         installation.exec().out == app.expectedOutput
         installation.assertIncludesLibraries("Greeter")
     }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftBothLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftBothLibraryLinkageIntegrationTest.groovy
@@ -21,13 +21,8 @@ import org.gradle.nativeplatform.fixtures.app.SwiftLib
 
 class SwiftBothLibraryLinkageIntegrationTest extends AbstractSwiftIntegrationTest {
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugSharedSwift", ":linkDebugShared"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebugShared${getVariantSuffix(architecture)}Swift", ":linkDebugShared${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebugShared${variant.capitalize()}Swift", ":linkDebugShared${variant.capitalize()}"]
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftSharedLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftSharedLibraryLinkageIntegrationTest.groovy
@@ -21,13 +21,8 @@ import org.gradle.nativeplatform.fixtures.app.SwiftLib
 
 class SwiftSharedLibraryLinkageIntegrationTest extends AbstractSwiftIntegrationTest {
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugSwift", ":linkDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebug${getVariantSuffix(architecture)}Swift", ":linkDebug${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Swift", ":linkDebug${variant.capitalize()}"]
     }
 
     @Override

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftStaticLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftStaticLibraryLinkageIntegrationTest.groovy
@@ -21,13 +21,8 @@ import org.gradle.nativeplatform.fixtures.app.SwiftLib
 
 class SwiftStaticLibraryLinkageIntegrationTest extends AbstractSwiftIntegrationTest {
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [":compileDebugSwift", ":createDebug"]
-    }
-
-    @Override
-    protected List<String> getTasksToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
-        return [":compileDebug${getVariantSuffix(architecture)}Swift", ":createDebug${getVariantSuffix(architecture)}"]
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Swift", ":createDebug${variant.capitalize()}"]
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppApplicationPlugin.java
@@ -45,6 +45,7 @@ import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform;
 import javax.inject.Inject;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
 import static org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE;
@@ -101,8 +102,8 @@ public class CppApplicationPlugin implements Plugin<ProjectInternal> {
 
                 for (BuildType buildType : BuildType.DEFAULT_BUILD_TYPES) {
                     for (TargetMachine targetMachine : targetMachines) {
-                        String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines);
-                        String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines);
+                        String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines.stream().map(TargetMachine::getOperatingSystemFamily).collect(Collectors.toSet()));
+                        String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines.stream().map(TargetMachine::getArchitecture).collect(Collectors.toSet()));
                         String variantName = buildType.getName() + operatingSystemSuffix + architectureSuffix;
 
                         Provider<String> group = project.provider(new Callable<String>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/plugins/CppLibraryPlugin.java
@@ -59,6 +59,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
 import static org.gradle.language.cpp.CppBinary.LINKAGE_ATTRIBUTE;
@@ -132,8 +133,8 @@ public class CppLibraryPlugin implements Plugin<ProjectInternal> {
                     for (TargetMachine targetMachine : targetMachines) {
                         for (Linkage linkage : linkages) {
 
-                            String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines);
-                            String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines);
+                            String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines.stream().map(TargetMachine::getOperatingSystemFamily).collect(Collectors.toSet()));
+                            String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines.stream().map(TargetMachine::getArchitecture).collect(Collectors.toSet()));
                             String linkageSuffix = createDimensionSuffix(linkage, linkages);
                             String variantName = buildType.getName() + linkageSuffix + operatingSystemSuffix + architectureSuffix;
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
@@ -29,8 +29,12 @@ import java.util.Set;
 
 public class Dimensions {
     public static String createDimensionSuffix(Named dimensionValue, Collection<?> multivalueProperty) {
+        return createDimensionSuffix(dimensionValue.getName(), multivalueProperty);
+    }
+
+    public static String createDimensionSuffix(String dimensionValue, Collection<?> multivalueProperty) {
         if (isDimensionVisible(multivalueProperty)) {
-            return StringUtils.capitalize(dimensionValue.getName().toLowerCase());
+            return StringUtils.capitalize(dimensionValue.toLowerCase());
         }
         return "";
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftApplicationPlugin.java
@@ -47,6 +47,7 @@ import org.gradle.util.GUtil;
 import javax.inject.Inject;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
 import static org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE;
@@ -109,8 +110,8 @@ public class SwiftApplicationPlugin implements Plugin<ProjectInternal> {
 
                 for (BuildType buildType : BuildType.DEFAULT_BUILD_TYPES) {
                     for (TargetMachine targetMachine : targetMachines) {
-                        String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines);
-                        String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines);
+                        String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines.stream().map(TargetMachine::getOperatingSystemFamily).collect(Collectors.toSet()));
+                        String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines.stream().map(TargetMachine::getArchitecture).collect(Collectors.toSet()));
                         String variantName = buildType.getName() + operatingSystemSuffix + architectureSuffix;
 
                         Provider<String> group = project.provider(new Callable<String>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/plugins/SwiftLibraryPlugin.java
@@ -54,6 +54,7 @@ import org.gradle.util.GUtil;
 import javax.inject.Inject;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
 import static org.gradle.language.cpp.CppBinary.LINKAGE_ATTRIBUTE;
@@ -121,8 +122,8 @@ public class SwiftLibraryPlugin implements Plugin<Project> {
                     for (TargetMachine targetMachine : targetMachines) {
                         for (Linkage linkage : linkages) {
 
-                            String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines);
-                            String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines);
+                            String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines.stream().map(TargetMachine::getOperatingSystemFamily).collect(Collectors.toSet()));
+                            String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines.stream().map(TargetMachine::getArchitecture).collect(Collectors.toSet()));
                             String linkageSuffix = createDimensionSuffix(linkage, linkages);
                             String variantName = buildType.getName() + linkageSuffix + operatingSystemSuffix + architectureSuffix;
 

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -91,7 +91,7 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
 
     protected abstract SourceElement getComponentUnderTest()
 
-    protected abstract List<String> getTasksToAssembleDevelopmentBinary()
+    protected abstract List<String> getTasksToAssembleDevelopmentBinary(String variant = "")
 
     protected abstract String getTaskNameToAssembleDevelopmentBinary()
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithBothLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithBothLibraryLinkageIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CppUnitTestComponentWithBothLibraryLinkageIntegrationTest extends Abstract
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [':compileDebugSharedCpp', ':compileTestCpp', ':linkTest', ':installTest', ':runTest']
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebugShared${variant.capitalize()}Cpp", ":compileTest${variant.capitalize()}Cpp", ":linkTest${variant.capitalize()}", ":installTest${variant.capitalize()}", ":runTest${variant.capitalize()}"]
     }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CppUnitTestComponentWithSharedLibraryLinkageIntegrationTest extends Abstra
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [':compileDebugCpp', ':compileTestCpp', ':linkTest', ':installTest', ':runTest']
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Cpp", ":compileTest${variant.capitalize()}Cpp", ":linkTest${variant.capitalize()}", ":installTest${variant.capitalize()}", ":runTest${variant.capitalize()}"]
     }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest.groovy
@@ -35,7 +35,7 @@ class CppUnitTestComponentWithStaticLibraryLinkageIntegrationTest extends Abstra
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [':compileDebugCpp', ':compileTestCpp', ':linkTest', ':installTest', ':runTest']
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileDebug${variant.capitalize()}Cpp", ":compileTest${variant.capitalize()}Cpp", ":linkTest${variant.capitalize()}", ":installTest${variant.capitalize()}", ":runTest${variant.capitalize()}"]
     }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithoutComponentIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/CppUnitTestComponentWithoutComponentIntegrationTest.groovy
@@ -33,7 +33,7 @@ class CppUnitTestComponentWithoutComponentIntegrationTest extends AbstractCppUni
     }
 
     @Override
-    protected List<String> getTasksToAssembleDevelopmentBinary() {
-        return [':compileTestCpp', ':linkTest', ':installTest', ':runTest']
+    protected List<String> getTasksToAssembleDevelopmentBinary(String variant) {
+        return [":compileTest${variant.capitalize()}Cpp", ":linkTest${variant.capitalize()}", ":installTest${variant.capitalize()}", ":runTest${variant.capitalize()}"]
     }
 }

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -81,6 +81,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.gradle.language.cpp.CppBinary.DEBUGGABLE_ATTRIBUTE;
 import static org.gradle.language.cpp.CppBinary.OPTIMIZED_ATTRIBUTE;
@@ -130,9 +131,9 @@ public class XCTestConventionPlugin implements Plugin<ProjectInternal> {
                 Usage runtimeUsage = objectFactory.named(Usage.class, Usage.NATIVE_RUNTIME);
                 BuildType buildType = BuildType.DEBUG;
                 for (TargetMachine targetMachine : targetMachines) {
-                    String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines);
-                    String architecturePrefix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines);
-                    String variantName = buildType.getName() + operatingSystemSuffix + architecturePrefix;
+                    String operatingSystemSuffix = createDimensionSuffix(targetMachine.getOperatingSystemFamily(), targetMachines.stream().map(TargetMachine::getOperatingSystemFamily).collect(Collectors.toSet()));
+                    String architectureSuffix = createDimensionSuffix(targetMachine.getArchitecture(), targetMachines.stream().map(TargetMachine::getArchitecture).collect(Collectors.toSet()));
+                    String variantName = buildType.getName() + operatingSystemSuffix + architectureSuffix;
 
                     Provider<String> group = project.provider(new Callable<String>() {
                         @Override


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
Fixes https://github.com/gradle/gradle-native/issues/948

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Fignore-operating-system-dimension)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
