### PR TITLE
Make `BlockingHttpServer.stop()` more reliable when requests are in progress

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServer.java
@@ -64,7 +64,7 @@ public class BlockingHttpServer extends ExternalResource {
         server = HttpServer.create(new InetSocketAddress(0), 10);
         server.setExecutor(EXECUTOR_SERVICE);
         serverId = COUNTER.incrementAndGet();
-        handler = new ChainingHttpHandler(lock, COUNTER, new MustBeRunning());
+        handler = new ChainingHttpHandler(lock, timeoutMs, COUNTER, new MustBeRunning());
         context = server.createContext("/", handler);
         this.timeoutMs = timeoutMs;
     }
@@ -313,7 +313,7 @@ public class BlockingHttpServer extends ExternalResource {
     }
 
     public void stop() {
-        handler.assertComplete();
+        handler.waitForCompletion();
         running = false;
         // Stop is very slow, clean it up later
         EXECUTOR_SERVICE.execute(new Runnable() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ChainingHttpHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ChainingHttpHandler.java
@@ -21,29 +21,35 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
+import org.gradle.internal.time.Clock;
+import org.gradle.internal.time.Time;
 
 import javax.annotation.Nullable;
-import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 
 class ChainingHttpHandler implements HttpHandler {
+    private final int timeoutMs;
     private final AtomicInteger counter;
     private final List<TrackingHttpHandler> handlers = new CopyOnWriteArrayList<TrackingHttpHandler>();
-    private final List<RequestOutcome> outcomes = new CopyOnWriteArrayList<RequestOutcome>();
+    private final List<RequestOutcome> outcomes = new ArrayList<RequestOutcome>();
+    private final Clock clock = Time.clock();
     private final Lock lock;
     private WaitPrecondition last;
     private boolean completed;
     private final Condition condition;
-    private int requestCount;
+    private int requestsStarted;
 
-    ChainingHttpHandler(Lock lock, AtomicInteger counter, WaitPrecondition first) {
+    ChainingHttpHandler(Lock lock, int timeoutMs, AtomicInteger counter, WaitPrecondition first) {
         this.lock = lock;
         this.condition = lock.newCondition();
+        this.timeoutMs = timeoutMs;
         this.counter = counter;
         this.last = first;
     }
@@ -60,23 +66,24 @@ class ChainingHttpHandler implements HttpHandler {
         }
     }
 
-    public void assertComplete() {
+    public void waitForCompletion() {
+        for (TrackingHttpHandler handler : handlers) {
+            handler.cancelBlockedRequests();
+        }
+
+        waitForRequestsToFinish();
+
         lock.lock();
         try {
             List<Throwable> failures = new ArrayList<Throwable>();
             for (RequestOutcome outcome : outcomes) {
-                if (outcome.failure != null) {
-                    failures.add(outcome.failure);
-                }
+                outcome.collectFailure(failures);
             }
             if (!completed) {
                 for (TrackingHttpHandler handler : handlers) {
-                    try {
-                        handler.assertComplete();
-                    } catch (Throwable t) {
-                        failures.add(t);
-                    }
+                    handler.assertComplete(failures);
                 }
+                handlers.clear();
                 completed = true;
             }
             if (!failures.isEmpty()) {
@@ -87,58 +94,92 @@ class ChainingHttpHandler implements HttpHandler {
         }
     }
 
+    private void waitForRequestsToFinish() {
+        long completionTimeout = clock.getCurrentTime() + timeoutMs;
+        for (RequestOutcome outcome : outcomes) {
+            long waitTime = completionTimeout - clock.getCurrentTime();
+            outcome.awaitCompletion(waitTime);
+        }
+    }
+
     @Override
-    public void handle(HttpExchange httpExchange) throws IOException {
+    public void handle(HttpExchange httpExchange) {
         try {
             int id = counter.incrementAndGet();
-            RequestOutcome outcome = new RequestOutcome();
-            outcomes.add(outcome);
-            String requestMethod = httpExchange.getRequestMethod();
-            String requestPath = httpExchange.getRequestURI().getPath();
 
-            System.out.println(String.format("[%d] handling %s %s", id, requestMethod, requestPath));
+            RequestOutcome outcome = requestStarted(httpExchange);
+            System.out.println(String.format("[%d] handling %s", id, outcome.getDisplayName()));
 
-            ResourceHandler resourceHandler = selectHandler(id, httpExchange, outcome);
-            if (resourceHandler != null) {
-                System.out.println(String.format("[%d] sending response for %s %s", id, requestMethod, requestPath));
-                try {
-                    resourceHandler.writeTo(id, httpExchange);
-                } catch (Throwable t) {
-                    System.out.println(String.format("[%d] handling %s %s failed with exception", id, requestMethod, requestPath));
-                    outcome.failure = new AssertionError(String.format("Failed to handle %s %s", httpExchange.getRequestMethod(), httpExchange.getRequestURI().getPath()), t);
-                }
-            } else {
-                System.out.println(String.format("[%d] sending error response for unexpected request", id));
-                if (requestMethod.equals("HEAD")) {
-                    httpExchange.sendResponseHeaders(500, -1);
+            try {
+                ResponseProducer responseProducer = selectProducer(id, httpExchange, outcome);
+                if (responseProducer != null) {
+                    System.out.println(String.format("[%d] sending response for %s", id, outcome.getDisplayName()));
+                    responseProducer.writeTo(id, httpExchange);
                 } else {
-                    byte[] message = String.format("Failed %s request to %s", requestMethod, requestPath).getBytes(Charsets.UTF_8);
-                    httpExchange.sendResponseHeaders(500, message.length);
-                    httpExchange.getResponseBody().write(message);
+                    System.out.println(String.format("[%d] sending error response for unexpected request", id));
+                    if (outcome.method.equals("HEAD")) {
+                        httpExchange.sendResponseHeaders(500, -1);
+                    } else {
+                        byte[] message = String.format("Failed request %s", outcome.getDisplayName()).getBytes(Charsets.UTF_8);
+                        httpExchange.sendResponseHeaders(500, message.length);
+                        httpExchange.getResponseBody().write(message);
+                    }
                 }
+            } catch (Throwable t) {
+                System.out.println(String.format("[%d] handling %s failed with exception", id, outcome.getDisplayName()));
+                requestFailed(outcome, t);
+            } finally {
+                requestCompleted(outcome);
             }
         } finally {
             httpExchange.close();
         }
     }
 
+    private RequestOutcome requestStarted(HttpExchange httpExchange) {
+        lock.lock();
+        RequestOutcome outcome;
+        try {
+            outcome = new RequestOutcome(lock, httpExchange.getRequestMethod(), httpExchange.getRequestURI().getPath());
+            outcomes.add(outcome);
+        } finally {
+            lock.unlock();
+        }
+        return outcome;
+    }
+
+    private void requestFailed(RequestOutcome outcome, Throwable t) {
+        lock.lock();
+        try {
+            if (outcome.failure == null) {
+                outcome.failure = new AssertionError(String.format("Failed to handle %s", outcome.getDisplayName()), t);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void requestCompleted(RequestOutcome outcome) {
+        outcome.completed();
+    }
+
     /**
      * Returns null on failure.
      */
     @Nullable
-    private ResourceHandler selectHandler(int id, HttpExchange httpExchange, RequestOutcome outcome) {
+    private ResponseProducer selectProducer(int id, HttpExchange httpExchange, RequestOutcome outcome) {
         lock.lock();
         try {
-            requestCount++;
+            requestsStarted++;
             condition.signalAll();
             if (completed) {
                 System.out.println(String.format("[%d] received request %s %s after HTTP server has stopped.", id, httpExchange.getRequestMethod(), httpExchange.getRequestURI()));
                 return null;
             }
             for (TrackingHttpHandler handler : handlers) {
-                ResourceHandler resourceHandler = handler.handle(id, httpExchange);
-                if (resourceHandler != null) {
-                    return resourceHandler;
+                ResponseProducer responseProducer = handler.selectResponseProducer(id, httpExchange);
+                if (responseProducer != null) {
+                    return responseProducer;
                 }
             }
             System.out.println(String.format("[%d] unexpected request %s %s", id, httpExchange.getRequestMethod(), httpExchange.getRequestURI()));
@@ -155,7 +196,7 @@ class ChainingHttpHandler implements HttpHandler {
     void waitForRequests(int requestCount) {
         lock.lock();
         try {
-            while (this.requestCount < requestCount) {
+            while (this.requestsStarted < requestCount) {
                 try {
                     condition.await();
                 } catch (InterruptedException e) {
@@ -168,7 +209,55 @@ class ChainingHttpHandler implements HttpHandler {
     }
 
     private static class RequestOutcome {
+        final Lock lock;
+        final Condition condition;
+        final String method;
+        final String url;
         Throwable failure;
+        boolean completed;
+
+        public RequestOutcome(Lock lock, String method, String url) {
+            this.lock = lock;
+            this.condition = lock.newCondition();
+            this.method = method;
+            this.url = url;
+        }
+
+        String getDisplayName() {
+            return method + " " + url;
+        }
+
+        public void completed() {
+            lock.lock();
+            try {
+                completed = true;
+                condition.signalAll();
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void awaitCompletion(long waitTime) {
+            lock.lock();
+            try {
+                while (!completed) {
+                    condition.await(waitTime, TimeUnit.MILLISECONDS);
+                }
+            } catch (InterruptedException e) {
+                throw UncheckedException.throwAsUncheckedException(e);
+            } finally {
+                lock.unlock();
+            }
+        }
+
+        public void collectFailure(Collection<Throwable> failures) {
+            if (failure != null) {
+                failures.add(failure);
+            }
+            if (!completed) {
+                failures.add(new AssertionError(String.format("Request %s has not yet completed.", getDisplayName())));
+            }
+        }
     }
 
     interface HandlerFactory<T extends TrackingHttpHandler> {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfOptionalRequestHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfOptionalRequestHandler.java
@@ -23,23 +23,13 @@ import java.util.concurrent.locks.Lock;
  * A cyclic barrier for {@link BlockingHttpServer} where expectations are optional.
  */
 class CyclicBarrierAnyOfOptionalRequestHandler extends CyclicBarrierAnyOfRequestHandler {
-    private final Lock lock;
-
     CyclicBarrierAnyOfOptionalRequestHandler(Lock lock, int testId, int timeoutMs, int maxConcurrent, WaitPrecondition previous, Collection<? extends ResourceExpectation> expectedRequests) {
         super(lock, testId, timeoutMs, maxConcurrent, previous, expectedRequests);
-        this.lock = lock;
     }
 
     @Override
-    public void assertComplete() {
-        lock.lock();
-        try {
-            if (failure != null) {
-                throw failure;
-            }
-        } finally {
-            lock.unlock();
-        }
+    public void assertComplete(Collection<Throwable> failures) throws AssertionError {
+        // Don't care
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfRequestHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierAnyOfRequestHandler.java
@@ -20,6 +20,7 @@ import com.sun.net.httpserver.HttpExchange;
 import org.gradle.internal.time.Clock;
 import org.gradle.internal.time.Time;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -43,7 +44,8 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
     private int waitingFor;
     private final WaitPrecondition previous;
     private long mostRecentEvent;
-    protected AssertionError failure;
+    private boolean cancelled;
+    private AssertionError failure;
 
     CyclicBarrierAnyOfRequestHandler(Lock lock, int testId, int timeoutMs, int maxConcurrent, WaitPrecondition previous, Collection<? extends ResourceExpectation> expectedRequests) {
         if (expectedRequests.size() < maxConcurrent) {
@@ -82,7 +84,7 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
     }
 
     @Override
-    public ResourceHandler handle(int id, HttpExchange httpExchange) throws Exception {
+    public ResponseProducer selectResponseProducer(int id, HttpExchange exchange) throws Exception {
         ResourceHandlerWrapper handler;
         lock.lock();
         try {
@@ -90,34 +92,30 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
                 // barrier open, let it travel on
                 return null;
             }
-            if (failure != null) {
-                // Busted
-                throw failure;
-            }
 
             long now = clock.getCurrentTime();
             if (mostRecentEvent < now) {
                 mostRecentEvent = now;
             }
 
-            String path = httpExchange.getRequestURI().getPath().substring(1);
+            String path = exchange.getRequestURI().getPath().substring(1);
             handler = selectPending(notReceived, path);
-            if (handler == null || !handler.getMethod().equals(httpExchange.getRequestMethod()) || waitingFor == 0) {
-                failure = new AssertionError(String.format("Unexpected request %s %s received. Waiting for %s further requests, already received %s, released %s, still expecting %s.", httpExchange.getRequestMethod(), path, waitingFor, received, released, format(notReceived)));
+            if (handler == null || !handler.getMethod().equals(exchange.getRequestMethod()) || waitingFor == 0) {
+                failure = new UnexpectedRequestException(String.format("Unexpected request %s /%s received. Waiting for %s further requests, already received %s, released %s, still expecting %s.", exchange.getRequestMethod(), path, waitingFor, received, released, format(notReceived)));
                 condition.signalAll();
                 throw failure;
             }
 
             notReceived.remove(handler);
             notReleased.add(handler);
-            received.add(httpExchange.getRequestMethod() + " " + path);
+            received.add(exchange.getRequestMethod() + " /" + path);
             handler.received();
             waitingFor--;
             if (waitingFor == 0) {
                 condition.signalAll();
             }
 
-            while (!handler.isReleased() && failure == null) {
+            while (!handler.isReleased() && failure == null && !cancelled) {
                 long waitMs = mostRecentEvent + timeoutMs - clock.getCurrentTime();
                 if (waitMs < 0) {
                     if (waitingFor > 0) {
@@ -137,6 +135,18 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
                 System.out.println(String.format("[%d] failure in another thread", id));
                 throw failure;
             }
+            if (cancelled) {
+                return new ResponseProducer() {
+                    @Override
+                    public void writeTo(int requestId, HttpExchange exchange) {
+                        try {
+                            exchange.sendResponseHeaders(200, -1);
+                        } catch (IOException e) {
+                            // Ignore
+                        }
+                    }
+                };
+            }
         } finally {
             lock.unlock();
         }
@@ -144,14 +154,27 @@ class CyclicBarrierAnyOfRequestHandler implements TrackingHttpHandler, WaitPreco
         return handler;
     }
 
-    public void assertComplete() {
+    @Override
+    public void cancelBlockedRequests() {
+        lock.lock();
+        try {
+            cancelled = true;
+            condition.signalAll();
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void assertComplete(Collection<Throwable> failures) throws AssertionError {
         lock.lock();
         try {
             if (failure != null) {
-                throw failure;
+                // Already reported
+                return;
             }
             if (!notReceived.isEmpty()) {
-                throw new AssertionError(String.format("Did not handle all expected requests. Waiting for %d further requests, received %s, released %s, not yet received %s.", waitingFor, received, released, format(notReceived)));
+                failures.add(new AssertionError(String.format("Did not handle all expected requests. Waiting for %d further requests, received %s, released %s, not yet received %s.", waitingFor, received, released, format(notReceived))));
             }
         } finally {
             lock.unlock();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/UnexpectedRequestException.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/UnexpectedRequestException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.http;
+
+public class UnexpectedRequestException extends AssertionError {
+    public UnexpectedRequestException(String message) {
+        super(message, null);
+    }
+}

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.hamcrest.Matchers
 import org.junit.Rule
-import spock.lang.Ignore
 
 class BlockingHttpServerTest extends ConcurrentSpec {
     @Rule
@@ -148,7 +147,6 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         noExceptionThrown()
     }
 
-    @Ignore("https://github.com/gradle/gradle-private/issues/1660")
     def "can verify that user agent matches particular criteria"() {
         def criteria = Matchers.equalTo("some-agent")
 

--- a/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/InetAddressesTest.groovy
+++ b/subprojects/messaging/src/test/groovy/org/gradle/internal/remote/internal/inet/InetAddressesTest.groovy
@@ -28,11 +28,6 @@ class InetAddressesTest extends Specification{
         !addresses.loopback.empty
     }
 
-    def "always contains at least one multicast interface"() {
-        expect:
-        !addresses.multicastInterfaces.empty
-    }
-
     @Requires(TestPrecondition.ONLINE)
     def "always contains at least one remote address"() {
         expect:


### PR DESCRIPTION
### Context

This PR improve the tracking of failures for requests that are in progress when `stop()` is called, plus some improvements to error reporting.

Also some unrelated cleanups.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
