### PR TITLE
Decorate all domain collection container for emitting build ops

### DIFF
--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CheckstyleReportsImpl.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.quality.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.plugins.quality.CheckstyleReports;
 import org.gradle.api.reporting.CustomizableHtmlReport;
 import org.gradle.api.reporting.SingleFileReport;
@@ -28,8 +29,8 @@ import javax.inject.Inject;
 
 public class CheckstyleReportsImpl extends TaskReportContainer<SingleFileReport> implements CheckstyleReports {
     @Inject
-    public CheckstyleReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
+    public CheckstyleReportsImpl(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(SingleFileReport.class, task, callbackActionDecorator);
 
         add(CustomizableHtmlReportImpl.class, "html", task);
         add(TaskGeneratedSingleFileReport.class, "xml", task);

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
@@ -34,7 +34,7 @@ public class CodeNarcReportsImpl extends TaskReportContainer<SingleFileReport> i
     @Deprecated
     public CodeNarcReportsImpl(Task task) {
         this(task, CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Constructor CodeNarcReportsImpl(Task)");
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor CodeNarcReportsImpl(Task)", "Don't ex");
     }
 
     @Inject

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/CodeNarcReportsImpl.java
@@ -17,17 +17,29 @@
 package org.gradle.api.plugins.quality.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.plugins.quality.CodeNarcReports;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
 import org.gradle.api.reporting.internal.TaskReportContainer;
+import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 
 public class CodeNarcReportsImpl extends TaskReportContainer<SingleFileReport> implements CodeNarcReports {
-    @Inject
+
+    /**
+     * This internal constructor is used by the 'nebula.lint' plugin which we test as part of our ci pipeline.
+     * */
+    @Deprecated
     public CodeNarcReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
+        this(task, CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Constructor CodeNarcReportsImpl(Task)");
+    }
+
+    @Inject
+    public CodeNarcReportsImpl(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(SingleFileReport.class, task, callbackActionDecorator);
 
         add(TaskGeneratedSingleFileReport.class, "xml", task);
         add(TaskGeneratedSingleFileReport.class, "html", task);

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/FindBugsReportsImpl.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.quality.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.plugins.quality.FindBugsXmlReport;
 import org.gradle.api.plugins.quality.internal.findbugs.FindBugsXmlReportImpl;
 import org.gradle.api.reporting.CustomizableHtmlReport;
@@ -30,8 +31,8 @@ import javax.inject.Inject;
 @SuppressWarnings("deprecation")
 public class FindBugsReportsImpl extends TaskReportContainer<SingleFileReport> implements FindBugsReportsInternal {
     @Inject
-    public FindBugsReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
+    public FindBugsReportsImpl(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(SingleFileReport.class, task, callbackActionDecorator);
 
         add(FindBugsXmlReportImpl.class, "xml", task);
         add(CustomizableHtmlReportImpl.class, "html", task);

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/JDependReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/JDependReportsImpl.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.quality.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.plugins.quality.JDependReports;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
@@ -27,8 +28,8 @@ import javax.inject.Inject;
 @SuppressWarnings("deprecation")
 public class JDependReportsImpl extends TaskReportContainer<SingleFileReport> implements JDependReports {
     @Inject
-    public JDependReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
+    public JDependReportsImpl(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(SingleFileReport.class, task, callbackActionDecorator);
 
         add(TaskGeneratedSingleFileReport.class, "xml", task);
         add(TaskGeneratedSingleFileReport.class, "text", task);

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdReportsImpl.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/internal/PmdReportsImpl.java
@@ -17,6 +17,7 @@
 package org.gradle.api.plugins.quality.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.plugins.quality.PmdReports;
 import org.gradle.api.reporting.SingleFileReport;
 import org.gradle.api.reporting.internal.TaskGeneratedSingleFileReport;
@@ -26,8 +27,8 @@ import javax.inject.Inject;
 
 public class PmdReportsImpl extends TaskReportContainer<SingleFileReport> implements PmdReports {
     @Inject
-    public PmdReportsImpl(Task task) {
-        super(SingleFileReport.class, task);
+    public PmdReportsImpl(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(SingleFileReport.class, task, callbackActionDecorator);
 
         add(TaskGeneratedSingleFileReport.class, "html", task);
         add(TaskGeneratedSingleFileReport.class, "xml", task);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -131,7 +131,7 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
     protected NamedDomainObjectProvider<T> createDomainObjectProvider(String name, @Nullable Action<? super T> configurationAction) {
         assertCanAdd(name);
         NamedDomainObjectProvider<T> provider = Cast.uncheckedCast(
-            getInstantiator().newInstance(NamedDomainObjectCreatingProvider.class, AbstractNamedDomainObjectContainer.this, name, getType(), getEventRegister().getDecorator().decorate(configurationAction))
+            getInstantiator().newInstance(NamedDomainObjectCreatingProvider.class, AbstractNamedDomainObjectContainer.this, name, getType(), configurationAction)
         );
         addLater(provider);
         return provider;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -29,6 +29,7 @@ import org.gradle.internal.Cast;
 import org.gradle.internal.metaobject.ConfigureDelegate;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.ConfigureUtil;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 
@@ -41,23 +42,27 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
         super(type, instantiator, namer, callbackDecorator);
     }
 
-    /**
-     * TODO: remove when all implementations ported to use a CollectionCallbackActionDecorator
-     * */
-    protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
-        this(type, instantiator, namer, CollectionCallbackActionDecorator.NOOP);
-    }
-
-    /**
-     * TODO: remove when all implementations ported to use a CollectionCallbackActionDecorator
-     * */
-    protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-        this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
-    }
-
-
     protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, Named.Namer.forType(type), callbackActionDecorator);
+    }
+
+    /**
+     * This internal constructor is used by 'nebula.plugin-plugin' which we test as part of our ci pipeline.
+     * */
+    @Deprecated
+    protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
+        this(type, instantiator, namer, CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator, Namer<? extends T>)", "Don't use internal API");
+    }
+
+
+    /**
+     * This internal constructor is used by the 'com.eriwen.gradle.css' and 'com.eriwen.gradle.js' plugin which we test as part of our ci pipeline.
+     * */
+    @Deprecated
+    protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
+        this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API cFactoryNamedDomainObjectContaineronstructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator)", "Don't use internal API");
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -62,7 +62,7 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
     @Deprecated
     protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
         this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Internal API cFactoryNamedDomainObjectContaineronstructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator)", "Don't use internal API");
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor FactoryNamedDomainObjectContaineronstructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator)", "Don't use internal API");
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractPolymorphicDomainObjectContainer.java
@@ -38,8 +38,8 @@ public abstract class AbstractPolymorphicDomainObjectContainer<T>
 
     private final ContainerElementsDynamicObject elementsDynamicObject = new ContainerElementsDynamicObject();
 
-    protected AbstractPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
-        super(type, instantiator, namer);
+    protected AbstractPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
+        super(type, instantiator, namer, callbackDecorator);
     }
 
     protected abstract <U extends T> U doCreate(String name, Class<U> type);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractValidatingNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractValidatingNamedDomainObjectContainer.java
@@ -36,20 +36,9 @@ public abstract class AbstractValidatingNamedDomainObjectContainer<T> extends Ab
         nameDescription = type.getSimpleName() + " name";
     }
 
-    /**
-     * TODO: remove when all implementations ported to use a CollectionCallbackActionDecorator
-     * */
-    protected AbstractValidatingNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
-        this(type, instantiator, namer, CollectionCallbackActionDecorator.NOOP);
-    }
-
     protected AbstractValidatingNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
         super(type, instantiator, callbackActionDecorator);
         nameDescription = type.getSimpleName() + " name";
-    }
-
-    protected AbstractValidatingNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-       this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
     }
 
     public T create(String name, Action<? super T> configureAction) throws InvalidUserDataException {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
@@ -33,10 +33,6 @@ public class DefaultDomainObjectSet<T> extends DefaultDomainObjectCollection<T> 
     // TODO: Combine these with MutationGuard
     private ImmutableActionSet<Void> beforeContainerChange = ImmutableActionSet.empty();
 
-    public DefaultDomainObjectSet(Class<? extends T> type) {
-        super(type, new IterationOrderRetainingSetElementSource<T>(), CollectionCallbackActionDecorator.NOOP);
-    }
-
     public DefaultDomainObjectSet(Class<? extends T> type, CollectionCallbackActionDecorator decorator) {
         super(type, new IterationOrderRetainingSetElementSource<T>(), decorator);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultDomainObjectSet.java
@@ -33,6 +33,14 @@ public class DefaultDomainObjectSet<T> extends DefaultDomainObjectCollection<T> 
     // TODO: Combine these with MutationGuard
     private ImmutableActionSet<Void> beforeContainerChange = ImmutableActionSet.empty();
 
+    /**
+     * This internal constructor is used by the 'com.android.application' plugin which we test as part of our ci pipeline.
+     * */
+    @Deprecated
+    public DefaultDomainObjectSet(Class<? extends T> type) {
+        super(type, new IterationOrderRetainingSetElementSource<T>(), CollectionCallbackActionDecorator.NOOP);
+    }
+
     public DefaultDomainObjectSet(Class<? extends T> type, CollectionCallbackActionDecorator decorator) {
         super(type, new IterationOrderRetainingSetElementSource<T>(), decorator);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectSet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultNamedDomainObjectSet.java
@@ -32,10 +32,6 @@ import java.util.Set;
 public class DefaultNamedDomainObjectSet<T> extends DefaultNamedDomainObjectCollection<T> implements NamedDomainObjectSet<T> {
     private final MutationGuard parentMutationGuard;
 
-    public DefaultNamedDomainObjectSet(Class<? extends T> type, Instantiator instantiator, Namer<? super T> namer) {
-        this(type, instantiator, namer, CollectionCallbackActionDecorator.NOOP);
-    }
-
     public DefaultNamedDomainObjectSet(Class<? extends T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator decorator) {
         super(type, new SortedSetElementSource<T>(new Namer.Comparator<T>(namer)), instantiator, namer, decorator);
         this.parentMutationGuard = MutationGuards.identity();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
@@ -27,13 +27,13 @@ public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorp
         implements ExtensiblePolymorphicDomainObjectContainer<T> {
     protected final DefaultPolymorphicNamedEntityInstantiator<T> namedEntityInstantiator;
 
-    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer) {
-        super(type, instantiator, namer);
+    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
+        super(type, instantiator, namer, callbackDecorator);
         namedEntityInstantiator = new DefaultPolymorphicNamedEntityInstantiator<T>(type, "this container");
     }
 
-    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-        this(type, instantiator, Named.Namer.forType(type));
+    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {
+        this(type, instantiator, Named.Namer.forType(type), callbackDecorator);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainer.java
@@ -20,6 +20,7 @@ import org.gradle.api.*;
 import org.gradle.internal.Cast;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.model.internal.core.NamedEntityInstantiator;
+import org.gradle.util.DeprecationLogger;
 
 import java.util.Set;
 
@@ -30,6 +31,15 @@ public class DefaultPolymorphicDomainObjectContainer<T> extends AbstractPolymorp
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, CollectionCallbackActionDecorator callbackDecorator) {
         super(type, instantiator, namer, callbackDecorator);
         namedEntityInstantiator = new DefaultPolymorphicNamedEntityInstantiator<T>(type, "this container");
+    }
+
+    /**
+     * This internal constructor is used by the 'nebula.lint' plugin which we test as part of our ci pipeline.
+     * */
+    @Deprecated
+    public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator) {
+        this(type, instantiator, Named.Namer.forType(type), CollectionCallbackActionDecorator.NOOP);
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor DefaultPolymorphicDomainObjectContainer(Class<T>, Instantiator)");
     }
 
     public DefaultPolymorphicDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/FactoryNamedDomainObjectContainer.java
@@ -35,9 +35,10 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      *
      * @param type The concrete type of element in the container (must implement {@link Named})
      * @param instantiator The instantiator to use to create any other collections based on this one
+     * @param collectionCallbackActionDecorator the decorator for collection callback action execution
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
-        this(type, instantiator, Named.Namer.forType(type), MutationGuards.identity());
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        this(type, instantiator, Named.Namer.forType(type), MutationGuards.identity(), collectionCallbackActionDecorator);
     }
 
     /**
@@ -46,9 +47,10 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param type The concrete type of element in the container (must implement {@link Named})
      * @param instantiator The instantiator to use to create any other collections based on this one
      * @param namer The naming strategy to use
+     * @param collectionCallbackActionDecorator the decorator for collection callback action execution
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, MutationGuard crossProjectConfiguratorMutationGuard) {
-        this(type, instantiator, namer, new ReflectiveNamedDomainObjectFactory<T>(type), crossProjectConfiguratorMutationGuard);
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, MutationGuard crossProjectConfiguratorMutationGuard, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        this(type, instantiator, namer, new ReflectiveNamedDomainObjectFactory<T>(type), crossProjectConfiguratorMutationGuard, collectionCallbackActionDecorator);
     }
 
     /**
@@ -57,9 +59,24 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param type The concrete type of element in the container (must implement {@link Named})
      * @param instantiator The instantiator to use to create any other collections based on this one
      * @param factory The factory responsible for creating new instances on demand
+     * @param collectionCallbackActionDecorator the decorator for collection callback action execution
      */
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, NamedDomainObjectFactory<T> factory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        this(type, instantiator, Named.Namer.forType(type), factory, MutationGuards.identity(), collectionCallbackActionDecorator);
+    }
+
+    /**
+     * <p>Creates a container that instantiates using the given factory.<p>
+     *
+     * @param type The concrete type of element in the container (must implement {@link Named})
+     * @param instantiator The instantiator to use to create any other collections based on this one
+     * @param factory The factory responsible for creating new instances on demand
+     *
+     * This internal constructor is used by 'nebula.plugin-plugin' plugin which we test as part of our ci pipeline.
+     */
+    @Deprecated
     public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, NamedDomainObjectFactory<T> factory) {
-        this(type, instantiator, Named.Namer.forType(type), factory, MutationGuards.identity());
+        this(type, instantiator, Named.Namer.forType(type), factory, MutationGuards.identity(), CollectionCallbackActionDecorator.NOOP);
     }
 
     /**
@@ -70,8 +87,8 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param namer The naming strategy to use
      * @param factory The factory responsible for creating new instances on demand
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, NamedDomainObjectFactory<T> factory, MutationGuard crossProjectConfiguratorMutationGuard) {
-        super(type, instantiator, namer);
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, NamedDomainObjectFactory<T> factory, MutationGuard crossProjectConfiguratorMutationGuard, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(type, instantiator, namer, collectionCallbackActionDecorator);
         this.factory = factory;
         this.crossProjectConfiguratorMutationGuard = crossProjectConfiguratorMutationGuard;
     }
@@ -83,8 +100,8 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param instantiator The instantiator to use to create any other collections based on this one
      * @param factoryClosure The closure responsible for creating new instances on demand
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, final Closure factoryClosure) {
-        this(type, instantiator, Named.Namer.forType(type), factoryClosure, MutationGuards.identity());
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, final Closure factoryClosure, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        this(type, instantiator, Named.Namer.forType(type), factoryClosure, MutationGuards.identity(), collectionCallbackActionDecorator);
     }
 
     /**
@@ -95,8 +112,8 @@ public class FactoryNamedDomainObjectContainer<T> extends AbstractNamedDomainObj
      * @param namer The naming strategy to use
      * @param factoryClosure The factory responsible for creating new instances on demand
      */
-    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, final Closure factoryClosure, MutationGuard mutationGuard) {
-        this(type, instantiator, namer, new ClosureObjectFactory<T>(type, factoryClosure), mutationGuard);
+    public FactoryNamedDomainObjectContainer(Class<T> type, Instantiator instantiator, Namer<? super T> namer, final Closure factoryClosure, MutationGuard mutationGuard, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        this(type, instantiator, namer, new ClosureObjectFactory<T>(type, factoryClosure), mutationGuard, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/DefaultSoftwareComponentContainer.java
@@ -23,7 +23,7 @@ import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.reflect.Instantiator;
 
 public class DefaultSoftwareComponentContainer extends DefaultNamedDomainObjectSet<SoftwareComponent> implements SoftwareComponentContainer {
-    public DefaultSoftwareComponentContainer(Instantiator instantiator) {
-        super(SoftwareComponentInternal.class, instantiator, CollectionCallbackActionDecorator.NOOP);
+    public DefaultSoftwareComponentContainer(Instantiator instantiator, CollectionCallbackActionDecorator decorator) {
+        super(SoftwareComponentInternal.class, instantiator, decorator);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -45,6 +45,7 @@ import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.initialization.dsl.ScriptHandler;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.DynamicPropertyNamer;
 import org.gradle.api.internal.ExtensibleDynamicObject;
@@ -266,6 +267,11 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
         @Hidden @Model
         NamedEntityInstantiator<Task> taskFactory(ServiceRegistry serviceRegistry) {
             return serviceRegistry.get(TaskInstantiator.class);
+        }
+
+        @Hidden @Model
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator(ServiceRegistry serviceRegistry) {
+            return serviceRegistry.get(CollectionCallbackActionDecorator.class);
         }
 
         @Hidden @Model
@@ -1307,19 +1313,19 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type) {
         Instantiator instantiator = getServices().get(Instantiator.class);
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), MutationGuards.of(getProjectConfigurator()));
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), MutationGuards.of(getProjectConfigurator()), services.get(CollectionCallbackActionDecorator.class));
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, NamedDomainObjectFactory<T> factory) {
         Instantiator instantiator = getServices().get(Instantiator.class);
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factory, MutationGuards.of(getProjectConfigurator()));
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factory, MutationGuards.of(getProjectConfigurator()), services.get(CollectionCallbackActionDecorator.class));
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, Closure factoryClosure) {
         Instantiator instantiator = getServices().get(Instantiator.class);
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure, MutationGuards.of(getProjectConfigurator()));
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure, MutationGuards.of(getProjectConfigurator()), services.get(CollectionCallbackActionDecorator.class));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/authentication/DefaultAuthenticationContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/authentication/DefaultAuthenticationContainer.java
@@ -17,14 +17,15 @@
 package org.gradle.internal.authentication;
 
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.authentication.Authentication;
 import org.gradle.internal.reflect.Instantiator;
 
 public class DefaultAuthenticationContainer extends DefaultPolymorphicDomainObjectContainer<Authentication> implements AuthenticationContainer {
 
-    public DefaultAuthenticationContainer(Instantiator instantiator) {
-        super(Authentication.class, instantiator);
+    public DefaultAuthenticationContainer(Instantiator instantiator, CollectionCallbackActionDecorator callbackDecorator) {
+        super(Authentication.class, instantiator, callbackDecorator);
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -197,9 +197,9 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultTaskContainerFactory(get(ModelRegistry.class), get(Instantiator.class), get(ITaskFactory.class), project, get(ProjectAccessListener.class), taskStatistics, buildOperationExecutor, crossProjectConfigurator, decorator);
     }
 
-    protected SoftwareComponentContainer createSoftwareComponentContainer() {
+    protected SoftwareComponentContainer createSoftwareComponentContainer(CollectionCallbackActionDecorator decorator) {
         Instantiator instantiator = get(Instantiator.class);
-        return instantiator.newInstance(DefaultSoftwareComponentContainer.class, instantiator);
+        return instantiator.newInstance(DefaultSoftwareComponentContainer.class, instantiator, decorator);
     }
 
     protected ProjectFinder createProjectFinder(final BuildStateRegistry buildStateRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/util/WrapUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/util/WrapUtil.java
@@ -18,6 +18,7 @@ package org.gradle.util;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectSet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.internal.reflect.DirectInstantiator;
@@ -52,7 +53,7 @@ public class WrapUtil {
      * Wraps the given items in a mutable domain object set.
      */
     public static <T> DomainObjectSet<T> toDomainObjectSet(Class<T> type, T... items) {
-        DefaultDomainObjectSet<T> set = new DefaultDomainObjectSet<T>(type);
+        DefaultDomainObjectSet<T> set = new DefaultDomainObjectSet<T>(type, CollectionCallbackActionDecorator.NOOP);
         set.addAll(Arrays.asList(items));
         return set;
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/AbstractNamedDomainObjectContainerTest.groovy
@@ -26,6 +26,7 @@ import spock.lang.Specification
 
 class AbstractNamedDomainObjectContainerTest extends Specification {
     Instantiator instantiator = new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE)
+    CollectionCallbackActionDecorator collectionCallbackActionDecorator = CollectionCallbackActionDecorator.NOOP
     AbstractNamedDomainObjectContainer<TestObject> container = instantiator.newInstance(TestContainer.class, instantiator)
 
     def "is dynamic object aware"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/CompositeDomainObjectSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/CompositeDomainObjectSetTest.groovy
@@ -23,7 +23,7 @@ class CompositeDomainObjectSetTest extends Specification {
     Class type = String
 
     protected collection(Object... entries) {
-        def collection = new DefaultDomainObjectSet(type)
+        def collection = new DefaultDomainObjectSet(type, CollectionCallbackActionDecorator.NOOP)
         entries.each { collection.add(it) }
         collection
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultDomainObjectSetTest.groovy
@@ -40,8 +40,8 @@ class DefaultDomainObjectSetTest extends AbstractDomainObjectCollectionSpec<Char
     }
 
     def "Set semantics preserved if backing collection is a filtered composite set"() {
-        def c1 = new DefaultDomainObjectSet<String>(String)
-        def c2 = new DefaultDomainObjectSet<String>(String)
+        def c1 = new DefaultDomainObjectSet<String>(String, callbackActionDecorator)
+        def c2 = new DefaultDomainObjectSet<String>(String, callbackActionDecorator)
         given:
         def composite = CompositeDomainObjectSet.<String>create(String, c1, c2)
         def set = new DefaultDomainObjectSet<String>(String, composite.getStore(), callbackActionDecorator)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerBaseTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerBaseTest.groovy
@@ -20,13 +20,13 @@ import org.gradle.model.internal.core.NamedEntityInstantiator
 
 class DefaultPolymorphicDomainObjectContainerBaseTest extends AbstractNamedDomainObjectContainerTest {
     def setup() {
-        container = instantiator.newInstance(PolymorphicTestContainer.class, instantiator)
+        container = instantiator.newInstance(PolymorphicTestContainer.class, instantiator, collectionCallbackActionDecorator)
     }
 }
 
 class PolymorphicTestContainer extends AbstractPolymorphicDomainObjectContainer<TestObject> {
-    PolymorphicTestContainer(Instantiator instantiator) {
-        super(TestObject, instantiator, new DynamicPropertyNamer())
+    PolymorphicTestContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(TestObject, instantiator, new DynamicPropertyNamer(), collectionCallbackActionDecorator)
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerDslTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerDslTest.groovy
@@ -27,11 +27,13 @@ class DefaultPolymorphicDomainObjectContainerDslTest extends AbstractProjectBuil
     def agedBarney = new DefaultAgeAwarePerson(name: "Barney", age: 42)
 
     def instantiator
+    def collectionCallbackActionDecorator = CollectionCallbackActionDecorator.NOOP
+
     def container
 
     def setup() {
         instantiator = project.services.get(Instantiator)
-        container = instantiator.newInstance(DefaultPolymorphicDomainObjectContainer, Person, instantiator)
+        container = instantiator.newInstance(DefaultPolymorphicDomainObjectContainer, Person, instantiator, collectionCallbackActionDecorator)
         project.extensions.add("container", container)
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -30,7 +30,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     def agedFred = new DefaultAgeAwarePerson(name: "fred", age: 42)
     def agedBarney = new DefaultAgeAwarePerson(name: "barney", age: 42)
 
-    def container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE)
+    def container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
 
     final boolean supportsBuildOperations = false
 
@@ -141,7 +141,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     }
 
     def "throws meaningful exception if it doesn't support creating domain objects without specifying a type"() {
-        container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE)
+        container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
 
         when:
         container.create("fred")
@@ -186,7 +186,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
 
     def "create elements with specified type based on type binding"() {
         container = new DefaultPolymorphicDomainObjectContainer<?>(Object, DirectInstantiator.INSTANCE,
-                { it instanceof Named ? it.name : "unknown" } as Named.Namer)
+                { it instanceof Named ? it.name : "unknown" } as Named.Namer, CollectionCallbackActionDecorator.NOOP)
 
         container.registerBinding(UnnamedPerson, DefaultUnnamedPerson)
         container.registerBinding(CtorNamedPerson, DefaultCtorNamedPerson)
@@ -235,7 +235,7 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     }
 
     def "throws meaningful exception if it doesn't support creating domain objects with the specified type"() {
-        container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE)
+        container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
 
         when:
         container.create("fred", Person)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultPolymorphicDomainObjectContainerTest.groovy
@@ -30,9 +30,9 @@ class DefaultPolymorphicDomainObjectContainerTest extends AbstractPolymorphicDom
     def agedFred = new DefaultAgeAwarePerson(name: "fred", age: 42)
     def agedBarney = new DefaultAgeAwarePerson(name: "barney", age: 42)
 
-    def container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
+    def container = new DefaultPolymorphicDomainObjectContainer<Person>(Person, DirectInstantiator.INSTANCE, callbackActionDecorator)
 
-    final boolean supportsBuildOperations = false
+    final boolean supportsBuildOperations = true
 
     @Override
     final PolymorphicDomainObjectContainer<Person> getContainer() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/FactoryNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/FactoryNamedDomainObjectContainerSpec.groovy
@@ -28,7 +28,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
     final namer = { it } as Namer
 
     def usesFactoryToCreateContainerElements() {
-        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, factory, MutationGuards.identity())
+        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, factory, MutationGuards.identity(), CollectionCallbackActionDecorator.NOOP)
 
         when:
         def result = container.create('a')
@@ -40,7 +40,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
     }
 
     def usesPublicConstructorWhenNoFactorySupplied() {
-        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, MutationGuards.identity())
+        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, MutationGuards.identity(), CollectionCallbackActionDecorator.NOOP)
 
         when:
         def result = container.create('a')
@@ -52,7 +52,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
 
     def usesClosureToCreateContainerElements() {
         def cl = { name -> "element $name" as String }
-        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, cl, MutationGuards.identity())
+        def container = new FactoryNamedDomainObjectContainer<String>(String.class, instantiator, namer, cl, MutationGuards.identity(), CollectionCallbackActionDecorator.NOOP)
 
         when:
         def result = container.create('a')
@@ -73,7 +73,7 @@ class FactoryNamedDomainObjectContainerSpec extends Specification {
     }
 
     protected getInstance(name) {
-        new FactoryNamedDomainObjectContainer(type, instantiator, new ReflectiveNamedDomainObjectFactory(type, *extraArgs)).create(name)
+        new FactoryNamedDomainObjectContainer(type, instantiator, new ReflectiveNamedDomainObjectFactory(type, *extraArgs), CollectionCallbackActionDecorator.NOOP).create(name)
     }
 
     static class JustName implements Named {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/NestedConfigureAutoCreateNamedDomainObjectContainerSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/NestedConfigureAutoCreateNamedDomainObjectContainerSpec.groovy
@@ -26,7 +26,7 @@ class NestedConfigureAutoCreateNamedDomainObjectContainerSpec extends Specificat
         String parentName
         String name
         Container(String parentName, String name, Closure factory) {
-            super(Object, new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE), new DynamicPropertyNamer(), factory, MutationGuards.identity())
+            super(Object, new ClassGeneratorBackedInstantiator(new AsmBackedClassGenerator(), DirectInstantiator.INSTANCE), new DynamicPropertyNamer(), factory, MutationGuards.identity(), CollectionCallbackActionDecorator.NOOP)
             this.parentName = parentName
             this.name = name
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/TestContainer.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/TestContainer.java
@@ -20,7 +20,7 @@ import org.gradle.internal.reflect.Instantiator;
 public class TestContainer extends AbstractNamedDomainObjectContainer<TestObject> {
 
     public TestContainer(org.gradle.internal.reflect.Instantiator instantiator) {
-        super(TestObject.class, instantiator, new DynamicPropertyNamer());
+        super(TestObject.class, instantiator, new DynamicPropertyNamer(), CollectionCallbackActionDecorator.NOOP);
     }
 
     protected TestObject doCreate(String name) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/TypedDomainObjectContainerWrapperTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/TypedDomainObjectContainerWrapperTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.Specification
 
 class TypedDomainObjectContainerWrapperTest extends Specification {
 
-    DefaultPolymorphicDomainObjectContainer<Type> parent = new DefaultPolymorphicDomainObjectContainer<Type>(Type, DirectInstantiator.INSTANCE)
+    DefaultPolymorphicDomainObjectContainer<Type> parent = new DefaultPolymorphicDomainObjectContainer<Type>(Type, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
 
     def setup() {
         parent.add(type("typeOne"))

--- a/subprojects/core/src/test/groovy/org/gradle/internal/authentication/DefaultAuthenticationContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/authentication/DefaultAuthenticationContainerTest.groovy
@@ -15,14 +15,16 @@
  */
 
 package org.gradle.internal.authentication
+
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.authentication.Authentication
 import org.gradle.internal.reflect.DirectInstantiator
 import spock.lang.Specification
 import spock.lang.Subject
 
-public class DefaultAuthenticationContainerTest extends Specification {
+class DefaultAuthenticationContainerTest extends Specification {
     @Subject
-    def container = new DefaultAuthenticationContainer(DirectInstantiator.INSTANCE)
+    def container = new DefaultAuthenticationContainer(DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
 
     def setup() {
         container.registerBinding(TestAuthentication, DefaultTestAuthentication)

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -49,8 +49,8 @@ class NameValidatorTest extends Specification {
     def domainObjectContainersWithValidation = [
         ["artifact types", new DefaultArtifactTypeContainer(DirectInstantiator.INSTANCE, AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
         ["configurations", new DefaultConfigurationContainer(null, DirectInstantiator.INSTANCE, domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null)],
-        ["flavors", new DefaultFlavorContainer(DirectInstantiator.INSTANCE)],
-        ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, DirectInstantiator.INSTANCE, TestUtil.objectFactory())]
+        ["flavors", new DefaultFlavorContainer(DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)],
+        ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, DirectInstantiator.INSTANCE, TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]
 
     def cleanup() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -285,7 +285,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                           MavenMutableModuleMetadataFactory metadataFactory,
                                                           IvyMutableModuleMetadataFactory ivyMetadataFactory,
                                                           IsolatableFactory isolatableFactory,
-                                                          ObjectFactory objectFactory) {
+                                                          ObjectFactory objectFactory,
+                                                          CollectionCallbackActionDecorator callbackDecorator) {
             return new DefaultBaseRepositoryFactory(
                 localMavenRepositoryLocator,
                 fileResolver,
@@ -304,7 +305,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 metadataFactory,
                 ivyMetadataFactory,
                 isolatableFactory,
-                objectFactory);
+                objectFactory,
+                callbackDecorator);
         }
 
         RepositoryHandler createRepositoryHandler(Instantiator instantiator, BaseRepositoryFactory baseRepositoryFactory, CollectionCallbackActionDecorator callbackDecorator) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -276,7 +276,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         this.artifacts = new DefaultPublishArtifactSet(Describables.of(displayName, "artifacts"), ownArtifacts, fileCollectionFactory);
 
-        this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory);
+        this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, callbackDecorator);
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilder;
         path = domainObjectContext.projectPath(name);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -55,6 +56,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final FileCollectionFactory fileCollectionFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private FactoryNamedDomainObjectContainer<ConfigurationVariant> variants;
     private ConfigurationVariantFactory variantFactory;
     private List<Capability> capabilities;
@@ -68,7 +70,8 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
                                             NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
                                             NotationParser<Object, Capability> capabilityNotationParser,
                                             FileCollectionFactory fileCollectionFactory,
-                                            ImmutableAttributesFactory attributesFactory) {
+                                            ImmutableAttributesFactory attributesFactory,
+                                            CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.displayName = displayName;
         this.artifacts = artifacts;
         this.allArtifacts = allArtifacts;
@@ -78,6 +81,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         this.capabilityNotationParser = capabilityNotationParser;
         this.fileCollectionFactory = fileCollectionFactory;
         this.attributesFactory = attributesFactory;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         this.attributes = attributesFactory.mutable(parentAttributes);
     }
 
@@ -151,7 +155,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         if (variants == null) {
             // Create variants container only as required
             variantFactory = new ConfigurationVariantFactory();
-            variants = new FactoryNamedDomainObjectContainer<ConfigurationVariant>(ConfigurationVariant.class, instantiator, variantFactory);
+            variants = new FactoryNamedDomainObjectContainer<ConfigurationVariant>(ConfigurationVariant.class, instantiator, variantFactory, collectionCallbackActionDecorator);
         }
         return variants;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -196,7 +196,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         @Override
         public ConfigurationVariant create(String name) {
             if (canCreate) {
-                return instantiator.newInstance(DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory);
+                return instantiator.newInstance(DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, collectionCallbackActionDecorator);
             } else {
                 throw new InvalidUserCodeException("Cannot create variant '" + name + "' after " + displayName + " has been resolved");
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
@@ -45,12 +46,13 @@ public class DefaultVariant implements ConfigurationVariantInternal {
                           AttributeContainerInternal parentAttributes,
                           NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
                           FileCollectionFactory fileCollectionFactory,
-                          ImmutableAttributesFactory cache) {
+                          ImmutableAttributesFactory cache,
+                          CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.parentDisplayName = parentDisplayName;
         this.name = name;
         attributes = cache.mutable(parentAttributes);
         this.artifactNotationParser = artifactNotationParser;
-        artifacts = new DefaultPublishArtifactSet(getAsDescribable(), new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact.class), fileCollectionFactory);
+        artifacts = new DefaultPublishArtifactSet(getAsDescribable(), new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact.class, collectionCallbackActionDecorator), fileCollectionFactory);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.FlatDirectoryArtifactRepository;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.BaseRepositoryFactory;
@@ -74,6 +75,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     private final IvyMutableModuleMetadataFactory ivyMetadataFactory;
     private final IsolatableFactory isolatableFactory;
     private final ObjectFactory objectFactory;
+    private CollectionCallbackActionDecorator callbackActionDecorator;
 
     public DefaultBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator,
                                         FileResolver fileResolver,
@@ -92,7 +94,8 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
                                         MavenMutableModuleMetadataFactory mavenMetadataFactory,
                                         IvyMutableModuleMetadataFactory ivyMetadataFactory,
                                         IsolatableFactory isolatableFactory,
-                                        ObjectFactory objectFactory) {
+                                        ObjectFactory objectFactory,
+                                        CollectionCallbackActionDecorator callbackActionDecorator) {
         this.localMavenRepositoryLocator = localMavenRepositoryLocator;
         this.fileResolver = fileResolver;
         this.metadataParser = metadataParser;
@@ -112,6 +115,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
         this.ivyMetadataFactory = ivyMetadataFactory;
         this.isolatableFactory = isolatableFactory;
         this.objectFactory = objectFactory;
+        this.callbackActionDecorator = callbackActionDecorator;
     }
 
     public FlatDirectoryArtifactRepository createFlatDirRepository() {
@@ -169,7 +173,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     }
 
     protected AuthenticationContainer createAuthenticationContainer() {
-        DefaultAuthenticationContainer container = instantiator.newInstance(DefaultAuthenticationContainer.class, instantiator);
+        DefaultAuthenticationContainer container = instantiator.newInstance(DefaultAuthenticationContainer.class, instantiator, callbackActionDecorator);
 
         for (Map.Entry<Class<Authentication>, Class<? extends Authentication>> e : authenticationSchemeRegistry.getRegisteredSchemes().entrySet()) {
             container.registerBinding(e.getKey(), e.getValue());

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultPublishArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultPublishArtifactSetTest.groovy
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts
 
 import org.gradle.api.Task
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.tasks.TaskDependency
 import spock.lang.Specification
@@ -24,7 +25,7 @@ import spock.lang.Specification
 import static org.gradle.api.internal.file.TestFiles.fileCollectionFactory
 
 class DefaultPublishArtifactSetTest extends Specification {
-    final store = new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact)
+    final store = new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, CollectionCallbackActionDecorator.NOOP)
     final set = new DefaultPublishArtifactSet('artifacts', store, fileCollectionFactory())
 
     def "set is built by the union of the tasks that build the publish artifacts"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -31,8 +31,8 @@ import spock.lang.Specification
 
 class DefaultConfigurationPublicationsTest extends Specification {
     def parentAttributes = ImmutableAttributes.EMPTY
-    def artifacts = new DefaultPublishArtifactSet("artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact), TestFiles.fileCollectionFactory())
-    def allArtifacts = new DefaultPublishArtifactSet("artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact), TestFiles.fileCollectionFactory())
+    def artifacts = new DefaultPublishArtifactSet("artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, CollectionCallbackActionDecorator.NOOP), TestFiles.fileCollectionFactory())
+    def allArtifacts = new DefaultPublishArtifactSet("artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, CollectionCallbackActionDecorator.NOOP), TestFiles.fileCollectionFactory())
     def artifactNotationParser = Stub(NotationParser)
     def capabilityNotationParser = Stub(NotationParser)
     def fileCollectionFactory = TestFiles.fileCollectionFactory()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.configurations
 
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet
 import org.gradle.api.internal.attributes.ImmutableAttributes
@@ -39,7 +40,7 @@ class DefaultConfigurationPublicationsTest extends Specification {
     def displayName = Describables.of("<config>")
     def publications = new DefaultConfigurationPublications(displayName, artifacts, {
         allArtifacts
-    }, parentAttributes, DirectInstantiator.INSTANCE, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory)
+    }, parentAttributes, DirectInstantiator.INSTANCE, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, CollectionCallbackActionDecorator.NOOP)
 
     def setup() {
         artifacts.whenObjectAdded { allArtifacts.add(it) }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/AbstractAuthenticationSupportedRepositoryTest.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.credentials.AwsCredentials
 import org.gradle.api.credentials.Credentials
 import org.gradle.api.credentials.HttpHeaderCredentials
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor
 import org.gradle.authentication.Authentication
@@ -38,7 +39,7 @@ import spock.lang.Unroll
 class AbstractAuthenticationSupportedRepositoryTest extends Specification {
 
     AuthSupportedRepository repo() {
-        new AuthSupportedRepository(DirectInstantiator.INSTANCE, new DefaultAuthenticationContainer(DirectInstantiator.INSTANCE))
+        new AuthSupportedRepository(DirectInstantiator.INSTANCE, new DefaultAuthenticationContainer(DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP))
     }
 
     def "should configure default password credentials using an action only"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.repositories
 
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
@@ -59,7 +60,8 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final DefaultBaseRepositoryFactory factory = new DefaultBaseRepositoryFactory(
         localMavenRepoLocator, fileResolver, transportFactory, locallyAvailableResourceFinder,
         artifactIdentifierFileStore, externalResourceFileStore, pomParser, metadataParser, authenticationSchemeRegistry, ivyContextManager, moduleIdentifierFactory,
-        TestUtil.instantiatorFactory(), Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory, ivyMetadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory)
+        TestUtil.instantiatorFactory(), Mock(FileResourceRepository), TestUtil.featurePreviews(), mavenMetadataFactory, ivyMetadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory),
+        CollectionCallbackActionDecorator.NOOP
     )
 
     def testCreateFlatDirResolver() {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/HtmlDependencyReportTask.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
@@ -68,7 +69,7 @@ public class HtmlDependencyReportTask extends ConventionTask implements Reportin
     private final DependencyReportContainer reports;
 
     public HtmlDependencyReportTask() {
-        reports = getObjectFactory().newInstance(DefaultDependencyReportContainer.class, this);
+        reports = getObjectFactory().newInstance(DefaultDependencyReportContainer.class, this, getCallbackActionDecorator());
         reports.getHtml().setEnabled(true);
         getOutputs().upToDateWhen(new Spec<Task>() {
             public boolean isSatisfiedBy(Task element) {
@@ -111,6 +112,16 @@ public class HtmlDependencyReportTask extends ConventionTask implements Reportin
 
     @Inject
     protected  VersionParser getVersionParser() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Required for decorating reports container callbacks for tracing user code application.
+     *
+     * @since 5.1
+     */
+    @Inject
+    protected CollectionCallbackActionDecorator getCallbackActionDecorator() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/DefaultDependencyReportContainer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/DefaultDependencyReportContainer.java
@@ -17,6 +17,7 @@
 package org.gradle.api.reporting.dependencies.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Report;
 import org.gradle.api.reporting.dependencies.DependencyReportContainer;
@@ -26,9 +27,10 @@ import org.gradle.api.reporting.internal.TaskReportContainer;
 import javax.inject.Inject;
 
 public class DefaultDependencyReportContainer extends TaskReportContainer<Report> implements DependencyReportContainer {
+
     @Inject
-    public DefaultDependencyReportContainer(Task task) {
-        super(Report.class, task);
+    public DefaultDependencyReportContainer(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(Report.class, task, callbackActionDecorator);
         add(TaskGeneratedSingleDirectoryReport.class, "html", task, "index.html");
     }
 

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -79,6 +79,28 @@
            "changes": [
                "org.gradle.tooling.events.task.TaskExecutionResult"
            ]
+       },
+       {
+           "type": "org.gradle.api.reporting.GenerateBuildDashboard",
+           "member": "Method org.gradle.api.reporting.GenerateBuildDashboard.getInstantiator()",
+           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
+           "changes": [
+               "Method has been removed"
+           ]
+       },
+       {
+           "type": "org.gradle.api.reporting.GenerateBuildDashboard",
+           "member": "Constructor GenerateBuildDashboard",
+           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
+           "changes": [
+               "Constructor has been removed"
+           ]
+       },
+       {
+           "type": "org.gradle.platform.base.binary.BaseBinarySpec",
+           "member": "Method org.gradle.platform.base.binary.BaseBinarySpec.create(java.lang.Class,java.lang.Class,org.gradle.platform.base.internal.ComponentSpecIdentifier,org.gradle.model.internal.core.MutableModelNode,org.gradle.model.internal.core.MutableModelNode,org.gradle.internal.reflect.Instantiator,org.gradle.model.internal.core.NamedEntityInstantiator,org.gradle.api.internal.CollectionCallbackActionDecorator)",
+           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
+           "changes": []
        }
    ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -81,25 +81,15 @@
            ]
        },
        {
-           "type": "org.gradle.api.reporting.GenerateBuildDashboard",
-           "member": "Method org.gradle.api.reporting.GenerateBuildDashboard.getInstantiator()",
-           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
-           "changes": [
-               "Method has been removed"
-           ]
-       },
-       {
-           "type": "org.gradle.api.reporting.GenerateBuildDashboard",
-           "member": "Constructor GenerateBuildDashboard",
-           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
-           "changes": [
-               "Constructor has been removed"
-           ]
-       },
-       {
            "type": "org.gradle.platform.base.binary.BaseBinarySpec",
            "member": "Method org.gradle.platform.base.binary.BaseBinarySpec.create(java.lang.Class,java.lang.Class,org.gradle.platform.base.internal.ComponentSpecIdentifier,org.gradle.model.internal.core.MutableModelNode,org.gradle.model.internal.core.MutableModelNode,org.gradle.internal.reflect.Instantiator,org.gradle.model.internal.core.NamedEntityInstantiator,org.gradle.api.internal.CollectionCallbackActionDecorator)",
-           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
+           "acceptation": "Method is not meant to be overwritten",
+           "changes": []
+       },
+       {
+           "type": "org.gradle.api.reporting.GenerateBuildDashboard",
+           "member": "Method org.gradle.api.reporting.GenerateBuildDashboard.getCollectionCallbackActionDecorator()",
+           "acceptation": "Method is not meant to be used in public API",
            "changes": []
        }
    ]

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -101,14 +101,6 @@
            "member": "Method org.gradle.platform.base.binary.BaseBinarySpec.create(java.lang.Class,java.lang.Class,org.gradle.platform.base.internal.ComponentSpecIdentifier,org.gradle.model.internal.core.MutableModelNode,org.gradle.model.internal.core.MutableModelNode,org.gradle.internal.reflect.Instantiator,org.gradle.model.internal.core.NamedEntityInstantiator,org.gradle.api.internal.CollectionCallbackActionDecorator)",
            "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
            "changes": []
-       },
-       {
-           "type": "org.gradle.plugins.signing.Sign",
-           "member": "Constructor Sign",
-           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
-           "changes": [
-               "Constructor has been removed"
-           ]
        }
    ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -101,6 +101,14 @@
            "member": "Method org.gradle.platform.base.binary.BaseBinarySpec.create(java.lang.Class,java.lang.Class,org.gradle.platform.base.internal.ComponentSpecIdentifier,org.gradle.model.internal.core.MutableModelNode,org.gradle.model.internal.core.MutableModelNode,org.gradle.internal.reflect.Instantiator,org.gradle.model.internal.core.NamedEntityInstantiator,org.gradle.api.internal.CollectionCallbackActionDecorator)",
            "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
            "changes": []
+       },
+       {
+           "type": "org.gradle.plugins.signing.Sign",
+           "member": "Constructor Sign",
+           "acceptation": "[ADD YOUR CUSTOM REASON HERE]",
+           "changes": [
+               "Constructor has been removed"
+           ]
        }
    ]
 }

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.tasks.Delete;
 import org.gradle.api.tasks.TaskProvider;
@@ -66,12 +67,14 @@ public class VisualStudioPlugin extends IdePlugin {
     private final Instantiator instantiator;
     private final FileResolver fileResolver;
     private final IdeArtifactRegistry artifactRegistry;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
-    public VisualStudioPlugin(Instantiator instantiator, FileResolver fileResolver, IdeArtifactRegistry artifactRegistry) {
+    public VisualStudioPlugin(Instantiator instantiator, FileResolver fileResolver, IdeArtifactRegistry artifactRegistry, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.instantiator = instantiator;
         this.fileResolver = fileResolver;
         this.artifactRegistry = artifactRegistry;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     @Override
@@ -86,7 +89,7 @@ public class VisualStudioPlugin extends IdePlugin {
         // Create Visual Studio project extensions
         final VisualStudioExtensionInternal extension;
         if (isRoot()) {
-            extension = (VisualStudioExtensionInternal) project.getExtensions().create(VisualStudioRootExtension.class, "visualStudio", DefaultVisualStudioRootExtension.class, project.getName(), instantiator, target.getObjects(), fileResolver, artifactRegistry);
+            extension = (VisualStudioExtensionInternal) project.getExtensions().create(VisualStudioRootExtension.class, "visualStudio", DefaultVisualStudioRootExtension.class, project.getName(), instantiator, target.getObjects(), fileResolver, artifactRegistry, collectionCallbackActionDecorator);
             final VisualStudioSolution solution = ((VisualStudioRootExtension) extension).getSolution();
             getLifecycleTask().configure(new Action<Task>() {
                 @Override
@@ -96,7 +99,7 @@ public class VisualStudioPlugin extends IdePlugin {
             });
             addWorkspace(solution);
         } else {
-            extension = (VisualStudioExtensionInternal) project.getExtensions().create(VisualStudioExtension.class, "visualStudio", DefaultVisualStudioExtension.class, instantiator, fileResolver, artifactRegistry);
+            extension = (VisualStudioExtensionInternal) project.getExtensions().create(VisualStudioExtension.class, "visualStudio", DefaultVisualStudioExtension.class, instantiator, fileResolver, artifactRegistry, collectionCallbackActionDecorator);
             getLifecycleTask().configure(new Action<Task>() {
                 @Override
                 public void execute(Task task) {

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioExtension.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioExtension.java
@@ -16,6 +16,7 @@
 package org.gradle.ide.visualstudio.internal;
 
 import org.gradle.api.NamedDomainObjectSet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.ide.visualstudio.VisualStudioProject;
 import org.gradle.internal.reflect.Instantiator;
@@ -24,8 +25,8 @@ import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 public class DefaultVisualStudioExtension implements VisualStudioExtensionInternal {
     private final VisualStudioProjectRegistry projectRegistry;
 
-    public DefaultVisualStudioExtension(Instantiator instantiator, FileResolver fileResolver, IdeArtifactRegistry ideArtifactRegistry) {
-        this.projectRegistry = new VisualStudioProjectRegistry(fileResolver, instantiator, ideArtifactRegistry);
+    public DefaultVisualStudioExtension(Instantiator instantiator, FileResolver fileResolver, IdeArtifactRegistry ideArtifactRegistry, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        this.projectRegistry = new VisualStudioProjectRegistry(fileResolver, instantiator, ideArtifactRegistry, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioRootExtension.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/DefaultVisualStudioRootExtension.java
@@ -17,6 +17,7 @@
 package org.gradle.ide.visualstudio.internal;
 
 import org.gradle.api.Action;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.ide.visualstudio.VisualStudioRootExtension;
@@ -27,8 +28,8 @@ import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
 public class DefaultVisualStudioRootExtension extends DefaultVisualStudioExtension implements VisualStudioRootExtension, VisualStudioExtensionInternal {
     private final VisualStudioSolution solution;
 
-    public DefaultVisualStudioRootExtension(String projectName, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver, IdeArtifactRegistry ideArtifactRegistry) {
-        super(instantiator, fileResolver, ideArtifactRegistry);
+    public DefaultVisualStudioRootExtension(String projectName, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver, IdeArtifactRegistry ideArtifactRegistry, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(instantiator, fileResolver, ideArtifactRegistry, collectionCallbackActionDecorator);
         this.solution = objectFactory.newInstance(DefaultVisualStudioSolution.class, projectName);
     }
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistry.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistry.java
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.visualstudio.internal;
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.ide.visualstudio.VisualStudioProject;
@@ -27,8 +28,8 @@ public class VisualStudioProjectRegistry extends DefaultNamedDomainObjectSet<Def
     private final FileResolver fileResolver;
     private final IdeArtifactRegistry ideArtifactRegistry;
 
-    public VisualStudioProjectRegistry(FileResolver fileResolver, Instantiator instantiator, IdeArtifactRegistry ideArtifactRegistry) {
-        super(DefaultVisualStudioProject.class, instantiator);
+    public VisualStudioProjectRegistry(FileResolver fileResolver, Instantiator instantiator, IdeArtifactRegistry ideArtifactRegistry, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(DefaultVisualStudioProject.class, instantiator, collectionCallbackActionDecorator);
         this.fileResolver = fileResolver;
         this.ideArtifactRegistry = ideArtifactRegistry;
     }

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinaryTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinaryTest.groovy
@@ -156,7 +156,7 @@ class NativeSpecVisualStudioTargetBinaryTest extends Specification {
     }
 
     def "include paths include component headers"() {
-        final inputs = new DefaultDomainObjectSet(LanguageSourceSet)
+        final inputs = new DefaultDomainObjectSet(LanguageSourceSet, CollectionCallbackActionDecorator.NOOP)
 
         when:
         exeBinary.inputs >> inputs
@@ -191,7 +191,7 @@ class NativeSpecVisualStudioTargetBinaryTest extends Specification {
         def deps1 = dependencySet(file1, file2)
         def deps2 = dependencySet(file3)
 
-        exeBinary.inputs >> new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet)
+        exeBinary.inputs >> new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet, CollectionCallbackActionDecorator.NOOP)
         exeBinary.libs >> [deps1, deps2]
 
         then:
@@ -199,7 +199,7 @@ class NativeSpecVisualStudioTargetBinaryTest extends Specification {
     }
 
     def "reflects source files of binary"() {
-        def sourceSets = new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet)
+        def sourceSets = new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet, CollectionCallbackActionDecorator.NOOP)
         def sourcefile1 = new File('file1')
         def sourcefile2 = new File('file2')
         def sourcefile3 = new File('file3')

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinaryTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/NativeSpecVisualStudioTargetBinaryTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DomainObjectSet
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.api.plugins.ExtensionAware
@@ -51,7 +52,7 @@ import static org.gradle.ide.visualstudio.internal.VisualStudioTargetBinary.Proj
 @UsesNativeServices
 class NativeSpecVisualStudioTargetBinaryTest extends Specification {
     final flavor = new DefaultFlavor("flavor1")
-    def flavors = new DefaultFlavorContainer(DirectInstantiator.INSTANCE)
+    def flavors = new DefaultFlavorContainer(DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
     def exe = Mock(NativeExecutableSpec) {
         getFlavors() >> flavors
     }

--- a/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistryTest.groovy
+++ b/subprojects/ide-native/src/test/groovy/org/gradle/ide/visualstudio/internal/VisualStudioProjectRegistryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.ide.visualstudio.internal
 
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry
@@ -25,7 +26,7 @@ import spock.lang.Specification
 class VisualStudioProjectRegistryTest extends Specification {
     def fileResolver = Mock(FileResolver)
     def ideArtifactRegistry = Mock(IdeArtifactRegistry)
-    def registry = new VisualStudioProjectRegistry(fileResolver, DirectInstantiator.INSTANCE, ideArtifactRegistry)
+    def registry = new VisualStudioProjectRegistry(fileResolver, DirectInstantiator.INSTANCE, ideArtifactRegistry, CollectionCallbackActionDecorator.NOOP)
 
     def "creates a matching visual studio project configuration for target binary"() {
         def executableBinary = targetBinary("vsConfig")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/MixedLegacyAndComponentJvmPluginIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/MixedLegacyAndComponentJvmPluginIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.integtests
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.archive.JarTestFixture
 
-public class MixedLegacyAndComponentJvmPluginIntegrationTest extends AbstractIntegrationSpec {
+class MixedLegacyAndComponentJvmPluginIntegrationTest extends AbstractIntegrationSpec {
     def "can combine legacy java and jvm-component plugins in a single project"() {
         settingsFile << "rootProject.name = 'test'"
         buildFile << '''

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DefaultIvyArtifactSet.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/DefaultIvyArtifactSet.java
@@ -18,6 +18,7 @@ package org.gradle.api.publish.ivy.internal.artifact;
 
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
@@ -39,8 +40,8 @@ public class DefaultIvyArtifactSet extends DefaultDomainObjectSet<IvyArtifact> i
     private final FileCollection files;
     private final NotationParser<Object, IvyArtifact> ivyArtifactParser;
 
-    public DefaultIvyArtifactSet(String publicationName, NotationParser<Object, IvyArtifact> ivyArtifactParser, FileCollectionFactory fileCollectionFactory) {
-        super(IvyArtifact.class);
+    public DefaultIvyArtifactSet(String publicationName, NotationParser<Object, IvyArtifact> ivyArtifactParser, FileCollectionFactory fileCollectionFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(IvyArtifact.class, collectionCallbackActionDecorator);
         this.publicationName = publicationName;
         this.ivyArtifactParser = ivyArtifactParser;
         this.files = fileCollectionFactory.create(builtBy, new ArtifactsFileCollection());

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependencySet.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependencySet.java
@@ -16,10 +16,11 @@
 
 package org.gradle.api.publish.ivy.internal.dependency;
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 
 public class DefaultIvyDependencySet extends DefaultDomainObjectSet<IvyDependencyInternal> {
-    public DefaultIvyDependencySet() {
-        super(IvyDependencyInternal.class);
+    public DefaultIvyDependencySet(CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(IvyDependencyInternal.class, collectionCallbackActionDecorator);
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyConfigurationContainer.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyConfigurationContainer.java
@@ -17,14 +17,15 @@
 package org.gradle.api.publish.ivy.internal.publication;
 
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.publish.ivy.IvyConfiguration;
 import org.gradle.api.publish.ivy.IvyConfigurationContainer;
 import org.gradle.internal.reflect.Instantiator;
 
 public class DefaultIvyConfigurationContainer extends AbstractNamedDomainObjectContainer<IvyConfiguration> implements IvyConfigurationContainer {
 
-    public DefaultIvyConfigurationContainer(Instantiator instantiator) {
-        super(IvyConfiguration.class, instantiator);
+    public DefaultIvyConfigurationContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(IvyConfiguration.class, instantiator, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -34,6 +34,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
@@ -119,19 +120,20 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     public DefaultIvyPublication(
         String name, Instantiator instantiator, ObjectFactory objectFactory, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
         ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-        ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews) {
+        ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.name = name;
         this.publicationIdentity = publicationIdentity;
         this.projectDependencyResolver = projectDependencyResolver;
-        configurations = instantiator.newInstance(DefaultIvyConfigurationContainer.class, instantiator);
+        this.configurations = instantiator.newInstance(DefaultIvyConfigurationContainer.class, instantiator, collectionCallbackActionDecorator);
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.featurePreviews = featurePreviews;
-        mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory);
-        metadataArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory);
-        derivedArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory);
-        publishableArtifacts = new CompositePublicationArtifactSet<IvyArtifact>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
-        ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class);
-        descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
+        this.mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.metadataArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.derivedArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.publishableArtifacts = new CompositePublicationArtifactSet<IvyArtifact>(IvyArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
+        this.ivyDependencies = instantiator.newInstance(DefaultIvyDependencySet.class, collectionCallbackActionDecorator);
+        this.descriptor = instantiator.newInstance(DefaultIvyModuleDescriptorSpec.class, this, instantiator, objectFactory);
     }
 
     public String getName() {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
@@ -72,11 +73,12 @@ public class IvyPublishPlugin implements Plugin<Project> {
     private final FileCollectionFactory fileCollectionFactory;
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final FeaturePreviews featurePreviews;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
     public IvyPublishPlugin(Instantiator instantiator, ObjectFactory objectFactory, DependencyMetaDataProvider dependencyMetaDataProvider, FileResolver fileResolver,
                             ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-                            ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews) {
+                            ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
@@ -85,6 +87,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
         this.fileCollectionFactory = fileCollectionFactory;
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.featurePreviews = featurePreviews;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     public void apply(final Project project) {
@@ -93,7 +96,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
         project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
             @Override
             public void execute(PublishingExtension extension) {
-                extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider, instantiator, objectFactory, fileResolver));
+                extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider, instantiator, objectFactory, fileResolver, collectionCallbackActionDecorator));
                 createTasksLater(project, extension, project.getLayout().getBuildDirectory());
             }
         });
@@ -183,12 +186,15 @@ public class IvyPublishPlugin implements Plugin<Project> {
         private final DependencyMetaDataProvider dependencyMetaDataProvider;
         private final ObjectFactory objectFactory;
         private final FileResolver fileResolver;
+        private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
-        private IvyPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver) {
+        private IvyPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver,
+                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
             this.dependencyMetaDataProvider = dependencyMetaDataProvider;
             this.instantiator = instantiator;
             this.objectFactory = objectFactory;
             this.fileResolver = fileResolver;
+            this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         }
 
         public IvyPublication create(String name) {
@@ -197,7 +203,8 @@ public class IvyPublishPlugin implements Plugin<Project> {
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
             return instantiator.newInstance(
                 DefaultIvyPublication.class,
-                name, instantiator, objectFactory, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, featurePreviews
+                name, instantiator, objectFactory, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, featurePreviews,
+                collectionCallbackActionDecorator
             );
         }
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Usage
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
@@ -284,7 +285,8 @@ class DefaultIvyPublicationTest extends Specification {
             projectDependencyResolver,
             TestFiles.fileCollectionFactory(),
             attributesFactory,
-            featurePreviews
+            featurePreviews,
+            CollectionCallbackActionDecorator.NOOP
         )
         publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
 
@@ -368,7 +370,8 @@ class DefaultIvyPublicationTest extends Specification {
             projectDependencyResolver,
             TestFiles.fileCollectionFactory(),
             attributesFactory,
-            featurePreviews
+            featurePreviews,
+            CollectionCallbackActionDecorator.NOOP
         )
         publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(moduleDescriptorFile))

--- a/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/JacocoReportsContainerImpl.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/internal/jacoco/JacocoReportsContainerImpl.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.jacoco;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.ConfigurableReport;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.SingleFileReport;
@@ -27,8 +28,8 @@ import org.gradle.testing.jacoco.tasks.JacocoReportsContainer;
 
 public class JacocoReportsContainerImpl extends TaskReportContainer<ConfigurableReport> implements JacocoReportsContainer {
 
-    public JacocoReportsContainerImpl(Task task) {
-        super(ConfigurableReport.class, task);
+    public JacocoReportsContainerImpl(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(ConfigurableReport.class, task, callbackActionDecorator);
         add(TaskGeneratedSingleDirectoryReport.class, "html", task, "index.html");
         add(TaskGeneratedSingleFileReport.class, "xml", task);
         add(TaskGeneratedSingleFileReport.class, "csv", task);

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReport.java
@@ -38,7 +38,7 @@ public class JacocoReport extends JacocoReportBase implements Reporting<JacocoRe
 
     public JacocoReport() {
         super();
-        reports = getInstantiator().newInstance(JacocoReportsContainerImpl.class, this);
+        reports = getInstantiator().newInstance(JacocoReportsContainerImpl.class, this, getCallbackActionDecorator());
     }
 
     /**

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/tasks/JacocoReportBase.java
@@ -22,6 +22,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Task;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.IsolatedAntBuilder;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.InputFiles;
@@ -71,6 +72,16 @@ public abstract class JacocoReportBase extends JacocoBase {
 
     @Inject
     protected Instantiator getInstantiator() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Required for decorating reports container callbacks for tracing user code application.
+     *
+     * @since 5.1
+     */
+    @Inject
+    protected CollectionCallbackActionDecorator getCallbackActionDecorator() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
@@ -18,6 +18,7 @@ package org.gradle.language.cpp.internal;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -37,15 +38,16 @@ import javax.inject.Inject;
 public class DefaultCppApplication extends DefaultCppComponent implements CppApplication, PublicationAwareComponent {
     private final ObjectFactory objectFactory;
     private final Property<CppExecutable> developmentBinary;
-    private final MainExecutableVariant mainVariant = new MainExecutableVariant();
+    private final MainExecutableVariant mainVariant;
     private final DefaultComponentDependencies dependencies;
 
     @Inject
-    public DefaultCppApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations) {
+    public DefaultCppApplication(String name, ObjectFactory objectFactory, FileOperations fileOperations, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         super(name, fileOperations, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(CppExecutable.class);
         this.dependencies = objectFactory.newInstance(DefaultComponentDependencies.class, getNames().withSuffix("implementation"));
+        this.mainVariant = new MainExecutableVariant(collectionCallbackActionDecorator);
     }
 
     public DefaultCppExecutable addExecutable(NativeVariantIdentity identity, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -23,6 +23,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
@@ -54,7 +55,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
     private final DefaultLibraryDependencies dependencies;
 
     @Inject
-    public DefaultCppLibrary(String name, ObjectFactory objectFactory, FileOperations fileOperations, ConfigurationContainer configurations) {
+    public DefaultCppLibrary(String name, ObjectFactory objectFactory, FileOperations fileOperations, ConfigurationContainer configurations, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         super(name, fileOperations, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(CppBinary.class);
@@ -73,7 +74,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         apiElements.setCanBeResolved(false);
         apiElements.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
 
-        mainVariant = new MainLibraryVariant("api", apiUsage, apiElements);
+        mainVariant = new MainLibraryVariant("api", apiUsage, apiElements, collectionCallbackActionDecorator);
     }
 
     public DefaultCppSharedLibrary addSharedLibrary(NativeVariantIdentity identity, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -27,7 +28,11 @@ import org.gradle.api.internal.component.UsageContext;
 import java.util.Set;
 
 public class MainExecutableVariant implements SoftwareComponentInternal, ComponentWithVariants {
-    private final DomainObjectSet<SoftwareComponent> variants = new DefaultDomainObjectSet<SoftwareComponent>(SoftwareComponent.class);
+    private final DomainObjectSet<SoftwareComponent> variants;
+
+    public MainExecutableVariant(CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        variants = new DefaultDomainObjectSet<SoftwareComponent>(SoftwareComponent.class, collectionCallbackActionDecorator);
+    }
 
     @Override
     public String getName() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -31,16 +32,17 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class MainLibraryVariant implements ComponentWithVariants, SoftwareComponentInternal {
-    private final DomainObjectSet<SoftwareComponent> variants = new DefaultDomainObjectSet<SoftwareComponent>(SoftwareComponent.class);
     private final String name;
     private final Usage usage;
     private final Set<PublishArtifact> artifacts = new LinkedHashSet<PublishArtifact>();
     private final Configuration dependencies;
+    private final DomainObjectSet<SoftwareComponent> variants;
 
-    public MainLibraryVariant(String name, Usage usage, Configuration dependencies) {
+    public MainLibraryVariant(String name, Usage usage, Configuration dependencies, CollectionCallbackActionDecorator decorator) {
         this.name = name;
         this.usage = usage;
         this.dependencies = dependencies;
+        this.variants = new DefaultDomainObjectSet<SoftwareComponent>(SoftwareComponent.class, decorator);
     }
 
     @Override

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppApplicationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.cpp.internal
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.language.cpp.CppPlatform
 import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.OperatingSystemFamily
@@ -31,7 +32,7 @@ class DefaultCppApplicationTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def project = TestUtil.createRootProject(tmpDir.testDirectory)
-    def application = new DefaultCppApplication("main", project.objects, project.fileOperations)
+    def application = new DefaultCppApplication("main", project.objects, project.fileOperations, CollectionCallbackActionDecorator.NOOP)
 
     def "has display name"() {
         expect:

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppLibraryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp.internal
 
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.language.cpp.CppPlatform
 import org.gradle.nativeplatform.MachineArchitecture
@@ -36,7 +37,7 @@ class DefaultCppLibraryTest extends Specification {
     DefaultCppLibrary library
 
     def setup() {
-        library = new DefaultCppLibrary("main", project.objects, project.fileOperations, project.configurations)
+        library = new DefaultCppLibrary("main", project.objects, project.fileOperations, project.configurations, CollectionCallbackActionDecorator.NOOP)
     }
 
     def "has display name"() {
@@ -174,8 +175,8 @@ class DefaultCppLibraryTest extends Specification {
     def "uses component name to determine header directories"() {
         def h1 = tmpDir.createFile("src/a/public")
         def h2 = tmpDir.createFile("src/b/public")
-        def c1 = new DefaultCppLibrary("a", project.objects, project.fileOperations, project.configurations)
-        def c2 = new DefaultCppLibrary("b", project.objects, project.fileOperations, project.configurations)
+        def c1 = new DefaultCppLibrary("a", project.objects, project.fileOperations, project.configurations, CollectionCallbackActionDecorator.NOOP)
+        def c2 = new DefaultCppLibrary("b", project.objects, project.fileOperations, project.configurations, CollectionCallbackActionDecorator.NOOP)
 
         expect:
         c1.publicHeaderDirs.files == [h1] as Set

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/DefaultMavenArtifactSet.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/DefaultMavenArtifactSet.java
@@ -17,6 +17,7 @@ package org.gradle.api.publish.maven.internal.artifact;
 
 import org.gradle.api.Action;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
@@ -38,8 +39,8 @@ public class DefaultMavenArtifactSet extends DefaultDomainObjectSet<MavenArtifac
     private final FileCollection files;
     private final NotationParser<Object, MavenArtifact> mavenArtifactParser;
 
-    public DefaultMavenArtifactSet(String publicationName, NotationParser<Object, MavenArtifact> mavenArtifactParser, FileCollectionFactory fileCollectionFactory) {
-        super(MavenArtifact.class);
+    public DefaultMavenArtifactSet(String publicationName, NotationParser<Object, MavenArtifact> mavenArtifactParser, FileCollectionFactory fileCollectionFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(MavenArtifact.class, collectionCallbackActionDecorator);
         this.publicationName = publicationName;
         this.mavenArtifactParser = mavenArtifactParser;
         this.files = fileCollectionFactory.create(builtBy, new ArtifactsFileCollection());

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -36,6 +36,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
@@ -133,14 +134,15 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     public DefaultMavenPublication(
         String name, MutableMavenProjectIdentity projectIdentity, NotationParser<Object, MavenArtifact> mavenArtifactParser, Instantiator instantiator,
         ObjectFactory objectFactory, ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-        FeaturePreviews featurePreviews, ImmutableAttributesFactory immutableAttributesFactory) {
+        FeaturePreviews featurePreviews, ImmutableAttributesFactory immutableAttributesFactory,
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.name = name;
         this.projectDependencyResolver = projectDependencyResolver;
         this.projectIdentity = projectIdentity;
         this.immutableAttributesFactory = immutableAttributesFactory;
-        mainArtifacts = instantiator.newInstance(DefaultMavenArtifactSet.class, name, mavenArtifactParser, fileCollectionFactory);
-        metadataArtifacts = new DefaultPublicationArtifactSet<MavenArtifact>(MavenArtifact.class, "metadata artifacts for " + name, fileCollectionFactory);
-        derivedArtifacts = new DefaultPublicationArtifactSet<MavenArtifact>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory);
+        this.mainArtifacts = instantiator.newInstance(DefaultMavenArtifactSet.class, name, mavenArtifactParser, fileCollectionFactory, collectionCallbackActionDecorator);
+        this.metadataArtifacts = new DefaultPublicationArtifactSet<MavenArtifact>(MavenArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
+        derivedArtifacts = new DefaultPublicationArtifactSet<MavenArtifact>(MavenArtifact.class, "derived artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
         publishableArtifacts = new CompositePublicationArtifactSet<MavenArtifact>(MavenArtifact.class, mainArtifacts, metadataArtifacts, derivedArtifacts);
         pom = instantiator.newInstance(DefaultMavenPom.class, this, instantiator, objectFactory);
         this.featurePreviews = featurePreviews;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
@@ -77,11 +78,13 @@ public class MavenPublishPlugin implements Plugin<Project> {
     private final FeaturePreviews featurePreviews;
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final ProviderFactory providerFactory;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
     public MavenPublishPlugin(Instantiator instantiator, ObjectFactory objectFactory, DependencyMetaDataProvider dependencyMetaDataProvider,
                               FileResolver fileResolver, ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
-                              FeaturePreviews featurePreviews, ImmutableAttributesFactory immutableAttributesFactory, ProviderFactory providerFactory) {
+                              FeaturePreviews featurePreviews, ImmutableAttributesFactory immutableAttributesFactory, ProviderFactory providerFactory,
+                              CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
         this.dependencyMetaDataProvider = dependencyMetaDataProvider;
@@ -91,6 +94,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
         this.featurePreviews = featurePreviews;
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.providerFactory = providerFactory;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     public void apply(final Project project) {
@@ -108,7 +112,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
         project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
             @Override
             public void execute(PublishingExtension extension) {
-                extension.getPublications().registerFactory(MavenPublication.class, new MavenPublicationFactory(dependencyMetaDataProvider, instantiator, fileResolver));
+                extension.getPublications().registerFactory(MavenPublication.class, new MavenPublicationFactory(dependencyMetaDataProvider, instantiator, fileResolver, collectionCallbackActionDecorator));
                 realizePublishingTasksLater(project, extension);
             }
         });
@@ -221,11 +225,13 @@ public class MavenPublishPlugin implements Plugin<Project> {
         private final Instantiator instantiator;
         private final DependencyMetaDataProvider dependencyMetaDataProvider;
         private final FileResolver fileResolver;
+        private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
-        private MavenPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, FileResolver fileResolver) {
+        private MavenPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, FileResolver fileResolver, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
             this.dependencyMetaDataProvider = dependencyMetaDataProvider;
             this.instantiator = instantiator;
             this.fileResolver = fileResolver;
+            this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
         }
 
         public MavenPublication create(final String name) {
@@ -233,7 +239,8 @@ public class MavenPublishPlugin implements Plugin<Project> {
             NotationParser<Object, MavenArtifact> artifactNotationParser = new MavenArtifactNotationParserFactory(instantiator, fileResolver).create();
             return instantiator.newInstance(
                 DefaultMavenPublication.class,
-                name, projectIdentity, artifactNotationParser, instantiator, objectFactory, projectDependencyResolver, fileCollectionFactory, featurePreviews, immutableAttributesFactory
+                name, projectIdentity, artifactNotationParser, instantiator, objectFactory, projectDependencyResolver, fileCollectionFactory, featurePreviews, immutableAttributesFactory,
+                collectionCallbackActionDecorator
             );
         }
 

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
@@ -481,7 +482,8 @@ class DefaultMavenPublicationTest extends Specification {
     def createPublication() {
         def instantiator = DirectInstantiator.INSTANCE
         def objectFactory = TestUtil.objectFactory()
-        def publication = new DefaultMavenPublication("pub-name", module, notationParser, instantiator, objectFactory, projectDependencyResolver, TestFiles.fileCollectionFactory(), featurePreviews, AttributeTestUtil.attributesFactory())
+        def publication = new DefaultMavenPublication("pub-name", module, notationParser, instantiator, objectFactory, projectDependencyResolver, TestFiles.fileCollectionFactory(),
+            featurePreviews, AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)
         publication.setPomGenerator(createArtifactGenerator(pomFile))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(gradleMetadataFile))
         return publication

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/DefaultProjectSourceSet.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/DefaultProjectSourceSet.java
@@ -15,12 +15,13 @@
  */
 package org.gradle.language.base.internal;
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.ProjectSourceSet;
 
 public class DefaultProjectSourceSet extends DefaultDomainObjectSet<LanguageSourceSet> implements ProjectSourceSet {
-    public DefaultProjectSourceSet() {
-        super(LanguageSourceSet.class);
+    public DefaultProjectSourceSet(CollectionCallbackActionDecorator decorator) {
+        super(LanguageSourceSet.class, decorator);
     }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/registry/DefaultLanguageTransformContainer.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/registry/DefaultLanguageTransformContainer.java
@@ -17,11 +17,12 @@
 package org.gradle.language.base.internal.registry;
 
 import com.google.common.reflect.TypeToken;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 
 public class DefaultLanguageTransformContainer extends DefaultDomainObjectSet<LanguageTransform<?, ?>> implements LanguageTransformContainer {
-    public DefaultLanguageTransformContainer() {
-        super(getLanguageTransformType());
+    public DefaultLanguageTransformContainer(CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(getLanguageTransformType(), collectionCallbackActionDecorator);
     }
 
     private static Class<LanguageTransform<?, ?>> getLanguageTransformType() {

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/ComponentModelBasePlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
@@ -121,8 +122,8 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
         }
 
         @Hidden @Model
-        LanguageTransformContainer languageTransforms() {
-            return new DefaultLanguageTransformContainer();
+        LanguageTransformContainer languageTransforms(CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+            return new DefaultLanguageTransformContainer(collectionCallbackActionDecorator);
         }
 
         // Finalizing here, as we need this to run after any 'assembling' task (jar, link, etc) is created.
@@ -145,8 +146,8 @@ public class ComponentModelBasePlugin implements Plugin<Project> {
         }
 
         @Model
-        PlatformContainer platforms(Instantiator instantiator) {
-            return instantiator.newInstance(DefaultPlatformContainer.class, instantiator);
+        PlatformContainer platforms(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+            return instantiator.newInstance(DefaultPlatformContainer.class, instantiator, collectionCallbackActionDecorator);
         }
 
         @Hidden @Model

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LanguageBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/plugins/LanguageBasePlugin.java
@@ -18,6 +18,7 @@ package org.gradle.language.base.plugins;
 import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.language.base.LanguageSourceSet;
 import org.gradle.language.base.ProjectSourceSet;
@@ -52,8 +53,8 @@ public class LanguageBasePlugin implements Plugin<Project> {
         }
 
         @Model
-        ProjectSourceSet sources(Instantiator instantiator) {
-            return instantiator.newInstance(DefaultProjectSourceSet.class);
+        ProjectSourceSet sources(Instantiator instantiator, CollectionCallbackActionDecorator decorator) {
+            return instantiator.newInstance(DefaultProjectSourceSet.class, decorator);
         }
     }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/component/internal/ComponentSpecFactory.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/component/internal/ComponentSpecFactory.java
@@ -17,6 +17,7 @@
 package org.gradle.platform.base.component.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Cast;
@@ -39,7 +40,8 @@ import javax.annotation.Nullable;
 public class ComponentSpecFactory extends BaseInstanceFactory<ComponentSpec> {
     private final ProjectIdentifier projectIdentifier;
 
-    public ComponentSpecFactory(final ProjectIdentifier projectIdentifier, final Instantiator instantiator, final NamedEntityInstantiator<Task> taskInstantiator, final ObjectFactory objectFactory) {
+    public ComponentSpecFactory(final ProjectIdentifier projectIdentifier, final Instantiator instantiator, final NamedEntityInstantiator<Task> taskInstantiator, final ObjectFactory objectFactory,
+                                final CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         super(ComponentSpec.class);
         this.projectIdentifier = projectIdentifier;
         registerFactory(DefaultComponentSpec.class, new ImplementationFactory<ComponentSpec, DefaultComponentSpec>() {
@@ -55,13 +57,14 @@ public class ComponentSpecFactory extends BaseInstanceFactory<ComponentSpec> {
                 MutableModelNode componentNode = findOwner(binaryNode);
                 ComponentSpecIdentifier id = getId(componentNode, name);
                 return BaseBinarySpec.create(
-                        publicType.getConcreteClass(),
-                        implementationType.getConcreteClass(),
-                        id,
-                        binaryNode,
-                        componentNode,
-                        instantiator,
-                        taskInstantiator);
+                    publicType.getConcreteClass(),
+                    implementationType.getConcreteClass(),
+                    id,
+                    binaryNode,
+                    componentNode,
+                    instantiator,
+                    taskInstantiator,
+                    collectionCallbackActionDecorator);
             }
         });
         registerFactory(BaseLanguageSourceSet.class, new ImplementationFactory<LanguageSourceSet, BaseLanguageSourceSet>() {

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultBinaryTasksCollection.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultBinaryTasksCollection.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownDomainObjectException;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.model.internal.core.NamedEntityInstantiator;
@@ -31,8 +32,8 @@ public class DefaultBinaryTasksCollection extends DefaultDomainObjectSet<Task> i
     private final BinarySpecInternal binary;
     private final NamedEntityInstantiator<Task> taskInstantiator;
 
-    public DefaultBinaryTasksCollection(BinarySpecInternal binarySpecInternal, NamedEntityInstantiator<Task> taskInstantiator) {
-        super(Task.class);
+    public DefaultBinaryTasksCollection(BinarySpecInternal binarySpecInternal, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(Task.class, collectionCallbackActionDecorator);
         this.binary = binarySpecInternal;
         this.taskInstantiator = taskInstantiator;
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultPlatformContainer.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultPlatformContainer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.platform.base.internal;
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.platform.base.Platform;
@@ -23,8 +24,8 @@ import org.gradle.platform.base.PlatformContainer;
 
 public class DefaultPlatformContainer extends DefaultPolymorphicDomainObjectContainer<Platform> implements PlatformContainer {
 
-    public DefaultPlatformContainer(Instantiator instantiator) {
-        super(Platform.class, instantiator);
+    public DefaultPlatformContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(Platform.class, instantiator, collectionCallbackActionDecorator);
     }
 
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/plugins/ComponentBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/plugins/ComponentBasePlugin.java
@@ -20,6 +20,7 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.reflect.Instantiator;
@@ -62,8 +63,8 @@ public class ComponentBasePlugin implements Plugin<Project> {
 
         @Hidden
         @Model
-        ComponentSpecFactory componentSpecFactory(ProjectIdentifier projectIdentifier, Instantiator instantiator, ObjectFactory objectFactory, NamedEntityInstantiator<Task> taskInstantiator) {
-            return new ComponentSpecFactory(projectIdentifier, instantiator, taskInstantiator, objectFactory);
+        ComponentSpecFactory componentSpecFactory(ProjectIdentifier projectIdentifier, Instantiator instantiator, ObjectFactory objectFactory, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+            return new ComponentSpecFactory(projectIdentifier, instantiator, taskInstantiator, objectFactory, collectionCallbackActionDecorator);
         }
 
         @ComponentType

--- a/subprojects/platform-base/src/test/groovy/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMapTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMapTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.DomainObjectCollection
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Named
 import org.gradle.api.NamedDomainObjectFactory
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.DefaultPolymorphicNamedEntityInstantiator
 import org.gradle.internal.Actions
@@ -48,10 +49,10 @@ class DomainObjectCollectionBackedModelMapTest extends Specification {
 
     def "reasonable error message when creating a non-constructible type"() {
         given:
-        def backingCollection = new DefaultDomainObjectSet(SomeType)
+        def backingCollection = new DefaultDomainObjectSet(SomeType, CollectionCallbackActionDecorator.NOOP)
         def instantiator = new DefaultPolymorphicNamedEntityInstantiator(SomeType, "the collection")
         instantiator.registerFactory(SomeType, new NamedDomainObjectFactory<SomeType>(){
-            public SomeType create(String name) {
+            SomeType create(String name) {
                 return new SomeType(name: name)
             }
         })

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/DefaultBinaryTasksCollectionTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/DefaultBinaryTasksCollectionTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
 import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.tasks.Copy
 import org.gradle.model.internal.core.NamedEntityInstantiator
 import spock.lang.Specification
@@ -27,7 +28,7 @@ import spock.lang.Specification
 class DefaultBinaryTasksCollectionTest extends Specification {
     def binary = Mock(BinarySpecInternal)
     def taskFactory = Mock(NamedEntityInstantiator)
-    def tasks = new DefaultBinaryTasksCollection(binary, taskFactory)
+    def tasks = new DefaultBinaryTasksCollection(binary, taskFactory, CollectionCallbackActionDecorator.NOOP)
     def task = Mock(Task)
 
     def "can create task"() {

--- a/subprojects/platform-base/src/testFixtures/groovy/org/gradle/platform/base/binary/BaseBinaryFixtures.groovy
+++ b/subprojects/platform-base/src/testFixtures/groovy/org/gradle/platform/base/binary/BaseBinaryFixtures.groovy
@@ -17,6 +17,7 @@
 package org.gradle.platform.base.binary
 
 import org.gradle.api.internal.AsmBackedClassGenerator
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.model.internal.core.MutableModelNode
 import org.gradle.model.internal.core.NamedEntityInstantiator
@@ -34,7 +35,7 @@ class BaseBinaryFixtures {
         return BaseInstanceFixtureSupport.create(publicType, BinarySpecInternal, implType, name) { MutableModelNode node ->
             def generated = GENERATOR.generate(implType)
             def identifier = componentNode ? componentNode.asImmutable(ModelType.of(ComponentSpecInternal), null).instance.identifier.child(name) : new DefaultComponentSpecIdentifier("project", name)
-            return BaseBinarySpec.create(publicType, generated, identifier, node, componentNode, DirectInstantiator.INSTANCE, {} as NamedEntityInstantiator)
+            return BaseBinarySpec.create(publicType, generated, identifier, node, componentNode, DirectInstantiator.INSTANCE, {} as NamedEntityInstantiator, CollectionCallbackActionDecorator.NOOP)
         }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultBuildTypeContainer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultBuildTypeContainer.java
@@ -17,14 +17,15 @@
 package org.gradle.nativeplatform.internal;
 
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.nativeplatform.BuildType;
 import org.gradle.nativeplatform.BuildTypeContainer;
 
 public class DefaultBuildTypeContainer extends AbstractNamedDomainObjectContainer<BuildType> implements BuildTypeContainer {
 
-    public DefaultBuildTypeContainer(Instantiator instantiator) {
-        super(BuildType.class, instantiator);
+    public DefaultBuildTypeContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(BuildType.class, instantiator, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultFlavorContainer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/DefaultFlavorContainer.java
@@ -17,14 +17,15 @@
 package org.gradle.nativeplatform.internal;
 
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.nativeplatform.Flavor;
 import org.gradle.nativeplatform.FlavorContainer;
 
 public class DefaultFlavorContainer extends AbstractValidatingNamedDomainObjectContainer<Flavor> implements FlavorContainer {
 
-    public DefaultFlavorContainer(Instantiator instantiator) {
-        super(Flavor.class, instantiator);
+    public DefaultFlavorContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(Flavor.class, instantiator, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraries.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraries.java
@@ -19,6 +19,7 @@ package org.gradle.nativeplatform.internal.prebuilt;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.nativeplatform.PrebuiltLibraries;
@@ -29,8 +30,8 @@ public class DefaultPrebuiltLibraries extends AbstractNamedDomainObjectContainer
     private final Action<PrebuiltLibrary> libraryInitializer;
     private String name;
 
-    public DefaultPrebuiltLibraries(String name, Instantiator instantiator, ObjectFactory objectFactory, Action<PrebuiltLibrary> libraryInitializer) {
-        super(PrebuiltLibrary.class, instantiator);
+    public DefaultPrebuiltLibraries(String name, Instantiator instantiator, ObjectFactory objectFactory, Action<PrebuiltLibrary> libraryInitializer, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(PrebuiltLibrary.class, instantiator, collectionCallbackActionDecorator);
         this.name = name;
         this.objectFactory = objectFactory;
         this.libraryInitializer = libraryInitializer;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraries.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraries.java
@@ -28,6 +28,7 @@ import org.gradle.nativeplatform.PrebuiltLibrary;
 public class DefaultPrebuiltLibraries extends AbstractNamedDomainObjectContainer<PrebuiltLibrary> implements PrebuiltLibraries {
     private final ObjectFactory objectFactory;
     private final Action<PrebuiltLibrary> libraryInitializer;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private String name;
 
     public DefaultPrebuiltLibraries(String name, Instantiator instantiator, ObjectFactory objectFactory, Action<PrebuiltLibrary> libraryInitializer, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
@@ -35,6 +36,7 @@ public class DefaultPrebuiltLibraries extends AbstractNamedDomainObjectContainer
         this.name = name;
         this.objectFactory = objectFactory;
         this.libraryInitializer = libraryInitializer;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     @Override
@@ -54,7 +56,7 @@ public class DefaultPrebuiltLibraries extends AbstractNamedDomainObjectContainer
 
     @Override
     protected PrebuiltLibrary doCreate(String name) {
-        return getInstantiator().newInstance(DefaultPrebuiltLibrary.class, name, objectFactory);
+        return getInstantiator().newInstance(DefaultPrebuiltLibrary.class, name, objectFactory, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibrary.java
@@ -18,6 +18,7 @@ package org.gradle.nativeplatform.internal.prebuilt;
 
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.nativeplatform.NativeLibraryBinary;
@@ -29,10 +30,10 @@ public class DefaultPrebuiltLibrary implements PrebuiltLibrary {
     private final SourceDirectorySet headers;
     private final DomainObjectSet<NativeLibraryBinary> binaries;
 
-    public DefaultPrebuiltLibrary(String name, ObjectFactory objectFactory) {
+    public DefaultPrebuiltLibrary(String name, ObjectFactory objectFactory, CollectionCallbackActionDecorator decorator) {
         this.name = name;
         headers = objectFactory.sourceDirectorySet("headers", "headers for prebuilt library '" + name + "'");
-        binaries = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class);
+        binaries = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class, decorator);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.internal.resolve;
 
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.nativeplatform.NativeLibraryBinary;
 
@@ -25,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CachingLibraryBinaryLocator implements LibraryBinaryLocator {
-    private static final DomainObjectSet<NativeLibraryBinary> NULL_RESULT = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class);
+    private static final DomainObjectSet<NativeLibraryBinary> NULL_RESULT = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class, CollectionCallbackActionDecorator.NOOP);
     private final LibraryBinaryLocator delegate;
     private final Map<LibraryIdentifier, DomainObjectSet<NativeLibraryBinary>> libraries = new HashMap<LibraryIdentifier, DomainObjectSet<NativeLibraryBinary>>();
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/NativeDependencyResolverServices.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/NativeDependencyResolverServices.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.nativeplatform.internal.resolve;
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.resolve.ProjectModelResolver;
 import org.gradle.nativeplatform.internal.prebuilt.PrebuiltLibraryBinaryLocator;
@@ -23,9 +24,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NativeDependencyResolverServices {
-    public LibraryBinaryLocator createLibraryBinaryLocator(ProjectModelResolver projectModelResolver) {
+    public LibraryBinaryLocator createLibraryBinaryLocator(ProjectModelResolver projectModelResolver, CollectionCallbackActionDecorator callbackActionDecorator) {
         List<LibraryBinaryLocator> locators = new ArrayList<LibraryBinaryLocator>();
-        locators.add(new ProjectLibraryBinaryLocator(projectModelResolver));
+        locators.add(new ProjectLibraryBinaryLocator(projectModelResolver, callbackActionDecorator));
         locators.add(new PrebuiltLibraryBinaryLocator(projectModelResolver));
         return new CachingLibraryBinaryLocator(new ChainedLibraryBinaryLocator(locators));
     }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocator.java
@@ -16,6 +16,7 @@
 package org.gradle.nativeplatform.internal.resolve;
 
 import org.gradle.api.DomainObjectSet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.resolve.ProjectModelResolver;
 import org.gradle.model.ModelMap;
@@ -29,9 +30,11 @@ import javax.annotation.Nullable;
 
 public class ProjectLibraryBinaryLocator implements LibraryBinaryLocator {
     private final ProjectModelResolver projectModelResolver;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
-    public ProjectLibraryBinaryLocator(ProjectModelResolver projectModelResolver) {
+    public ProjectLibraryBinaryLocator(ProjectModelResolver projectModelResolver, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.projectModelResolver = projectModelResolver;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     // Converts the binaries of a project library into regular binary instances
@@ -49,7 +52,7 @@ public class ProjectLibraryBinaryLocator implements LibraryBinaryLocator {
             return null;
         }
         ModelMap<NativeBinarySpec> projectBinaries = library.getBinaries().withType(NativeBinarySpec.class);
-        DomainObjectSet<NativeLibraryBinary> binaries = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class);
+        DomainObjectSet<NativeLibraryBinary> binaries = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class, collectionCallbackActionDecorator);
         for (NativeBinarySpec nativeBinarySpec : projectBinaries.values()) {
             binaries.add((NativeLibraryBinary) nativeBinarySpec);
         }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -26,6 +26,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
@@ -117,19 +118,21 @@ import java.io.File;
 @Incubating
 public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
     private final Instantiator instantiator;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
-    public NativeComponentModelPlugin(Instantiator instantiator) {
+    public NativeComponentModelPlugin(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.instantiator = instantiator;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     @Override
     public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(ComponentModelBasePlugin.class);
 
-        project.getExtensions().create(BuildTypeContainer.class, "buildTypes", DefaultBuildTypeContainer.class, instantiator);
-        project.getExtensions().create(FlavorContainer.class, "flavors", DefaultFlavorContainer.class, instantiator);
-        project.getExtensions().create(NativeToolChainRegistry.class, "toolChains", DefaultNativeToolChainRegistry.class, instantiator);
+        project.getExtensions().create(BuildTypeContainer.class, "buildTypes", DefaultBuildTypeContainer.class, instantiator, collectionCallbackActionDecorator);
+        project.getExtensions().create(FlavorContainer.class, "flavors", DefaultFlavorContainer.class, instantiator, collectionCallbackActionDecorator);
+        project.getExtensions().create(NativeToolChainRegistry.class, "toolChains", DefaultNativeToolChainRegistry.class, instantiator, collectionCallbackActionDecorator);
     }
 
     static class Rules extends RuleSource {
@@ -154,13 +157,17 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
         }
 
         @Model
-        Repositories repositories(ServiceRegistry serviceRegistry, FlavorContainer flavors, PlatformContainer platforms, BuildTypeContainer buildTypes) {
+        Repositories repositories(ServiceRegistry serviceRegistry,
+                                  FlavorContainer flavors,
+                                  PlatformContainer platforms,
+                                  BuildTypeContainer buildTypes,
+                                  CollectionCallbackActionDecorator callbackActionDecorator) {
             Instantiator instantiator = serviceRegistry.get(Instantiator.class);
             ObjectFactory sourceDirectorySetFactory = serviceRegistry.get(ObjectFactory.class);
             NativePlatforms nativePlatforms = serviceRegistry.get(NativePlatforms.class);
             FileCollectionFactory fileCollectionFactory = serviceRegistry.get(FileCollectionFactory.class);
             Action<PrebuiltLibrary> initializer = new PrebuiltLibraryInitializer(instantiator, fileCollectionFactory, nativePlatforms, platforms.withType(NativePlatform.class), buildTypes, flavors);
-            return new DefaultRepositories(instantiator, sourceDirectorySetFactory, initializer);
+            return new DefaultRepositories(instantiator, sourceDirectorySetFactory, initializer, callbackActionDecorator);
         }
 
         @Model
@@ -416,11 +423,14 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
     }
 
     private static class DefaultRepositories extends DefaultPolymorphicDomainObjectContainer<ArtifactRepository> implements Repositories {
-        private DefaultRepositories(final Instantiator instantiator, final ObjectFactory objectFactory, final Action<PrebuiltLibrary> binaryFactory) {
-            super(ArtifactRepository.class, instantiator, new ArtifactRepositoryNamer());
+        private DefaultRepositories(final Instantiator instantiator,
+                                    final ObjectFactory objectFactory,
+                                    final Action<PrebuiltLibrary> binaryFactory,
+                                    final CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+            super(ArtifactRepository.class, instantiator, new ArtifactRepositoryNamer(), collectionCallbackActionDecorator);
             registerFactory(PrebuiltLibraries.class, new NamedDomainObjectFactory<PrebuiltLibraries>() {
                 public PrebuiltLibraries create(String name) {
-                    return instantiator.newInstance(DefaultPrebuiltLibraries.class, name, instantiator, objectFactory, binaryFactory);
+                    return instantiator.newInstance(DefaultPrebuiltLibraries.class, name, instantiator, objectFactory, binaryFactory, collectionCallbackActionDecorator);
                 }
             });
         }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistry.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistry.java
@@ -17,6 +17,7 @@ package org.gradle.nativeplatform.toolchain.internal;
 
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.nativeplatform.platform.NativePlatform;
@@ -34,8 +35,8 @@ public class DefaultNativeToolChainRegistry extends DefaultPolymorphicDomainObje
     private final Map<String, Class<? extends NativeToolChain>> registeredDefaults = new LinkedHashMap<String, Class<? extends NativeToolChain>>();
     private final List<NativeToolChainInternal> searchOrder = new ArrayList<NativeToolChainInternal>();
 
-    public DefaultNativeToolChainRegistry(Instantiator instantiator) {
-        super(NativeToolChain.class, instantiator);
+    public DefaultNativeToolChainRegistry(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(NativeToolChain.class, instantiator, collectionCallbackActionDecorator);
         whenObjectAdded(new Action<NativeToolChain>() {
             public void execute(NativeToolChain toolChain) {
                 searchOrder.add((NativeToolChainInternal) toolChain);

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultNativeExecutableBinarySpecTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultNativeExecutableBinarySpecTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.internal
 
-
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.nativeplatform.BuildType
 import org.gradle.nativeplatform.NativeExecutableBinarySpec
 import org.gradle.nativeplatform.NativeExecutableSpec
@@ -39,7 +39,7 @@ class DefaultNativeExecutableBinarySpecTest extends Specification {
 
     final testUtil = TestUtil.create(tmpDir)
     def namingScheme = DefaultBinaryNamingScheme.component("bigOne").withBinaryType("executable")
-    def tasks = new DefaultNativeExecutableBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null))
+    def tasks = new DefaultNativeExecutableBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null, CollectionCallbackActionDecorator.NOOP))
 
     def "has useful string representation"() {
         given:

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpecTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/DefaultStaticLibraryBinarySpecTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.nativeplatform.internal
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.SourceDirectorySet
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.language.nativeplatform.HeaderExportingSourceSet
 import org.gradle.nativeplatform.BuildType
 import org.gradle.nativeplatform.NativeLibrarySpec
@@ -47,7 +48,7 @@ class DefaultStaticLibraryBinarySpecTest extends Specification {
     def buildType = Stub(BuildType)
     final resolver = Stub(NativeDependencyResolver)
     final outputFile = Mock(File)
-    def tasks = new DefaultStaticLibraryBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null))
+    def tasks = new DefaultStaticLibraryBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null, CollectionCallbackActionDecorator.NOOP))
 
     def "has useful string representation"() {
         expect:

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/NativeBinarySpecTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/NativeBinarySpecTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.nativeplatform.internal
 
-
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.language.nativeplatform.DependentSourceSet
 import org.gradle.model.internal.core.MutableModelNode
 import org.gradle.nativeplatform.BuildType
@@ -156,7 +156,7 @@ class NativeBinarySpecTest extends Specification {
 
     static class TestNativeBinarySpec extends AbstractNativeBinarySpec {
         def owner
-        def tasks = new DefaultBinaryTasksCollection(this, null)
+        def tasks = new DefaultBinaryTasksCollection(this, null, CollectionCallbackActionDecorator.NOOP)
 
         String getOutputFileName() {
             return null

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/configure/CreateDefaultFlavorsTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/configure/CreateDefaultFlavorsTest.groovy
@@ -15,6 +15,8 @@
  */
 
 package org.gradle.nativeplatform.internal.configure
+
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.nativeplatform.internal.DefaultFlavor
 import org.gradle.nativeplatform.internal.DefaultFlavorContainer
@@ -22,7 +24,7 @@ import org.gradle.nativeplatform.plugins.NativeComponentModelPlugin
 import spock.lang.Specification
 
 class CreateDefaultFlavorsTest extends Specification {
-    def flavorContainer = new DefaultFlavorContainer(DirectInstantiator.INSTANCE)
+    def flavorContainer = new DefaultFlavorContainer(DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP)
     def rule = new NativeComponentModelPlugin.Rules()
 
     def "has a single default flavor when not configured"() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraryTest.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.nativeplatform.internal.prebuilt
 
-
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultPrebuiltLibraryTest extends Specification {
     def "has useful display name"() {
-        def lib = new DefaultPrebuiltLibrary("someLib", TestUtil.objectFactory())
+        def lib = new DefaultPrebuiltLibrary("someLib", TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)
 
         expect:
         lib.toString() == "prebuilt library 'someLib'"

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocatorTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.nativeplatform.internal.resolve
 
 import org.gradle.api.UnknownProjectException
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.resolve.ProjectModelResolver
 import org.gradle.model.ModelMap
@@ -35,7 +36,7 @@ class ProjectLibraryBinaryLocatorTest extends Specification {
     def binary = Mock(MockNativeLibraryBinary)
     def binaries = Mock(ModelMap)
     def nativeBinaries = Mock(ModelMap)
-    def convertedBinaries = new DefaultDomainObjectSet(NativeLibraryBinary)
+    def convertedBinaries = new DefaultDomainObjectSet(NativeLibraryBinary, CollectionCallbackActionDecorator.NOOP)
     def locator = new ProjectLibraryBinaryLocator(projectLocator)
 
     def setup() {

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocatorTest.groovy
@@ -37,7 +37,7 @@ class ProjectLibraryBinaryLocatorTest extends Specification {
     def binaries = Mock(ModelMap)
     def nativeBinaries = Mock(ModelMap)
     def convertedBinaries = new DefaultDomainObjectSet(NativeLibraryBinary, CollectionCallbackActionDecorator.NOOP)
-    def locator = new ProjectLibraryBinaryLocator(projectLocator)
+    def locator = new ProjectLibraryBinaryLocator(projectLocator, CollectionCallbackActionDecorator.NOOP)
 
     def setup() {
         convertedBinaries.add(binary)

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/toolchain/internal/DefaultNativeToolChainRegistryTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.toolchain.internal
 import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectFactory
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.internal.reflect.Instantiator
 import org.gradle.nativeplatform.toolchain.internal.compilespec.CCompileSpec
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
@@ -34,8 +35,8 @@ class DefaultNativeToolChainRegistryTest extends Specification {
     def project = TestUtil.create(testDir).rootProject()
 
     def instantiator = project.services.get(Instantiator)
-    def registry = instantiator.newInstance(DefaultNativeToolChainRegistry, instantiator)
-    def NamedDomainObjectFactory<TestNativeToolChain> factory = Mock(NamedDomainObjectFactory)
+    def registry = instantiator.newInstance(DefaultNativeToolChainRegistry, instantiator, CollectionCallbackActionDecorator.NOOP)
+    def factory = Mock(NamedDomainObjectFactory)
     def platform = new DefaultNativePlatform("platform")
 
     def "setup"() {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/internal/distribution/DefaultPlayDistributionContainer.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/internal/distribution/DefaultPlayDistributionContainer.java
@@ -17,12 +17,13 @@
 package org.gradle.play.internal.distribution;
 
 import org.gradle.api.distribution.Distribution;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.play.distribution.PlayDistributionContainer;
 
 public class DefaultPlayDistributionContainer extends DefaultPolymorphicDomainObjectContainer<Distribution> implements PlayDistributionContainer {
-    public DefaultPlayDistributionContainer(Instantiator instantiator) {
-        super(Distribution.class, instantiator);
+    public DefaultPlayDistributionContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(Distribution.class, instantiator, collectionCallbackActionDecorator);
     }
 }

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayDistributionPlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.FileCopyDetails;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.copy.CopySpecInternal;
 import org.gradle.api.tasks.Sync;
@@ -78,8 +79,8 @@ public class PlayDistributionPlugin extends RuleSource {
     public static final String STAGE_LIFECYCLE_TASK_NAME = "stage";
 
     @Model
-    PlayDistributionContainer distributions(Instantiator instantiator) {
-        return new DefaultPlayDistributionContainer(instantiator);
+    PlayDistributionContainer distributions(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        return new DefaultPlayDistributionContainer(instantiator, collectionCallbackActionDecorator);
     }
 
     @Mutate

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/internal/DefaultDistributionContainer.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/internal/DefaultDistributionContainer.java
@@ -18,6 +18,7 @@ package org.gradle.api.distribution.internal;
 import org.gradle.api.distribution.Distribution;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.internal.reflect.Instantiator;
 
@@ -27,8 +28,8 @@ import org.gradle.internal.reflect.Instantiator;
 public class DefaultDistributionContainer extends AbstractNamedDomainObjectContainer<Distribution> implements DistributionContainer {
     private final FileOperations fileOperations;
 
-    public DefaultDistributionContainer(Class<Distribution> type, Instantiator instantiator, FileOperations fileOperations) {
-        super(type, instantiator);
+    public DefaultDistributionContainer(Class<Distribution> type, Instantiator instantiator, FileOperations fileOperations, CollectionCallbackActionDecorator callbackDecorator) {
+        super(type, instantiator, callbackDecorator);
         this.fileOperations = fileOperations;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/distribution/plugins/DistributionPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.distribution.Distribution;
 import org.gradle.api.distribution.DistributionContainer;
 import org.gradle.api.distribution.internal.DefaultDistributionContainer;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.file.FileOperations;
@@ -62,17 +63,19 @@ public class DistributionPlugin implements Plugin<ProjectInternal> {
 
     private final Instantiator instantiator;
     private final FileOperations fileOperations;
+    private final CollectionCallbackActionDecorator callbackActionDecorator;
 
     @Inject
-    public DistributionPlugin(Instantiator instantiator, FileOperations fileOperations) {
+    public DistributionPlugin(Instantiator instantiator, FileOperations fileOperations, CollectionCallbackActionDecorator callbackActionDecorator) {
         this.instantiator = instantiator;
         this.fileOperations = fileOperations;
+        this.callbackActionDecorator = callbackActionDecorator;
     }
 
     @Override
     public void apply(final ProjectInternal project) {
         project.getPluginManager().apply(BasePlugin.class);
-        DistributionContainer distributions = project.getExtensions().create(DistributionContainer.class, "distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations);
+        DistributionContainer distributions = project.getExtensions().create(DistributionContainer.class, "distributions", DefaultDistributionContainer.class, Distribution.class, instantiator, fileOperations, callbackActionDecorator);
 
         // TODO - refactor this action out so it can be unit tested
         distributions.all(new Action<Distribution>() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
@@ -44,7 +44,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 
 public class DefaultClassDirectoryBinarySpec extends AbstractBuildableComponentSpec implements ClassDirectoryBinarySpecInternal {
-    private final DefaultDomainObjectSet<LanguageSourceSet> sourceSets = new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet.class);
+    private final DefaultDomainObjectSet<LanguageSourceSet> sourceSets;
     private final SourceSet sourceSet;
     private final JavaToolChain toolChain;
     private final JavaPlatform platform;
@@ -56,6 +56,7 @@ public class DefaultClassDirectoryBinarySpec extends AbstractBuildableComponentS
         this.sourceSet = sourceSet;
         this.toolChain = toolChain;
         this.platform = platform;
+        this.sourceSets = new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet.class, collectionCallbackActionDecorator);
         this.tasks = instantiator.newInstance(DefaultBinaryTasksCollection.class, this, taskInstantiator, collectionCallbackActionDecorator);
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
@@ -19,6 +19,7 @@ import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.internal.AbstractBuildableComponentSpec;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.reflect.Instantiator;
@@ -50,12 +51,12 @@ public class DefaultClassDirectoryBinarySpec extends AbstractBuildableComponentS
     private final BinaryTasksCollection tasks;
     private boolean buildable = true;
 
-    public DefaultClassDirectoryBinarySpec(ComponentSpecIdentifier componentIdentifier, SourceSet sourceSet, JavaToolChain toolChain, JavaPlatform platform, Instantiator instantiator, NamedEntityInstantiator<Task> taskInstantiator) {
+    public DefaultClassDirectoryBinarySpec(ComponentSpecIdentifier componentIdentifier, SourceSet sourceSet, JavaToolChain toolChain, JavaPlatform platform, Instantiator instantiator, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         super(componentIdentifier, ClassDirectoryBinarySpec.class);
         this.sourceSet = sourceSet;
         this.toolChain = toolChain;
         this.platform = platform;
-        this.tasks = instantiator.newInstance(DefaultBinaryTasksCollection.class, this, taskInstantiator);
+        this.tasks = instantiator.newInstance(DefaultBinaryTasksCollection.class, this, taskInstantiator, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetContainer.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetContainer.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.Namer;
 import org.gradle.api.internal.AbstractValidatingNamedDomainObjectContainer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.reflect.TypeOf;
@@ -32,12 +33,12 @@ public class DefaultSourceSetContainer extends AbstractValidatingNamedDomainObje
     private final TaskResolver taskResolver;
     private final Instantiator instantiator;
 
-    public DefaultSourceSetContainer(FileResolver fileResolver, TaskResolver taskResolver, Instantiator classGenerator, ObjectFactory objectFactory) {
+    public DefaultSourceSetContainer(FileResolver fileResolver, TaskResolver taskResolver, Instantiator classGenerator, ObjectFactory objectFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         super(SourceSet.class, classGenerator, new Namer<SourceSet>() {
             public String determineName(SourceSet ss) {
                 return ss.getName();
             }
-        });
+        }, collectionCallbackActionDecorator);
         this.fileResolver = fileResolver;
         this.taskResolver = taskResolver;
         this.instantiator = classGenerator;

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -33,6 +33,7 @@ import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.internal.ReusableAction;
@@ -77,11 +78,13 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
 
     private final Instantiator instantiator;
     private final ObjectFactory objectFactory;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
-    public JavaBasePlugin(Instantiator instantiator, ObjectFactory objectFactory) {
+    public JavaBasePlugin(Instantiator instantiator, ObjectFactory objectFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.instantiator = instantiator;
         this.objectFactory = objectFactory;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     public void apply(final ProjectInternal project) {
@@ -108,7 +111,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
     }
 
     private JavaPluginConvention addExtensions(final ProjectInternal project) {
-        JavaPluginConvention javaConvention = new DefaultJavaPluginConvention(project, instantiator);
+        JavaPluginConvention javaConvention = new DefaultJavaPluginConvention(project, instantiator, collectionCallbackActionDecorator);
         project.getConvention().getPlugins().put("java", javaConvention);
         project.getExtensions().add(SourceSetContainer.class, "sourceSets", javaConvention.getSourceSets());
         project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.java.DefaultJavaSourceSet;
 import org.gradle.api.internal.java.DefaultJvmResourceSet;
 import org.gradle.api.internal.jvm.ClassDirectoryBinarySpecInternal;
@@ -59,13 +60,15 @@ class JavaBasePluginRules implements Plugin<Project> {
     private final Instantiator instantiator;
     private final JavaToolChain javaToolChain;
     private final NamedEntityInstantiator<Task> taskInstantiator;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
-    public JavaBasePluginRules(ModelRegistry modelRegistry, Instantiator instantiator, JavaToolChain javaToolChain, TaskInstantiator taskInstantiator) {
+    public JavaBasePluginRules(ModelRegistry modelRegistry, Instantiator instantiator, JavaToolChain javaToolChain, TaskInstantiator taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.modelRegistry = modelRegistry;
         this.instantiator = instantiator;
         this.javaToolChain = javaToolChain;
         this.taskInstantiator = taskInstantiator;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     @Override
@@ -92,7 +95,7 @@ class JavaBasePluginRules implements Plugin<Project> {
                 Provider<JavaCompile> compileTask = tasks.named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
 
                 DefaultComponentSpecIdentifier binaryId = new DefaultComponentSpecIdentifier(project.getPath(), sourceSet.getName());
-                ClassDirectoryBinarySpecInternal binary = instantiator.newInstance(DefaultClassDirectoryBinarySpec.class, binaryId, sourceSet, javaToolChain, DefaultJavaPlatform.current(), instantiator, taskInstantiator);
+                ClassDirectoryBinarySpecInternal binary = instantiator.newInstance(DefaultClassDirectoryBinarySpec.class, binaryId, sourceSet, javaToolChain, DefaultJavaPlatform.current(), instantiator, taskInstantiator, collectionCallbackActionDecorator);
 
                 Classpath compileClasspath = new SourceSetCompileClasspath(sourceSet);
                 DefaultJavaSourceSet javaSourceSet = instantiator.newInstance(DefaultJavaSourceSet.class, binaryId.child("java"), sourceSet.getJava(), compileClasspath);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -19,6 +19,7 @@ package org.gradle.api.plugins.internal;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.file.FileLookup;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer;
@@ -53,9 +54,9 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
     private JavaVersion srcCompat;
     private JavaVersion targetCompat;
 
-    public DefaultJavaPluginConvention(ProjectInternal project, Instantiator instantiator) {
+    public DefaultJavaPluginConvention(ProjectInternal project, Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.project = project;
-        sourceSets = instantiator.newInstance(DefaultSourceSetContainer.class, project.getFileResolver(), project.getTasks(), instantiator, project.getServices().get(ObjectFactory.class));
+        sourceSets = instantiator.newInstance(DefaultSourceSetContainer.class, project.getFileResolver(), project.getTasks(), instantiator, project.getServices().get(ObjectFactory.class), collectionCallbackActionDecorator);
         docsDirName = "docs";
         testResultsDirName = TestingBasePlugin.TEST_RESULTS_DIR_NAME;
         testReportDirName = TestingBasePlugin.TESTS_DIR_NAME;

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpecTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpecTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.jvm
 
-
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.reflect.DirectInstantiator
 import org.gradle.jvm.platform.JavaPlatform
@@ -34,6 +34,7 @@ class DefaultClassDirectoryBinarySpecTest extends Specification {
     }
 
     private DefaultClassDirectoryBinarySpec binary(String name) {
-        new DefaultClassDirectoryBinarySpec(new DefaultComponentSpecIdentifier(":", name), Stub(SourceSet), Stub(JavaToolChain), Stub(JavaPlatform), DirectInstantiator.INSTANCE, Mock(NamedEntityInstantiator))
+        new DefaultClassDirectoryBinarySpec(new DefaultComponentSpecIdentifier(":", name), Stub(SourceSet), Stub(JavaToolChain), Stub(JavaPlatform),
+            DirectInstantiator.INSTANCE, Mock(NamedEntityInstantiator), CollectionCallbackActionDecorator.NOOP)
     }
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetContainerTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetContainerTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.tasks
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.tasks.SourceSet
 import org.gradle.internal.reflect.DirectInstantiator
@@ -25,7 +26,7 @@ class DefaultSourceSetContainerTest extends Specification {
 
     def "can create a source set"() {
         given:
-        def container = new DefaultSourceSetContainer(TestFiles.resolver(), null, DirectInstantiator.INSTANCE, TestUtil.objectFactory())
+        def container = new DefaultSourceSetContainer(TestFiles.resolver(), null, DirectInstantiator.INSTANCE, TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)
 
         when:
         SourceSet set = container.create("main")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/DefaultJavaPluginConventionTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.plugins
 import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.JavaVersion
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.tasks.DefaultSourceSetContainer
 import org.gradle.api.java.archives.Manifest
@@ -43,7 +44,7 @@ class DefaultJavaPluginConventionTest extends Specification {
 
     def setup() {
         project.pluginManager.apply(ReportingBasePlugin)
-        convention = new DefaultJavaPluginConvention(project, instantiator)
+        convention = new DefaultJavaPluginConvention(project, instantiator,  CollectionCallbackActionDecorator.NOOP)
     }
 
     def defaultValues() {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationArtifactSet.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationArtifactSet.java
@@ -17,6 +17,7 @@
 package org.gradle.api.publish.internal;
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
@@ -33,8 +34,8 @@ public class DefaultPublicationArtifactSet<T extends PublicationArtifact> extend
     private final String name;
     private final FileCollection files;
 
-    public DefaultPublicationArtifactSet(Class<T> type, String name, FileCollectionFactory fileCollectionFactory) {
-        super(type);
+    public DefaultPublicationArtifactSet(Class<T> type, String name, FileCollectionFactory fileCollectionFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(type, collectionCallbackActionDecorator);
         this.name = name;
         files = fileCollectionFactory.create(new AbstractTaskDependency() {
             @Override

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationContainer.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/DefaultPublicationContainer.java
@@ -17,14 +17,15 @@
 package org.gradle.api.publish.internal;
 
 import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.internal.reflect.Instantiator;
 
 public class DefaultPublicationContainer extends DefaultPolymorphicDomainObjectContainer<Publication> implements PublicationContainer {
-    public DefaultPublicationContainer(Instantiator instantiator) {
-        super(Publication.class, instantiator);
+    public DefaultPublicationContainer(Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        super(Publication.class, instantiator, collectionCallbackActionDecorator);
     }
 
     @Override

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/plugins/PublishingPlugin.java
@@ -21,6 +21,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.ArtifactPublicationServices;
@@ -52,19 +53,26 @@ public class PublishingPlugin implements Plugin<Project> {
     private final ProjectPublicationRegistry projectPublicationRegistry;
     private final FeaturePreviews featurePreviews;
     private final DocumentationRegistry documentationRegistry;
+    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
 
     @Inject
-    public PublishingPlugin(ArtifactPublicationServices publicationServices, Instantiator instantiator, ProjectPublicationRegistry projectPublicationRegistry, FeaturePreviews featurePreviews, DocumentationRegistry documentationRegistry) {
+    public PublishingPlugin(ArtifactPublicationServices publicationServices,
+                            Instantiator instantiator,
+                            ProjectPublicationRegistry projectPublicationRegistry,
+                            FeaturePreviews featurePreviews,
+                            DocumentationRegistry documentationRegistry,
+                            CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
         this.publicationServices = publicationServices;
         this.instantiator = instantiator;
         this.projectPublicationRegistry = projectPublicationRegistry;
         this.featurePreviews = featurePreviews;
         this.documentationRegistry = documentationRegistry;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
     }
 
     public void apply(final Project project) {
         RepositoryHandler repositories = publicationServices.createRepositoryHandler();
-        PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator);
+        PublicationContainer publications = instantiator.newInstance(DefaultPublicationContainer.class, instantiator, collectionCallbackActionDecorator);
         PublishingExtension extension = project.getExtensions().create(PublishingExtension.class, PublishingExtension.NAME, DefaultPublishingExtension.class, repositories, publications);
         project.getTasks().register(PUBLISH_LIFECYCLE_TASK_NAME, new Action<Task>() {
             @Override

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/DefaultPublicationContainerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.publish.internal
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.UnknownDomainObjectException
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.ThreadGlobalInstantiator
 import org.gradle.api.publish.Publication
 import org.gradle.internal.reflect.Instantiator
@@ -27,7 +28,7 @@ import spock.lang.Specification
 class DefaultPublicationContainerTest extends Specification {
 
     Instantiator instantiator = ThreadGlobalInstantiator.getOrCreate()
-    DefaultPublicationContainer container = instantiator.newInstance(DefaultPublicationContainer, instantiator)
+    DefaultPublicationContainer container = instantiator.newInstance(DefaultPublicationContainer, instantiator, CollectionCallbackActionDecorator.NOOP)
 
     def "exception is thrown on unknown access"() {
         given:

--- a/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/internal/TaskReportContainerIntegTest.groovy
+++ b/subprojects/reporting/src/integTest/groovy/org/gradle/api/reporting/internal/TaskReportContainerIntegTest.groovy
@@ -28,12 +28,13 @@ class TaskReportContainerIntegTest extends AbstractIntegrationSpec {
         buildFile << """
             import org.gradle.api.reporting.*
             import org.gradle.api.reporting.internal.*
+            import org.gradle.api.internal.CollectionCallbackActionDecorator
             
             ext.value = "bar"
 
             class TestTaskReportContainer extends TaskReportContainer<Report> {
                 TestTaskReportContainer(Task task) {
-                    super(Report, task)
+                    super(Report, task, CollectionCallbackActionDecorator.NOOP)
                     add(TaskGeneratedSingleFileReport, "file1", task)
                     add(TaskGeneratedSingleFileReport, "file2", task)
                     add(TaskGeneratedSingleDirectoryReport, "dir1", task, null)

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
@@ -24,6 +24,7 @@ import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.Transformer;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.internal.BuildDashboardGenerator;
 import org.gradle.api.reporting.internal.DefaultBuildDashboardReports;
 import org.gradle.api.tasks.Input;
@@ -49,14 +50,10 @@ public class GenerateBuildDashboard extends DefaultTask implements Reporting<Bui
 
     private final BuildDashboardReports reports;
 
-    public GenerateBuildDashboard() {
-        reports = getInstantiator().newInstance(DefaultBuildDashboardReports.class, this);
-        reports.getHtml().setEnabled(true);
-    }
-
     @Inject
-    protected Instantiator getInstantiator() {
-        throw new UnsupportedOperationException();
+    public GenerateBuildDashboard(Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
+        reports = instantiator.newInstance(DefaultBuildDashboardReports.class, this, callbackActionDecorator);
+        reports.getHtml().setEnabled(true);
     }
 
     @Input

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/GenerateBuildDashboard.java
@@ -50,10 +50,19 @@ public class GenerateBuildDashboard extends DefaultTask implements Reporting<Bui
 
     private final BuildDashboardReports reports;
 
-    @Inject
-    public GenerateBuildDashboard(Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
-        reports = instantiator.newInstance(DefaultBuildDashboardReports.class, this, callbackActionDecorator);
+    public GenerateBuildDashboard() {
+        reports = getInstantiator().newInstance(DefaultBuildDashboardReports.class, this, getCollectionCallbackActionDecorator());
         reports.getHtml().setEnabled(true);
+    }
+
+    @Inject
+    protected Instantiator getInstantiator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Inject
+    protected CollectionCallbackActionDecorator getCollectionCallbackActionDecorator() {
+        throw new UnsupportedOperationException();
     }
 
     @Input

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultBuildDashboardReports.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultBuildDashboardReports.java
@@ -17,14 +17,15 @@
 package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.BuildDashboardReports;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Report;
 
 public class DefaultBuildDashboardReports extends TaskReportContainer<Report> implements BuildDashboardReports {
 
-    public DefaultBuildDashboardReports(Task task) {
-        super(DirectoryReport.class, task);
+    public DefaultBuildDashboardReports(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(DirectoryReport.class, task, callbackActionDecorator);
         add(TaskGeneratedSingleDirectoryReport.class, "html", task, "index.html");
     }
 

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/DefaultReportContainer.java
@@ -20,6 +20,7 @@ import groovy.lang.Closure;
 import org.gradle.api.Action;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectSet;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.reporting.Report;
 import org.gradle.api.reporting.ReportContainer;
@@ -39,8 +40,8 @@ public class DefaultReportContainer<T extends Report> extends DefaultNamedDomain
     };
     private NamedDomainObjectSet<T> enabled;
 
-    public DefaultReportContainer(Class<? extends T> type, Instantiator instantiator) {
-        super(type, instantiator, Report.NAMER);
+    public DefaultReportContainer(Class<? extends T> type, Instantiator instantiator, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(type, instantiator, Report.NAMER, callbackActionDecorator);
 
         enabled = matching(new Spec<T>() {
             public boolean isSatisfiedBy(T element) {

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/TaskReportContainer.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/internal/TaskReportContainer.java
@@ -17,6 +17,7 @@
 package org.gradle.api.reporting.internal;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.reporting.Report;
@@ -25,8 +26,8 @@ import org.gradle.internal.reflect.Instantiator;
 public abstract class TaskReportContainer<T extends Report> extends DefaultReportContainer<T> {
     private final TaskInternal task;
 
-    public TaskReportContainer(Class<? extends T> type, final Task task) {
-        super(type, ((ProjectInternal) task.getProject()).getServices().get(Instantiator.class));
+    public TaskReportContainer(Class<? extends T> type, final Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(type, ((ProjectInternal) task.getProject()).getServices().get(Instantiator.class), callbackActionDecorator);
         this.task = (TaskInternal) task;
     }
 

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/DefaultReportContainerTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/DefaultReportContainerTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.internal.AsmBackedClassGenerator
 import org.gradle.api.internal.ClassGeneratorBackedInstantiator
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.api.reporting.Report
 import org.gradle.api.reporting.ReportContainer
@@ -38,7 +39,7 @@ class DefaultReportContainerTest extends Specification {
 
     static class TestReportContainer extends DefaultReportContainer {
         TestReportContainer(Closure c) {
-            super(Report, DefaultReportContainerTest.instantiator)
+            super(Report, DefaultReportContainerTest.instantiator, CollectionCallbackActionDecorator.NOOP)
 
             c.delegate = new Object() {
                 Report createReport(String name) {

--- a/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskReportContainerTest.groovy
+++ b/subprojects/reporting/src/test/groovy/org/gradle/api/reporting/internal/TaskReportContainerTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.reporting.internal
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.reporting.Report
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.TaskPropertyTestUtils
@@ -31,6 +32,7 @@ class TaskReportContainerTest extends Specification {
 
     final Project project = ProjectBuilder.builder().build()
     final TestTask task = project.task("testTask", type: TestTask)
+
     def container = createContainer {
         dir("b")
         file("a")
@@ -43,7 +45,7 @@ class TaskReportContainerTest extends Specification {
 
     static class TestReportContainer extends TaskReportContainer<Report> {
         TestReportContainer(Task task, Closure c) {
-            super(Report, task)
+            super(Report, task, CollectionCallbackActionDecorator.NOOP)
 
             c.delegate = new Object() {
                 Report file(String name) {

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -27,6 +27,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.publish.Publication;
@@ -63,9 +64,11 @@ public class Sign extends DefaultTask implements SignatureSpec {
     private SignatureType signatureType;
     private Signatory signatory;
     private boolean required = true;
-    private final DefaultDomainObjectSet<Signature> signatures = new DefaultDomainObjectSet<Signature>(Signature.class);
+    private final DefaultDomainObjectSet<Signature> signatures;
 
-    public Sign() {
+    @Inject
+    public Sign(CollectionCallbackActionDecorator decorator) {
+        this.signatures = new DefaultDomainObjectSet<Signature>(Signature.class, decorator);
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf(task -> isRequired() || getSignatory() != null);
     }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -67,8 +67,8 @@ public class Sign extends DefaultTask implements SignatureSpec {
     private final DefaultDomainObjectSet<Signature> signatures;
 
     @Inject
-    public Sign(CollectionCallbackActionDecorator decorator) {
-        this.signatures = new DefaultDomainObjectSet<Signature>(Signature.class, decorator);
+    public Sign() {
+        this.signatures = new DefaultDomainObjectSet<Signature>(Signature.class, getCallbackActionDecorator());
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf(task -> isRequired() || getSignatory() != null);
     }
@@ -323,5 +323,15 @@ public class Sign extends DefaultTask implements SignatureSpec {
 
     public void setRequired(boolean required) {
         this.required = required;
+    }
+
+    /**
+     * Required for decorating reports container callbacks for tracing user code application.
+     *
+     * @since 5.1
+     */
+    @Inject
+    protected CollectionCallbackActionDecorator  getCallbackActionDecorator() {
+        throw new UnsupportedOperationException();
     }
 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestTaskReports.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/DefaultTestTaskReports.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.testing;
 
 import org.gradle.api.Task;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.reporting.ConfigurableReport;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Report;
@@ -27,8 +28,8 @@ import org.gradle.api.tasks.testing.TestTaskReports;
 
 public class DefaultTestTaskReports extends TaskReportContainer<Report> implements TestTaskReports {
 
-    public DefaultTestTaskReports(Task task) {
-        super(ConfigurableReport.class, task);
+    public DefaultTestTaskReports(Task task, CollectionCallbackActionDecorator callbackActionDecorator) {
+        super(ConfigurableReport.class, task, callbackActionDecorator);
 
         add(DefaultJUnitXmlReport.class, "junitXml", task);
         add(TaskGeneratedSingleDirectoryReport.class, "html", task, "index.html");

--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/AbstractTestTask.java
@@ -31,6 +31,7 @@ import org.gradle.api.Action;
 import org.gradle.api.GradleException;
 import org.gradle.api.Incubating;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.tasks.testing.DefaultTestTaskReports;
 import org.gradle.api.internal.tasks.testing.FailFastTestListenerInternal;
@@ -118,7 +119,7 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
         testListenerBroadcaster = listenerManager.createAnonymousBroadcaster(TestListener.class);
         binaryResultsDirectory = getProject().getObjects().directoryProperty();
 
-        reports = instantiator.newInstance(DefaultTestTaskReports.class, this);
+        reports = instantiator.newInstance(DefaultTestTaskReports.class, this, getCallbackActionDecorator());
         reports.getJunitXml().setEnabled(true);
         reports.getHtml().setEnabled(true);
 
@@ -152,6 +153,16 @@ public abstract class AbstractTestTask extends ConventionTask implements Verific
 
     @Inject
     protected ListenerManager getListenerManager() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Required for decorating reports container callbacks for tracing user code application.
+     *
+     * @since 5.1
+     */
+    @Inject
+    protected CollectionCallbackActionDecorator  getCallbackActionDecorator() {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/internal/DefaultNativeTestSuiteBinarySpecTest.groovy
+++ b/subprojects/testing-native/src/test/groovy/org/gradle/nativeplatform/test/internal/DefaultNativeTestSuiteBinarySpecTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.nativeplatform.test.internal
 
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.nativeplatform.tasks.InstallExecutable
 import org.gradle.nativeplatform.tasks.LinkExecutable
 import org.gradle.nativeplatform.test.tasks.RunTestExecutable
@@ -30,7 +31,7 @@ class DefaultNativeTestSuiteBinarySpecTest extends Specification {
     TestNameTestDirectoryProvider testDir = new TestNameTestDirectoryProvider()
     final def testUtil = TestUtil.create(testDir)
 
-    def tasks = new DefaultNativeTestSuiteBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null))
+    def tasks = new DefaultNativeTestSuiteBinarySpec.DefaultTasksCollection(new DefaultBinaryTasksCollection(null, null, CollectionCallbackActionDecorator.NOOP))
 
     def "returns null for link, install and run when none defined"() {
         expect:


### PR DESCRIPTION
### Context

- Follow up on https://github.com/gradle/gradle/pull/7734 on decorating *all* domain collection containers for emitting build operations when callback action is executed. 

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status