### PR TITLE
Document repository content filtering

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -134,5 +134,5 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
      * @since 5.1
      */
     @Incubating
-    void mavenContent(Action<? super RepositoryContentDescriptor> configureAction);
+    void mavenContent(Action<? super MavenRepositoryContentDescriptor> configureAction);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -25,7 +25,7 @@ import org.gradle.api.artifacts.ComponentMetadataListerDetails;
 import org.gradle.api.artifacts.ComponentMetadataSupplierDetails;
 import org.gradle.api.artifacts.repositories.AuthenticationContainer;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
+import org.gradle.api.artifacts.repositories.MavenRepositoryContentDescriptor;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -50,6 +50,7 @@ import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransp
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.Cast;
 import org.gradle.internal.action.InstantiatingAction;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
@@ -241,8 +242,8 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     }
 
     @Override
-    public void mavenContent(Action<? super RepositoryContentDescriptor> configureAction) {
-        content(configureAction);
+    public void mavenContent(Action<? super MavenRepositoryContentDescriptor> configureAction) {
+        content(Cast.uncheckedCast(configureAction));
     }
 
     ImmutableMetadataSources createMetadataSources(MavenMetadataLoader mavenMetadataLoader) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -29,6 +29,26 @@ Instead of listing all available tasks, [`gradle tasks` can now show only the ta
 
 This feature was contributed by [Alex Saveau](https://github.com/SUPERCILEX).
 
+## Repository content filtering
+
+It is now possible to match repositories to dependencies, so that Gradle doesn't search for a dependency in a repository if it's never going to be found there.
+
+Example:
+```
+repositories {
+    maven {
+        url "https://repo.mycompany.com"
+        content {
+           includeGroupByRegex "com\\.mycompany.*"
+        }
+    }
+}
+```
+
+This filtering can also be used to separate snapshot repositories from release repositories.
+
+Look at the [userguide](userguide/declaring_repositories.html#sec::matching_repositories_to_dependencies) for more details.
+
 ## Improvements for plugin authors
 
 ### Conveniences for properties of type Map

--- a/subprojects/docs/src/docs/userguide/declaring_repositories.adoc
+++ b/subprojects/docs/src/docs/userguide/declaring_repositories.adoc
@@ -69,3 +69,50 @@ include::sample[dir="/userguide/dependencyManagement/declaringRepositories/multi
 ====
 The order of declaration determines how Gradle will check for dependencies at runtime. If Gradle finds a module descriptor in a particular repository, it will attempt to download all of the artifacts for that module from _the same repository_. You can learn more about the inner workings of <<introduction_dependency_management.adoc#sec:dependency_resolution,Gradle's resolution mechanism>>.
 ====
+
+[[sec::matching_repositories_to_dependencies]]
+== Matching repositories to dependencies
+
+[NOTE]
+====
+
+Matching repositories to dependencies is an <<feature_lifecycle.adoc#feature_lifecycle,incubating>> feature.
+
+====
+
+Gradle exposes an API to declare what a repository may or may not contain.
+There are different use cases for it:
+
+- performance, when you know a dependency will never be found in a specific repository
+- security, by avoiding leaking what dependencies are used in a private project
+- reliability, when some repositories contain corrupted metadata or artifacts
+
+It's even more important when considering that order of repositories matter.
+
+=== Declaring a repository filter
+
+.Declaring repository contents
+====
+include::sample[dir="/userguide/dependencyManagement/declaringRepositories/filtering/groovy",files="build.gradle[tags=repository-filter]"]
+include::sample[dir="/userguide/dependencyManagement/declaringRepositories/filtering/kotlin",files="build.gradle.kts[tags=repository-filter]"]
+====
+
+By default, repositories include everything and exclude nothing:
+
+* If you declare an include, then it excludes everything _but_ what is included.
+* If you declare an exclude, then it includes everything _but_ what is excluded.
+* If you declare both includes and excludes, then it includes only what is explicitly included and not excluded.
+
+It is possible to filter either by explicit _group_, _module_ or _version_, either strictly or using regular expressions.
+See link:{javadocPath}/org/gradle/api/artifacts/repositories/RepositoryContentDescriptor.html[RepositoryContentDescriptor] for details.
+
+=== Maven repository filtering
+
+For Maven repositories, it's often the case that a repository would either contain releases or snapshots.
+Gradle lets you declare what kind of artifacts are found in a repository using this DSL:
+
+.Splitting snaphshots and releases
+====
+include::sample[dir="/userguide/dependencyManagement/declaringRepositories/filtering/groovy",files="build.gradle[tags=repository-snapshots]"]
+include::sample[dir="/userguide/dependencyManagement/declaringRepositories/filtering/kotlin",files="build.gradle.kts[tags=repository-snapshots]"]
+====

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/groovy/build.gradle
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::repository-filter[]
+repositories {
+    maven {
+        url "http://repo.mycompany.com/maven2"
+        content {
+            // this repository *only* contains artifacts with group "my.company"
+            includeGroup "my.company"
+        }
+    }
+    jcenter {
+        content {
+            // this repository contains everything BUT artifacts with group starting with "my.company"
+            excludeGroupByRegex "my\\.company.*"
+        }
+    }
+}
+// end::repository-filter[]
+
+// tag::repository-snapshots[]
+repositories {
+    maven {
+        url "http://repo.mycompany.com/releases"
+        mavenContent {
+            releasesOnly()
+        }
+    }
+    maven {
+        url "http://repo.mycompany.com/snapshots"
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+}
+// end::repository-snapshots[]
+
+configurations {
+    libs
+}
+
+dependencies {
+    libs "com.google.guava:guava:23.0"
+}
+
+task copyLibs(type:Copy) {
+    from configurations.libs
+    into "$buildDir/libs"
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/groovy/settings.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "filtering-repository"

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/kotlin/build.gradle.kts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::repository-filter[]
+repositories {
+    maven {
+        url = uri("http://repo.mycompany.com/maven2")
+        content {
+            // this repository *only* contains artifacts with group "my.company"
+            includeGroup("my.company")
+        }
+    }
+    jcenter {
+        content {
+            // this repository contains everything BUT artifacts with group starting with "my.company"
+            excludeGroupByRegex("my\\.company.*")
+        }
+    }
+}
+// end::repository-filter[]
+
+// tag::repository-snapshots[]
+repositories {
+    maven {
+        url = uri("http://repo.mycompany.com/releases")
+        mavenContent {
+            releasesOnly()
+        }
+    }
+    maven {
+        url = uri("http://repo.mycompany.com/snapshots")
+        mavenContent {
+            snapshotsOnly()
+        }
+    }
+}
+// end::repository-snapshots[]
+
+val libs by configurations.creating
+
+dependencies {
+    libs("com.google.guava:guava:23.0")
+}
+
+task<Copy>("copyLibs") {
+    from(libs)
+    into("$buildDir/libs")
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/kotlin/settings.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "filtering-repository"

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/repository-filtering.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/declaringRepositories/filtering/repository-filtering.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: dependencies
+},{
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: dependencies
+}]


### PR DESCRIPTION
### Context

This commit adds documentation for repository content filtering.
It also contains a fix for the static DSL, that was preventing
the Kotlin DSL from finding the methods specific to the Maven
repositories (wrong delegation type).

Fixes #7858
