### PR TITLE
Tag CACHE_MISS upon unexpected cache miss

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     implementation("com.gradle:build-scan-plugin:2.0.2")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
+    implementation(project(":plugins"))
 }
 
 gradlePlugin {

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -76,21 +76,21 @@ open class BuildScanPlugin : Plugin<Project> {
     private
     fun Project.monitorUnexpectedCacheMisses() {
         gradle.taskGraph.afterTask {
-            if (!state.skipped && !isExcludedBuild() && this.isMonitored()) {
+            if (!state.skipped && !isExcludedBuild() && this.isMonitoredForCacheMiss()) {
                 buildScan.tag("CACHE_MISS")
             }
         }
     }
 
     private
-    fun Task.isMonitored() =
+    fun Task.isMonitoredForCacheMiss() =
         this is AbstractCompile || this is ClasspathManifest
 
     private
     fun Project.isExcludedBuild() =
         // Two expected cache-miss:
         // 1. compileAll is seed build
-        // 2. Gradleexception is building on Java 8
+        // 2. Gradleception which re-builds Gradle with a new Gradle version
         gradle.startParameter.taskNames.contains("compileAll") || "Gradle_Check_Gradleception" == System.getenv("BUILD_TYPE_ID")
 
     private

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -76,7 +76,7 @@ open class BuildScanPlugin : Plugin<Project> {
     private
     fun Project.monitorUnexpectedCacheMisses() {
         gradle.taskGraph.afterTask {
-            if (!state.skipped && !currentBuildContainsCompileAll() && this.isMonitored()) {
+            if (!state.skipped && !isExcludedBuild() && this.isMonitored()) {
                 buildScan.tag("CACHE_MISS")
             }
         }
@@ -87,7 +87,11 @@ open class BuildScanPlugin : Plugin<Project> {
         this is AbstractCompile || this is ClasspathManifest
 
     private
-    fun Project.currentBuildContainsCompileAll() = gradle.startParameter.taskNames.contains("compileAll")
+    fun Project.isExcludedBuild() =
+        // Two expected cache-miss:
+        // 1. compileAll is seed build
+        // 2. Gradleexception is building on Java 8
+        gradle.startParameter.taskNames.contains("compileAll") || "Gradle_Check_Gradleception" == System.getenv("BUILD_TYPE_ID")
 
     private
     fun Project.extractCheckstyleAndCodenarcData() {

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -66,11 +66,11 @@ open class BuildScanPlugin : Plugin<Project> {
 
         if (isCiServer && !isTravis) {
             extractAllReportsFromCI()
+            monitorUnexpectedCacheMisses()
         }
 
         extractCheckstyleAndCodenarcData()
         extractBuildCacheData()
-        monitorUnexpectedCacheMisses()
     }
 
     private


### PR DESCRIPTION
### Context

This is the first-step implementation of https://github.com/gradle/gradle-private/issues/1681

Previously sometimes we see unexpected cache misses in the build, which we want to monitor. This PR marks all non-skipped `AbstractCompile` and `ClasspathManifest` tasks as `CACHE_MISS` if current build is not `compileAll`, so that this build can be searched in build scan later.

