### PR TITLE
Add sign to performance test graphs

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
@@ -79,7 +79,9 @@ public class FormatSupport {
         Amount<Duration> current = currentVersion.getMedian();
         Amount<Duration> diff = current.minus(base);
 
-        return String.format("%s (%.2f%%)", diff.format(), 100.0 * FormatSupport.getDifferenceRatio(baselineVersion, currentVersion).doubleValue());
+        String sign = diff.getValue().doubleValue() > 0 ? "+" : "";
+
+        return String.format("%s%s (%.2f%%)", sign, diff.format(), 100.0 * FormatSupport.getDifferenceRatio(baselineVersion, currentVersion).doubleValue());
     }
 
     public static String getFormattedConfidence(DataSeries<Duration> baselineVersion, DataSeries<Duration> currentVersion) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FormatSupport.java
@@ -57,7 +57,9 @@ public class FormatSupport {
             // This is a workaround for https://github.com/gradle/gradle-private/issues/1690
             return new BigDecimal(0);
         }
-        return new BigDecimal(100.0 * confidenceInDifference(baseline.getTotalTime(), current.getTotalTime())).setScale(2, RoundingMode.HALF_UP);
+
+        double sign = Math.signum(getDifferencePercentage(baseline, current).doubleValue());
+        return new BigDecimal(sign * 100.0 * confidenceInDifference(baseline.getTotalTime(), current.getTotalTime())).setScale(2, RoundingMode.HALF_UP);
     }
 
     public static Number getDifferencePercentage(MeasuredOperationList baseline, MeasuredOperationList current) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -184,9 +184,9 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
         private String color;
 
         private BackgroundColor(List<Number> xy) {
-            int index = xy.get(0).intValue();
+            double index = xy.get(0).doubleValue();
             double differencePercentage = xy.get(1).doubleValue();
-            xaxis = ImmutableMap.of("from", index, "to", index + 1);
+            xaxis = ImmutableMap.of("from", index - 0.5, "to", index + 0.5);
             if (differencePercentage > 2) {
                 color = RED;
             } else if (differencePercentage > 0) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -100,8 +100,8 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
             this.totalTime = totalTime;
             this.confidence = confidence;
             this.difference = difference;
-            if (difference != null) {
-                this.background = difference.stream().flatMap(data -> data.data.stream()).map(BackgroundColor::new).collect(Collectors.toList());
+            if (confidence != null) {
+                this.background = confidence.stream().flatMap(data -> data.data.stream()).map(BackgroundColor::ofConfidence).filter(Objects::nonNull).collect(Collectors.toList());
             }
         }
 
@@ -183,19 +183,25 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
         private Map xaxis;
         private String color;
 
-        private BackgroundColor(List<Number> xy) {
+        private static BackgroundColor ofConfidence(List<Number> xy) {
             double index = xy.get(0).doubleValue();
-            double differencePercentage = xy.get(1).doubleValue();
-            xaxis = ImmutableMap.of("from", index - 0.5, "to", index + 0.5);
-            if (differencePercentage > 2) {
-                color = RED;
-            } else if (differencePercentage > 0) {
-                color = ORANGE;
-            } else if (differencePercentage > -2) {
-                color = LIGHT_GREEN;
+            double confidencePercentage = xy.get(1).doubleValue();
+            if (confidencePercentage > 90) {
+                return new BackgroundColor(index, RED);
+            } else if (confidencePercentage > 80) {
+                return new BackgroundColor(index, ORANGE);
+            } else if (confidencePercentage > -80) {
+                return null;
+            } else if (confidencePercentage > -90) {
+                return new BackgroundColor(index, LIGHT_GREEN);
             } else {
-                color = GREEN;
+                return new BackgroundColor(index, GREEN);
             }
+        }
+
+        private BackgroundColor(double index, String color) {
+            this.xaxis = ImmutableMap.of("from", index - 0.5, "to", index + 0.5);
+            this.color = color;
         }
 
         public Map getXaxis() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -16,6 +16,7 @@
 
 package org.gradle.performance.results;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import groovy.json.JsonGenerator;
 import org.gradle.reporting.ReportRenderer;
@@ -26,6 +27,7 @@ import java.io.Writer;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -91,12 +93,16 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
         private List<ExecutionData> totalTime;
         private List<ExecutionData> confidence;
         private List<ExecutionData> difference;
+        private List<BackgroundColor> background;
 
         AllExecutionData(List<ExecutionLabel> executionLabels, List<ExecutionData> totalTime, List<ExecutionData> confidence, List<ExecutionData> difference) {
             this.executionLabels = executionLabels;
             this.totalTime = totalTime;
             this.confidence = confidence;
             this.difference = difference;
+            if (difference != null) {
+                this.background = difference.stream().flatMap(data -> data.data.stream()).map(BackgroundColor::new).collect(Collectors.toList());
+            }
         }
 
         public List<ExecutionLabel> getExecutionLabels() {
@@ -113,6 +119,10 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
 
         public List<ExecutionData> getDifference() {
             return difference;
+        }
+
+        public List<BackgroundColor> getBackground() {
+            return background;
         }
     }
 
@@ -134,7 +144,7 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
         }
     }
 
-    class ExecutionLabel {
+    static class ExecutionLabel {
         private String id;
         private String branch;
         private String date;
@@ -161,6 +171,39 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
 
         public List<String> getCommits() {
             return commits;
+        }
+    }
+
+    static class BackgroundColor {
+        // https://www.w3schools.com/colors/colors_picker.asp
+        private static final String RED = "#ff0000";
+        private static final String ORANGE = "#ff8000";
+        private static final String LIGHT_GREEN = "#80ff00";
+        private static final String GREEN = "#00ff00";
+        private Map xaxis;
+        private String color;
+
+        private BackgroundColor(List<Number> xy) {
+            int index = xy.get(0).intValue();
+            double differencePercentage = xy.get(1).doubleValue();
+            xaxis = ImmutableMap.of("from", index, "to", index + 1);
+            if (differencePercentage > 2) {
+                color = RED;
+            } else if (differencePercentage > 0) {
+                color = ORANGE;
+            } else if (differencePercentage > -2) {
+                color = LIGHT_GREEN;
+            } else {
+                color = GREEN;
+            }
+        }
+
+        public Map getXaxis() {
+            return xaxis;
+        }
+
+        public String getColor() {
+            return color;
         }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -175,33 +175,33 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
     }
 
     static class BackgroundColor {
-        // https://www.w3schools.com/colors/colors_picker.asp
-        private static final String RED = "#ff0000";
-        private static final String ORANGE = "#ff8000";
-        private static final String LIGHT_GREEN = "#80ff00";
-        private static final String GREEN = "#00ff00";
+        private static final int THRESHOLD = 80;
         private Map xaxis;
         private String color;
 
-        private static BackgroundColor ofConfidence(List<Number> xy) {
+        static BackgroundColor ofConfidence(List<Number> xy) {
             double index = xy.get(0).doubleValue();
             double confidencePercentage = xy.get(1).doubleValue();
-            if (confidencePercentage > 90) {
-                return new BackgroundColor(index, RED);
-            } else if (confidencePercentage > 80) {
-                return new BackgroundColor(index, ORANGE);
-            } else if (confidencePercentage > -80) {
-                return null;
-            } else if (confidencePercentage > -90) {
-                return new BackgroundColor(index, LIGHT_GREEN);
+
+            if (Math.abs(confidencePercentage) >= THRESHOLD) {
+                return new BackgroundColor(index, redComponent(confidencePercentage), greenComponent(confidencePercentage));
             } else {
-                return new BackgroundColor(index, GREEN);
+                return null;
             }
         }
 
-        private BackgroundColor(double index, String color) {
+        // See TestDataGeneratorTest for examples
+        private static int redComponent(double confidencePercentage) {
+            return (int) (128 + (THRESHOLD + confidencePercentage) * 128 / (100 - THRESHOLD));
+        }
+
+        private static int greenComponent(double confidencePercentage) {
+            return (int) (128 - (confidencePercentage - THRESHOLD) * 128 / (100 - THRESHOLD));
+        }
+
+        private BackgroundColor(double index, int redComponent, int greenComponent) {
             this.xaxis = ImmutableMap.of("from", index - 0.5, "to", index + 0.5);
-            this.color = color;
+            this.color = String.format("#%02x%02x00", redComponent > 255 ? 255 : redComponent, greenComponent > 255 ? 255 : greenComponent);
         }
 
         public Map getXaxis() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestDataGenerator.java
@@ -184,24 +184,28 @@ public class TestDataGenerator extends ReportRenderer<PerformanceTestHistory, Wr
             double confidencePercentage = xy.get(1).doubleValue();
 
             if (Math.abs(confidencePercentage) >= THRESHOLD) {
-                return new BackgroundColor(index, redComponent(confidencePercentage), greenComponent(confidencePercentage));
+                return new BackgroundColor(index, redComponent(confidencePercentage), greenComponent(confidencePercentage), opacity(confidencePercentage));
             } else {
                 return null;
             }
         }
 
         // See TestDataGeneratorTest for examples
+        private static double opacity(double confidencePercentage) {
+            return (Math.abs(confidencePercentage) - THRESHOLD) / (100 - THRESHOLD);
+        }
+
         private static int redComponent(double confidencePercentage) {
-            return (int) (128 + (THRESHOLD + confidencePercentage) * 128 / (100 - THRESHOLD));
+            return confidencePercentage > 0 ? 255 : 0;
         }
 
         private static int greenComponent(double confidencePercentage) {
-            return (int) (128 - (confidencePercentage - THRESHOLD) * 128 / (100 - THRESHOLD));
+            return confidencePercentage < 0 ? 255 : 0;
         }
 
-        private BackgroundColor(double index, int redComponent, int greenComponent) {
+        private BackgroundColor(double index, int redComponent, int greenComponent, double opacity) {
             this.xaxis = ImmutableMap.of("from", index - 0.5, "to", index + 0.5);
-            this.color = String.format("#%02x%02x00", redComponent > 255 ? 255 : redComponent, greenComponent > 255 ? 255 : greenComponent);
+            this.color = String.format("rgba(%d,%d,0,%.1f)", redComponent, greenComponent, opacity);
         }
 
         public Map getXaxis() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -60,6 +60,8 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             p().text("Tasks: " + getTasks(testHistory)).end();
             p().text("Clean tasks: " + getCleanTasks(testHistory)).end();
 
+            div().id("tooltip").end();
+
             addPerformanceGraphs();
 
             h3().text("Test details").end();
@@ -187,10 +189,10 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             }
 
             private void addPerformanceGraphs() {
-                List<Chart> charts = Lists.newArrayList(new Chart("totalTime", "total time", "s", "totalTimeChart"));
+                List<Chart> charts = Lists.newArrayList(new Chart("totalTime", "total time", "s", "totalTimeChart", false));
                 if(testHistory instanceof CrossVersionPerformanceTestHistory) {
-                    charts.add(new Chart("confidence", "confidence", "%", "confidenceChart"));
-                    charts.add(new Chart("difference", "difference", "%", "differenceChart"));
+                    charts.add(new Chart("confidence", "confidence", "%", "confidenceChart", true));
+                    charts.add(new Chart("difference", "difference", "%", "differenceChart", false));
                 }
 
                 charts.forEach(chart -> {
@@ -214,12 +216,14 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
         private String label;
         private String unit;
         private String chartId;
+        private boolean renderBackground;
 
-        private Chart(String field, String label, String unit, String chartId) {
+        private Chart(String field, String label, String unit, String chartId, boolean renderBackground) {
             this.field = field;
             this.label = label;
             this.unit = unit;
             this.chartId = chartId;
+            this.renderBackground = renderBackground;
         }
 
         public String getField() {
@@ -236,6 +240,10 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
 
         public String getChartId() {
             return chartId;
+        }
+
+        public boolean isRenderBackground() {
+            return renderBackground;
         }
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -191,8 +191,8 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
             private void addPerformanceGraphs() {
                 List<Chart> charts = Lists.newArrayList(new Chart("totalTime", "total time", "s", "totalTimeChart", false));
                 if(testHistory instanceof CrossVersionPerformanceTestHistory) {
-                    charts.add(new Chart("confidence", "confidence", "%", "confidenceChart", true));
-                    charts.add(new Chart("difference", "difference", "%", "differenceChart", false));
+                    charts.add(new Chart("confidence", "confidence", "%", "confidenceChart", false));
+                    charts.add(new Chart("difference", "difference", "%", "differenceChart", true));
                 }
 
                 charts.forEach(chart -> {

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
@@ -115,13 +115,7 @@
 
     function determineMinY(data, unit) {
         if (unit == '%') {
-            var min = 0
-            for(var i = 0; i < data.length; ++i) {
-                if(data[i][1] < min) {
-                    min = data[i][1]
-                }
-            }
-            return min - 10
+            return -100
         } else {
             return 0
         }

--- a/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
+++ b/subprojects/internal-performance-testing/src/main/resources/org/gradle/reporting/performanceGraph.js
@@ -21,11 +21,18 @@
 
     function renderGraphs(allDataJson, charts) {
         charts.forEach(function(chart) {
-            renderGraph(allDataJson[chart.field], allDataJson.executionLabels, chart.label, chart.unit, chart.chartId)
+            renderGraph(
+                allDataJson[chart.field],
+                allDataJson.executionLabels,
+                chart.label,
+                chart.unit,
+                chart.chartId,
+                chart.renderBackground ? allDataJson.background : []
+            )
         })
     }
 
-    function renderGraph(data, executionLabels, label, unit, chartId) {
+    function renderGraph(data, executionLabels, label, unit, chartId, background) {
         if(!data) {
             return
         }
@@ -44,7 +51,7 @@
                         return '<a href="#" class="chart-legend" onClick="performanceTests.togglePlot(\''+chartId+'\', \''+label+'\'); return false;">'+label+'</a>';
                     }
             },
-            grid: { hoverable: true, clickable: true },
+            grid: { hoverable: true, clickable: true, markings: background },
             xaxis: { tickFormatter:
                     function(index, value) {
                         if (index === parseInt(index, 10)) { // portable way to check if sth is an integer

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/ResultSpecification.groovy
@@ -106,8 +106,8 @@ abstract class ResultSpecification extends Specification {
         result1.version('master').results.addAll(measuredOperations([2]))
 
         CrossVersionPerformanceResults result2 = crossVersionResults([startTime: 200])
-        result2.version('5.0-mockbaseline-2').results.addAll(measuredOperations([2]))
-        result2.version('master').results.addAll(measuredOperations([1]))
+        result2.version('5.0-mockbaseline-2').results.addAll(measuredOperations([2, 2]))
+        result2.version('master').results.addAll(measuredOperations([1, 1]))
 
         return new CrossVersionPerformanceTestHistory('mockCrossVersion',
             ['5.0-mockbaseline-1', '5.0-mockbaseline-2'],

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -79,6 +79,10 @@ class TestDataGeneratorTest extends ResultSpecification {
                     data: [[1, 68.27]]
                 ],
             ],
+            background: [
+                [xaxis: [from: 0, to: 1], color: "#ff0000"],
+                [xaxis: [from: 1, to: 2], color: "#00ff00"]
+            ]
         ]
     }
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -76,12 +76,11 @@ class TestDataGeneratorTest extends ResultSpecification {
                 ],
                 [
                     label: 'master vs 5.0-mockbaseline-2',
-                    data: [[1, 68.27]]
+                    data: [[1, -87.87]]
                 ],
             ],
             background: [
-                [xaxis: [from: -0.5, to: 0.5], color: "#ff0000"],
-                [xaxis: [from: 0.5, to: 1.5], color: "#00ff00"]
+                [xaxis: [from: 0.5, to: 1.5], color: "#80ff00"]
             ]
         ]
     }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -80,7 +80,7 @@ class TestDataGeneratorTest extends ResultSpecification {
                 ],
             ],
             background: [
-                [xaxis: [from: 0.5, to: 1.5], color: "#80ff00"]
+                [xaxis: [from: 0.5, to: 1.5], color: "#4dff00"]
             ]
         ]
     }
@@ -116,5 +116,23 @@ class TestDataGeneratorTest extends ResultSpecification {
                 ]
             ]
         ]
+    }
+
+    def 'can calculate background color'() {
+        expect:
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 100]).xaxis == [from: -0.5, to: 0.5]
+        TestDataGenerator.BackgroundColor.ofConfidence([1, 100]).xaxis == [from: 0.5, to: 1.5]
+
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 100]).color == '#ff0000' // red
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 90]).color == '#ff4000' // orange-red
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 80]).color == '#ff8000' // orange
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 70]) == null
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 60]) == null
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 0]) == null
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -40]) == null
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -50]) == null
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -80]).color == '#80ff00' // light-light-green
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -90]).color == '#40ff00' // light-green
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -100]).color == '#00ff00' // green
     }
 }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -80,7 +80,7 @@ class TestDataGeneratorTest extends ResultSpecification {
                 ],
             ],
             background: [
-                [xaxis: [from: 0.5, to: 1.5], color: "#4dff00"]
+                [xaxis: [from: 0.5, to: 1.5], color: "rgba(0,255,0,0.4)"]
             ]
         ]
     }
