### PR TITLE
Fetch branch name from environment variable when necessary

### DIFF
--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -30,3 +30,7 @@ gradlePlugin {
         }
     }
 }
+
+tasks.withType<Test> {
+    environment("BUILD_BRANCH", "myBranch")
+}

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
@@ -48,12 +48,7 @@ open class DetermineBaselines : DefaultTask() {
     }
 
     private
-    fun currentBranchIsMasterOrRelease() =
-        when (project.stringPropertyOrNull(PropertyNames.branchName)) {
-            "master" -> true
-            "release" -> true
-            else -> false
-        }
+    fun currentBranchIsMasterOrRelease() = project.determineCurrentBranch() in listOf("master", "release")
 
     private
     fun Property<String>.isDefaultValue() = !isPresent || get() in listOf("", defaultBaseline, Config.baseLineList)

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -44,7 +44,6 @@ object PropertyNames {
     const val performanceTestVerbose = "performanceTest.verbose"
     const val baselines = "org.gradle.performance.baselines"
     const val buildTypeId = "org.gradle.performance.buildTypeId"
-    const val branchName = "org.gradle.performance.branchName"
 
     const val teamCityUsername = "teamCityUsername"
     const val teamCityPassword = "teamCityPassword"
@@ -63,6 +62,9 @@ object Config {
 
     const val adhocTestDbUrl = "jdbc:h2:./build/database"
 }
+
+
+fun Project.determineCurrentBranch() = System.getenv("BUILD_BRANCH") ?: execAndGetStdout("git", "rev-parse", "--abbrev-ref", "HEAD")
 
 
 private
@@ -308,7 +310,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             scenarioList = buildDir / Config.performanceTestScenarioListFileName
             buildTypeId = stringPropertyOrNull(PropertyNames.buildTypeId)
             workerTestTaskName = stringPropertyOrNull(PropertyNames.workerTestTaskName) ?: "fullPerformanceTest"
-            branchName = stringPropertyOrNull(PropertyNames.branchName)
+            branchName = determineCurrentBranch()
             teamCityUrl = Config.teamCityUrl
             teamCityUsername = stringPropertyOrNull(PropertyNames.teamCityUsername)
             teamCityPassword = stringPropertyOrNull(PropertyNames.teamCityPassword)

--- a/buildSrc/subprojects/plugins/src/test/groovy/org/gradle/plugins/performance/PerformanceTestIntegrationTest.groovy
+++ b/buildSrc/subprojects/plugins/src/test/groovy/org/gradle/plugins/performance/PerformanceTestIntegrationTest.groovy
@@ -17,7 +17,7 @@ class PerformanceTestIntegrationTest extends AbstractIntegrationTest {
             task assertChannel {
                 doLast {
                     distributedPerformanceTests.each { distributedPerformanceTest ->
-                        assert distributedPerformanceTest.channel.endsWith("-branch")
+                        assert distributedPerformanceTest.channel.endsWith("-myBranch")
                     }
                 }
             }
@@ -27,6 +27,6 @@ class PerformanceTestIntegrationTest extends AbstractIntegrationTest {
             include 'internalPerformanceTesting', 'docs', 'launcher', 'apiMetadata'
         """
         expect:
-        build("assertChannel", "-Porg.gradle.performance.branchName=branch")
+        build("assertChannel")
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/util/Git.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/util/Git.groovy
@@ -33,7 +33,7 @@ class Git {
     private Git() {
         def repository = new FileRepositoryBuilder().findGitDir().build()
         try {
-            branchName = repository.branch
+            branchName = System.getenv("BUILD_BRANCH") ?: repository.branch
             commitId = repository.resolve(repository.fullBranch).name
         } finally {
             repository.close()


### PR DESCRIPTION
This fixes https://github.com/gradle/gradle-private/issues/1690

Previously we use JGit's branch, which might be not accurate.
Now we prefer `BUILD_BRANCH` environment variable over JGit.

After the fix, the `vcsbranch` in DB:

![image](https://user-images.githubusercontent.com/12689835/49712341-f0278200-fc7e-11e8-982a-1d9da928f5fd.png)

