### PR TITLE
fix covered edit button on some pages

### DIFF
--- a/subprojects/docs/src/docs/css/base.css
+++ b/subprojects/docs/src/docs/css/base.css
@@ -656,7 +656,7 @@ h3.releaseinfo {
 
     #content h2[id] {
         /* Little extra room above h2s */
-        margin-top: -44px;
+        margin-top: -1em;
     }
 
     #content h3[id], #content h4[id] {

--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1535,7 +1535,7 @@ div.screenshot {
 
     #content h2[id] {
         /* Little extra room above h2s */
-        margin-top: -44px;
+        margin-top: -1em;
     }
 
     #content h3[id], #content h4[id] {


### PR DESCRIPTION
Move the headers down a bit to make sure the edit button is always clickable. Resolves #7898.

This also adds more space between sections. If the space is too much, we can go through and add summary paragraphs before each page of the user manual affected by this bug. wdyt?

Before:
<img width="934" alt="screenshot 2018-12-03 at 18 25 24" src="https://user-images.githubusercontent.com/4601577/49445114-5fa9f700-f7d1-11e8-84d6-10b8d49d27c5.png">

After:
<img width="927" alt="screenshot 2018-12-04 at 14 25 13" src="https://user-images.githubusercontent.com/4601577/49445122-633d7e00-f7d1-11e8-9d41-6a351493a87f.png">
