### PR TITLE
Introduce BuildOperationType for executing scheduled transforms

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -16,7 +16,9 @@
 
 package org.gradle.integtests.resolve.transform
 
+import org.gradle.api.internal.artifacts.transform.ExecuteScheduledTransformationStepBuildOperationType
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.BuildOperationsFixture
 import org.gradle.integtests.fixtures.ExperimentalIncrementalArtifactTransformationsRunner
 import org.junit.runner.RunWith
 import spock.lang.Issue
@@ -1781,8 +1783,9 @@ Found the following transforms:
         output.count("Transforming") == 1
     }
 
+    def "notifies transform listeners and build operation listeners on successful execution"() {
+        def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
 
-    def "notifies the transform listener on execution"() {
         given:
         buildFile << """                                                                   
             import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
@@ -1814,7 +1817,7 @@ Found the following transforms:
                 dependencies {
                     compile project(":lib")
                 }
-                ${configurationAndTransform()}
+                ${configurationAndTransform('FileSizer')}
             }
         """
 
@@ -1824,6 +1827,74 @@ Found the following transforms:
         then:
         outputContains("Before transformer FileSizer on artifact lib.jar (project :lib)")
         outputContains("After transformer FileSizer on artifact lib.jar (project :lib)")
+
+        and:
+        with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)) {
+            it.failure == null
+            displayName == "Transform artifact lib.jar (project :lib) with FileSizer"
+            details.transformerName == "FileSizer"
+            details.subjectName == "artifact lib.jar (project :lib)"
+        }
+    }
+
+    def "notifies transform listeners and build operation listeners on failed execution"() {
+        def buildOperations = new BuildOperationsFixture(executer, temporaryFolder)
+
+        given:
+        buildFile << """                                                                   
+            import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener
+            import org.gradle.internal.event.ListenerManager
+
+            project.services.get(ListenerManager).addListener(new ArtifactTransformListener() {
+                @Override
+                void beforeTransformerInvocation(Describable transformer, Describable subject) {
+                    println "Before transformer \${transformer.displayName} on \${subject.displayName}"
+                }
+                
+                @Override
+                void afterTransformerInvocation(Describable transformer, Describable subject) {
+                    println "After transformer \${transformer.displayName} on \${subject.displayName}"
+                }
+            })
+
+            project(":lib") {
+                task jar(type: Jar) {
+                    archiveName = 'lib.jar'
+                    destinationDir = buildDir                    
+                }
+                artifacts {
+                    compile jar
+                }
+            }
+            
+            project(":app") {
+                dependencies {
+                    compile project(":lib")
+                }
+                ${configurationAndTransform('BrokenTransform')}
+            }
+
+            class BrokenTransform extends ArtifactTransform {
+                List<File> transform(File input) {
+                    throw new GradleException('broken')
+                }
+            }
+        """
+
+        when:
+        fails "app:resolve"
+
+        then:
+        outputContains("Before transformer BrokenTransform on artifact lib.jar (project :lib)")
+        outputContains("After transformer BrokenTransform on artifact lib.jar (project :lib)")
+
+        and:
+        with(buildOperations.only(ExecuteScheduledTransformationStepBuildOperationType)) {
+            it.failure.contains("TransformationException")
+            displayName == "Transform artifact lib.jar (project :lib) with BrokenTransform"
+            details.transformerName == "BrokenTransform"
+            details.subjectName == "artifact lib.jar (project :lib)"
+        }
     }
 
     @Issue("https://github.com/gradle/gradle/issues/6156")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationType.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ExecuteScheduledTransformationStepBuildOperationType.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.internal.operations.BuildOperationType;
