### PR TITLE
Added info about -Xmx change for Gradle Daemon to upgrading_version_4.adoc

### DIFF
--- a/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
@@ -81,6 +81,7 @@ The following breaking changes are not from deprecations, but the result of chan
 While it applies the Java Plugin, it behaves slightly different (e.g. it adds the `api` configuration). Thus, make sure to check whether your build behaves as expected after upgrading.
  * The `html` property on `CheckstyleReport` and `FindBugsReport` now returns a https://docs.gradle.org/current/dsl/org.gradle.api.reporting.CustomizableHtmlReport.html[`CustomizableHtmlReport`] instance that is easier to configure from statically typed languages like Java and Kotlin.
  * The <<#rel5.0:configuration_avoidance, Configuration Avoidance API>> has been updated to prevent the creation and configuration of tasks that are never used.
+  * The default maximum heap size for the <<gradle_daemon.adoc#the-gradle-daemon, Gradle Daemon>> has been decreased from 1GB to 512MB. If after updating to Gradle 5.0 your build fails with an `OutOfMemoryError`, try <<gradle_daemon.adoc#how-much-memory-does-the-daemon-use-and-can-i-give-it-more, increasing this value>> (quick fix: setting `org.gradle.jvmargs=-Xmx1g` in `gradle.properties` will bring back the default behavior of Gradle 4.x).
 
 The following breaking changes will appear as deprecation warnings with Gradle 4.10:
 


### PR DESCRIPTION
### Context
The default maximum heap size for Gradle Daemon changed from 1GB to 512GB in Gradle 5.0. Yet, it has not been documented as a potentially braking change (which I believe it is).

Related issue: #7746

### Aside

Perhaps it results from your release cycle, but current released version of the [Gradle Daemon docs](https://docs.gradle.org/current/userguide/gradle_daemon.html#sec:how_much_memory_does_the_daemon_use_and_can_i_give_it_more) is out-of-date (still says "1GB"), even though it has already been updated [on master](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/userguide/gradle_daemon.adoc#how-much-memory-does-the-daemon-use-and-can-i-give-it-more) (says "512MB").

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] ~Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective~
- [ ] ~Provide unit tests (under `<subproject>/src/test`) to verify logic~
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] ~Ensure that tests pass locally: `./gradlew <changed-subproject>:check`~

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
