### PR TITLE
Fix GradleVersion comparison and refactor GradleVersion

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -36,6 +36,8 @@ public class GradleVersion implements Comparable<GradleVersion> {
     public static final String URL = "http://www.gradle.org";
     private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d+)(\\.\\d+)+)(-(\\p{Alpha}+)-(\\w+))?(-(SNAPSHOT|\\d{14}([-+]\\d{4})?))?");
     private static final int STAGE_MILESTONE = 0;
+    private static final int STAGE_PREVIEW = 2;
+    private static final int STAGE_RC = 3;
 
     private final String version;
     private final int majorPart;
@@ -103,7 +105,6 @@ public class GradleVersion implements Comparable<GradleVersion> {
 
     private GradleVersion(String version, String buildTime, String commitId) {
         this.version = version;
-        this.commitId = commitId;
         this.buildTime = buildTime;
         Matcher matcher = VERSION_PATTERN.matcher(version);
         if (!matcher.matches()) {
@@ -113,42 +114,60 @@ public class GradleVersion implements Comparable<GradleVersion> {
         versionPart = matcher.group(1);
         majorPart = Integer.parseInt(matcher.group(2), 10);
 
-        if (matcher.group(4) != null) {
-            int stageNumber;
-            if (matcher.group(5).equals("milestone")) {
-                stageNumber = STAGE_MILESTONE;
-            } else if (matcher.group(5).equals("preview")) {
-                stageNumber = 2;
-            } else if (matcher.group(5).equals("rc")) {
-                stageNumber = 3;
-            } else {
-                stageNumber = 1;
-            }
-            String stageString = matcher.group(6);
-            stage = Stage.from(stageNumber, stageString);
-        } else {
-            stage = null;
-        }
+        this.commitId = parseOrSetCommitId(commitId, matcher);
+        this.stage = parseStage(matcher);
+        this.snapshot = parseSnapshot(matcher);
+    }
 
-        if ("snapshot".equals(matcher.group(5)) || "commit".equals(matcher.group(5))) {
-            snapshot = 0L;
+    private Long parseSnapshot(Matcher matcher) {
+        if ("snapshot".equals(matcher.group(5)) || isCommitVersion(matcher)) {
+            return 0L;
         } else if (matcher.group(8) == null) {
-            snapshot = null;
+            return null;
         } else if ("SNAPSHOT".equals(matcher.group(8))) {
-            snapshot = 0L;
+            return 0L;
         } else {
             try {
                 if (matcher.group(9) != null) {
-                    snapshot = new SimpleDateFormat("yyyyMMddHHmmssZ").parse(matcher.group(8)).getTime();
+                    return new SimpleDateFormat("yyyyMMddHHmmssZ").parse(matcher.group(8)).getTime();
                 } else {
                     SimpleDateFormat format = new SimpleDateFormat("yyyyMMddHHmmss");
                     format.setTimeZone(TimeZone.getTimeZone("UTC"));
-                    snapshot = format.parse(matcher.group(8)).getTime();
+                    return format.parse(matcher.group(8)).getTime();
                 }
             } catch (ParseException e) {
                 throw UncheckedException.throwAsUncheckedException(e);
             }
         }
+    }
+
+    private Stage parseStage(Matcher matcher) {
+        if (matcher.group(4) == null || isCommitVersion(matcher)) {
+            return null;
+        } else if (isStage("milestone", matcher)) {
+            return Stage.from(STAGE_MILESTONE, matcher.group(6));
+        } else if (isStage("preview", matcher)) {
+            return Stage.from(STAGE_PREVIEW, matcher.group(6));
+        } else if (isStage("rc", matcher)) {
+            return Stage.from(STAGE_RC, matcher.group(6));
+        } else {
+            return Stage.from(1, matcher.group(6));
+        }
+    }
+
+    private boolean isCommitVersion(Matcher matcher) {
+        return "commit".equals(matcher.group(5));
+    }
+
+    private boolean isStage(String stage, Matcher matcher) {
+        return stage.equals(matcher.group(5));
+    }
+
+    private String parseOrSetCommitId(String commitId, Matcher matcher) {
+        if ("commit".equals(matcher.group(5))) {
+            return matcher.group(6);
+        }
+        return commitId;
     }
 
     @Override
@@ -228,17 +247,14 @@ public class GradleVersion implements Comparable<GradleVersion> {
             return -1;
         }
 
-        if (snapshot != null && gradleVersion.snapshot != null) {
-            return snapshot.compareTo(gradleVersion.snapshot);
-        }
-        if (snapshot == null && gradleVersion.snapshot != null) {
-            return 1;
-        }
-        if (snapshot != null && gradleVersion.snapshot == null) {
-            return -1;
-        }
+        Long thisSnapshot = snapshot == null ? Long.MAX_VALUE : snapshot;
+        Long theirSnapshot = gradleVersion.snapshot == null ? Long.MAX_VALUE : gradleVersion.snapshot;
 
-        return 0;
+        if (thisSnapshot == theirSnapshot) {
+            return version.compareTo(gradleVersion.version);
+        } else {
+            return thisSnapshot.compareTo(theirSnapshot);
+        }
     }
 
     @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -47,6 +47,11 @@ class GradleVersionTest extends Specification {
         version.baseVersion
     }
 
+    def 'can parse commitId from commit version'() {
+        expect:
+        GradleVersion.version('5.1-commit-123abc').commitId == '123abc'
+    }
+
     @Issue("https://issues.gradle.org/browse/GRADLE-1892")
     def "build time should always print in UTC"() {
         expect:
@@ -106,12 +111,16 @@ class GradleVersionTest extends Specification {
                 '1.2.1']
     }
 
+    void canCompareTwoVersions(String a, String b) {
+        assert GradleVersion.version(a) > GradleVersion.version(b)
+        assert GradleVersion.version(b) < GradleVersion.version(a)
+        assert GradleVersion.version(a) == GradleVersion.version(a)
+        assert GradleVersion.version(b) == GradleVersion.version(b)
+    }
+
     def canCompareMajorVersions() {
         expect:
-        GradleVersion.version(a) > GradleVersion.version(b)
-        GradleVersion.version(b) < GradleVersion.version(a)
-        GradleVersion.version(a) == GradleVersion.version(a)
-        GradleVersion.version(b) == GradleVersion.version(b)
+        canCompareTwoVersions(a, b)
 
         where:
         a      | b
@@ -123,10 +132,7 @@ class GradleVersionTest extends Specification {
 
     def canComparePointVersions() {
         expect:
-        GradleVersion.version(a) > GradleVersion.version(b)
-        GradleVersion.version(b) < GradleVersion.version(a)
-        GradleVersion.version(a) == GradleVersion.version(a)
-        GradleVersion.version(b) == GradleVersion.version(b)
+        canCompareTwoVersions(a, b)
 
         where:
         a                   | b
@@ -139,10 +145,7 @@ class GradleVersionTest extends Specification {
 
     def canComparePointVersionAndMajorVersions() {
         expect:
-        GradleVersion.version(a) > GradleVersion.version(b)
-        GradleVersion.version(b) < GradleVersion.version(a)
-        GradleVersion.version(a) == GradleVersion.version(a)
-        GradleVersion.version(b) == GradleVersion.version(b)
+        canCompareTwoVersions(a, b)
 
         where:
         a       | b
@@ -152,10 +155,7 @@ class GradleVersionTest extends Specification {
 
     def canComparePreviewsMilestonesAndRCVersions() {
         expect:
-        GradleVersion.version(a) > GradleVersion.version(b)
-        GradleVersion.version(b) < GradleVersion.version(a)
-        GradleVersion.version(a) == GradleVersion.version(a)
-        GradleVersion.version(b) == GradleVersion.version(b)
+        canCompareTwoVersions(a, b)
 
         where:
         a                 | b
@@ -170,10 +170,7 @@ class GradleVersionTest extends Specification {
 
     def canComparePatchVersion() {
         expect:
-        GradleVersion.version(a) > GradleVersion.version(b)
-        GradleVersion.version(b) < GradleVersion.version(a)
-        GradleVersion.version(a) == GradleVersion.version(a)
-        GradleVersion.version(b) == GradleVersion.version(b)
+        canCompareTwoVersions(a, b)
 
         where:
         a                  | b
@@ -185,10 +182,7 @@ class GradleVersionTest extends Specification {
 
     def canCompareSnapshotVersions() {
         expect:
-        GradleVersion.version(a) > GradleVersion.version(b)
-        GradleVersion.version(b) < GradleVersion.version(a)
-        GradleVersion.version(a) == GradleVersion.version(a)
-        GradleVersion.version(b) == GradleVersion.version(b)
+        canCompareTwoVersions(a, b)
 
         where:
         a                         | b
@@ -202,6 +196,21 @@ class GradleVersionTest extends Specification {
         '0.9'                     | '0.9-20101220100000'
         '0.9'                     | '0.9-SNAPSHOT'
         '0.9'                     | '0.9-snapshot-1'
+    }
+
+    def canCompareCommitVersions() {
+        expect:
+        canCompareTwoVersions(a, b)
+
+        where:
+        a                       | b
+        '5.1'                   | '5.1-commit-123456789'
+        '5.1'                   | '5.1-commit-bcda90482104'
+        '5.1-commit-1234'       | '5.0'
+        '5.1-commit-1234abcdef' | '4.10.2'
+        '5.1-commit-1234'       | '5.0-commit-1234'
+        '5.0-commit-222'        | '5.0-commit-111'
+        '5.0-commit-f1efb03'    | '5.0-commit-f1efb02'
     }
 
     def "can get version base"() {


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/1682

Previously, there's an issue in `GradleVersion` comparison: `5.0-commit-1a2b3c` would be regarded as equal to `5.0-commit-2b3c4d`. This is because in `compareTo` method,

```
        if (snapshot != null && gradleVersion.snapshot != null) {
            return snapshot.compareTo(gradleVersion.snapshot);
        }
        if (snapshot == null && gradleVersion.snapshot != null) {
            return 1;
        }
        if (snapshot != null && gradleVersion.snapshot == null) {
            return -1;
        }

        return 0;  // Even when the two version string are different
```

This PR fixes this issue by comparing `GradleVersion.version` when everything else are equal.

Also, this PR does a lot of refactoring work:

- Extract magic stage number to constants `STAGE_PREVIEW`/`STAGE_RC `.
- Extract methods to improve readability.