### PR TITLE
Use same time source for waiting and measuring

### DIFF
--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -260,10 +260,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
             class MyPlugin implements Plugin<Project> {
                 void apply(Project project) {
                     project.afterEvaluate {
-                        long start = System.currentTimeMillis()
-                        while (System.currentTimeMillis() - start < $sleepMillis) {
-                            Thread.sleep($sleepMillis)
-                        } 
+                        ${simulateWork(sleepMillis)}
                     }
                 }
             }
@@ -292,10 +289,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
                 void apply(Project project) {
                     project.configurations.all {
                         if (name == 'foo') {
-                            long start = System.currentTimeMillis()
-                            while (System.currentTimeMillis() - start < $sleepMillis) {
-                                Thread.sleep($sleepMillis)
-                            }
+                            ${simulateWork(sleepMillis)}
                         }
                     }
                 }
@@ -327,10 +321,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
                 void apply(Project project) {
                     project.configurations.all {
                         if (name == 'foo') {
-                            long start = System.currentTimeMillis()
-                            while (System.currentTimeMillis() - start < $sleepDurationMillis) {
-                                Thread.sleep(${sleepDurationMillis / 2})
-                            }
+                            ${simulateWork(sleepDurationMillis)}
                         }
                     }
                 }
@@ -347,6 +338,17 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
         def result = pluginResults.find { it.plugin.displayName.contains("MyPlugin") }
         result.totalConfigurationTime >= Duration.ofMillis(sleepDurationMillis)
         result.totalConfigurationTime < Duration.ofMillis(2 * sleepDurationMillis)
+    }
+
+    def simulateWork(long durationMillis) {
+        """
+            def start = org.gradle.internal.time.Time.currentTimeMillis()
+            Thread.sleep($durationMillis)
+            def elapsed
+            while ((elapsed = org.gradle.internal.time.Time.currentTimeMillis() - start) < $durationMillis) {
+                Thread.sleep($durationMillis - elapsed)
+            }
+        """
     }
 
     void containsPluginApplicationResultsForJavaPluginAndScriptPlugins(String displayName, File buildscriptDir) {


### PR DESCRIPTION
The test now uses the same time source to measure simulated working
times the build operation executor uses to measure the durations of
build operations. Thus, this commit should fix the flakiness on Windows
were `System.currentTimeMillis()` is not as reliable as on other
operating systems.