### PR TITLE
Fix virtual platform triggering failure

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -91,6 +91,10 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
         return Collections.singleton("default");
     }
 
+    LenientPlatformResolveMetadata withVersion(ModuleComponentIdentifier moduleComponentIdentifier, ModuleVersionIdentifier moduleVersionIdentifier) {
+        return new LenientPlatformResolveMetadata(moduleComponentIdentifier, moduleVersionIdentifier, platformState, platformNode, resolveState);
+    }
+
     @Nullable
     @Override
     public ConfigurationMetadata getConfiguration(String name) {


### PR DESCRIPTION
### Context

This commit fixes a bug where a virtual platform used as
a constraint could fail the build by trying to fetch it
from a repository, where it was later defined as virtual.

Fixes #7916
