### PR TITLE
Compute dependencies between transform nodes

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultResolverResults.java
@@ -101,14 +101,6 @@ public class DefaultResolverResults implements ResolverResults {
     }
 
     @Override
-    public void graphResolved(VisitedArtifactSet visitedArtifacts) {
-        this.visitedArtifacts = visitedArtifacts;
-        this.resolvedLocalComponentsResult = null;
-        this.resolutionResult = null;
-        this.fatalFailure = null;
-    }
-
-    @Override
     public void graphResolved(ResolutionResult resolutionResult, ResolvedLocalComponentsResult resolvedLocalComponentsResult, VisitedArtifactSet visitedArtifacts) {
         this.resolutionResult = resolutionResult;
         this.resolvedLocalComponentsResult = resolvedLocalComponentsResult;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolverResults.java
@@ -47,11 +47,6 @@ public interface ResolverResults {
     /**
      * Marks the dependency graph resolution as successful, with the given result.
      */
-    void graphResolved(VisitedArtifactSet visitedArtifacts);
-
-    /**
-     * Marks the dependency graph resolution as successful, with the given result.
-     */
     void graphResolved(ResolutionResult resolutionResult, ResolvedLocalComponentsResult resolvedLocalComponentsResult, VisitedArtifactSet visitedArtifacts);
 
     void failed(ResolveException failure);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -73,6 +73,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ResolvedFilesCollectingVisit
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.RootComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.projectresult.ResolvedProjectConfiguration;
+import org.gradle.api.internal.artifacts.transform.ExecutionGraphDependenciesResolverAwareContext;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -1606,7 +1607,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                 results = cachedResolverResults;
             }
             SelectedArtifactSet selected = results.getVisitedArtifacts().select(dependencySpec, requestedAttributes, componentIdentifierSpec, allowNoMatchingVariants);
-            FailureCollectingTaskDependencyResolveContext collectingContext = new FailureCollectingTaskDependencyResolveContext(context);
+            FailureCollectingTaskDependencyResolveContext collectingContext = new ExecutionGraphDependenciesResolverAwareContext(context, results);
             selected.visitDependencies(collectingContext);
             if (!lenient) {
                 rethrowFailure("task dependencies", collectingContext.getFailures());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/DefaultConfigurationResolver.java
@@ -124,9 +124,11 @@ public class DefaultConfigurationResolver implements ConfigurationResolver {
     public void resolveBuildDependencies(ConfigurationInternal configuration, ResolverResults result) {
         ResolutionStrategyInternal resolutionStrategy = configuration.getResolutionStrategy();
         ResolutionFailureCollector failureCollector = new ResolutionFailureCollector(componentSelectorConverter);
+        InMemoryResolutionResultBuilder resolutionResultBuilder = new InMemoryResolutionResultBuilder();
+        CompositeDependencyGraphVisitor graphVisitor = new CompositeDependencyGraphVisitor(failureCollector, resolutionResultBuilder);
         DefaultResolvedArtifactsBuilder artifactsVisitor = new DefaultResolvedArtifactsBuilder(currentBuild, buildProjectDependencies, resolutionStrategy.getSortOrder());
-        resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, failureCollector, artifactsVisitor, attributesSchema, artifactTypeRegistry);
-        result.graphResolved(new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.<UnresolvedDependency>emptySet()), artifactsVisitor.complete(), artifactTransforms, configuration.getIncoming()));
+        resolver.resolve(configuration, ImmutableList.<ResolutionAwareRepository>of(), metadataHandler, IS_LOCAL_EDGE, graphVisitor, artifactsVisitor, attributesSchema, artifactTypeRegistry);
+        result.graphResolved(resolutionResultBuilder.getResolutionResult(), new ResolvedLocalComponentsResultGraphVisitor(currentBuild), new BuildDependenciesOnlyVisitedArtifactSet(failureCollector.complete(Collections.<UnresolvedDependency>emptySet()), artifactsVisitor.complete(), artifactTransforms, configuration.getIncoming()));
     }
 
     public void resolveGraph(ConfigurationInternal configuration, ResolverResults results) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/InMemoryResolutionResultBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice;
