### PR TITLE
Fixed a small typo in the user guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/dependency_management_attribute_based_matching.adoc
+++ b/subprojects/docs/src/docs/userguide/dependency_management_attribute_based_matching.adoc
@@ -61,7 +61,7 @@ A configuration which has `canBeResolved` set to `false` is not meant to be reso
 Such a configuration is there _only to declare dependencies_.
 The reason is that depending on the usage (compile classpath, runtime classpath), it _can_ resolve to different graphs.
 It is an error to try to resolve a configuration which has `canBeResolved` set to `false`.
-To some extend, this is similar to an _abstract class_ (`canBeResolved`=false) which is not supposed to be instantiated, and a concrete class extending the abstract class (`canBeResolved`=true).
+To some extent, this is similar to an _abstract class_ (`canBeResolved`=false) which is not supposed to be instantiated, and a concrete class extending the abstract class (`canBeResolved`=true).
 A resolvable configuration will extend at least one non resolvable configuration (and may extend more than one).
 
 On the other end, at the library project side (the _producer_), we also use configurations to represent what can be consumed.


### PR DESCRIPTION
### Context
A small typo fix on the user guide under [Managing Dependencies](https://docs.gradle.org/current/userguide/dependency_management_attribute_based_matching.html#sec:abm_configuration_kinds)

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
