### PR TITLE
Implement fallback for touching empty files

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GFileUtils.java
@@ -16,6 +16,7 @@
 package org.gradle.util;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.ArrayUtils;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.internal.IoActions;
 import org.gradle.util.internal.LimitedDescription;
@@ -24,6 +25,7 @@ import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
@@ -69,7 +71,26 @@ public class GFileUtils {
         try {
             Files.setLastModifiedTime(file.toPath(), FileTime.fromMillis(System.currentTimeMillis()));
         } catch (IOException e) {
-            throw new UncheckedIOException("Could not update time stamp for " + file, e);
+            if (file.isFile() && file.length() == 0) {
+                // On Linux, users cannot touch files they don't own but have write access to
+                // because the JDK uses futimes() instead of futimens() [note the 'n'!]
+                // see https://github.com/gradle/gradle/issues/7873
+                touchFileByWritingEmptyByteArray(file);
+            } else {
+                throw new UncheckedIOException("Could not update timestamp for " + file, e);
+            }
+        }
+    }
+
+    private static void touchFileByWritingEmptyByteArray(File file) {
+        FileOutputStream out = null;
+        try {
+            out = new FileOutputStream(file);
+            out.write(ArrayUtils.EMPTY_BYTE_ARRAY);
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not update timestamp for " + file, e);
+        } finally {
+            IoActions.closeQuietly(out);
         }
     }
 


### PR DESCRIPTION
On Linux, users cannot set the last modification timestamp of files they
don't own but have write access to because the JDK uses `futimes`
instead of `futimens` (note the extra 'n'!).

Resolves #7873.