+
+import org.gradle.api.artifacts.result.ResolutionResult;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphNode;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphSelector;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphVisitor;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.RootGraphNode;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DefaultResolutionResultBuilder;
+
+/**
+ * Dependency graph visitor that will build a {@link ResolutionResult} eagerly.
+ * It is designed to be used during resolution for build dependencies.
+ *
+ * @see DefaultConfigurationResolver#resolveBuildDependencies(ConfigurationInternal, org.gradle.api.internal.artifacts.ResolverResults)
+ */
+public class InMemoryResolutionResultBuilder implements DependencyGraphVisitor {
+
+    private final DefaultResolutionResultBuilder resolutionResultBuilder = new DefaultResolutionResultBuilder();
+    private ResolutionResult resolutionResult;
+
+    @Override
+    public void start(RootGraphNode root) {
+    }
+
+    @Override
+    public void visitNode(DependencyGraphNode node) {
+        resolutionResultBuilder.visitComponent(node.getOwner());
+    }
+
+    @Override
+    public void visitSelector(DependencyGraphSelector selector) {
+
+    }
+
+    @Override
+    public void visitEdges(DependencyGraphNode node) {
+        resolutionResultBuilder.visitOutgoingEdges(node.getOwner().getResultId(), node.getOutgoingEdges());
+    }
+
+    @Override
+    public void finish(DependencyGraphNode root) {
+        resolutionResult = resolutionResultBuilder.complete(root.getOwner().getResultId());
+    }
+
+    public ResolutionResult getResolutionResult() {
+        if (resolutionResult == null) {
+            throw new IllegalStateException("Resolution result not computed yet");
+        }
+        return resolutionResult;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -54,6 +54,12 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
 
     @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
-        context.add(new DefaultTransformationDependency(transformation, delegate, resolvableDependencies));
+        ExtraExecutionGraphDependenciesResolverFactory extraExecutionGraphDependenciesResolverFactory;
+        if (context instanceof ExecutionGraphDependenciesResolverAwareContext) {
+            extraExecutionGraphDependenciesResolverFactory = ((ExecutionGraphDependenciesResolverAwareContext) context).getExecutionGraphDependenciesResolverFactory();
+        } else {
+            extraExecutionGraphDependenciesResolverFactory = ExtraExecutionGraphDependenciesResolverFactory.ALWAYS_EMPTY_RESOLVER_FACTORY;
+        }
+        context.add(new DefaultTransformationDependency(transformation, delegate, resolvableDependencies, extraExecutionGraphDependenciesResolverFactory));
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExecutionGraphDependenciesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExecutionGraphDependenciesResolver.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.artifacts.result.DependencyResult;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.SelectedArtifactSet;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.specs.Specs;
+import org.gradle.execution.plan.Node;
+import org.gradle.execution.plan.TaskDependencyResolver;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class DefaultExecutionGraphDependenciesResolver implements ExecutionGraphDependenciesResolver {
+
+    private final VisitedArtifactSet visitedArtifacts;
+    private final Set<ComponentIdentifier> buildDependencies;
+
+    public DefaultExecutionGraphDependenciesResolver(ComponentIdentifier componentIdentifier, ResolverResults results) {
+        this.visitedArtifacts = results.getVisitedArtifacts();
+        this.buildDependencies = computeProjectDependencies(componentIdentifier, results.getResolutionResult().getAllComponents());
+    }
+
+    @Override
+    public Set<Node> computeDependencyNodes(TaskDependencyResolver dependencyResolver, ImmutableAttributes fromAttributes) {
+        if (buildDependencies.isEmpty()) {
+            return Collections.emptySet();
+        } else {
+            SelectedArtifactSet projectArtifacts = visitedArtifacts.select(Specs.satisfyAll(), fromAttributes, element -> {
+                return buildDependencies.contains(element);
+            }, true);
+            return dependencyResolver.resolveDependenciesFor(null, projectArtifacts);
+        }
+    }
+
+    private static Set<ComponentIdentifier> computeProjectDependencies(ComponentIdentifier componentIdentifier, Set<ResolvedComponentResult> componentResults) {
+        ResolvedComponentResult targetComponent = null;
+        for (ResolvedComponentResult component : componentResults) {
+            if (component.getId().equals(componentIdentifier)) {
+                targetComponent = component;
+                break;
+            }
+        }
+        if (targetComponent == null) {
+            throw new AssertionError("Could not find component " + componentIdentifier + " in provided results.");
+        }
+        Set<ComponentIdentifier> buildDependencies = new HashSet<>();
+        collectDependenciesIdentifiers(buildDependencies, new HashSet<>(), targetComponent.getDependencies());
+        return buildDependencies;
+    }
+
+    private static void collectDependenciesIdentifiers(Set<ComponentIdentifier> dependenciesIdentifiers, Set<ComponentIdentifier> visited, Set<? extends DependencyResult> dependencies) {
+        for (DependencyResult dependency : dependencies) {
+            if (dependency instanceof ResolvedDependencyResult) {
+                ResolvedDependencyResult resolvedDependency = (ResolvedDependencyResult) dependency;
+                ResolvedComponentResult selected = resolvedDependency.getSelected();
+                if (selected.getId() instanceof ProjectComponentIdentifier) {
+                    dependenciesIdentifiers.add(selected.getId());
+                }
+                if (visited.add(selected.getId())) {
+                    // Do not traverse if seen already
+                    collectDependenciesIdentifiers(dependenciesIdentifiers, visited, selected.getDependencies());
+                }
+            }
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.internal.artifacts.ResolverResults;
+
+public class DefaultExtraExecutionGraphDependenciesResolverFactory implements ExtraExecutionGraphDependenciesResolverFactory {
+    private final ResolverResults results;
+
+    public DefaultExtraExecutionGraphDependenciesResolverFactory(ResolverResults results) {
+        this.results = results;
+    }
+
+    @Override
+    public ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier, Transformation transformation) {
+        if (transformation.requiresDependencies()) {
+            return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, results);
+        } else {
+            return ExecutionGraphDependenciesResolver.EMPTY_RESOLVER;
+        }
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationDependency.java
@@ -25,11 +25,15 @@ public class DefaultTransformationDependency implements TransformationDependency
     private final Transformation transformation;
     private final ResolvedArtifactSet artifacts;
     private final ResolvableDependencies resolvableDependencies;
+    private final ExtraExecutionGraphDependenciesResolverFactory extraExecutionGraphDependenciesResolverFactory;
 
-    public DefaultTransformationDependency(Transformation transformation, ResolvedArtifactSet artifacts, ResolvableDependencies resolvableDependencies) {
+    public DefaultTransformationDependency(Transformation transformation, ResolvedArtifactSet artifacts,
+                                           ResolvableDependencies resolvableDependencies,
+                                           ExtraExecutionGraphDependenciesResolverFactory extraExecutionGraphDependenciesResolverFactory) {
         this.transformation = transformation;
         this.artifacts = artifacts;
         this.resolvableDependencies = resolvableDependencies;
+        this.extraExecutionGraphDependenciesResolverFactory = extraExecutionGraphDependenciesResolverFactory;
     }
 
     public Transformation getTransformation() {
@@ -42,6 +46,10 @@ public class DefaultTransformationDependency implements TransformationDependency
 
     public ResolvableDependencies getResolvableDependencies() {
         return resolvableDependencies;
+    }
+
+    public ExtraExecutionGraphDependenciesResolverFactory getExtraExecutionGraphDependenciesResolverFactory() {
+        return extraExecutionGraphDependenciesResolverFactory;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutionGraphDependenciesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutionGraphDependenciesResolver.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.execution.plan.Node;
+import org.gradle.execution.plan.TaskDependencyResolver;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Companion type to {@link TransformationNode} that knows how to compute extra dependent nodes aside from the to be transformed artifact.
+ * Instances of this type should not be shared beyond a single transformation chain.
+ *
+ * @see ExtraExecutionGraphDependenciesResolverFactory
+ */
+public interface ExecutionGraphDependenciesResolver {
+    ExecutionGraphDependenciesResolver EMPTY_RESOLVER = new ExecutionGraphDependenciesResolver() {
+        @Override
+        public Set<Node> computeDependencyNodes(TaskDependencyResolver dependencyResolver, ImmutableAttributes fromAttributes) {
+            return Collections.emptySet();
+        }
+    };
+
+    /**
+     * Computes the extra dependency nodes.
+     *
+     * @param dependencyResolver the resolver
+     * @param fromAttributes the origin attributes of the transform
+     * @return a set of {@link Node}, can be empty
+     */
+    Set<Node> computeDependencyNodes(TaskDependencyResolver dependencyResolver, ImmutableAttributes fromAttributes);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutionGraphDependenciesResolverAwareContext.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecutionGraphDependenciesResolverAwareContext.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.tasks.FailureCollectingTaskDependencyResolveContext;
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+
+public class ExecutionGraphDependenciesResolverAwareContext extends FailureCollectingTaskDependencyResolveContext {
+    private final DefaultExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory;
+
+    public ExecutionGraphDependenciesResolverAwareContext(TaskDependencyResolveContext context, ResolverResults results) {
+        super(context);
+        dependenciesResolverFactory = new DefaultExtraExecutionGraphDependenciesResolverFactory(results);
+    }
+
+    public ExtraExecutionGraphDependenciesResolverFactory getExecutionGraphDependenciesResolverFactory() {
+        return dependenciesResolverFactory;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExtraExecutionGraphDependenciesResolverFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+
+/**
+ * Factory for {@link ExecutionGraphDependenciesResolver} that relies on the information provided to its {@code create} method.
+ */
+public interface ExtraExecutionGraphDependenciesResolverFactory {
+    ExtraExecutionGraphDependenciesResolverFactory ALWAYS_EMPTY_RESOLVER_FACTORY = new ExtraExecutionGraphDependenciesResolverFactory() {
+        @Override
+        public ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier, Transformation transformation) {
+            return ExecutionGraphDependenciesResolver.EMPTY_RESOLVER;
+        }
+    };
+
+    /**
+     * Creates a {@link ExecutionGraphDependenciesResolver} based on the provided {@code ComponentIdentifier} and {@code Transformation}.
+     *
+     * @param componentIdentifier the identifier of the artifact under transform
+     * @param transformation the transformation definition
+     *
+     * @return an {@code ExecutionGraphDependenciesResolver} based on the provided parameters
+     */
+    ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier, Transformation transformation);
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeDependencyResolver.java
@@ -37,7 +37,7 @@ public class TransformationNodeDependencyResolver implements DependencyResolver 
     public boolean resolve(Task task, Object node, Action<? super Node> resolveAction) {
         if (node instanceof DefaultTransformationDependency) {
             DefaultTransformationDependency transformation = (DefaultTransformationDependency) node;
-            Collection<TransformationNode> transformations = transformationNodeFactory.getOrCreate(transformation.getArtifacts(), transformation.getTransformation(), transformation.getResolvableDependencies());
+            Collection<TransformationNode> transformations = transformationNodeFactory.getOrCreate(transformation.getArtifacts(), transformation.getTransformation(), transformation.getResolvableDependencies(), transformation.getExtraExecutionGraphDependenciesResolverFactory());
             for (TransformationNode transformationNode : transformations) {
                 resolveAction.execute(transformationNode);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeFactory.java
@@ -22,5 +22,5 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.Resol
 import java.util.Collection;
 
 public interface TransformationNodeFactory {
-    Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ResolvableDependencies resolvableDependencies);
+    Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ResolvableDependencies resolvableDependencies, ExtraExecutionGraphDependenciesResolverFactory extraExecutionGraphDependenciesResolverFactory);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Action;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Try;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,6 +76,10 @@ public class TransformationStep implements Transformation {
     @Override
     public void visitTransformationSteps(Action<? super TransformationStep> action) {
         action.execute(this);
+    }
+
+    public ImmutableAttributes getFromAttributes() {
+        return transformer.getFromAttributes();
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -576,8 +576,8 @@ class DefaultConfigurationSpec extends Specification {
         _ * artifactTaskDependencies.getDependencies(_) >> requiredTasks
 
         and:
-        _ * resolver.resolveBuildDependencies(_, _) >> { ConfigurationInternal config, DefaultResolverResults resolverResults ->
-            resolverResults.graphResolved(visitedArtifactSet)
+        _ * resolver.resolveBuildDependencies(_, _) >> { ConfigurationInternal config, ResolverResults resolverResults ->
+            resolverResults.graphResolved(Stub(ResolutionResult), Stub(ResolvedLocalComponentsResult), visitedArtifactSet)
         }
 
         expect:
@@ -1138,7 +1138,7 @@ class DefaultConfigurationSpec extends Specification {
 
         and:
         1 * resolver.resolveBuildDependencies(config, _) >> { ConfigurationInternal c, ResolverResults r ->
-            r.graphResolved(visitedArtifacts())
+            r.graphResolved(Stub(ResolutionResult), Stub(ResolvedLocalComponentsResult), visitedArtifacts())
         }
         0 * resolver._
     }
@@ -1192,7 +1192,7 @@ class DefaultConfigurationSpec extends Specification {
 
         and:
         1 * resolver.resolveBuildDependencies(config, _) >> { ConfigurationInternal c, ResolverResults r ->
-            r.graphResolved(visitedArtifacts())
+            r.graphResolved(Stub(ResolutionResult), Stub(ResolvedLocalComponentsResult), visitedArtifacts())
         }
         0 * resolver._
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ShortCircuitEmptyConfigurationResolverSpec.groovy
@@ -29,7 +29,6 @@ import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyIntern
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingProvider
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactVisitor
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.VisitedArtifactSet
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.api.specs.Specs
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -229,19 +228,6 @@ class ShortCircuitEmptyConfigurationResolverSpec extends Specification {
         given:
         dependencies.isEmpty() >> false
         configuration.getAllDependencies() >> dependencies
-
-        when:
-        dependencyResolver.resolveArtifacts(configuration, results)
-
-        then:
-        1 * delegate.resolveArtifacts(configuration, results)
-    }
-
-    def "delegates to backing service to resolve artifacts when there are no dependencies but result seems to have state"() {
-        given:
-        dependencies.isEmpty() >> true
-        configuration.getAllDependencies() >> dependencies
-        results.graphResolved(Mock(VisitedArtifactSet))
 
         when:
         dependencyResolver.resolveArtifacts(configuration, results)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform
+
+import com.google.common.collect.ImmutableCollection
+import org.gradle.api.Action
+import org.gradle.api.Task
+import org.gradle.api.artifacts.ResolvableDependencies
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildableSingleResolvedArtifactSet
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.execution.plan.Node
+import org.gradle.execution.plan.TaskDependencyResolver
+import org.jetbrains.annotations.NotNull
+import spock.lang.Specification
+
+class TransformationNodeSpec extends Specification {
+
+    def artifactSet = Mock(BuildableSingleResolvedArtifactSet)
+    def dependencyResolver = Mock(TaskDependencyResolver)
+    def artifactNode = new TestNode()
+    def hardSuccessor = Mock(Action)
+    def transformationStep = Mock(TransformationStep)
+
+    def "initial node with empty extra resolver only adds dependency on artifact node"() {
+
+        given:
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER)
+
+        when:
+        node.resolveDependencies(dependencyResolver, hardSuccessor)
+
+        then:
+        1 * dependencyResolver.resolveDependenciesFor(null, artifactSet) >> [artifactNode]
+        1 * hardSuccessor.execute(artifactNode)
+        0 * hardSuccessor._
+    }
+
+    def "initial node with non empty extra resolver only adds dependency on artifact node when extra provides none"() {
+        def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
+
+        given:
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+
+        when:
+        node.resolveDependencies(dependencyResolver, hardSuccessor)
+
+        then:
+        1 * transformationStep.fromAttributes >> ImmutableAttributes.EMPTY
+        1 * dependencyResolver.resolveDependenciesFor(null, artifactSet) >> [artifactNode]
+        1 * graphDependenciesResolver.computeDependencyNodes(dependencyResolver, ImmutableAttributes.EMPTY) >> []
+        1 * hardSuccessor.execute(artifactNode)
+        0 * hardSuccessor._
+    }
+
+    def "initial node with non empty extra resolver adds dependency on all nodes when extra provides one"() {
+        def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
+        def extraNode = new TestNode()
+
+        given:
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+
+        when:
+        node.resolveDependencies(dependencyResolver, hardSuccessor)
+
+        then:
+        1 * transformationStep.fromAttributes >> ImmutableAttributes.EMPTY
+        1 * dependencyResolver.resolveDependenciesFor(null, artifactSet) >> [artifactNode]
+        1 * graphDependenciesResolver.computeDependencyNodes(dependencyResolver, ImmutableAttributes.EMPTY) >> [extraNode]
+        1 * hardSuccessor.execute(artifactNode)
+        1 * hardSuccessor.execute(extraNode)
+        0 * hardSuccessor._
+    }
+
+    def "chained node with empty extra resolver only adds dependency on previous step"() {
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER)
+
+        given:
+        def node = TransformationNode.chained(Mock(TransformationStep), initialNode)
+
+        when:
+        node.resolveDependencies(dependencyResolver, hardSuccessor)
+
+        then:
+        1 * hardSuccessor.execute(initialNode)
+        0 * hardSuccessor._
+    }
+
+    def "chained node with non empty extra resolver only adds dependency on previous step when extra provides none"() {
+        def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+        def chainedStep = Mock(TransformationStep)
+
+        given:
+        def node = TransformationNode.chained(chainedStep, initialNode)
+
+        when:
+        node.resolveDependencies(dependencyResolver, hardSuccessor)
+
+        then:
+        1 * chainedStep.fromAttributes >> ImmutableAttributes.EMPTY
+        1 * graphDependenciesResolver.computeDependencyNodes(dependencyResolver, ImmutableAttributes.EMPTY) >> []
+        1 * hardSuccessor.execute(initialNode)
+        0 * hardSuccessor._
+    }
+
+    def "chained node with non empty extra resolver only adds dependency on all nodes when extra provides one"() {
+        def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+        def chainedStep = Mock(TransformationStep)
+        def extraNode = new TestNode()
+
+        given:
+        def node = TransformationNode.chained(chainedStep, initialNode)
+
+        when:
+        node.resolveDependencies(dependencyResolver, hardSuccessor)
+
+        then:
+        1 * chainedStep.fromAttributes >> ImmutableAttributes.EMPTY
+        1 * graphDependenciesResolver.computeDependencyNodes(dependencyResolver, ImmutableAttributes.EMPTY) >> [extraNode]
+        1 * hardSuccessor.execute(initialNode)
+        1 * hardSuccessor.execute(extraNode)
+        0 * hardSuccessor._
+    }
+
+    class TestNode extends Node {
+
+        @Override
+        void collectTaskInto(ImmutableCollection.Builder<Task> builder) {
+
+        }
+
+        @Override
+        Throwable getNodeFailure() {
+            return null
+        }
+
+        @Override
+        void rethrowNodeFailure() {
+
+        }
+
+        @Override
+        void prepareForExecution() {
+
+        }
+
+        @Override
+        void resolveDependencies(TaskDependencyResolver dependencyResolver, Action<Node> processHardSuccessor) {
+
+        }
+
+        @Override
+        Set<Node> getFinalizers() {
+            return null
+        }
+
+        @Override
+        String toString() {
+            return null
+        }
+
+        @Override
+        int compareTo(@NotNull Node o) {
+            return 0
+        }
+    }
+}


### PR DESCRIPTION
During execution graph computation, we now make sure that transform node
consuming dependencies artifacts are properly linked with project or
transform node producing said artifacts.

This PR is still work in progress, with the following to be done:
* ~~Revert forcing full configuration resolution and instead populate more the `ResolverResult` even during partial resolution~~ This is now done!
* Add tests, lots of them

Main focus of comments right now: Changes in `TransformNode` and the path to get the required info there.