### PR TITLE
Only count execution time of container callbacks once

### DIFF
--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/ClientForwardingProjectConfigurationOperationListener.java
@@ -71,14 +71,18 @@ class ClientForwardingProjectConfigurationOperationListener extends SubtreeFilte
     public void finished(BuildOperationDescriptor buildOperation, OperationFinishEvent finishEvent) {
         super.finished(buildOperation, finishEvent);
         if (isEnabled()) {
-            PluginApplication pluginApplication = pluginApplicationTracker.getPluginApplication(buildOperation.getId());
+            PluginApplication pluginApplication = pluginApplicationTracker.getRunningPluginApplication(buildOperation.getId());
             if (pluginApplication != null) {
                 ProjectConfigurationResult result = parentTracker.findClosestExistingAncestor(buildOperation.getParentId(), results::get);
-                if (result != null) {
+                if (result != null && hasNoEnclosingRunningPluginApplicationForSamePlugin(buildOperation, pluginApplication.getPlugin())) {
                     result.increment(pluginApplication, finishEvent.getEndTime() - finishEvent.getStartTime());
                 }
             }
         }
+    }
+
+    private boolean hasNoEnclosingRunningPluginApplicationForSamePlugin(BuildOperationDescriptor buildOperation, InternalPluginIdentifier plugin) {
+        return !pluginApplicationTracker.hasRunningPluginApplication(buildOperation.getParentId(), pluginApplication -> pluginApplication.getPlugin().equals(plugin));
     }
 
     @Override

--- a/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOriginTracker.java
+++ b/subprojects/tooling-api-builders/src/main/java/org/gradle/tooling/internal/provider/runner/TaskOriginTracker.java
@@ -59,7 +59,7 @@ class TaskOriginTracker implements BuildOperationListener {
 
     private void storeOrigin(BuildOperationDescriptor buildOperation, long taskId) {
         origins.computeIfAbsent(taskId, key -> {
-            PluginApplication pluginApplication = pluginApplicationTracker.findCurrentPluginApplication(buildOperation.getParentId());
+            PluginApplication pluginApplication = pluginApplicationTracker.findRunningPluginApplication(buildOperation.getParentId());
             return pluginApplication == null ? null : pluginApplication.getPlugin();
         });
     }


### PR DESCRIPTION
Prior to this commit, the execution time of callbacks executed eagerly
during plugin application, e.g. for already existing items in an `all`
callback, was counted twice: once for its execution and once as part of
the enclosing plugin application operation.