### PR TITLE
No special treatment of milestone versions when calculating next major

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/GradleVersion.java
@@ -187,9 +187,6 @@ public class GradleVersion implements Comparable<GradleVersion> {
     }
 
     public GradleVersion getNextMajor() {
-        if (stage != null && stage.stage == STAGE_MILESTONE) {
-            return version(majorPart + ".0");
-        }
         return version((majorPart + 1) + ".0");
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/GradleVersionTest.groovy
@@ -237,16 +237,9 @@ class GradleVersionTest extends Specification {
         '20.17-20101220100000+1000'           | "21.0"
         '0.9-SNAPSHOT'                        | "1.0"
         '3.0-snapshot-1'                      | "4.0"
-    }
-
-    def "milestones are part of previous major version"() {
-        expect:
-        GradleVersion.version(v).nextMajor == GradleVersion.version(major)
-
-        where:
-        v                                     | major
-        '1.0-milestone-3'                     | "1.0"
-        '1.0-milestone-3-20121012100000+1000' | "1.0"
-        '2.0-milestone-3'                     | "2.0" // not that we're planning to do this
+        '5.1-milestone-1'                     | "6.0"
+        '1.0-milestone-3'                     | "2.0"
+        '1.0-milestone-3-20121012100000+1000' | "2.0"
+        '2.0-milestone-3'                     | "3.0"
     }
 }


### PR DESCRIPTION
A special treatment was added for Gradle 1.0. This did assume that
there will be no milestones for minor releases. This was an issue with
5.1-milestone-1, which is a minor release milestone.

Since the special treatment is not necessary for any milestone release
(major or minor) we remove it.