### PR TITLE
Fix native testing for xcode 10

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
@@ -32,6 +32,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Issue
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPATIBLE
+import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32_AND_64
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 import static org.gradle.util.TextUtil.escapeString
 
@@ -320,6 +321,7 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     }
 
     @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+    @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
     def "rebuilds binary with target platform change"() {
         Assume.assumeTrue(canBuildForMultiplePlatforms)
         given:

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativePreCompiledHeaderIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativePreCompiledHeaderIntegrationTest.groovy
@@ -540,7 +540,7 @@ abstract class AbstractNativePreCompiledHeaderIntegrationTest extends AbstractIn
     }
 
     String getUniquePragmaOutput(String message) {
-        if (toolChain.displayName == "clang") {
+        if (toolChain.displayName.startsWith("clang")) {
             return "warning: ${message}"
         } else if (toolChain.displayName.startsWith("gcc") || toolChain.displayName == "mingw") {
             return "message: ${message}"

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/DuplicateBaseNamesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/DuplicateBaseNamesIntegrationTest.groovy
@@ -30,10 +30,12 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPATIBLE
+import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 
 class DuplicateBaseNamesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
+    @RequiresInstalledToolChain(SUPPORTS_32)
     def "can have sourcefiles with same base name but different directories"() {
         setup:
         testApp.writeSources(file("src/main"))
@@ -75,6 +77,7 @@ model {
      * story-language-source-sets-filter-source-files-by-file-extension
      * is implemented
      * */
+    @RequiresInstalledToolChain(SUPPORTS_32)
     def "can have sourcefiles with same base name in same directory"() {
         setup:
         def testApp = new DuplicateMixedSameBaseNamesTestApp(AbstractInstalledToolChainIntegrationSpec.toolChain)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIncrementalBuildIntegrationTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.language.assembler
 
 import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.MixedLanguageHelloWorldApp
 import org.gradle.test.fixtures.file.TestFile
@@ -25,6 +27,7 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.IgnoreIf
 
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
 class AssemblyLanguageIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
     HelloWorldApp app = new MixedLanguageHelloWorldApp(AbstractInstalledToolChainIntegrationSpec.toolChain)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/assembler/AssemblyLanguageIntegrationTest.groovy
@@ -18,11 +18,14 @@
 package org.gradle.language.assembler
 
 import org.gradle.language.AbstractNativeLanguageIntegrationTest
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.AssemblerWithCHelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 
 import static org.gradle.util.Matchers.containsText
 
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
 class AssemblyLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest {
 
     HelloWorldApp helloWorldApp = new AssemblerWithCHelloWorldApp(toolChain)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/c/MixedLanguageIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/c/MixedLanguageIntegrationTest.groovy
@@ -18,9 +18,12 @@ package org.gradle.language.c
 
 import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.language.AbstractNativeLanguageIntegrationTest
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.HelloWorldApp
 import org.gradle.nativeplatform.fixtures.app.MixedLanguageHelloWorldApp
 
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
 class MixedLanguageIntegrationTest extends AbstractNativeLanguageIntegrationTest {
 
     HelloWorldApp helloWorldApp = new MixedLanguageHelloWorldApp(toolChain)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.nativeplatform.MachineArchitecture
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.util.Matchers
+import org.junit.Assume
 
 abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegrationTest {
     def "skip assemble tasks when no source"() {
@@ -49,6 +50,8 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
     def "can build for current machine when multiple target machines are specified"() {
+        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
+
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -107,6 +110,8 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
     def "can build current architecture when other, non-buildable architectures are specified"() {
+        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
+
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -125,6 +130,8 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
     def "ignores duplicate target machines"() {
+        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
+
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
@@ -17,10 +17,9 @@
 package org.gradle.language.cpp
 
 import org.gradle.nativeplatform.MachineArchitecture
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.util.Matchers
-
-import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.WINDOWS_GCC
-import static org.junit.Assume.assumeFalse
 
 abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegrationTest {
     def "skip assemble tasks when no source"() {
@@ -50,8 +49,6 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
     def "can build for current machine when multiple target machines are specified"() {
-        assumeFalse(toolChain.meets(WINDOWS_GCC))
-
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -69,9 +66,8 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
     }
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
+    @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
     def "can build for multiple target machines"() {
-        assumeFalse(toolChain.meets(WINDOWS_GCC))
-
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -111,8 +107,6 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
     def "can build current architecture when other, non-buildable architectures are specified"() {
-        assumeFalse(toolChain.meets(WINDOWS_GCC))
-        
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -131,8 +125,6 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
 
     // TODO Move this to AbstractCppComponentIntegrationTest when unit test works properly with architecture
     def "ignores duplicate target machines"() {
-        assumeFalse(toolChain.meets(WINDOWS_GCC))
-
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationPublishingIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp
 
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppApp
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrary
@@ -24,7 +25,6 @@ import org.gradle.nativeplatform.fixtures.app.CppLogger
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
-import org.junit.Assume
 
 import static org.gradle.nativeplatform.MachineArchitecture.ARCHITECTURE_ATTRIBUTE
 import static org.gradle.nativeplatform.MachineArchitecture.X86
@@ -462,9 +462,8 @@ class CppApplicationPublishingIntegrationTest extends AbstractCppPublishingInteg
 
     // macOS can only build 64-bit under 10.14+
     @Requires(TestPrecondition.NOT_MAC_OS_X)
+    @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
     def "can publish the binaries of an application with multiple target architectures to a Maven repository"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
-
         def app = new CppApp()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.language.cpp
 
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibraries
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrariesWithApiDependencies
@@ -803,9 +804,8 @@ dependencies { implementation 'some.group:greeter:1.2' }
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
+    @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
     def "can publish a library and its dependencies to a Maven repository when multiple target architectures are specified"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
-
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -27,7 +27,6 @@ import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.maven.MavenDependencyExclusion
 import org.gradle.test.fixtures.maven.MavenFileRepository
 import org.hamcrest.Matchers
-import org.junit.Assume
 import spock.lang.Issue
 
 import static org.gradle.nativeplatform.MachineArchitecture.*
@@ -873,9 +872,8 @@ dependencies { implementation 'some.group:greeter:1.2' }
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
+    @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
     def "fails when a dependency is published without a matching target architecture"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
-
         def app = new CppAppWithLibrariesWithApiDependencies()
 
         given:

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppStaticLibraryPublishingIntegrationTest.groovy
@@ -16,10 +16,10 @@
 
 package org.gradle.language.cpp
 
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppAppWithLibrariesWithApiDependencies
 import org.gradle.test.fixtures.file.TestFile
-import org.junit.Assume
 
 import static org.gradle.nativeplatform.MachineArchitecture.*
 import static org.gradle.nativeplatform.OperatingSystemFamily.*
@@ -91,9 +91,8 @@ class CppStaticLibraryPublishingIntegrationTest extends AbstractCppPublishingInt
         installation(consumer.file("build/install/main/debug")).exec().out == app.expectedOutput
     }
 
+    @RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32_AND_64)
     def "can publish a library and its dependencies to a Maven repository when multiple target architectures are specified"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
-
         def app = new CppAppWithLibrariesWithApiDependencies()
         def targetMachines = [machine(currentOsFamilyName, X86), machine(currentOsFamilyName, X86_64)]
 

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/nativeplatform/NativeLanguageSamplesIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.junit.Rule
 import spock.lang.IgnoreIf
 
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPATIBLE
+import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.SUPPORTS_32_AND_64
 import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.VISUALCPP
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
@@ -47,6 +48,7 @@ class NativeLanguageSamplesIntegrationTest extends AbstractInstalledToolChainInt
         return new Sample(testDirectoryProvider, "native-binaries/${name}", name)
     }
 
+    @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
     @IgnoreIf({GradleContextualExecuter.parallel})
     def "assembler"() {
         given:

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.cpp
 
 import org.gradle.language.AbstractNativeLanguageComponentIntegrationTest
+import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
@@ -86,7 +87,12 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     protected String getCurrentHostOperatingSystemFamilyDsl() {
-        return DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
+        String osFamily = DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
+        if (osFamily == OperatingSystemFamily.MACOS) {
+            return "macOS"
+        } else {
+            return osFamily
+        }
     }
 
     protected abstract SourceElement getComponentUnderTest()

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.language.swift
 
 import org.gradle.language.AbstractNativeLanguageComponentIntegrationTest
+import org.gradle.nativeplatform.OperatingSystemFamily
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
@@ -209,7 +210,12 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
 
 
     protected String getCurrentHostOperatingSystemFamilyDsl() {
-        return DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
+        String osFamily = DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
+        if (osFamily == OperatingSystemFamily.MACOS) {
+            return "macOS"
+        } else {
+            return osFamily
+        }
     }
 
     abstract String getDevelopmentBinaryCompileTask()

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -175,7 +175,7 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
     boolean isObjectiveCWithAslr() {
         return (sourceType == "Objc" || sourceType == "Objcpp") &&
             OperatingSystem.current().isLinux() &&
-            toolChain.displayName == "clang"
+            toolChain.displayName.startsWith("clang")
     }
 
     protected void maybeWait() {

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -62,6 +62,12 @@ import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISU
 import static org.gradle.nativeplatform.fixtures.msvcpp.VisualStudioVersion.VISUALSTUDIO_2017;
 
 public class AvailableToolChains {
+    private static final Comparator<ToolChainCandidate> LATEST_FIRST = Collections.reverseOrder(new Comparator<ToolChainCandidate>() {
+        @Override
+        public int compare(ToolChainCandidate toolchain1, ToolChainCandidate toolchain2) {
+            return toolchain1.getVersion().compareTo(toolchain2.getVersion());
+        }
+    });
     private static List<ToolChainCandidate> toolChains;
 
     /**
@@ -106,12 +112,12 @@ public class AvailableToolChains {
                 compilers.add(findMinGW());
                 compilers.add(findCygwin());
             } else if (OperatingSystem.current().isMacOsX()) {
-                compilers.add(findClang());
+                compilers.addAll(findClangs(true));
                 compilers.addAll(findGccs(false));
                 compilers.addAll(findSwiftcs());
             } else {
                 compilers.addAll(findGccs(true));
-                compilers.add(findClang());
+                compilers.addAll(findClangs(false));
                 compilers.addAll(findSwiftcs());
             }
             toolChains = compilers;
@@ -119,12 +125,33 @@ public class AvailableToolChains {
         return toolChains;
     }
 
-    static private ToolChainCandidate findClang() {
-        File compilerExe = OperatingSystem.current().findInPath("clang");
-        if (compilerExe != null) {
-            return new InstalledClang();
+    static private List<ToolChainCandidate> findClangs(boolean mustFind) {
+        GccMetadataProvider versionDeterminer = GccMetadataProvider.forClang(TestFiles.execActionFactory());
+
+        Set<File> clangCandidates = ImmutableSet.copyOf(OperatingSystem.current().findAllInPath("clang"));
+        List<ToolChainCandidate> toolChains = Lists.newArrayList();
+        if (!clangCandidates.isEmpty()) {
+            File firstInPath = clangCandidates.iterator().next();
+            for (File candidate : clangCandidates) {
+                SearchResult<GccMetadata> version = versionDeterminer.getCompilerMetaData(candidate, Collections.<String>emptyList(), Collections.<File>emptyList());
+                if (version.isAvailable()) {
+                    InstalledClang clang = new InstalledClang(version.getComponent().getVersion());
+                    if (!candidate.equals(firstInPath)) {
+                        // Not the first g++ in the path, needs the path variable updated
+                        clang.inPath(candidate.getParentFile());
+                    }
+                    toolChains.add(clang);
+                }
+            }
         }
-        return new UnavailableToolChain(ToolFamily.CLANG);
+
+        if (mustFind && toolChains.isEmpty()) {
+            toolChains.add(new UnavailableToolChain(ToolFamily.CLANG));
+        }
+
+        toolChains.sort(LATEST_FIRST);
+
+        return toolChains;
     }
 
     static private boolean isTestableVisualStudioVersion(final VersionNumber version) {
@@ -155,6 +182,8 @@ public class AvailableToolChains {
         if (toolChains.isEmpty()) {
             toolChains.add(new UnavailableToolChain(ToolFamily.VISUAL_CPP));
         }
+
+        toolChains.sort(LATEST_FIRST);
 
         return toolChains;
     }
@@ -198,9 +227,12 @@ public class AvailableToolChains {
                 }
             }
         }
+
         if (mustFind && toolChains.isEmpty()) {
             toolChains.add(new UnavailableToolChain(ToolFamily.GCC));
         }
+
+        toolChains.sort(LATEST_FIRST);
 
         return toolChains;
     }
@@ -241,16 +273,11 @@ public class AvailableToolChains {
 
         if (toolChains.isEmpty()) {
             toolChains.add(new UnavailableToolChain(ToolFamily.SWIFTC));
-            return toolChains;
         } else {
-            toolChains.sort(Collections.reverseOrder(new Comparator<ToolChainCandidate>() {
-                @Override
-                public int compare(ToolChainCandidate toolchain1, ToolChainCandidate toolchain2) {
-                    return toolchain1.getVersion().compareTo(toolchain2.getVersion());
-                }
-            }));
-            return toolChains;
+            toolChains.sort(LATEST_FIRST);
         }
+
+        return toolChains;
     }
 
     public enum ToolFamily {
@@ -470,7 +497,7 @@ public class AvailableToolChains {
 
         @Override
         public boolean meets(ToolChainRequirement requirement) {
-            return requirement == ToolChainRequirement.GCC || requirement == ToolChainRequirement.GCC_COMPATIBLE || requirement == ToolChainRequirement.AVAILABLE;
+            return requirement == ToolChainRequirement.GCC || requirement == ToolChainRequirement.GCC_COMPATIBLE || requirement == ToolChainRequirement.AVAILABLE || requirement == ToolChainRequirement.SUPPORTS_32_AND_64;
         }
 
         @Override
@@ -539,7 +566,14 @@ public class AvailableToolChains {
 
         @Override
         public boolean meets(ToolChainRequirement requirement) {
-            return super.meets(requirement) || requirement == ToolChainRequirement.WINDOWS_GCC;
+            switch (requirement) {
+                case WINDOWS_GCC:
+                    return true;
+                case SUPPORTS_32_AND_64:
+                    return false;
+                default:
+                    return super.meets(requirement);
+            }
         }
 
         @Override
@@ -641,6 +675,7 @@ public class AvailableToolChains {
             switch (requirement) {
                 case AVAILABLE:
                 case VISUALCPP:
+                case SUPPORTS_32_AND_64:
                     return true;
                 case VISUALCPP_2012_OR_NEWER:
                     return version.compareTo(VISUALSTUDIO_2012.getVersion()) >= 0;
@@ -717,18 +752,31 @@ public class AvailableToolChains {
     }
 
     public static class InstalledClang extends GccCompatibleToolChain {
-        public InstalledClang() {
-            super(ToolFamily.CLANG, VersionNumber.UNKNOWN);
+        public InstalledClang(VersionNumber versionNumber) {
+            super(ToolFamily.CLANG, versionNumber);
         }
 
         @Override
         public boolean meets(ToolChainRequirement requirement) {
-            return requirement == ToolChainRequirement.CLANG || requirement == ToolChainRequirement.GCC_COMPATIBLE || requirement == ToolChainRequirement.AVAILABLE;
+            switch(requirement) {
+                case AVAILABLE:
+                case CLANG:
+                case GCC_COMPATIBLE:
+                    return true;
+                case SUPPORTS_32_AND_64:
+                    return getVersion().compareTo(VersionNumber.parse("10.0.0")) < 0;
+                default:
+                    return false;
+            }
         }
 
         @Override
         public String getBuildScriptConfig() {
-            return "clang(Clang)";
+            String config = String.format("%s(%s)\n", getId(), getImplementationClass());
+            for (File pathEntry : getPathEntries()) {
+                config += String.format("%s.path file('%s')\n", getId(), pathEntry.toURI());
+            }
+            return config;
         }
 
         @Override

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -767,7 +767,7 @@ public class AvailableToolChains {
                     return true;
                 case SUPPORTS_32:
                 case SUPPORTS_32_AND_64:
-                    return getVersion().compareTo(VersionNumber.parse("10.0.0")) < 0;
+                    return (!OperatingSystem.current().isMacOsX()) || getVersion().compareTo(VersionNumber.parse("10.0.0")) < 0;
                 default:
                     return false;
             }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -497,7 +497,7 @@ public class AvailableToolChains {
 
         @Override
         public boolean meets(ToolChainRequirement requirement) {
-            return requirement == ToolChainRequirement.GCC || requirement == ToolChainRequirement.GCC_COMPATIBLE || requirement == ToolChainRequirement.AVAILABLE || requirement == ToolChainRequirement.SUPPORTS_32_AND_64;
+            return requirement == ToolChainRequirement.GCC || requirement == ToolChainRequirement.GCC_COMPATIBLE || requirement == ToolChainRequirement.AVAILABLE || requirement == ToolChainRequirement.SUPPORTS_32 || requirement == ToolChainRequirement.SUPPORTS_32_AND_64;
         }
 
         @Override
@@ -567,6 +567,7 @@ public class AvailableToolChains {
         @Override
         public boolean meets(ToolChainRequirement requirement) {
             switch (requirement) {
+                case SUPPORTS_32:
                 case WINDOWS_GCC:
                     return true;
                 case SUPPORTS_32_AND_64:
@@ -675,6 +676,7 @@ public class AvailableToolChains {
             switch (requirement) {
                 case AVAILABLE:
                 case VISUALCPP:
+                case SUPPORTS_32:
                 case SUPPORTS_32_AND_64:
                     return true;
                 case VISUALCPP_2012_OR_NEWER:
@@ -763,6 +765,7 @@ public class AvailableToolChains {
                 case CLANG:
                 case GCC_COMPATIBLE:
                     return true;
+                case SUPPORTS_32:
                 case SUPPORTS_32_AND_64:
                     return getVersion().compareTo(VersionNumber.parse("10.0.0")) < 0;
                 default:

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
@@ -49,6 +49,8 @@ public enum ToolChainRequirement {
     SWIFTC_3,
     // Any Swift 4.x compiler
     SWIFTC_4,
+    // Supports building 32-bit binaries
+    SUPPORTS_32,
     // Supports building both 32-bit and 64-bit binaries
     SUPPORTS_32_AND_64
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/ToolChainRequirement.java
@@ -48,5 +48,7 @@ public enum ToolChainRequirement {
     // Any Swift 3.x compiler
     SWIFTC_3,
     // Any Swift 4.x compiler
-    SWIFTC_4
+    SWIFTC_4,
+    // Supports building both 32-bit and 64-bit binaries
+    SUPPORTS_32_AND_64
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.nativeplatform.test
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+
 import spock.lang.Unroll
 
 abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
@@ -72,8 +73,8 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
 
         then:
         result.assertTasksExecuted(tasksToCompileComponentUnderTest, tasksToBuildAndRunUnitTest, ":test")
-        result.assertTasksSkipped(tasksToCompileComponentUnderTest)
-        result.assertTasksNotSkipped(tasksToBuildAndRunUnitTest, ":test")
+        result.assertTasksSkipped(tasksToCompileComponentUnderTest + tasksToRelocate)
+        result.assertTasksNotSkipped(tasksToBuildAndRunUnitTest - tasksToRelocate, ":test")
     }
 
     // Creates a single project build with no source

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/AbstractNativeUnitTestIntegrationTest.groovy
@@ -73,8 +73,8 @@ abstract class AbstractNativeUnitTestIntegrationTest extends AbstractInstalledTo
 
         then:
         result.assertTasksExecuted(tasksToCompileComponentUnderTest, tasksToBuildAndRunUnitTest, ":test")
-        result.assertTasksSkipped(tasksToCompileComponentUnderTest + tasksToRelocate)
-        result.assertTasksNotSkipped(tasksToBuildAndRunUnitTest - tasksToRelocate, ":test")
+        result.assertTasksSkipped(tasksToCompileComponentUnderTest)
+        result.assertTasksNotSkipped(tasksToBuildAndRunUnitTest, ":test")
     }
 
     // Creates a single project build with no source

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithApplicationIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithApplicationIntegrationTest.groovy
@@ -82,4 +82,9 @@ class CppUnitTestWithApplicationIntegrationTest extends AbstractNativeUnitTestIn
     protected String[] getTasksToAssembleComponentUnderTest() {
         return [":linkDebug", ":installDebug"]
     }
+
+    @Override
+    protected String[] getTasksToRelocate(String architecture) {
+        return tasks.withArchitecture(architecture).test.relocate
+    }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithApplicationIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithApplicationIntegrationTest.groovy
@@ -82,9 +82,4 @@ class CppUnitTestWithApplicationIntegrationTest extends AbstractNativeUnitTestIn
     protected String[] getTasksToAssembleComponentUnderTest() {
         return [":linkDebug", ":installDebug"]
     }
-
-    @Override
-    protected String[] getTasksToRelocate(String architecture) {
-        return tasks.withArchitecture(architecture).test.relocate
-    }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitDependentComponentsIntegrationSpec.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitDependentComponentsIntegrationSpec.groovy
@@ -18,12 +18,15 @@ package org.gradle.nativeplatform.test.cunit
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32)
 class CUnitDependentComponentsIntegrationSpec extends AbstractInstalledToolChainIntegrationSpec {
 
     def prebuiltDir = buildContext.getSamplesDir().file("native-binaries/cunit/libs")

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitIntegrationTest.groovy
@@ -20,6 +20,8 @@ import org.gradle.ide.visualstudio.fixtures.ProjectFile
 import org.gradle.ide.visualstudio.fixtures.SolutionFile
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CHelloWorldApp
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -27,6 +29,7 @@ import org.gradle.util.TextUtil
 import spock.lang.Issue
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32)
 class CUnitIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
     def prebuiltDir = buildContext.getSamplesDir().file("native-binaries/cunit/libs")

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cunit/CUnitSamplesIntegrationTest.groovy
@@ -20,6 +20,7 @@ package org.gradle.nativeplatform.test.cunit
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.Requires
@@ -29,6 +30,7 @@ import org.junit.Rule
 import static org.junit.Assume.assumeTrue
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32)
 class CUnitSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     @Rule public final Sample cunit = sample(temporaryFolder, 'cunit')
 

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestDependentComponentsIntegrationSpec.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestDependentComponentsIntegrationSpec.groovy
@@ -18,12 +18,15 @@ package org.gradle.nativeplatform.test.googletest
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.gradle.util.TextUtil
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32)
 class GoogleTestDependentComponentsIntegrationSpec extends AbstractInstalledToolChainIntegrationSpec {
 
     def prebuiltDir = buildContext.getSamplesDir().file("native-binaries/google-test/libs")

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestIntegrationTest.groovy
@@ -19,6 +19,8 @@ import org.gradle.ide.visualstudio.fixtures.ProjectFile
 import org.gradle.ide.visualstudio.fixtures.SolutionFile
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
+import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.CppHelloWorldApp
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -28,6 +30,7 @@ import spock.lang.Issue
 import static org.gradle.util.TextUtil.normaliseLineSeparators
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32)
 class GoogleTestIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
 
     def prebuiltDir = buildContext.getSamplesDir().file("native-binaries/google-test/libs")

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestSamplesIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestSamplesIntegrationTest.groovy
@@ -19,6 +19,7 @@ package org.gradle.nativeplatform.test.googletest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.test.fixtures.file.TestDirectoryProvider
 import org.gradle.util.Requires
@@ -27,6 +28,7 @@ import org.junit.Rule
 import static org.junit.Assume.*
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
+@RequiresInstalledToolChain(ToolChainRequirement.SUPPORTS_32)
 class GoogleTestSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
     @Rule public final Sample googleTest = sample(temporaryFolder, 'google-test')
 

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
@@ -52,6 +52,6 @@ abstract class AbstractSwiftXCTestIntegrationTest extends AbstractNativeUnitTest
     String[] getTasksToBuildAndRunUnitTest() {
         return [":compileTestSwift", ":linkTest", ":installTest", ":xcTest"]
     }
-
+    
     protected abstract XCTestSourceElement getPassingTestFixture()
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestIntegrationTest.groovy
@@ -52,6 +52,6 @@ abstract class AbstractSwiftXCTestIntegrationTest extends AbstractNativeUnitTest
     String[] getTasksToBuildAndRunUnitTest() {
         return [":compileTestSwift", ":linkTest", ":installTest", ":xcTest"]
     }
-    
+
     protected abstract XCTestSourceElement getPassingTestFixture()
 }


### PR DESCRIPTION
This fixes the native tests so that they will pass on Xcode 10 and ignore the tests that require 32 bit or both 32 and 64 bit toolchains.

It also allows Xcode 9 toolchains to be discovered if they are added to the system path.

Note that this does NOT fix the issue with extra "swiftdeps~moduleonly" files on Xcode 10.