+import org.gradle.internal.scan.NotUsedByScanPlugin;
+
+/**
+ * @since 5.1
+ */
+@NotUsedByScanPlugin
+public class ExecuteScheduledTransformationStepBuildOperationType implements BuildOperationType<ExecuteScheduledTransformationStepBuildOperationType.Details, ExecuteScheduledTransformationStepBuildOperationType.Result> {
+
+    public interface Details {
+
+        /**
+         * Returns the display name of the transformer.
+         */
+        String getTransformerName();
+
+        /**
+         * Returns the display name of the transformation subject.
+         */
+        String getSubjectName();
+
+    }
+
+    public interface Result {
+    }
+
+    static final Result RESULT = new Result() {
+    };
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -152,23 +152,20 @@ public abstract class TransformationNode extends Node {
             return dependencyResolver.resolveDependenciesFor(null, artifactSet);
         }
 
-        private class InitialArtifactTransformationStepOperation implements RunnableBuildOperation {
+        private class InitialArtifactTransformationStepOperation extends ArtifactTransformationStepBuildOperation {
             private final BuildOperationExecutor buildOperationExecutor;
-
-            private TransformationSubject transformedSubject;
 
             public InitialArtifactTransformationStepOperation(BuildOperationExecutor buildOperationExecutor) {
                 this.buildOperationExecutor = buildOperationExecutor;
             }
 
             @Override
-            public BuildOperationDescriptor.Builder description() {
-                String subject = "artifact " + artifactSet.getArtifactId().getDisplayName();
-                return buildOperationDescriptor(subject, transformationStep);
+            protected String describeSubject() {
+                return "artifact " + artifactSet.getArtifactId().getDisplayName();
             }
 
             @Override
-            public void run(BuildOperationContext context) {
+            protected TransformationSubject transform() {
                 ResolveArtifacts resolveArtifacts = new ResolveArtifacts(artifactSet);
                 buildOperationExecutor.runAll(resolveArtifacts);
                 ResolvedArtifactCollectingVisitor visitor = new ResolvedArtifactCollectingVisitor();
@@ -181,18 +178,13 @@ public abstract class TransformationNode extends Node {
                     } else {
                         failure = new DefaultLenientConfiguration.ArtifactResolveException("artifacts", transformationStep.getDisplayName(), "artifact transform", failures);
                     }
-                    this.transformedSubject = TransformationSubject.failure("artifact " + artifactSet.getArtifactId().getDisplayName(), failure);
-                    return;
+                    return TransformationSubject.failure("artifact " + artifactSet.getArtifactId().getDisplayName(), failure);
                 }
                 ResolvedArtifactResult artifact = Iterables.getOnlyElement(visitor.getArtifacts());
                 dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(transformationStep, artifact.getId(), resolvableDependencies);
                 TransformationSubject initialArtifactTransformationSubject = TransformationSubject.initial(artifact.getId(), artifact.getFile());
 
-                this.transformedSubject = transformationStep.transform(initialArtifactTransformationSubject, dependenciesProvider);
-            }
-
-            public TransformationSubject getTransformedSubject() {
-                return transformedSubject;
+                return transformationStep.transform(initialArtifactTransformationSubject, dependenciesProvider);
             }
         }
     }
@@ -223,27 +215,19 @@ public abstract class TransformationNode extends Node {
             processHardSuccessor.execute(previousTransformationNode);
         }
 
-        private class ChainedArtifactTransformStepOperation implements RunnableBuildOperation {
-
-            private TransformationSubject transformedSubject;
+        private class ChainedArtifactTransformStepOperation extends ArtifactTransformationStepBuildOperation {
+            @Override
+            protected String describeSubject() {
+                return previousTransformationNode.getTransformedSubject().getDisplayName();
+            }
 
             @Override
-            public void run(BuildOperationContext context) {
+            protected TransformationSubject transform() {
                 TransformationSubject transformedSubject = previousTransformationNode.getTransformedSubject();
                 if (transformedSubject.getFailure() != null) {
-                    this.transformedSubject = transformedSubject;
-                    return;
+                    return transformedSubject;
                 }
-                this.transformedSubject = transformationStep.transform(transformedSubject, getDependenciesProvider());
-            }
-
-            @Override
-            public BuildOperationDescriptor.Builder description() {
-                return buildOperationDescriptor(previousTransformationNode.getTransformedSubject().getDisplayName(), transformationStep);
-            }
-
-            public TransformationSubject getTransformedSubject() {
-                return transformedSubject;
+                return transformationStep.transform(transformedSubject, getDependenciesProvider());
             }
         }
     }
@@ -286,10 +270,55 @@ public abstract class TransformationNode extends Node {
         }
     }
 
-    private static BuildOperationDescriptor.Builder buildOperationDescriptor(String subject, TransformationStep step) {
-        String basicName = subject + " with " + step.getDisplayName();
-        return BuildOperationDescriptor.displayName("Transform " + basicName)
-            .progressDisplayName("Transforming " + basicName)
-            .operationType(BuildOperationCategory.TRANSFORM);
+    abstract class ArtifactTransformationStepBuildOperation implements RunnableBuildOperation {
+
+        private TransformationSubject transformedSubject;
+
+        @Override
+        public final BuildOperationDescriptor.Builder description() {
+            String transformerName = transformationStep.getDisplayName();
+            String subjectName = describeSubject();
+            String basicName = subjectName + " with " + transformerName;
+            return BuildOperationDescriptor.displayName("Transform " + basicName)
+                .progressDisplayName("Transforming " + basicName)
+                .operationType(BuildOperationCategory.TRANSFORM)
+                .details(new OperationDetails(transformerName, subjectName));
+        }
+
+        protected abstract String describeSubject();
+
+        @Override
+        public final void run(BuildOperationContext context) {
+            transformedSubject = transform();
+            context.setResult(ExecuteScheduledTransformationStepBuildOperationType.RESULT);
+            context.failed(transformedSubject.getFailure());
+        }
+
+        protected abstract TransformationSubject transform();
+
+        public TransformationSubject getTransformedSubject() {
+            return transformedSubject;
+        }
+    }
+
+    private static class OperationDetails implements ExecuteScheduledTransformationStepBuildOperationType.Details {
+
+        private final String transformerName;
+        private final String subjectName;
+
+        public OperationDetails(String transformerName, String subjectName) {
+            this.transformerName = transformerName;
+            this.subjectName = subjectName;
+        }
+
+        @Override
+        public String getTransformerName() {
+            return transformerName;
+        }
+
+        @Override
+        public String getSubjectName() {
+            return subjectName;
+        }
     }
 }


### PR DESCRIPTION
The new `ExecuteScheduledTransformBuildOperationType` can be used to
listen for transform execution and report the display name of
transformer and subject as well as potential transformation failures.