### PR TITLE
Restrict cases where to do HTTP retries

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpAuthenticationDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/http/HttpAuthenticationDependencyResolutionIntegrationTest.groovy
@@ -32,6 +32,11 @@ import static org.gradle.test.fixtures.server.http.AuthScheme.NTLM
 class HttpAuthenticationDependencyResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
     static String badCredentials = "credentials{username 'testuser'; password 'bad'}"
 
+    def setup() {
+        // by setting this to >1, we assert that an authentication error is NOT going to cause retries
+        maxHttpRetries = 3
+    }
+
     @Unroll
     def "can resolve dependencies using #authSchemeName scheme from #authScheme authenticated HTTP ivy repository"() {
         given:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
+import org.apache.http.HttpStatus;
+import org.apache.http.conn.HttpHostConnectException;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
@@ -34,6 +36,7 @@ import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ModuleSource;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.resolve.ArtifactNotFoundException;
 import org.gradle.internal.resolve.ArtifactResolveException;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -43,7 +46,10 @@ import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResu
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
 import org.gradle.internal.resolve.result.ErroringResolveResult;
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
 
+import java.net.SocketTimeoutException;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -138,56 +144,56 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         @Override
         public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
             performOperationWithRetries(result,
-                () -> delegate.listModuleVersions(dependency, result),
-                () -> new ModuleVersionResolveException(dependency.getSelector(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                throwable -> {
-                    ModuleComponentSelector selector = dependency.getSelector();
-                    String message = "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".";
-                    return new ModuleVersionResolveException(selector, message, throwable);
-                });
+                    () -> delegate.listModuleVersions(dependency, result),
+                    () -> new ModuleVersionResolveException(dependency.getSelector(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    throwable -> {
+                        ModuleComponentSelector selector = dependency.getSelector();
+                        String message = "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".";
+                        return new ModuleVersionResolveException(selector, message, throwable);
+                    });
         }
 
         @Override
         public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
             performOperationWithRetries(result,
-                () -> delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result),
-                () -> new ModuleVersionResolveException(moduleComponentIdentifier, BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                throwable -> new ModuleVersionResolveException(moduleComponentIdentifier, throwable)
+                    () -> delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result),
+                    () -> new ModuleVersionResolveException(moduleComponentIdentifier, BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    throwable -> new ModuleVersionResolveException(moduleComponentIdentifier, throwable)
             );
         }
 
         @Override
         public void resolveArtifactsWithType(ComponentResolveMetadata component, ArtifactType artifactType, BuildableArtifactSetResolveResult result) {
             performOperationWithRetries(result,
-                () -> delegate.resolveArtifactsWithType(component, artifactType, result),
-                () -> new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                throwable -> new ArtifactResolveException(component.getId(), throwable)
+                    () -> delegate.resolveArtifactsWithType(component, artifactType, result),
+                    () -> new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    throwable -> new ArtifactResolveException(component.getId(), throwable)
             );
         }
 
         @Override
         public void resolveArtifacts(ComponentResolveMetadata component, BuildableComponentArtifactsResolveResult result) {
             performOperationWithRetries(result,
-                () -> delegate.resolveArtifacts(component, result),
-                () -> new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                throwable -> new ArtifactResolveException(component.getId(), throwable));
+                    () -> delegate.resolveArtifacts(component, result),
+                    () -> new ArtifactResolveException(component.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    throwable -> new ArtifactResolveException(component.getId(), throwable));
         }
 
         @Override
         public void resolveArtifact(ComponentArtifactMetadata artifact, ModuleSource moduleSource, BuildableArtifactResolveResult result) {
             performOperationWithRetries(result,
-                () -> {
-                    delegate.resolveArtifact(artifact, moduleSource, result);
-                    if (result.hasResult()) {
-                        ArtifactResolveException failure = result.getFailure();
-                        if (!(failure instanceof ArtifactNotFoundException)) {
-                            return failure;
+                    () -> {
+                        delegate.resolveArtifact(artifact, moduleSource, result);
+                        if (result.hasResult()) {
+                            ArtifactResolveException failure = result.getFailure();
+                            if (!(failure instanceof ArtifactNotFoundException)) {
+                                return failure;
+                            }
                         }
-                    }
-                    return null;
-                },
-                () -> new ArtifactResolveException(artifact.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
-                throwable -> new ArtifactResolveException(artifact.getId(), throwable));
+                        return null;
+                    },
+                    () -> new ArtifactResolveException(artifact.getId(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    throwable -> new ArtifactResolveException(artifact.getId(), throwable));
         }
 
         private <E extends Throwable, R extends ErroringResolveResult<E>> void performOperationWithRetries(R result,
@@ -244,7 +250,8 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
                     unexpectedFailure = throwable;
                     failure = onError.transform(throwable);
                 }
-                if (retries == maxTentativesCount) {
+                boolean doNotRetry = !isLikelyTransientNetworkingIssue(failure);
+                if (doNotRetry || retries == maxTentativesCount) {
                     if (unexpectedFailure != null) {
                         repositoryBlacklister.blacklistRepository(repositoryId, unexpectedFailure);
                     }
@@ -260,6 +267,42 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
                     }
                 }
             }
+        }
+
+        /**
+         * Determines if an error should cause a retry. We will currently retry:
+         * <ul>
+         * <li>on a network timeout</li>
+         * <li>on a server error (return code 5xx)</li>
+         * <li>on rate limiting</li>
+         * </ul>
+         */
+        private static <E extends Throwable> boolean isLikelyTransientNetworkingIssue(E failure) {
+            if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
+                return true;
+            }
+            if (failure instanceof DefaultMultiCauseException) {
+                List<? extends Throwable> causes = ((DefaultMultiCauseException) failure).getCauses();
+                for (Throwable cause : causes) {
+                    if (isLikelyTransientNetworkingIssue(cause)) {
+                        return true;
+                    }
+                }
+            }
+            if (failure instanceof HttpErrorStatusCodeException) {
+                HttpErrorStatusCodeException httpError = (HttpErrorStatusCodeException) failure;
+                return httpError.isServerError() || isTransientClientError(httpError.getStatusCode());
+            }
+            Throwable cause = failure.getCause();
+            if (cause != null && cause != failure) {
+                return isLikelyTransientNetworkingIssue(cause);
+            }
+            return false;
+        }
+
+        private static boolean isTransientClientError(int statusCode) {
+            return statusCode == HttpStatus.SC_REQUEST_TIMEOUT ||
+                    statusCode == 429; // Too many requests (not available through HttpStatus.XXX)
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepositoryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve
 
+import org.apache.http.conn.HttpHostConnectException
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
@@ -35,6 +36,8 @@ import org.gradle.internal.resolve.result.BuildableArtifactSetResolveResult
 import org.gradle.internal.resolve.result.BuildableComponentArtifactsResolveResult
 import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult
 import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
@@ -44,7 +47,21 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
     private static final String REPOSITORY_ID = 'abc'
     def delegate = Mock(ModuleComponentRepositoryAccess)
     def repositoryBlacklister = Mock(RepositoryBlacklister)
-    def someException = new RuntimeException('Something went wrong')
+
+    @Shared
+    def runtimeError = new RuntimeException('Something went wrong')
+    @Shared
+    def connectTimeout = new SocketTimeoutException()
+    @Shared
+    def cannotConnect = new HttpHostConnectException(null, null)
+    @Shared
+    def missing = status(404)
+    @Shared
+    def clientTimeout = status(408)
+    @Shared
+    def tooManyRequests = status(429)
+    @Shared
+    def unauthorized = status(403)
 
     @Subject
     ErrorHandlingModuleComponentRepository.ErrorHandlingModuleComponentRepositoryAccess access
@@ -53,9 +70,18 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         new ErrorHandlingModuleComponentRepository.ErrorHandlingModuleComponentRepositoryAccess(delegate, 'abc', repositoryBlacklister, maxRetries, backoff, 'abc')
     }
 
-    @Unroll("can list module versions (max retries = #retries)")
+    private static HttpErrorStatusCodeException status(int statusCode) {
+        new HttpErrorStatusCodeException("GET", "DUMMY", statusCode, "test") {
+            @Override
+            String toString() {
+                "status $statusCode"
+            }
+        }
+    }
+
+    @Unroll("can list module versions (max retries = #maxRetries, exception=#exception)")
     def "can list module versions"() {
-        access = createAccess(retries)
+        access = createAccess(maxRetries)
 
         given:
         def dependency = Mock(ModuleDependencyMetadata)
@@ -70,11 +96,11 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.listModuleVersions(dependency, result)
 
         when: 'exception is thrown in resolution'
-        retries * delegate.listModuleVersions(dependency, result) >> { throw someException }
+        effectiveRetries * delegate.listModuleVersions(dependency, result) >> { throw exception }
         access.listModuleVersions(dependency, result)
 
         then: 'resolution fails and repo is blacklisted'
-        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, someException)
+        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ModuleVersionResolveException)
 
         when: 'repo is already blacklisted'
@@ -86,12 +112,12 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         0 * delegate._
 
         where:
-        retries << (1..3)
+        [maxRetries, exception, effectiveRetries] << retryCombinations()
     }
 
