### PR TITLE
Deincubate configuration avoidance APIs

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/DomainObjectCollection.java
@@ -168,7 +168,6 @@ public interface DomainObjectCollection<T> extends Collection<T> {
      * @param action A {@link Action} that can configure the element when required.
      * @since 4.9
      */
-    @Incubating
     void configureEach(Action<? super T> action);
 
     // note: this is here to override the default Groovy Collection.findAll { } method.

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollection.java
@@ -226,7 +226,6 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @throws UnknownDomainObjectException If a object with the given name is not defined.
      * @since 4.10
      */
-    @Incubating
     NamedDomainObjectProvider<T> named(String name) throws UnknownDomainObjectException;
 
     /**
@@ -238,7 +237,6 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @throws UnknownDomainObjectException If a object with the given name is not defined.
      * @since 5.0
      */
-    @Incubating
     NamedDomainObjectProvider<T> named(String name, Action<? super T> configurationAction) throws UnknownDomainObjectException;
 
     /**
@@ -250,7 +248,6 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @throws UnknownDomainObjectException If a object with the given name is not defined.
      * @since 5.0
      */
-    @Incubating
     <S extends T> NamedDomainObjectProvider<S> named(String name, Class<S> type) throws UnknownDomainObjectException;
 
     /**
@@ -264,7 +261,6 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @throws UnknownDomainObjectException If a object with the given name is not defined.
      * @since 5.0
      */
-    @Incubating
     <S extends T> NamedDomainObjectProvider<S> named(String name, Class<S> type, Action<? super S> configurationAction) throws UnknownDomainObjectException;
 
     /**
@@ -273,6 +269,5 @@ public interface NamedDomainObjectCollection<T> extends DomainObjectCollection<T
      * @since 4.10
      */
     @Internal
-    @Incubating
     NamedDomainObjectCollectionSchema getCollectionSchema();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollectionSchema.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectCollectionSchema.java
@@ -24,7 +24,6 @@ import org.gradle.api.reflect.TypeOf;
  * @since 4.10
  * @see NamedDomainObjectCollection
  */
-@Incubating
 public interface NamedDomainObjectCollectionSchema {
     /**
      * Returns an iterable of the schemas for each element in the collection.
@@ -36,7 +35,6 @@ public interface NamedDomainObjectCollectionSchema {
      *
      * @since 4.10
      */
-    @Incubating
     interface NamedDomainObjectSchema {
         /**
          * The name of the domain object.

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
@@ -93,7 +93,6 @@ public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, 
      * @throws InvalidUserDataException If a object with the given name already exists in this project.
      * @since 4.10
      */
-    @Incubating
     NamedDomainObjectProvider<T> register(String name, Action<? super T> configurationAction) throws InvalidUserDataException;
 
     /**
@@ -106,6 +105,5 @@ public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, 
      * @throws InvalidUserDataException If a object with the given name already exists in this project.
      * @since 4.10
      */
-    @Incubating
     NamedDomainObjectProvider<T> register(String name) throws InvalidUserDataException;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectProvider.java
@@ -24,7 +24,6 @@ import org.gradle.api.provider.Provider;
  * @param <T> type of domain object
  * @since 4.10
  */
-@Incubating
 public interface NamedDomainObjectProvider<T> extends Provider<T> {
     /**
      * Configures the domain object with the given action. Actions are run in the order added.

--- a/subprojects/core-api/src/main/java/org/gradle/api/PolymorphicDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/PolymorphicDomainObjectContainer.java
@@ -96,7 +96,6 @@ public interface PolymorphicDomainObjectContainer<T> extends NamedDomainObjectCo
      * @throws InvalidUserDataException If a object with the given name already exists in this project.
      * @since 4.10
      */
-    @Incubating
     <U extends T> NamedDomainObjectProvider<U> register(String name, Class<U> type, Action<? super U> configurationAction) throws InvalidUserDataException;
 
     /**
@@ -111,6 +110,5 @@ public interface PolymorphicDomainObjectContainer<T> extends NamedDomainObjectCo
      * @throws InvalidUserDataException If a object with the given name already exists in this project.
      * @since 4.10
      */
-    @Incubating
     <U extends T> NamedDomainObjectProvider<U> register(String name, Class<U> type) throws InvalidUserDataException;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Provider.java
@@ -65,7 +65,6 @@ import java.util.concurrent.Callable;
  * @param <T> Type of value represented by provider
  * @since 4.0
  */
-@Incubating
 @HasInternalProtocol
 @NonExtensible
 public interface Provider<T> {
@@ -120,6 +119,7 @@ public interface Provider<T> {
      * @param transformer The transformer to apply to values. Should not return {@code null}.
      * @since 5.0
      */
+    @Incubating
     <S> Provider<S> flatMap(Transformer<? extends Provider<? extends S>, ? super T> transformer);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
@@ -92,7 +92,6 @@ public interface TaskCollection<T extends Task> extends NamedDomainObjectSet<T> 
      * @throws UnknownTaskException If a task with the given name is not defined.
      * @since 4.9
      */
-    @Incubating
     TaskProvider<T> named(String name) throws UnknownTaskException;
 
     /**
@@ -100,7 +99,6 @@ public interface TaskCollection<T extends Task> extends NamedDomainObjectSet<T> 
      *
      * @since 5.0
      */
-    @Incubating
     TaskProvider<T> named(String name, Action<? super T> configurationAction) throws UnknownTaskException;
 
 
@@ -109,7 +107,6 @@ public interface TaskCollection<T extends Task> extends NamedDomainObjectSet<T> 
      *
      * @since 5.0
      */
-    @Incubating
     <S extends T> TaskProvider<S> named(String name, Class<S> type) throws UnknownTaskException;
 
     /**
@@ -117,6 +114,5 @@ public interface TaskCollection<T extends Task> extends NamedDomainObjectSet<T> 
      *
      * @since 5.0
      */
-    @Incubating
     <S extends T> TaskProvider<S> named(String name, Class<S> type, Action<? super S> configurationAction) throws UnknownTaskException;
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskCollection.java
@@ -17,7 +17,6 @@ package org.gradle.api.tasks;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
-import org.gradle.api.Incubating;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -204,7 +204,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @since 4.9
      */
-    @Incubating
     TaskProvider<Task> register(String name, Action<? super Task> configurationAction) throws InvalidUserDataException;
 
     /**
@@ -220,7 +219,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @since 4.9
      */
-    @Incubating
     <T extends Task> TaskProvider<T> register(String name, Class<T> type, Action<? super T> configurationAction) throws InvalidUserDataException;
 
     /**
@@ -235,7 +233,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @since 4.9
      */
-    @Incubating
     <T extends Task> TaskProvider<T> register(String name, Class<T> type) throws InvalidUserDataException;
 
     /**
@@ -251,7 +248,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws NullPointerException If any of the values in {@code constructorArgs} is null.
      * @since 4.9
      */
-    @Incubating
     <T extends Task> TaskProvider<T> register(String name, Class<T> type, Object... constructorArgs) throws InvalidUserDataException;
 
     /**
@@ -264,7 +260,6 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
      * @throws InvalidUserDataException If a task with the given name already exists in this project.
      * @since 4.9
      */
-    @Incubating
     TaskProvider<Task> register(String name) throws InvalidUserDataException;
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
@@ -18,7 +18,6 @@ package org.gradle.api.tasks;
 
 import org.gradle.api.Action;
 import org.gradle.api.NamedDomainObjectProvider;
-import org.gradle.api.Incubating;
 import org.gradle.api.Task;
 
 /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskProvider.java
@@ -27,7 +27,6 @@ import org.gradle.api.Task;
  * @param <T> Task type
  * @since 4.8
  */
-@Incubating
 public interface TaskProvider<T extends Task> extends NamedDomainObjectProvider<T> {
     /**
      * Configures the task with the given action. Actions are run in the order added.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -46,6 +46,31 @@ The following are the features that have been promoted in this Gradle release.
 ### Example promoted
 -->
 
+### Configuration avoidance for Tasks
+
+[In a recent blog post](https://blog.gradle.org/preview-avoiding-task-configuration-time), we described a new API for creating and configuration `Task` instances that allow Gradle to avoid creating and configuring tasks that do not need to be executed.
+
+In this release, we now [recommend that you use this new API when working with tasks](userguide/task_configuration_avoidance.html). 
+
+By default, the Kotlin DSL [uses the new APIs](current/userguide/kotlin_dsl.html#type-safe-accessors).
+
+"Old style" task declarations in the Groovy DSL continue to be eager and force creation/configuration of any tasks created this way.
+```
+// "Old style" task declaration uses Task create API.  This always creates a task.
+task myTask(type: MyTask) {
+    // This is always called
+}
+```
+
+In Groovy, to use the new API:
+```
+tasks.register("myTask", MyTask) {
+    
+}
+```
+
+The existing API is not deprecated, but as builds transition to the new API, we will consider deprecating the API in a future release.
+
 ## Fixed issues
 
 ### Inherited configuration-wide dependency excludes are now published


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
