### PR TITLE
BuildScriptBuilder: Do not print a trailing space for empty header lines

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -1073,7 +1073,11 @@ public class BuildScriptBuilder {
             if (!lines.isEmpty()) {
                 println(" *");
                 for (String headerLine : lines) {
-                    println(" * " + headerLine);
+                    if (headerLine.isEmpty()) {
+                        println(" *");
+                    } else {
+                        println(" * " + headerLine);
+                    }
                 }
             }
             println(" */");


### PR DESCRIPTION
The file comment is split on "\n", so "\n\n" creates an empty header
line. Avoid a trailing space to be created in that case as having
trailing whitespace in code is commonly regarded as bad practice, esp.
for code managed in Git.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>

### Context
This fixes a small annoyance for people using the `gradle init` command.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