@@ -123,16 +123,16 @@ class TestDataGeneratorTest extends ResultSpecification {
         TestDataGenerator.BackgroundColor.ofConfidence([0, 100]).xaxis == [from: -0.5, to: 0.5]
         TestDataGenerator.BackgroundColor.ofConfidence([1, 100]).xaxis == [from: 0.5, to: 1.5]
 
-        TestDataGenerator.BackgroundColor.ofConfidence([0, 100]).color == '#ff0000' // red
-        TestDataGenerator.BackgroundColor.ofConfidence([0, 90]).color == '#ff4000' // orange-red
-        TestDataGenerator.BackgroundColor.ofConfidence([0, 80]).color == '#ff8000' // orange
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 100]).color == 'rgba(255,0,0,1.0)'
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 90]).color == 'rgba(255,0,0,0.5)'
+        TestDataGenerator.BackgroundColor.ofConfidence([0, 80]).color == 'rgba(255,0,0,0.0)'
         TestDataGenerator.BackgroundColor.ofConfidence([0, 70]) == null
         TestDataGenerator.BackgroundColor.ofConfidence([0, 60]) == null
         TestDataGenerator.BackgroundColor.ofConfidence([0, 0]) == null
         TestDataGenerator.BackgroundColor.ofConfidence([0, -40]) == null
         TestDataGenerator.BackgroundColor.ofConfidence([0, -50]) == null
