### PR TITLE
Fix extra attributes are ignored when selecting transforms chains from candidates

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinder.java
@@ -78,7 +78,8 @@ public class ConsumerProvidedVariantFinder {
 
         for (final VariantTransformRegistry.Registration candidate : candidates) {
             ConsumerVariantMatchResult inputVariants = new ConsumerVariantMatchResult();
-            collectConsumerVariants(actual, candidate.getFrom(), inputVariants);
+            AttributeContainerInternal requestedPrevious = computeRequestedAttributes(requested, candidate);
+            collectConsumerVariants(actual, requestedPrevious, inputVariants);
             if (!inputVariants.hasMatches()) {
                 continue;
             }
@@ -88,6 +89,10 @@ public class ConsumerProvidedVariantFinder {
                 result.matched(variantAttributes, transformation, inputVariant.depth + 1);
             }
         }
+    }
+
+    private AttributeContainerInternal computeRequestedAttributes(AttributeContainerInternal result, VariantTransformRegistry.Registration transform) {
+        return attributesFactory.concat(result.asImmutable(), transform.getFrom().asImmutable()).asImmutable();
     }
 
     private AttributeSpecificCache getCache(AttributeContainer attributes) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
@@ -27,8 +27,11 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.api.internal.attributes.AttributesSchemaInternal
 import org.gradle.internal.component.model.AttributeMatcher
 import org.gradle.util.AttributeTestUtil
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
+
+import static org.spockframework.util.CollectionUtil.mapOf
 
 class ConsumerProvidedVariantFinderTest extends Specification {
     def matcher = Mock(AttributeMatcher)
@@ -48,6 +51,20 @@ class ConsumerProvidedVariantFinderTest extends Specification {
 
         List<File> transform(File input) {
             return transformer.transform(input)
+        }
+    }
+
+    /**
+     * Match all AttributeContainer that contains the same attributes.
+     *
+     * This method is for writing argument constraint in spock interaction. When search for
+     * chains, ConsumerProvidedVariantFinder may create a new instance of the AttributeContainer
+     * to call {@link AttributeMatcher#isMatching(AttributeContainerInternal, AttributeContainerInternal)}.
+     * So we cannot use the origin object instance to write method specification in spock interaction.
+     */
+    def attributesIs(AttributeContainer except, Map<Attribute<Object>, Object> vals) {
+        return except.keySet().size() == vals.size() && vals.every { entry ->
+            except.getAttribute(entry.key) == entry.value
         }
     }
 
@@ -177,10 +194,10 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         1 * matcher.isMatching(c2, requested) >> false
         1 * matcher.isMatching(c5, requested) >> true
         1 * matcher.isMatching(source, c4) >> false
-        1 * matcher.isMatching(c5, c4) >> false
-        1 * matcher.isMatching(c2, c4) >> true
-        1 * matcher.isMatching(c3, c4) >> false
+        1 * matcher.isMatching(c3, { attributesIs(it, mapOf(a1, "4")) }) >> false
+        1 * matcher.isMatching(c2, { attributesIs(it, mapOf(a1, "4")) }) >> true
         1 * matcher.isMatching(source, c1) >> true
+        1 * matcher.isMatching(c5, { attributesIs(it, mapOf(a1, "4")) }) >> false
         0 * matcher._
 
         when:
@@ -253,9 +270,9 @@ class ConsumerProvidedVariantFinderTest extends Specification {
         1 * matcher.isMatching(c4, requested) >> false
         1 * matcher.isMatching(c5, requested) >> true
         1 * matcher.isMatching(source, c4) >> false
-        1 * matcher.isMatching(c4, c4) >> true
-        1 * matcher.isMatching(c3, c4) >> false
-        1 * matcher.isMatching(c5, c4) >> false
+        1 * matcher.isMatching(c4, { attributesIs(it, mapOf(a1, "4")) }) >> true
+        1 * matcher.isMatching(c3, { attributesIs(it, mapOf(a1, "4")) }) >> false
+        1 * matcher.isMatching(c5, { attributesIs(it, mapOf(a1, "4")) }) >> false
         1 * matcher.isMatching(source, c2) >> true
         1 * matcher.isMatching(source, c3) >> false
         0 * matcher._
@@ -271,6 +288,47 @@ class ConsumerProvidedVariantFinderTest extends Specification {
 
         where:
         registrationsIndex << (0..3).permutations()
+    }
+
+    @Issue("gradle/gradle#7061")
+    def "selects chain of transforms that only all the attributes are satisfied"() {
+        def c1 = attributes().attribute(a1, "1").attribute(a2, 1).asImmutable()
+        def c4 = attributes().attribute(a1, "2").attribute(a2, 2).asImmutable()
+        def c5 = attributes().attribute(a1, "2").attribute(a2, 3).asImmutable()
+        def c6 = attributes().attribute(a1, "2").asImmutable()
+        def c7 = attributes().attribute(a1, "3").asImmutable()
+        def requested = attributes().attribute(a1, "3").attribute(a2, 3).asImmutable()
+        def source = c1
+        def reg1 = registration(c1, c4, {})
+        def reg2 = registration(c1, c5, {})
+        def reg3 = registration(c6, c7, {})
+
+        given:
+        transformRegistrations.transforms >> [reg1, reg2, reg3]
+
+        when:
+        def result = new ConsumerVariantMatchResult()
+        matchingCache.collectConsumerVariants(source, requested, result)
+
+        then:
+        result.matches.size() == 1
+
+        and:
+        _ * schema.matcher() >> matcher
+        _ * matcher.ignoreAdditionalProducerAttributes() >> matcher
+        _ * matcher.ignoreAdditionalConsumerAttributes() >> matcher
+        1 * matcher.isMatching(c4, requested) >> false
+        1 * matcher.isMatching(c5, requested) >> false
+        1 * matcher.isMatching(c7, requested) >> true
+        1 * matcher.isMatching(source, c6) >> false
+        1 * matcher.isMatching(c4, { attributesIs(it, mapOf(a1, "2", a2, 3)) }) >> false // "2" 3 ; c5
+        1 * matcher.isMatching(c5, { attributesIs(it, mapOf(a1, "2", a2, 3)) }) >> true
+        1 * matcher.isMatching(source, c1) >> true
+        1 * matcher.isMatching(c7, { attributesIs(it, mapOf(a1, "2", a2, 3)) }) >> false
+        0 * matcher._
+
+        expect:
+        result.matches.size() == 1
     }
 
     def "returns empty list when no transforms are available to produce requested variant"() {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -144,6 +144,7 @@ We would like to thank the following community members for making contributions 
  - [John Bennewitz](https://github.com/b-john) - Allow C++ binary to relocate on Linux (gradle/gradle#6176)
  - [Alex Saveau](https://github.com/SUPERCILEX) - Add option to display tasks from a specific group only (gradle/gradle#7788) 
  - [Till Krullmann](https://github.com/tkrullmann) - Add `MapProperty` (gradle/gradle#6863)
+ - [TO XZ](https://github.com/noproxy) - Gradle should always respect the extra attributes when selecting artifacts transforms chains (gradle/gradle#7061)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 


### PR DESCRIPTION
This is a takeover from #7373 as it felt wrong force pushing on a master branch.

When selecting transforms chains from candidates, additional attributes
should not be ignored. If we just use the last transform's from to
search chains, we may get a wrong chain which cannot produce the requested
 artifact at all.