### PR TITLE
Make allVersionsCrossVersion also run functional tests to pick up 'all version' tests

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -266,7 +266,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
     // Cross version tests select a small set of versions to cover when run as part of this stage
     quickFeedbackCrossVersion(false, false, true),
     // Cross version tests select all versions to cover when run as part of this stage
-    allVersionsCrossVersion(false, false, true, 240),
+    allVersionsCrossVersion(false, true, true, 240),
     parallel(false, true, false),
     noDaemon(false, true, false, 240),
     soak(false, false, false),


### PR DESCRIPTION
This is is preparation for moving "all" version testing to later in the CI pipeline.  The goal is that we will continue to run the same build types in each job, but whereas functional tests currently test "all versions" in the platform jobs, they will now only test a limited, partial set of versions in platform. Then we'll run the full exhaustive set of versions later in the allVersionsCrossVersion jobs.

This change only sets up allVersionsCrossVersion so it they will run for additional projects (i.e. functional test projects, too).  There will be a follow up change on master to change the versions tested for the affected build types and flip the switch on moving the "all version" testing to later in the pipeline.