### PR TITLE
Snippets *.gradle.kts: val cannot be reassigned

### DIFF
--- a/subprojects/docs/src/docs/userguide/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build_cache.adoc
@@ -210,7 +210,7 @@ When possible, it is better to use delegation instead of creating a subclass.
 That is the case for the built in `JavaExec`, `Exec`, `Copy` and `Sync` tasks, which have a method on `Project` to do the actual work.
 
 If you're a modern JavaScript developer, you know that bundling can be quite long, and is worth caching.
-To achieve that, we need to tell Gradle that it's allowed to cache the output of that task, using the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html] annotation.
+To achieve that, we need to tell Gradle that it's allowed to cache the output of that task, using the link:{javadocPath}/org/gradle/api/tasks/CacheableTask.html[@CacheableTask]  annotation.
 
 This is sufficient to make the task cacheable on your own machine.
 However, input files are identified by default by their absolute path.

--- a/subprojects/docs/src/samples/buildCache/build-src/kotlin/gradle/buildCacheSettings.gradle.kts
+++ b/subprojects/docs/src/samples/buildCache/build-src/kotlin/gradle/buildCacheSettings.gradle.kts
@@ -6,7 +6,7 @@ buildCache {
         isEnabled = !isCiServer
     }
     remote<HttpBuildCache> {
-        url = uri("https://example.com:8123/cache/")
+        setUrl("https://example.com:8123/cache/")
         isPush = isCiServer
     }
 }

--- a/subprojects/docs/src/samples/buildCache/configure-built-in-caches/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/buildCache/configure-built-in-caches/kotlin/settings.gradle.kts
@@ -1,7 +1,7 @@
 // tag::configure-directory-build-cache[]
 buildCache {
     local<DirectoryBuildCache> {
-        directory = File(rootDir, "build-cache")
+        setDirectory(file("build-cache"))
         removeUnusedEntriesAfterDays = 30
     }
 }
@@ -10,7 +10,7 @@ buildCache {
 // tag::configure-http-build-cache[]
 buildCache {
     remote<HttpBuildCache> {
-        url = uri("http://example.com:8123/cache/")
+        setUrl("http://example.com:8123/cache/")
         credentials {
             username = "build-cache-user"
             password = "some-complicated-password"

--- a/subprojects/docs/src/samples/buildCache/configure-by-init-script/kotlin/init.gradle.kts
+++ b/subprojects/docs/src/samples/buildCache/configure-by-init-script/kotlin/init.gradle.kts
@@ -2,7 +2,7 @@ gradle.settingsEvaluated {
     buildCache {
         // vvv Your custom configuration goes here
         remote<HttpBuildCache> {
-            url = uri("https://example.com:8123/cache/")
+            setUrl("https://example.com:8123/cache/")
         }
         // ^^^ Your custom configuration goes here
     }

--- a/subprojects/docs/src/samples/buildCache/developer-ci-setup/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/buildCache/developer-ci-setup/kotlin/settings.gradle.kts
@@ -6,7 +6,7 @@ buildCache {
         isEnabled = !isCiServer
     }
     remote<HttpBuildCache> {
-        url = uri("https://example.com:8123/cache/")
+        setUrl("https://example.com:8123/cache/")
         isPush = isCiServer
     }
 }

--- a/subprojects/docs/src/samples/buildCache/http-build-cache/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/buildCache/http-build-cache/kotlin/settings.gradle.kts
@@ -1,7 +1,7 @@
 // tag::http-build-cache[]
 buildCache {
     remote<HttpBuildCache> {
-        url = uri("https://example.com:8123/cache/")
+        setUrl("https://example.com:8123/cache/")
     }
 }
 // end::http-build-cache[]
@@ -9,7 +9,7 @@ buildCache {
 // tag::allow-untrusted-server[]
 buildCache {
     remote<HttpBuildCache> {
-        url = uri("https://example.com:8123/cache/")
+        setUrl("https://example.com:8123/cache/")
         isAllowUntrustedServer = true
     }
 }


### PR DESCRIPTION
Initially I just wanted to fix the broken link in https://docs.gradle.org/current/userguide/build_cache.html#using_annotations

Then I tried the samples in that guide and I got errors

![image](https://user-images.githubusercontent.com/459464/49273347-ed55b180-f474-11e8-8955-9372a9db5b1b.png)

So I thought I will fix that as well. 

The thing is: this error could be present in more places that only `subprojects/docs/src/samples/buildCache/configure-built-in-caches`
