### PR TITLE
Handle dot in project name correctly without dropping part of the project name

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -25,8 +25,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import static org.gradle.internal.FileUtils.withExtension;
-
 public abstract class OperatingSystem {
     public static final Windows WINDOWS = new Windows();
     public static final MacOs MAC_OS = new MacOs();
@@ -124,6 +122,24 @@ public abstract class OperatingSystem {
     public abstract String getLinkLibrarySuffix();
 
     public abstract String getLinkLibraryName(String libraryPath);
+
+    public static String withExtension(String filePath, String extension) {
+        if (filePath.toLowerCase().endsWith(extension)) {
+            return filePath;
+        }
+        return removeExtension(filePath) + extension;
+    }
+
+    public static String removeExtension(String filePath) {
+        int fileNameStart = Math.max(filePath.lastIndexOf('/'), filePath.lastIndexOf('\\'));
+        int extensionPos = filePath.lastIndexOf('.');
+
+        if (extensionPos > fileNameStart && filePath.matches("^.*\\.(bat|BAT|exe|EXE|dll|DLL|lib|LIB|so|a)$")) {
+            return filePath.substring(0, extensionPos);
+        }
+        return filePath;
+    }
+
 
     @UsedByScanPlugin
     public abstract String getFamilyName();

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
@@ -84,6 +84,8 @@ class OperatingSystemTest extends Specification {
         os.getScriptName("a.exe") == "a.bat"
         os.getScriptName("a.b/c") == "a.b/c.bat"
         os.getScriptName("a.b\\c") == "a.b\\c.bat"
+        os.getScriptName("any/path/to/filesystem/base.name") == "any/path/to/filesystem/base.name.bat"
+        os.getScriptName("any/path/to/filesystem/base-name") == "any/path/to/filesystem/base-name.bat"
     }
 
     def "windows transforms executable names"() {
@@ -97,6 +99,8 @@ class OperatingSystemTest extends Specification {
         os.getExecutableName("a.bat") == "a.exe"
         os.getExecutableName("a.b/c") == "a.b/c.exe"
         os.getExecutableName("a.b\\c") == "a.b\\c.exe"
+        os.getExecutableName("any/path/to/filesystem/base.name") == "any/path/to/filesystem/base.name.exe"
+        os.getExecutableName("any/path/to/filesystem/base-name") == "any/path/to/filesystem/base-name.exe"
     }
 
     def "windows transforms shared library names"() {
@@ -110,9 +114,18 @@ class OperatingSystemTest extends Specification {
         os.getSharedLibraryName("a") == "a.dll"
         os.getSharedLibraryName("a.lib") == "a.dll"
         os.getSharedLibraryName("a.b/c") == "a.b/c.dll"
+        os.getSharedLibraryName("abc.def/a") == "abc.def/a.dll"
+        os.getSharedLibraryName("abc.def/ghi.jkl") == "abc.def/ghi.jkl.dll"
+        os.getSharedLibraryName("any/path/to/filesystem/base.name") == "any/path/to/filesystem/base.name.dll"
+        os.getSharedLibraryName("any/path/to/filesystem/base-name") == "any/path/to/filesystem/base-name.dll"
+        os.getSharedLibraryName("a.b\\c") == "a.b\\c.dll"
         os.getSharedLibraryName("a.b\\c") == "a.b\\c.dll"
         os.getLinkLibraryName("a") == "a.lib"
         os.getLinkLibraryName("a.lib") == "a.lib"
+        os.getLinkLibraryName("abc.def") == "abc.def.lib"
+        os.getLinkLibraryName("abc/def") == "abc/def.lib"
+        os.getLinkLibraryName("abc/def/base-name") == "abc/def/base-name.lib"
+        os.getLinkLibraryName("abc/def/base.name") == "abc/def/base.name.lib"
     }
 
     def "windows transforms static library names"() {
@@ -124,6 +137,8 @@ class OperatingSystemTest extends Specification {
         os.getStaticLibraryName("a.LIB") == "a.LIB"
         os.getStaticLibraryName("a") == "a.lib"
         os.getStaticLibraryName("a.dll") == "a.lib"
+        os.getStaticLibraryName("any/path/to/filesystem/base-name") == "any/path/to/filesystem/base-name.lib"
+        os.getStaticLibraryName("any/path/to/filesystem/base.name") == "any/path/to/filesystem/base.name.lib"
         os.getStaticLibraryName("a.b/c") == "a.b/c.lib"
         os.getStaticLibraryName("a.b\\c") == "a.b\\c.lib"
     }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationIntegrationTest.groovy
@@ -148,6 +148,26 @@ class SwiftApplicationIntegrationTest extends AbstractSwiftIntegrationTest imple
         installation("build/install/main/debug").exec().out == app.expectedOutput
     }
 
+    def "sources are compiled and linked with Swift tools with 'dot' in project name"() {
+        given:
+        def app = new SwiftApp()
+        settingsFile << "rootProject.name = 'app.test'"
+        app.writeToProject(testDirectory)
+
+        and:
+        buildFile << """
+            apply plugin: 'swift-application'
+         """
+
+        expect:
+        succeeds "assemble"
+        result.assertTasksExecuted(":compileDebugSwift", ":linkDebug", ":installDebug", ":assemble")
+
+        executable("build/exe/main/debug/app.test").assertExists()
+        file("build/modules/main/debug/app.test.swiftmodule").assertIsFile()
+        installation("build/install/main/debug").exec().out == app.expectedOutput
+    }
+
     def "can build debug and release variant of the executable"() {
         given:
         def app = new SwiftAppWithOptionalFeature()


### PR DESCRIPTION
Issue [#960](https://github.com/gradle/gradle-native/issues/960)
Handle dot in project name without dropping part of the project name.

Signed-off-by: Kent Fletcher <kfletcher@sumglobal.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
