### PR TITLE
Activate container callback build operations by default

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/CollectionCallbackActionDecorator.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/CollectionCallbackActionDecorator.java
@@ -22,10 +22,6 @@ import javax.annotation.Nullable;
 
 public interface CollectionCallbackActionDecorator {
 
-    // TODO when removing this feature toggle, also remove this class from the allowed
-    //      classes in org.gradle.integtests.tooling.fixture.ToolingApiClasspathProvider
-    String CALLBACK_EXECUTION_BUILD_OPS_TOGGLE = "org.gradle.internal.domain-collection-callback-ops";
-
     @Nullable
     <T> Action<T> decorate(@Nullable Action<T> action);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultCollectionEventRegister.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultCollectionEventRegister.java
@@ -83,7 +83,7 @@ public class DefaultCollectionEventRegister<T> implements CollectionEventRegiste
 
     @Override
     public Action<? super T> registerLazyAddAction(Action<? super T> addAction) {
-        return registerLazyAddDecoratedAction(addAction);
+        return registerLazyAddDecoratedAction(decorate(addAction));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/DefaultBuildOperationExecutor.java
@@ -215,7 +215,7 @@ public class DefaultBuildOperationExecutor implements BuildOperationExecutor, St
     }
 
     private BuildOperationState maybeStartUnmanagedThreadOperation(BuildOperationState parentState) {
-        if (!GradleThread.isManaged() && parentState == null) {
+        if (parentState == null && !GradleThread.isManaged()) {
             parentState = UnmanagedThreadOperation.create(clock);
             parentState.setRunning(true);
             setCurrentBuildOperation(parentState);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
@@ -17,8 +17,8 @@
 package org.gradle.internal.service.scopes;
 
 import org.gradle.StartParameter;
-import org.gradle.api.internal.DefaultCollectionCallbackActionDecorator;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DefaultCollectionCallbackActionDecorator;
 import org.gradle.configuration.internal.DefaultListenerBuildOperationDecorator;
 import org.gradle.configuration.internal.DefaultUserCodeApplicationContext;
 import org.gradle.configuration.internal.ListenerBuildOperationDecorator;
@@ -175,7 +175,7 @@ public class CrossBuildSessionScopeServices implements Closeable {
         }
 
         CollectionCallbackActionDecorator createDomainObjectCollectioncallbackActionDecorator(BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext) {
-            return Boolean.getBoolean(CollectionCallbackActionDecorator.CALLBACK_EXECUTION_BUILD_OPS_TOGGLE) ? new DefaultCollectionCallbackActionDecorator(buildOperationExecutor, userCodeApplicationContext) : CollectionCallbackActionDecorator.NOOP;
+            return new DefaultCollectionCallbackActionDecorator(buildOperationExecutor, userCodeApplicationContext);
         }
     }
 }

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/configuration/ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/configuration/ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.integtests.configuration
 
-
-import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.ExecuteDomainObjectCollectionCallbackBuildOperationType
 import org.gradle.api.internal.plugins.ApplyPluginBuildOperationType
 import org.gradle.api.internal.tasks.RealizeTaskBuildOperationType
@@ -34,12 +32,6 @@ class ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest ext
 
     private static Closure fooTaskRealizationOpsQuery = { it.only(RealizeTaskBuildOperationType, { it.details.taskPath == ':foo' }) }
     private static Closure addingPluginBuildOpQuery = { it.only(ApplyPluginBuildOperationType, { it.details.pluginClass == 'AddingPlugin' }) }
-
-    def setup() {
-        executer.beforeExecute {
-            withArgument("-D${CollectionCallbackActionDecorator.CALLBACK_EXECUTION_BUILD_OPS_TOGGLE}=true")
-        }
-    }
 
     @Unroll
     def '#containerType container callbacks emit registrant when using #callbackName callback(before creation registered)'() {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/progress/DefaultProgressLoggerFactory.java
@@ -22,6 +22,7 @@ import org.gradle.internal.logging.events.ProgressStartEvent;
 import org.gradle.internal.operations.BuildOperationCategory;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationIdFactory;
+import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.time.Clock;
@@ -93,6 +94,7 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
         if (parentOperation != null && !(parentOperation instanceof ProgressLoggerImpl)) {
             throw new IllegalArgumentException("Unexpected parent logger.");
         }
+        BuildOperationRef currentBuildOperation = currentBuildOperationRef.get();
         return new ProgressLoggerImpl(
             (ProgressLoggerImpl) parentOperation,
             new OperationIdentifier(buildOperationIdFactory.nextId()),
@@ -100,8 +102,8 @@ public class DefaultProgressLoggerFactory implements ProgressLoggerFactory {
             progressListener,
             clock,
             false,
-            currentBuildOperationRef.getId(),
-            currentBuildOperationRef.getParentId(),
+            currentBuildOperation != null ? currentBuildOperation.getId() : null,
+            currentBuildOperation != null ? currentBuildOperation.getParentId() : null,
             null
         );
     }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventTransformer.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventTransformer.java
@@ -83,8 +83,8 @@ public class OutputEventTransformer implements OutputEventListener {
             }
         } else if (event instanceof ProgressCompleteEvent) {
             ProgressCompleteEvent completeEvent = (ProgressCompleteEvent) event;
-            effectiveProgressOperation.remove(completeEvent.getProgressOperationId());
-            if (forwarded.remove(completeEvent.getProgressOperationId())) {
+            OperationIdentifier mappedEvent = effectiveProgressOperation.remove(completeEvent.getProgressOperationId());
+            if (mappedEvent == null && forwarded.remove(completeEvent.getProgressOperationId())) {
                 listener.onOutput(event);
             }
         } else if (event instanceof ProgressEvent) {

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.tooling.r51
 
 import org.gradle.api.Action
-import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -297,9 +296,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
         """
 
         when:
-        runBuild("tasks", EnumSet.of(OperationType.PROJECT_CONFIGURATION)) {
-            it.withArguments("-D${CollectionCallbackActionDecorator.CALLBACK_EXECUTION_BUILD_OPS_TOGGLE}=true")
-        }
+        runBuild("tasks", EnumSet.of(OperationType.PROJECT_CONFIGURATION))
 
         then:
         def pluginResults = getPluginConfigurationOperationResult(":").getPluginApplicationResults()
@@ -329,9 +326,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
         """
 
         when:
-        runBuild("tasks", EnumSet.of(OperationType.PROJECT_CONFIGURATION)) {
-            it.withArguments("-D${CollectionCallbackActionDecorator.CALLBACK_EXECUTION_BUILD_OPS_TOGGLE}=true")
-        }
+        runBuild("tasks", EnumSet.of(OperationType.PROJECT_CONFIGURATION))
 
         then:
         def pluginResults = getPluginConfigurationOperationResult(":").getPluginApplicationResults()

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskOriginCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/TaskOriginCrossVersionSpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.tooling.r51
 
 import org.gradle.api.Action
-import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.integtests.tooling.fixture.ProgressEvents
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
@@ -61,7 +60,7 @@ class TaskOriginCrossVersionSpec extends ToolingApiSpecification {
         runBuild('build')
 
         then:
-        task(':classes').originPlugin.displayName == "org.gradle.java"
+        task(':classes').originPlugin.displayName == "org.gradle.api.plugins.JavaBasePlugin"
         task(':jar').originPlugin.displayName == "org.gradle.java"
         task(':assemble').originPlugin.displayName == "org.gradle.language.base.plugins.LifecycleBasePlugin"
         task(':test').originPlugin.displayName == "org.gradle.java"
@@ -146,9 +145,7 @@ class TaskOriginCrossVersionSpec extends ToolingApiSpecification {
         """
 
         when:
-        runBuild('printFoo') {
-            it.withArguments("-D${CollectionCallbackActionDecorator.CALLBACK_EXECUTION_BUILD_OPS_TOGGLE}=true")
-        }
+        runBuild('printFoo')
 
         then:
         task(':printFoo').originPlugin.displayName == "MyPlugin"

--- a/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClasspathProvider.groovy
+++ b/subprojects/tooling-api/src/testFixtures/groovy/org/gradle/integtests/tooling/fixture/ToolingApiClasspathProvider.groovy
@@ -18,7 +18,6 @@ package org.gradle.integtests.tooling.fixture
 
 import org.apache.commons.io.output.TeeOutputStream
 import org.gradle.api.Action
-import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.internal.classloader.DefaultClassLoaderFactory
 import org.gradle.internal.classloader.FilteringClassLoader
 import org.gradle.internal.classloader.MultiParentClassLoader
@@ -73,7 +72,6 @@ trait ToolingApiClasspathProvider {
         sharedSpec.allowClass(ToolingApiVersion)
         sharedSpec.allowClass(TeeOutputStream)
         sharedSpec.allowClass(ClassLoaderFixture)
-        sharedSpec.allowClass(CollectionCallbackActionDecorator) // TODO remove this class when the CALLBACK_EXECUTION_BUILD_OPS_TOGGLE feature toggle is removed
         classpathConfigurer.execute(sharedSpec)
         def sharedClassLoader = classLoaderFactory.createFilteringClassLoader(getClass().classLoader, sharedSpec)
 


### PR DESCRIPTION
I did a few small enhancements, leaving the overhead at ~2%, which I'm ready to accept for now. 

We already have logic that filters out [uninteresting progress events](https://github.com/gradle/gradle/blob/master/subprojects/logging/src/main/java/org/gradle/internal/logging/sink/OutputEventTransformer.java), which avoids the bulk of unnecessary work. The 2% mentioned above are fully due to creating these events, e.g. looking up their parent in a threadlocal, creating the object, getting the current time etc. 

We could do slightly better by not creating them in the first place. It would be a bit messier, because the `ProgressLoggerFactory` is not aware of all the other loggers that are using the current build operation as their reference point. That's why the filtering currently happens at the funnel point where all events go through. We could change this by letting the `ProgressLoggerFactory` publish information about the current **interesting**  build operation and use that as the reference point for other loggers. Then we could avoid creating the uninteresting events entirely. We'd have to transport this information across thread boundaries, so that the hierarchy is preserved when using workers for instance. Overall I doubt this is going to save that much and probably not worth the extra complexity.

I think we're better off looking for performance improvements elsewhere. 