### PR TITLE
Always run code quality tasks in buildSrc

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -111,12 +111,10 @@ if (findProperty("gradlebuild.skipBuildSrcChecks") == "true") {
     }
 }
 
+apply(from = "../gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")
+
 // TODO Avoid duplication of what defines a CI Server with BuildEnvironment
 val isCiServer: Boolean by extra { "CI" in System.getenv() }
-if (!isCiServer || System.getProperty("enableCodeQuality")?.toLowerCase() == "true") {
-    apply(from = "../gradle/shared-with-buildSrc/code-quality-configuration.gradle.kts")
-}
-
 if (isCiServer) {
     gradle.buildFinished {
         allprojects.forEach { project ->


### PR DESCRIPTION
### Context

Back to https://github.com/gradle/gradle/commit/e215b27afaada8462e4824a6eb9bbe5c9e3a0532,
we disabled buildSrc code quality tasks to speed up the build. Now is 2018, with build cache
this is no longer a problem. Plus, conditionally enabling these tasks causes cache misses,
so we always enable the buildSrc code quality tasks.

