### PR TITLE
Artifact transform disambiguation

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1021,11 +1021,6 @@ Found the following transforms:
   - artifactType 'transformed'
   - usage 'api'
 Found the following transforms:
-  - Transform from configuration ':lib:compile' variant variant1:
-      - artifactType 'jar'
-      - buildType 'release'
-      - flavor 'free'
-      - usage 'api'
   - Transform from configuration ':lib:compile' variant variant2:
       - artifactType 'jar'
       - buildType 'release'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+
+class DisambiguateArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    def "disambiguates A -> B -> C and B -> C by selecting the later"() {
+        def m1 = mavenRepo.module("test", "test", "1.3").publish()
+        m1.artifactFile.text = "1234"
+
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+            include 'lib'
+            include 'app'
+        """
+
+        file('lib/src/main/java/test/MyClass.java') << """
+package test;
+
+public class MyClass {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}
+"""
+
+        buildFile << """
+def artifactType = Attribute.of('artifactType', String)
+//attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
+
+allprojects {
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+project(':lib') {
+    apply plugin: 'java-library'
+}
+
+project(':app') {
+    apply plugin: 'java'
+
+    dependencies {
+        implementation 'test:test:1.3'
+        implementation project(':lib')
+    }
+
+    dependencies {
+        registerTransform {
+            from.attribute(artifactType, 'java-classes-directory')
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API_CLASSES))
+            to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, 'size'))
+            artifactTransform(FileSizer)
+        }
+        registerTransform {
+            from.attribute(artifactType, 'jar')
+            from.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API_CLASSES))
+            to.attribute(artifactType, 'java-classes-directory')
+            to.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API_CLASSES))
+            artifactTransform(FileSizer)
+        }
+    }
+
+    task resolve(type: Copy) {
+        def artifacts = configurations.compileClasspath.incoming.artifactView {
+            attributes { it.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, 'size')) }
+            if (project.hasProperty("lenient")) {
+                lenient(true)
+            }
+        }.artifacts
+        from artifacts.artifactFiles
+        into "\${buildDir}/libs"
+        doLast {
+            println "files: " + artifacts.collect { it.file.name }
+            println "ids: " + artifacts.collect { it.id }
+            println "components: " + artifacts.collect { it.id.componentIdentifier }
+            println "variants: " + artifacts.collect { it.variant.attributes }
+        }
+    }
+}
+
+class FileSizer extends ArtifactTransform {
+    FileSizer() {
+        println "Creating FileSizer"
+    }
+    
+    List<File> transform(File input) {
+        assert outputDirectory.directory && outputDirectory.list().length == 0
+        def output = new File(outputDirectory, input.name + ".txt")
+        println "Transforming \${input.name} to \${output.name}"
+        output.text = String.valueOf(input.length())
+        return [output]
+    }
+}
+
+"""
+
+
+
+        when:
+        run "resolve"
+
+        then:
+        output.count("Transforming") == 3
+        output.count("Transforming main to main.txt") == 1
+        output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 1
+        output.count("Transforming test-1.3.jar.txt to test-1.3.jar.txt.txt") == 1
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
@@ -26,6 +26,10 @@ import org.gradle.api.Describable;
  */
 public interface Transformation extends Describable {
 
+    boolean endsWith(Transformation otherTransform);
+
+    int stepsCount();
+
     /**
      * Transforms the given input subject. May call the underlying transformer(s) or retrieve a cached value.
      * @param subjectToTransform

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChain.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationChain.java
@@ -25,10 +25,34 @@ public class TransformationChain implements Transformation {
 
     private final Transformation first;
     private final Transformation second;
+    private final int stepsCount;
 
     public TransformationChain(Transformation first, Transformation second) {
         this.first = first;
         this.second = second;
+        this.stepsCount = first.stepsCount() + second.stepsCount();
+    }
+
+    @Override
+    public boolean endsWith(Transformation otherTransform) {
+        int otherStepsCount = otherTransform.stepsCount();
+        if (otherStepsCount > this.stepsCount) {
+            return false;
+        } else if (otherStepsCount == 1) {
+            return second == otherTransform;
+        }
+
+        TransformationChain otherChain = (TransformationChain) otherTransform;
+        if (otherChain.second != second) {
+            return false;
+        } else {
+            return first.endsWith(otherChain.first);
+        }
+    }
+
+    @Override
+    public int stepsCount() {
+        return stepsCount;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationStep.java
@@ -42,6 +42,16 @@ public class TransformationStep implements Transformation {
     }
 
     @Override
+    public boolean endsWith(Transformation otherTransform) {
+        return this == otherTransform;
+    }
+
+    @Override
+    public int stepsCount() {
+        return 1;
+    }
+
+    @Override
     public TransformationSubject transform(TransformationSubject subjectToTransform, ArtifactTransformDependenciesProvider dependenciesProvider) {
         if (subjectToTransform.getFailure() != null) {
             return subjectToTransform;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ChainedTransformerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ChainedTransformerTest.groovy
@@ -51,6 +51,17 @@ class ChainedTransformerTest extends Specification {
         @Override
         void visitTransformationSteps(Action<? super TransformationStep> action) {
         }
+
+
+        @Override
+        boolean endsWith(Transformation otherTransform) {
+            return false
+        }
+
+        @Override
+        int stepsCount() {
+            return 1
+        }
     }
 
     class NonCachingTransformation implements Transformation {
@@ -72,6 +83,17 @@ class ChainedTransformerTest extends Specification {
 
         @Override
         void visitTransformationSteps(Action<? super TransformationStep> action) {
+        }
+
+
+        @Override
+        boolean endsWith(Transformation otherTransform) {
+            return false
+        }
+
+        @Override
+        int stepsCount() {
+            return 1
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationMatchingSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationMatchingSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform
+
+import spock.lang.Specification
+
+class TransformationMatchingSpec extends Specification {
+
+    def "different TransformationStep does not contain each other"() {
+        given:
+        def step1 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step2 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+
+        expect:
+        !step1.endsWith(step2)
+        !step2.endsWith(step1)
+    }
+
+    def "TransformationStep contains itself"() {
+        given:
+        def step = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+
+        expect:
+        step.endsWith(step)
+    }
+
+    def "chain contains its final step"() {
+        given:
+        def step1 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step2 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def chain = new TransformationChain(step1, step2)
+
+        expect:
+        chain.endsWith(step2)
+        !chain.endsWith(step1)
+        !step1.endsWith(chain)
+        !step2.endsWith(chain)
+
+    }
+
+    def "chain contains itself"() {
+        given:
+        def step1 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step2 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def chain = new TransformationChain(step1, step2)
+
+        expect:
+        chain.endsWith(chain)
+    }
+
+    def "longer chain contains shorter chain"() {
+        given:
+        def step1 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step2 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step3 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def subChain = new TransformationChain(step2, step3)
+        def longChain = new TransformationChain(new TransformationChain(step1, step2), step3)
+
+        expect:
+        longChain.endsWith(subChain)
+        !subChain.endsWith(longChain)
+    }
+
+    def "different chains do not contain each other"() {
+        given:
+        def step1 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step2 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def step3 = new TransformationStep(Mock(Transformer), Mock(TransformerInvoker))
+        def chain1 = new TransformationChain(step2, step3)
+        def chain2 = new TransformationChain(step1, step2)
+        def chain3 = new TransformationChain(step1, step3)
+
+        expect:
+        !chain1.endsWith(chain2)
+        !chain2.endsWith(chain1)
+        !chain3.endsWith(chain2)
+        !chain3.endsWith(chain1)
+        !chain2.endsWith(chain3)
+        !chain1.endsWith(chain3)
+
+
+
+    }
+}


### PR DESCRIPTION
Before this commit, the moment there were two transform path matching,
we failed and asked the user to disambiguate.
However there are cases where we can do disambiguation as paths are
equivalent and one is clearly better than the other.
This fixes the case when a shorter path is the suffix of a longer one.