### PR TITLE
Stack traces emitted by Gradle are stabilised to improve deduplication

### DIFF
--- a/subprojects/logging/logging.gradle.kts
+++ b/subprojects/logging/logging.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     runtimeOnly(library("jcl_to_slf4j"))
 
     testImplementation(project(":internalTesting"))
+
+    integTestRuntimeOnly(project(":apiMetadata"))
 }
 
 gradlebuildJava {


### PR DESCRIPTION
- filtering out all system stackframes from emitted stacktraces

### Context

To improve reproducibility of stacktraces we filter out stackframes from system classes. 
 
See specification at https://docs.google.com/document/d/1vRvXz2MtShN-PV4jfOm4cX7B8nYKrLTAtiNrK_hsUSc/edit#

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
