### PR TITLE
Misc artifact transform improvements

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformDependenciesProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformDependenciesProvider.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.internal.attributes.ImmutableAttributes;
-
 interface ArtifactTransformDependenciesProvider {
-    ArtifactTransformDependenciesInternal forAttributes(ImmutableAttributes attributes);
+    ArtifactTransformDependenciesInternal forTransformer(Transformer transformer);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependenciesProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependenciesProvider.java
@@ -73,8 +73,8 @@ class DefaultArtifactTransformDependenciesProvider implements ArtifactTransformD
         this.resolvableDependencies = resolvableDependencies;
     }
 
-    public static ArtifactTransformDependenciesProvider create(Transformation transformation, ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies) {
-        return transformation.requiresDependencies()
+    public static ArtifactTransformDependenciesProvider create(boolean requiresDependencies, ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies) {
+        return requiresDependencies
             ? new DefaultArtifactTransformDependenciesProvider(artifactId, resolvableDependencies)
             : EMPTY;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependenciesProvider.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformDependenciesProvider.java
@@ -59,7 +59,7 @@ class DefaultArtifactTransformDependenciesProvider implements ArtifactTransformD
 
     static final ArtifactTransformDependenciesProvider EMPTY = new ArtifactTransformDependenciesProvider() {
         @Override
-        public ArtifactTransformDependenciesInternal forAttributes(ImmutableAttributes attributes) {
+        public ArtifactTransformDependenciesInternal forTransformer(Transformer transformer) {
             return EMPTY_DEPENDENCIES;
         }
     };
@@ -73,14 +73,17 @@ class DefaultArtifactTransformDependenciesProvider implements ArtifactTransformD
         this.resolvableDependencies = resolvableDependencies;
     }
 
-    public static ArtifactTransformDependenciesProvider create(boolean requiresDependencies, ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies) {
-        return requiresDependencies
-            ? new DefaultArtifactTransformDependenciesProvider(artifactId, resolvableDependencies)
-            : EMPTY;
+    public static ArtifactTransformDependenciesProvider create(ComponentArtifactIdentifier artifactId, ResolvableDependencies resolvableDependencies) {
+        return new DefaultArtifactTransformDependenciesProvider(artifactId, resolvableDependencies);
     }
 
     @Override
-    public ArtifactTransformDependenciesInternal forAttributes(ImmutableAttributes attributes) {
+    public ArtifactTransformDependenciesInternal forTransformer(Transformer transformer) {
+        if (!transformer.requiresDependencies()) {
+            return EMPTY_DEPENDENCIES;
+        }
+
+        ImmutableAttributes fromAttributes = transformer.getFromAttributes();
         return DeprecationLogger.whileDisabled(() -> {
             // Temporarily ignore deprecation warning while triggering the configuration and artifact resolution
             // This is unsafe as some other thread may be using the projects state.
@@ -92,10 +95,10 @@ class DefaultArtifactTransformDependenciesProvider implements ArtifactTransformD
                 conf.componentFilter(element -> {
                     return dependenciesIdentifiers.contains(element);
                 });
-                if (!attributes.isEmpty()) {
+                if (!fromAttributes.isEmpty()) {
                     conf.attributes(container -> {
-                        for (Attribute<?> attribute : attributes.keySet()) {
-                            copyAttribute(attributes, container, attribute);
+                        for (Attribute<?> attribute : fromAttributes.keySet()) {
+                            copyAttribute(fromAttributes, container, attribute);
                         }
                     });
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
@@ -40,7 +40,7 @@ public class DefaultTransformationNodeFactory implements TransformationNodeFacto
         Function<BuildableSingleResolvedArtifactSet, TransformationNode> nodeCreator = singleArtifact -> {
             ExecutionGraphDependenciesResolver resolver;
             resolver = extraExecutionGraphDependenciesResolverFactory.create(singleArtifact.getArtifactId().getComponentIdentifier(), transformation);
-            return getOrCreateInternal(singleArtifact, transformationChain, resolvableDependencies, resolver, transformation.requiresDependencies());
+            return getOrCreateInternal(singleArtifact, transformationChain, resolvableDependencies, resolver);
         };
         collectTransformNodes(artifactSet, builder, nodeCreator);
         return builder.build();
@@ -62,15 +62,15 @@ public class DefaultTransformationNodeFactory implements TransformationNodeFacto
         });
     }
 
-    private TransformationNode getOrCreateInternal(BuildableSingleResolvedArtifactSet singleArtifactSet, List<TransformationStep> transformationChain, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver, boolean requiresDependencies) {
+    private TransformationNode getOrCreateInternal(BuildableSingleResolvedArtifactSet singleArtifactSet, List<TransformationStep> transformationChain, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver) {
         ArtifactTransformKey key = new ArtifactTransformKey(singleArtifactSet.getArtifactId(), transformationChain);
         TransformationNode transformationNode = transformations.get(key);
         if (transformationNode == null) {
             if (transformationChain.size() == 1) {
-                ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(requiresDependencies, singleArtifactSet.getArtifactId(), resolvableDependencies);
+                ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(singleArtifactSet.getArtifactId(), resolvableDependencies);
                 transformationNode = TransformationNode.initial(transformationChain.get(0), singleArtifactSet, dependenciesProvider, executionGraphDependenciesResolver);
             } else {
-                TransformationNode previous = getOrCreateInternal(singleArtifactSet, transformationChain.subList(0, transformationChain.size() - 1), resolvableDependencies, executionGraphDependenciesResolver, requiresDependencies);
+                TransformationNode previous = getOrCreateInternal(singleArtifactSet, transformationChain.subList(0, transformationChain.size() - 1), resolvableDependencies, executionGraphDependenciesResolver);
                 transformationNode = TransformationNode.chained(transformationChain.get(transformationChain.size() - 1), previous);
             }
             transformations.put(key, transformationNode);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
@@ -67,7 +67,8 @@ public class DefaultTransformationNodeFactory implements TransformationNodeFacto
         TransformationNode transformationNode = transformations.get(key);
         if (transformationNode == null) {
             if (transformationChain.size() == 1) {
-                transformationNode = TransformationNode.initial(transformationChain.get(0), singleArtifactSet, resolvableDependencies, executionGraphDependenciesResolver, requiresDependencies);
+                ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(requiresDependencies, singleArtifactSet.getArtifactId(), resolvableDependencies);
+                transformationNode = TransformationNode.initial(transformationChain.get(0), singleArtifactSet, dependenciesProvider, executionGraphDependenciesResolver);
             } else {
                 TransformationNode previous = getOrCreateInternal(singleArtifactSet, transformationChain.subList(0, transformationChain.size() - 1), resolvableDependencies, executionGraphDependenciesResolver, requiresDependencies);
                 transformationNode = TransformationNode.chained(transformationChain.get(transformationChain.size() - 1), previous);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
@@ -40,7 +40,7 @@ public class DefaultTransformationNodeFactory implements TransformationNodeFacto
         Function<BuildableSingleResolvedArtifactSet, TransformationNode> nodeCreator = singleArtifact -> {
             ExecutionGraphDependenciesResolver resolver;
             resolver = extraExecutionGraphDependenciesResolverFactory.create(singleArtifact.getArtifactId().getComponentIdentifier(), transformation);
-            return getOrCreateInternal(singleArtifact, transformationChain, resolvableDependencies, resolver);
+            return getOrCreateInternal(singleArtifact, transformationChain, resolvableDependencies, resolver, transformation.requiresDependencies());
         };
         collectTransformNodes(artifactSet, builder, nodeCreator);
         return builder.build();
@@ -62,14 +62,14 @@ public class DefaultTransformationNodeFactory implements TransformationNodeFacto
         });
     }
 
-    private TransformationNode getOrCreateInternal(BuildableSingleResolvedArtifactSet singleArtifactSet, List<TransformationStep> transformationChain, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver) {
+    private TransformationNode getOrCreateInternal(BuildableSingleResolvedArtifactSet singleArtifactSet, List<TransformationStep> transformationChain, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver, boolean requiresDependencies) {
         ArtifactTransformKey key = new ArtifactTransformKey(singleArtifactSet.getArtifactId(), transformationChain);
         TransformationNode transformationNode = transformations.get(key);
         if (transformationNode == null) {
             if (transformationChain.size() == 1) {
-                transformationNode = TransformationNode.initial(transformationChain.iterator().next(), singleArtifactSet, resolvableDependencies, executionGraphDependenciesResolver);
+                transformationNode = TransformationNode.initial(transformationChain.get(0), singleArtifactSet, resolvableDependencies, executionGraphDependenciesResolver, requiresDependencies);
             } else {
-                TransformationNode previous = getOrCreateInternal(singleArtifactSet, transformationChain.subList(0, transformationChain.size() - 1), resolvableDependencies, executionGraphDependenciesResolver);
+                TransformationNode previous = getOrCreateInternal(singleArtifactSet, transformationChain.subList(0, transformationChain.size() - 1), resolvableDependencies, executionGraphDependenciesResolver, requiresDependencies);
                 transformationNode = TransformationNode.chained(transformationChain.get(transformationChain.size() - 1), previous);
             }
             transformations.put(key, transformationNode);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -53,8 +53,8 @@ public abstract class TransformationNode extends Node {
         return new ChainedTransformationNode(current, previous);
     }
 
-    public static TransformationNode initial(TransformationStep initial, BuildableSingleResolvedArtifactSet artifact, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver) {
-        return new InitialTransformationNode(initial, artifact, resolvableDependencies, executionGraphDependenciesResolver);
+    public static TransformationNode initial(TransformationStep initial, BuildableSingleResolvedArtifactSet artifact, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver, boolean requiresDependencies) {
+        return new InitialTransformationNode(initial, artifact, resolvableDependencies, executionGraphDependenciesResolver, requiresDependencies);
     }
 
     protected TransformationNode(TransformationStep transformationStep) {
@@ -121,14 +121,16 @@ public abstract class TransformationNode extends Node {
     private static class InitialTransformationNode extends TransformationNode {
         private final BuildableSingleResolvedArtifactSet artifactSet;
         private final ExecutionGraphDependenciesResolver executionGraphDependenciesResolver;
+        private final boolean requiresDependencies;
         private final ResolvableDependencies resolvableDependencies;
         private ArtifactTransformDependenciesProvider dependenciesProvider;
 
-        public InitialTransformationNode(TransformationStep transformationStep, BuildableSingleResolvedArtifactSet artifactSet, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver) {
+        public InitialTransformationNode(TransformationStep transformationStep, BuildableSingleResolvedArtifactSet artifactSet, ResolvableDependencies resolvableDependencies, ExecutionGraphDependenciesResolver executionGraphDependenciesResolver, boolean requiresDependencies) {
             super(transformationStep);
             this.artifactSet = artifactSet;
             this.resolvableDependencies = resolvableDependencies;
             this.executionGraphDependenciesResolver = executionGraphDependenciesResolver;
+            this.requiresDependencies = requiresDependencies;
         }
 
         @Override
@@ -194,7 +196,7 @@ public abstract class TransformationNode extends Node {
                     return;
                 }
                 ResolvedArtifactResult artifact = Iterables.getOnlyElement(visitor.getArtifacts());
-                dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(transformationStep, artifact.getId(), resolvableDependencies);
+                dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(requiresDependencies, artifact.getId(), resolvableDependencies);
                 TransformationSubject initialArtifactTransformationSubject = TransformationSubject.initial(artifact.getId(), artifact.getFile());
 
                 this.transformedSubject = transformationStep.transform(initialArtifactTransformationSubject, dependenciesProvider);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -50,7 +50,7 @@ public class TransformationStep implements Transformation {
             LOGGER.info("Transforming {} with {}", subjectToTransform.getDisplayName(), transformer.getDisplayName());
         }
         ImmutableList<File> primaryInputs = subjectToTransform.getFiles();
-        ArtifactTransformDependenciesInternal dependencies = dependenciesProvider.forAttributes(transformer.getFromAttributes());
+        ArtifactTransformDependenciesInternal dependencies = dependenciesProvider.forTransformer(transformer);
         ImmutableList.Builder<File> builder = ImmutableList.builder();
         for (File primaryInput : primaryInputs) {
             Try<ImmutableList<File>> result = transformerInvoker.invoke(transformer, primaryInput, dependencies, subjectToTransform);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -54,7 +54,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     public void artifactAvailable(ResolvableArtifact artifact) {
         ComponentArtifactIdentifier artifactId = artifact.getId();
         File file = artifact.getFile();
-        ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(transformation.requiresDependencies(), artifactId, resolvableDependencies);
+        ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(artifactId, resolvableDependencies);
         TransformationSubject initialSubject = TransformationSubject.initial(artifactId, file);
         TransformationOperation operation = new TransformationOperation(transformation, initialSubject, dependenciesProvider);
         artifactResults.put(artifactId, operation);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -54,7 +54,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     public void artifactAvailable(ResolvableArtifact artifact) {
         ComponentArtifactIdentifier artifactId = artifact.getId();
         File file = artifact.getFile();
-        ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(transformation, artifactId, resolvableDependencies);
+        ArtifactTransformDependenciesProvider dependenciesProvider = DefaultArtifactTransformDependenciesProvider.create(transformation.requiresDependencies(), artifactId, resolvableDependencies);
         TransformationSubject initialSubject = TransformationSubject.initial(artifactId, file);
         TransformationOperation operation = new TransformationOperation(transformation, initialSubject, dependenciesProvider);
         artifactResults.put(artifactId, operation);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
-import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.reflect.ObjectInstantiationException
 import org.gradle.internal.Try
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
@@ -51,7 +50,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         fingerprint(_ as FileCollectionFingerprinter) >> { FileCollectionFingerprinter fingerprinter -> fingerprinter.empty() }
     }
     def dependenciesProvider = Stub(ArtifactTransformDependenciesProvider) {
-        forAttributes(_ as ImmutableAttributes) >> dependencies
+        forTransformer(_ as Transformer) >> dependencies
     }
     def instantiatorFactory = TestUtil.instantiatorFactory()
     def outputDirectory = tmpDir.createDir("OUTPUT_DIR")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform
 import com.google.common.collect.ImmutableCollection
 import org.gradle.api.Action
 import org.gradle.api.Task
-import org.gradle.api.artifacts.ResolvableDependencies
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.BuildableSingleResolvedArtifactSet
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.execution.plan.Node
@@ -38,7 +37,7 @@ class TransformationNodeSpec extends Specification {
     def "initial node with empty extra resolver only adds dependency on artifact node"() {
 
         given:
-        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER, false)
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ArtifactTransformDependenciesProvider), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER)
 
         when:
         node.resolveDependencies(dependencyResolver, hardSuccessor)
@@ -53,7 +52,7 @@ class TransformationNodeSpec extends Specification {
         def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
 
         given:
-        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ArtifactTransformDependenciesProvider), graphDependenciesResolver)
 
         when:
         node.resolveDependencies(dependencyResolver, hardSuccessor)
@@ -71,7 +70,7 @@ class TransformationNodeSpec extends Specification {
         def extraNode = new TestNode()
 
         given:
-        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ArtifactTransformDependenciesProvider), graphDependenciesResolver)
 
         when:
         node.resolveDependencies(dependencyResolver, hardSuccessor)
@@ -86,7 +85,7 @@ class TransformationNodeSpec extends Specification {
     }
 
     def "chained node with empty extra resolver only adds dependency on previous step"() {
-        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER, false)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ArtifactTransformDependenciesProvider), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER)
 
         given:
         def node = TransformationNode.chained(Mock(TransformationStep), initialNode)
@@ -101,7 +100,7 @@ class TransformationNodeSpec extends Specification {
 
     def "chained node with non empty extra resolver only adds dependency on previous step when extra provides none"() {
         def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
-        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ArtifactTransformDependenciesProvider), graphDependenciesResolver)
         def chainedStep = Mock(TransformationStep)
 
         given:
@@ -119,7 +118,7 @@ class TransformationNodeSpec extends Specification {
 
     def "chained node with non empty extra resolver only adds dependency on all nodes when extra provides one"() {
         def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
-        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ArtifactTransformDependenciesProvider), graphDependenciesResolver)
         def chainedStep = Mock(TransformationStep)
         def extraNode = new TestNode()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -38,7 +38,7 @@ class TransformationNodeSpec extends Specification {
     def "initial node with empty extra resolver only adds dependency on artifact node"() {
 
         given:
-        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER)
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER, false)
 
         when:
         node.resolveDependencies(dependencyResolver, hardSuccessor)
@@ -53,7 +53,7 @@ class TransformationNodeSpec extends Specification {
         def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
 
         given:
-        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
 
         when:
         node.resolveDependencies(dependencyResolver, hardSuccessor)
@@ -71,7 +71,7 @@ class TransformationNodeSpec extends Specification {
         def extraNode = new TestNode()
 
         given:
-        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+        def node = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
 
         when:
         node.resolveDependencies(dependencyResolver, hardSuccessor)
@@ -86,7 +86,7 @@ class TransformationNodeSpec extends Specification {
     }
 
     def "chained node with empty extra resolver only adds dependency on previous step"() {
-        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), ExecutionGraphDependenciesResolver.EMPTY_RESOLVER, false)
 
         given:
         def node = TransformationNode.chained(Mock(TransformationStep), initialNode)
@@ -101,7 +101,7 @@ class TransformationNodeSpec extends Specification {
 
     def "chained node with non empty extra resolver only adds dependency on previous step when extra provides none"() {
         def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
-        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
         def chainedStep = Mock(TransformationStep)
 
         given:
@@ -119,7 +119,7 @@ class TransformationNodeSpec extends Specification {
 
     def "chained node with non empty extra resolver only adds dependency on all nodes when extra provides one"() {
         def graphDependenciesResolver = Mock(ExecutionGraphDependenciesResolver)
-        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver)
+        def initialNode = TransformationNode.initial(transformationStep, artifactSet, Mock(ResolvableDependencies), graphDependenciesResolver, false)
         def chainedStep = Mock(TransformationStep)
         def extraNode = new TestNode()
 


### PR DESCRIPTION
* The set of dependencies identifiers was computed each time we were
searching for artifacts. Given that identifiers resolution will always
be the same, result is cached on first execution.
* When building `TransformationNode`, the code was only looking at the
`requireDependencies` from the initial step. Instead it needs to look at
the value for the whole chain.
* The `ArtifactTransformDependenciesProvider` is now created by the
transformation node factory instead of inside the initial node.
This reduces the state a `TransformationNode` carries around.