-    @Unroll("can resolve component meta data (max retries = #retries)")
+    @Unroll("can resolve component meta data (max retries = #maxRetries, exception=#exception)")
     def "can resolve component meta data"() {
-        access = createAccess(retries)
+        access = createAccess(maxRetries)
 
         given:
         def moduleComponentIdentifier = new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId('a', 'b'), '1.0')
@@ -106,11 +132,11 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result)
 
         when: 'exception is thrown in resolution'
-        retries * delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result) >> { throw someException }
+        effectiveRetries * delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result) >> { throw exception }
         access.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result)
 
         then: 'resolution fails and repo is blacklisted'
-        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, someException)
+        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ModuleVersionResolveException)
 
         when: 'repo is already blacklisted'
@@ -122,12 +148,12 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         0 * delegate._
 
         where:
-        retries << (1..3)
+        [maxRetries, exception, effectiveRetries] << retryCombinations()
     }
 
-    @Unroll("can resolve artifacts with type (max retries = #retries)")
+    @Unroll("can resolve artifacts with type (max retries = #maxRetries, exception=#exception)")
     def "can resolve artifacts with type"() {
-        access = createAccess(retries)
+        access = createAccess(maxRetries)
 
         given:
         def component = Mock(ComponentResolveMetadata)
@@ -144,11 +170,11 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.resolveArtifactsWithType(component, artifactType, result)
 
         when: 'exception is thrown in resolution'
-        retries * delegate.resolveArtifactsWithType(component, artifactType, result) >> { throw someException }
+        effectiveRetries * delegate.resolveArtifactsWithType(component, artifactType, result) >> { throw exception }
         access.resolveArtifactsWithType(component, artifactType, result)
 
         then: 'resolution fails and repo is blacklisted'
-        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, someException)
+        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ArtifactResolveException)
 
         when: 'repo is already blacklisted'
