### PR TITLE
Modify margin and padding for h5 headings

### DIFF
--- a/subprojects/docs/src/docs/css/manual.css
+++ b/subprojects/docs/src/docs/css/manual.css
@@ -1529,7 +1529,7 @@ div.screenshot {
       Pushes the section headings to just below the top nav bar when a user
       navigates directly to section anchors.
      */
-    #content h2[id], #content h3[id], #content h4[id] {
+    #content h2[id], #content h3[id], #content h4[id], #content h5[id] {
         padding-top: 60px;
     }
 
@@ -1538,7 +1538,7 @@ div.screenshot {
         margin-top: -44px;
     }
 
-    #content h3[id], #content h4[id] {
+    #content h3[id], #content h4[id], #content h5[id] {
         margin-top: -60px;
     }
 


### PR DESCRIPTION
This means that clicking on a link to an h5 anchor will make it appear below
the top nav.

Fixes [dotorg-docs#320](https://github.com/gradle/dotorg-docs/issues/320)