-        TestDataGenerator.BackgroundColor.ofConfidence([0, -80]).color == '#80ff00' // light-light-green
-        TestDataGenerator.BackgroundColor.ofConfidence([0, -90]).color == '#40ff00' // light-green
-        TestDataGenerator.BackgroundColor.ofConfidence([0, -100]).color == '#00ff00' // green
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -80]).color == 'rgba(0,255,0,0.0)'
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -90]).color == 'rgba(0,255,0,0.5)'
+        TestDataGenerator.BackgroundColor.ofConfidence([0, -100]).color == 'rgba(0,255,0,1.0)'
     }
 }

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/TestDataGeneratorTest.groovy
@@ -80,8 +80,8 @@ class TestDataGeneratorTest extends ResultSpecification {
                 ],
             ],
             background: [
-                [xaxis: [from: 0, to: 1], color: "#ff0000"],
-                [xaxis: [from: 1, to: 2], color: "#00ff00"]
+                [xaxis: [from: -0.5, to: 0.5], color: "#ff0000"],
+                [xaxis: [from: 0.5, to: 1.5], color: "#00ff00"]
             ]
         ]
     }


### PR DESCRIPTION
### Context

This PR did some improvements for https://github.com/gradle/gradle-private/issues/1685 . Previously we display confidence and difference in different graphs, which make it hard to recognize whether a high confidence result is improvement or regression. This PR adds a background color for the confidence graph:

![image](https://user-images.githubusercontent.com/12689835/49262951-986d6780-f483-11e8-9ed6-bd6e7d754403.png) 

Red/Orange is regression and Green/LightGreen is improvement.

I also want to keep the difference graph because we can easily see fluctuation and trend from it.