@@ -160,12 +186,12 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         0 * delegate._
 
         where:
-        retries << (1..3)
+        [maxRetries, exception, effectiveRetries] << retryCombinations()
     }
 
-    @Unroll("can resolve artifacts (max retries = #retries)")
+    @Unroll("can resolve artifacts (max retries = #maxRetries, exception=#exception)")
     def "can resolve artifacts"() {
-        access = createAccess(retries)
+        access = createAccess(maxRetries)
 
         given:
         def component = Mock(ComponentResolveMetadata)
@@ -181,11 +207,11 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.resolveArtifacts(component, result)
 
         when: 'exception is thrown in resolution'
-        retries * delegate.resolveArtifacts(component, result) >> { throw someException }
+        effectiveRetries * delegate.resolveArtifacts(component, result) >> { throw exception }
         access.resolveArtifacts(component, result)
 
         then: 'resolution fails and repo is blacklisted'
-        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, someException)
+        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ArtifactResolveException)
 
         when: 'repo is already blacklisted'
@@ -197,12 +223,12 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         0 * delegate._
 
         where:
-        retries << (1..3)
+        [maxRetries, exception, effectiveRetries] << retryCombinations()
     }
 
-    @Unroll("can resolve artifact (max retries = #retries)")
+    @Unroll("can resolve artifact (max retries = #maxRetries, exception=#exception)")
     def "can resolve artifact"() {
-        access = createAccess(retries)
+        access = createAccess(maxRetries)
 
         given:
         def artifact = Mock(ComponentArtifactMetadata)
@@ -219,11 +245,11 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         1 * delegate.resolveArtifact(artifact, moduleSource, result)
 
         when: 'exception is thrown in resolution'
-        retries * delegate.resolveArtifact(artifact, moduleSource, result) >> { throw someException }
+        effectiveRetries * delegate.resolveArtifact(artifact, moduleSource, result) >> { throw exception }
         access.resolveArtifact(artifact, moduleSource, result)
 
         then: 'resolution fails and repo is blacklisted'
-        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, someException)
+        1 * repositoryBlacklister.blacklistRepository(REPOSITORY_ID, { hasCause(it, exception) })
         1 * result.failed(_ as ArtifactResolveException)
 
         when: 'repo is already blacklisted'
@@ -235,6 +261,43 @@ class ErrorHandlingModuleComponentRepositoryTest extends Specification {
         0 * delegate._
 
         where:
-        retries << (1..3)
+        [maxRetries, exception, effectiveRetries] << retryCombinations()
+    }
+
+    List<List<?>> retryCombinations() {
+        def retries = []
+        (1..3).each { ret ->
+            // no retries on runtime errors, missing resources, authentication errors
+            retries << [ret, runtimeError, 1]
+            retries << [ret, missing, 1]
+            retries << [ret, unauthorized, 1]
+            // retries on connect timeouts, too many requests, client timeouts
+            retries << [ret, connectTimeout, ret]
+            retries << [ret, cannotConnect, ret]
+            retries << [ret, tooManyRequests, ret]
+            retries << [ret, clientTimeout, ret]
+            // retries on server errors
+            if (ret < 3) {
+                // testing 1 and 2 is good enough coverage
+                (500..<600).each { code ->
+                    retries << [ret, status(code), ret]
+                }
+                // no retries on arbitrary codes
+                (100..<200).each { code ->
+                    retries << [ret, status(code), 1]
+                }
+            }
+        }
+        retries
+    }
+
+    static boolean hasCause(Throwable actual, Throwable cause) {
+        if (actual == cause) {
+            return true
+        }
+        if (actual.cause && actual.cause != actual) {
+            return hasCause(actual.cause, cause)
+        }
+        return false
     }
 }

--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpErrorStatusCodeException.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/HttpErrorStatusCodeException.java
@@ -35,4 +35,8 @@ public class HttpErrorStatusCodeException extends RuntimeException {
     public boolean isServerError() {
         return statusCode >= 500 && statusCode < 600;
     }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
 }


### PR DESCRIPTION
### Context

This commit restricts the number of cases where we're going to perform HTTP retries. Instead of any error, we will now retry when:

- a connection timeout occurs (client or server)
- the server responds an error code between 500 and 600
- response code is a too many requests error

Fixes #7850
