### PR TITLE
Allow a convention to be defined for property types and tweak default values

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/DirectoryProperty.java
@@ -58,6 +58,18 @@ public interface DirectoryProperty extends Property<Directory> {
     DirectoryProperty value(Directory value);
 
     /**
+     * {@inheritDoc}
+     */
+    @Override
+    DirectoryProperty convention(Directory value);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    DirectoryProperty convention(Provider<? extends Directory> valueProvider);
+
+    /**
      * Returns a {@link Directory} whose value is the given path resolved relative to the value of this directory.
      *
      * @param path The path. Can be absolute.

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/RegularFileProperty.java
@@ -42,7 +42,7 @@ public interface RegularFileProperty extends Property<RegularFile> {
     Provider<File> getAsFile();
 
     /**
-     * Sets the location of this file.
+     * Sets the location of this file, using a {@link File} instance.
      */
     void set(File file);
 
@@ -51,4 +51,16 @@ public interface RegularFileProperty extends Property<RegularFile> {
      */
     @Override
     RegularFileProperty value(RegularFile value);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    RegularFileProperty convention(RegularFile value);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    RegularFileProperty convention(Provider<? extends RegularFile> valueProvider);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -96,6 +96,7 @@ public interface ObjectFactory {
      * <ul>
      * <li>For {@link List} properties, you should use {@link #listProperty(Class)}.</li>
      * <li>For {@link Set} properties, you should use {@link #setProperty(Class)}.</li>
+     * <li>For {@link Map} properties, you should use {@link #mapProperty(Class, Class)}.</li>
      * <li>For {@link org.gradle.api.file.Directory} properties, you should use {@link #directoryProperty()}.</li>
      * <li>For {@link org.gradle.api.file.RegularFile} properties, you should use {@link #fileProperty()}.</li>
      * </ul>
@@ -107,7 +108,7 @@ public interface ObjectFactory {
     <T> Property<T> property(Class<T> valueType);
 
     /**
-     * Creates a {@link ListProperty} implementation to hold a {@link List} of the given element type {@code T}. The property has no initial value.
+     * Creates a {@link ListProperty} implementation to hold a {@link List} of the given element type {@code T}. The property has an empty list as its initial value.
      *
      * <p>The implementation will return immutable {@link List} values from its query methods.</p>
      *
@@ -119,7 +120,7 @@ public interface ObjectFactory {
     <T> ListProperty<T> listProperty(Class<T> elementType);
 
     /**
-     * Creates a {@link SetProperty} implementation to hold a {@link Set} of the given element type {@code T}. The property has no initial value.
+     * Creates a {@link SetProperty} implementation to hold a {@link Set} of the given element type {@code T}. The property has an empty list as its initial value.
      *
      * <p>The implementation will return immutable {@link Set} values from its query methods.</p>
      *
@@ -131,7 +132,7 @@ public interface ObjectFactory {
     <T> SetProperty<T> setProperty(Class<T> elementType);
 
     /**
-     * Creates a {@link MapProperty} implementation to hold a {@link Map} of the given key type {@code K} and value type {@code V}. The property has no initial value.
+     * Creates a {@link MapProperty} implementation to hold a {@link Map} of the given key type {@code K} and value type {@code V}. The property has an empty map as its initial value.
      *
      * <p>The implementation will return immutable {@link Map} values from its query methods.</p>
      * @param keyType the type of key.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -100,12 +100,22 @@ public interface HasMultipleValues<T> {
     void addAll(Provider<? extends Iterable<? extends T>> provider);
 
     /**
-     * Specifies the values to use as the convention for this property. The convention is used when no value has been set for this property.
+     * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.
      *
      * @param elements The elements
+     * @return this
      * @since 5.1
      */
-    void convention(Iterable<? extends T> elements);
+    HasMultipleValues<T> convention(Iterable<? extends T> elements);
+
+    /**
+     * Specifies the provider of the value to use as the convention for this property. The convention is used when no value has been set for this property.
+     *
+     * @param provider The provider of the elements
+     * @return this
+     * @since 5.1
+     */
+    HasMultipleValues<T> convention(Provider<? extends Iterable<? extends T>> provider);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Iterable)} or {@link #add(Object)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/HasMultipleValues.java
@@ -100,6 +100,14 @@ public interface HasMultipleValues<T> {
     void addAll(Provider<? extends Iterable<? extends T>> provider);
 
     /**
+     * Specifies the values to use as the convention for this property. The convention is used when no value has been set for this property.
+     *
+     * @param elements The elements
+     * @since 5.1
+     */
+    void convention(Iterable<? extends T> elements);
+
+    /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Iterable)} or {@link #add(Object)} will fail.
      *
      * <p>When this property has elements provided by a {@link Provider}, the value of the provider is queried when this method is called  and the value of the provider will no longer be tracked.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/ListProperty.java
@@ -39,4 +39,16 @@ public interface ListProperty<T> extends Provider<List<T>>, HasMultipleValues<T>
      */
     @Override
     ListProperty<T> empty();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> convention(Iterable<? extends T> elements);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/MapProperty.java
@@ -138,6 +138,22 @@ public interface MapProperty<K, V> extends Provider<Map<K, V>> {
     Provider<Set<K>> keySet();
 
     /**
+     * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.
+     *
+     * @param value The value.
+     * @return this
+     */
+    MapProperty<K, V> convention(Map<? extends K, ? extends V> value);
+
+    /**
+     * Specifies the provider of the value to use as the convention for this property. The convention is used when no value has been set for this property.
+     *
+     * @param valueProvider The provider of the value.
+     * @return this
+     */
+    MapProperty<K, V> convention(Provider<? extends Map<? extends K, ? extends V>> valueProvider);
+
+    /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Map)} or {@link #put(Object, Object)} will fail.
      *
      * <p>When this property has elements provided by a {@link Provider}, the value of the provider is queried when this method is called  and the value of the provider will no longer be tracked.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/Property.java
@@ -65,7 +65,25 @@ public interface Property<T> extends Provider<T> {
      * @return this
      * @since 5.0
      */
-    Property<T> value(T value);
+    Property<T> value(@Nullable T value);
+
+    /**
+     * Specifies the value to use as the convention for this property. The convention is used when no value has been set for this property.
+     *
+     * @param value The value.
+     * @return this
+     * @since 5.1
+     */
+    Property<T> convention(T value);
+
+    /**
+     * Specifies the provider of the value to use as the convention for this property. The convention is used when no value has been set for this property.
+     *
+     * @param valueProvider The provider of the value.
+     * @return this
+     * @since 5.1
+     */
+    Property<T> convention(Provider<? extends T> valueProvider);
 
     /**
      * Disallows further changes to the value of this property. Calls to methods that change the value of this property, such as {@link #set(Object)} or {@link #set(Provider)} will fail.

--- a/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/provider/SetProperty.java
@@ -39,4 +39,16 @@ public interface SetProperty<T> extends Provider<Set<T>>, HasMultipleValues<T> {
      */
     @Override
     SetProperty<T> empty();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> convention(Iterable<? extends T> elements);
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileSetPropertyIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/FileSetPropertyIntegrationTest.groovy
@@ -98,7 +98,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
 
             class MergeTask extends DefaultTask {
                 @InputFiles
-                final SetProperty<RegularFile> inputFiles = project.objects.setProperty(RegularFile).empty()
+                final SetProperty<RegularFile> inputFiles = project.objects.setProperty(RegularFile)
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
                 
@@ -163,7 +163,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
                 @InputFile
                 final RegularFileProperty inputFile = project.objects.fileProperty()
                 @OutputFiles
-                final SetProperty<RegularFile> outputFiles = project.objects.setProperty(RegularFile).empty()
+                final SetProperty<RegularFile> outputFiles = project.objects.setProperty(RegularFile)
                 
                 @TaskAction
                 void go() {
@@ -176,7 +176,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
 
             class MergeTask extends DefaultTask {
                 @InputFiles
-                final SetProperty<RegularFile> inputFiles = project.objects.setProperty(RegularFile).empty()
+                final SetProperty<RegularFile> inputFiles = project.objects.setProperty(RegularFile)
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
                 
@@ -243,7 +243,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
 
             class MergeTask extends DefaultTask {
                 @InputFiles
-                final SetProperty<Directory> inputDirs = project.objects.setProperty(Directory).empty()
+                final SetProperty<Directory> inputDirs = project.objects.setProperty(Directory)
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
 
@@ -309,7 +309,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
                 final RegularFileProperty inputFile = project.objects.fileProperty()
 
                 @OutputDirectories
-                final SetProperty<Directory> outputDirs = project.objects.setProperty(Directory).empty()
+                final SetProperty<Directory> outputDirs = project.objects.setProperty(Directory)
 
                 @TaskAction
                 void go() {
@@ -322,7 +322,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
 
             class MergeTask extends DefaultTask {
                 @InputFiles
-                final SetProperty<Directory> inputDirs = project.objects.setProperty(Directory).empty()
+                final SetProperty<Directory> inputDirs = project.objects.setProperty(Directory)
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
 
@@ -398,7 +398,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
             
-            def generatedFiles = objects.setProperty(RegularFile).empty() 
+            def generatedFiles = objects.setProperty(RegularFile) 
             
             task createFile1(type: FileOutputTask)
             generatedFiles.add(createFile1.outputFile)
@@ -462,7 +462,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
 
             class MergeTask extends DefaultTask {
                 @InputFiles
-                final SetProperty<Directory> inputDirs = project.objects.setProperty(Directory).empty()
+                final SetProperty<Directory> inputDirs = project.objects.setProperty(Directory)
                 @OutputFile
                 final RegularFileProperty outputFile = project.objects.fileProperty()
 
@@ -473,7 +473,7 @@ class FileSetPropertyIntegrationTest extends AbstractIntegrationSpec {
                 }
             }
 
-            def generatedFiles = objects.setProperty(Directory).empty() 
+            def generatedFiles = objects.setProperty(Directory) 
 
             task createDir1(type: DirOutputTask)
             generatedFiles.add(createDir1.outputDir)

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDependencyInferenceIntegrationTest.groovy
@@ -448,7 +448,7 @@ The following types/formats are supported:
                 out1 = file("b-1.txt")
                 out2 = file("b-2.txt")
             }
-            def files = objects.setProperty(RegularFile).empty()
+            def files = objects.setProperty(RegularFile)
             files.add(a.out1)
             files.add(b.out2)
             tasks.register("c", InputFilesTask) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFilePropertyFactory.java
@@ -189,6 +189,18 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
             super.value(value);
             return this;
         }
+
+        @Override
+        public RegularFileProperty convention(RegularFile value) {
+            super.convention(value);
+            return this;
+        }
+
+        @Override
+        public RegularFileProperty convention(Provider<? extends RegularFile> valueProvider) {
+            super.convention(valueProvider);
+            return this;
+        }
     }
 
     static class ResolvingDirectory extends AbstractResolvingProvider<Directory> {
@@ -244,6 +256,18 @@ public class DefaultFilePropertyFactory implements FilePropertyFactory {
         @Override
         public DirectoryProperty value(Directory value) {
             super.value(value);
+            return this;
+        }
+
+        @Override
+        public DirectoryProperty convention(Directory value) {
+            super.convention(value);
+            return this;
+        }
+
+        @Override
+        public DirectoryProperty convention(Provider<? extends Directory> valueProvider) {
+            super.convention(valueProvider);
             return this;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -44,6 +44,7 @@ import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class DefaultObjectFactory implements ObjectFactory {
@@ -106,6 +107,8 @@ public class DefaultObjectFactory implements ObjectFactory {
             DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() to create a property of type List<T>", "ObjectFactory.listProperty()");
         } else if (Set.class.isAssignableFrom(valueType)) {
             DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type Set<T>", "ObjectFactory.setProperty()");
+        } else if (Map.class.isAssignableFrom(valueType)) {
+            DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type Map<K, V>", "ObjectFactory.mapProperty()");
         } else if (Directory.class.isAssignableFrom(valueType)) {
             DeprecationLogger.nagUserOfReplacedMethodInvocation("ObjectFactory.property() method to create a property of type Directory", "ObjectFactory.directoryProperty()");
         } else if (RegularFile.class.isAssignableFrom(valueType)) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -27,7 +27,7 @@ import spock.lang.Unroll
 class DefaultObjectFactoryTest extends Specification {
     def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory))
 
-    def "can create a property"() {
+    def "property has no value"() {
         expect:
         def property = factory.property(Boolean)
         !property.present
@@ -75,11 +75,11 @@ class DefaultObjectFactoryTest extends Specification {
         factory.sourceDirectorySet("name", "display") != null
     }
 
-    def "can create a List property"() {
+    def "list property has empty list as value"() {
         expect:
         def property = factory.listProperty(String)
-        !property.present
-        property.getOrNull() == null
+        property.present
+        property.get().empty
     }
 
     @Unroll
@@ -89,7 +89,6 @@ class DefaultObjectFactoryTest extends Specification {
 
         expect:
         property.elementType == boxedType
-        !property.present
 
         where:
         type           | boxedType
@@ -103,11 +102,11 @@ class DefaultObjectFactoryTest extends Specification {
         Character.TYPE | Character
     }
 
-    def "can create a Set property"() {
+    def "set property has empty set as value"() {
         expect:
         def property = factory.setProperty(String)
-        !property.present
-        property.getOrNull() == null
+        property.present
+        property.get().empty
     }
 
     @Unroll
@@ -117,7 +116,6 @@ class DefaultObjectFactoryTest extends Specification {
 
         expect:
         property.elementType == boxedType
-        !property.present
 
         where:
         type           | boxedType
@@ -129,6 +127,13 @@ class DefaultObjectFactoryTest extends Specification {
         Float.TYPE     | Float
         Double.TYPE    | Double
         Character.TYPE | Character
+    }
+
+    def "map property has empty map as value"() {
+        expect:
+        def property = factory.mapProperty(String, Boolean)
+        property.present
+        property.get().isEmpty()
     }
 
     @Unroll
@@ -139,7 +144,6 @@ class DefaultObjectFactoryTest extends Specification {
         expect:
         property.keyType == boxedType
         property.valueType == boxedType
-        !property.present
 
         where:
         type           | boxedType

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -55,6 +55,10 @@ Look at the [userguide](userguide/declaring_repositories.html#sec::matching_repo
 
 This release includes a lazy [`MapProperty`](javadoc/org/gradle/api/provider/MapProperty.html) type which allows efficient configuration of maps in the Gradle model.
 
+### Allow a convention to be specified for a collection property
+
+A `convention` method is now available for `ListProperty` and `SetProperty` types, which allows the <em>convention</em> for a property to be specified. The convention is the value that is used when no value has been explicitly configured for the property.
+
 ## Tooling API: Enhanced/additional progress events
 
 The following Tooling API types reported as part of [`ProgressEvents`](javadoc/org/gradle/tooling/events/ProgressEvent.html) to registered [`ProgressListeners`](javadoc/org/gradle/tooling/events/ProgressListener.html) have been enhanced to include additional information:

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -13,9 +13,15 @@ We would like to thank the following community contributors to this release of G
 [Alex Saveau](https://github.com/SUPERCILEX)
 [Till Krullmann](https://github.com/tkrullmann)
 
-## Use plugins from included build using the `plugins { }` block 
+## Apply plugins from included build using `plugins { }` block 
 
-The `plugins { }` block in build scripts can now be used to refer to plugins defined in included builds.
+The [`plugins { }`](userguide/plugins.html#sec:plugins_block) block in build scripts can now be used to refer to plugins defined in included builds. In previous versions of Gradle, this was possible but required some additional boiler-plate code in the settings file. This boiler-plate is now no longer required.
+
+This change makes it super easy to add a test build for a Gradle plugin and streamlines the process of implementing a Gradle plugin. You can also use this feature to conveniently work on changes to a plugin and builds that use that plugin at the same time, to implement a plugin that is both published and used by projects in the same source repository, or to structure a complex build into a number of plugins.
+
+Using the `plugins { } ` block also makes the Gradle Kotlin DSL much more convenient to use.
+
+You can find out more about composite builds in the [user manual](userguide/composite_builds.html).
 
 ## Stricter validation with `validateTaskProperties`
 
@@ -47,17 +53,21 @@ repositories {
 
 This filtering can also be used to separate snapshot repositories from release repositories.
 
-Look at the [userguide](userguide/declaring_repositories.html#sec::matching_repositories_to_dependencies) for more details.
+Look at the [user manual](userguide/declaring_repositories.html#sec::matching_repositories_to_dependencies) for more details.
 
 ## Improvements for plugin authors
 
-### Conveniences for properties of type Map
+### Conveniences for Map properties
 
-This release includes a lazy [`MapProperty`](javadoc/org/gradle/api/provider/MapProperty.html) type which allows efficient configuration of maps in the Gradle model.
+This release includes a lazy [`MapProperty`](javadoc/org/gradle/api/provider/MapProperty.html) type which allows efficient configuration of maps in the Gradle model, for example in a project extension or task property.
 
-### Allow a convention to be specified for a property
+See the [user manual](userguide/lazy_configuration.html#sec:working_with_maps) for more details.
 
-A `convention` method is now available for property types, which allows the <em>convention</em> for a property to be specified. The convention is the value that is used when no value has been explicitly configured for the property.
+### Specify a convention for a property
+
+A `convention` method is now available for property types, which allows the <em>convention</em> for a property to be specified. The convention is a value that is used when no value has been explicitly configured for the property.
+
+See the [user manual](userguide/lazy_configuration.html#sec:applying_conventions) for more details.
 
 ## Tooling API: Enhanced/additional progress events
 
@@ -78,7 +88,7 @@ The additional data and the new operation types are only available if the versio
 ## Promoted features
 
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
-See the User guide section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
+See the User manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.
 
 The following are the features that have been promoted in this Gradle release.
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -55,9 +55,9 @@ Look at the [userguide](userguide/declaring_repositories.html#sec::matching_repo
 
 This release includes a lazy [`MapProperty`](javadoc/org/gradle/api/provider/MapProperty.html) type which allows efficient configuration of maps in the Gradle model.
 
-### Allow a convention to be specified for a collection property
+### Allow a convention to be specified for a property
 
-A `convention` method is now available for `ListProperty` and `SetProperty` types, which allows the <em>convention</em> for a property to be specified. The convention is the value that is used when no value has been explicitly configured for the property.
+A `convention` method is now available for property types, which allows the <em>convention</em> for a property to be specified. The convention is the value that is used when no value has been explicitly configured for the property.
 
 ## Tooling API: Enhanced/additional progress events
 
@@ -133,28 +133,25 @@ Use `setFrom` instead.
     validateTaskProperties.getClasses().setFrom(fileCollection)
     validateTaskProperties.getClasspath().setFrom(fileCollection)
     
-### Breaking changes
-
-<!-- add any notable changes here in a summary -->
+## Potential breaking changes
 
 See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn about breaking changes and considerations for upgrading from Gradle 5.x.
+
+### Collection properties default to empty collection
+
+In Gradle 5.0, the collection property instances created using `ObjectFactory` would have no value defined, requiring plugin authors to explicitly set an initial value. This proved to be awkward and error prone so `ObjectFactory` now returns instances with an empty collection as their initial value.
+
+### Worker API: working directory of a worker can no longer be set 
+
+Since JDK 11 no longer supports changing the working directory of a running process, setting the working directory of a worker via its fork options is now prohibited.
+All workers now use the same working directory to enable reuse.
+Please pass files and directories as arguments instead.
 
 ### Changes to native linking tasks
 
 To expand our idiomatic [Provider API](userguide/lazy_configuration.html) practices, the install name property from `org.gradle.nativeplatform.tasks.LinkSharedLibrary` is affected by this change.
 - `getInstallName()` was changed to return a `Property`.
 - `setInstallName(String)` was removed. Use `Property.set()` instead.
-    
-## Potential breaking changes
-
-<!--
-### Example breaking change
--->
-### Worker API: working directory of a worker can no longer be set 
-
-Since JDK 11 no longer supports changing the working directory of a running process, setting the working directory of a worker via its fork options is now prohibited.
-All workers now use the same working directory to enable reuse.
-Please pass files and directories as arguments instead.
 
 ### Passing arguments to Windows Resource Compiler
 
@@ -168,6 +165,11 @@ The fix for gradle/gradle#6996 means that the list of `beforeResolve` actions ar
 Instead, a copied configuration receives a copy of the `beforeResolve` actions at the time the copy is made.
 Any `beforeResolve` actions added after copying (to either configuration) will not be shared between the original and the copy.
 This may break plugins that relied on the previous behaviour.
+
+### Changes to incubating Pom customizaton types
+
+- The type of `MavenPomDeveloper.properties` has changed from `Property<Map<String, String>>` to `MapProperty<String, String>`.
+- The type of `MavenPomContributor.properties` has changed from `Property<Map<String, String>>` to `MapProperty<String, String>`.
 
 ## External contributions
 

--- a/subprojects/docs/src/docs/userguide/lazy_configuration.adoc
+++ b/subprojects/docs/src/docs/userguide/lazy_configuration.adoc
@@ -251,6 +251,30 @@ include::{samplesPath}/providers/mapProperty/mapProperty.out[]
 include::{samplesPath}/providers/mapProperty/mapProperty.out[]
 ----
 
+[[sec:applying_conventions]]
+== Applying a convention to a property
+
+Often you want to apply some _contention_, or default value, to a property to be used if no value has been configured for the property. You can use the `convention()` method for this. This method accepts either a value or a `Provider` and this will be used as the value until some other value is configured.
+
+.Property conventions
+====
+include::sample[dir="providers/propertyConvention/groovy",files="build.gradle[]"]
+include::sample[dir="providers/propertyConvention/kotlin",files="build.gradle.kts[]"]
+====
+
+.Output of **`gradle show`**
+[.multi-language-text.lang-groovy]
+----
+> gradle show
+include::{samplesPath}/providers/propertyConvention/propertyConvention.out[]
+----
+.Output of **`gradle show`**
+[.multi-language-text.lang-kotlin]
+----
+> gradle show
+include::{samplesPath}/providers/propertyConvention/propertyConvention.out[]
+----
+
 [[sec:unmodifiable_property]]
 == Making a property unmodifiable
 

--- a/subprojects/docs/src/samples/providers/listProperty/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/listProperty/groovy/build.gradle
@@ -14,7 +14,7 @@ class Producer extends DefaultTask {
 
 class Consumer extends DefaultTask {
     @InputFiles
-    final ListProperty<RegularFile> inputFiles = project.objects.listProperty(RegularFile).empty()
+    final ListProperty<RegularFile> inputFiles = project.objects.listProperty(RegularFile)
 
     @TaskAction
     void consume() {

--- a/subprojects/docs/src/samples/providers/listProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/listProperty/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ open class Producer : DefaultTask() {
 
 open class Consumer : DefaultTask() {
     @InputFiles
-    val inputFiles: ListProperty<RegularFile> = project.objects.listProperty(RegularFile::class).empty()
+    val inputFiles: ListProperty<RegularFile> = project.objects.listProperty(RegularFile::class)
 
     @TaskAction
     fun consume() {

--- a/subprojects/docs/src/samples/providers/mapProperty/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/mapProperty/groovy/build.gradle
@@ -1,6 +1,6 @@
 class Generator extends DefaultTask {
     @Input
-    final MapProperty<String, Integer> properties = project.objects.mapProperty(String, Integer).empty()
+    final MapProperty<String, Integer> properties = project.objects.mapProperty(String, Integer)
 
     @TaskAction
     void generate() {

--- a/subprojects/docs/src/samples/providers/mapProperty/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/mapProperty/kotlin/build.gradle.kts
@@ -1,6 +1,6 @@
 open class Generator: DefaultTask() {
     @Input
-    val properties: MapProperty<String, Int> = project.objects.mapProperty(String::class, Int::class).empty()
+    val properties: MapProperty<String, Int> = project.objects.mapProperty(String::class, Int::class)
 
     @TaskAction
     fun generate() {

--- a/subprojects/docs/src/samples/providers/propertyConvention/groovy/build.gradle
+++ b/subprojects/docs/src/samples/providers/propertyConvention/groovy/build.gradle
@@ -1,0 +1,19 @@
+task show {
+    doLast {
+        def property = objects.property(String)
+
+        // Set a convention
+        property.convention("convention 1")
+        println("value = " + property.get())
+
+        // Can replace the convention
+        property.convention("convention 2")
+        println("value = " + property.get())
+
+        property.set("value")
+
+        // Once a value is set, the convention is ignored
+        property.convention("ignored convention")
+        println("value = " + property.get())
+    }
+}

--- a/subprojects/docs/src/samples/providers/propertyConvention/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/providers/propertyConvention/groovy/settings.gradle
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = 'propertyConvention'

--- a/subprojects/docs/src/samples/providers/propertyConvention/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/providers/propertyConvention/kotlin/build.gradle.kts
@@ -1,0 +1,18 @@
+tasks.create("show") {
+    doLast {
+        val property = objects.property(String::class)
+
+        property.convention("convention 1")
+        println("value = " + property.get())
+
+        // Can replace the convention
+        property.convention("convention 2")
+        println("value = " + property.get())
+
+        property.set("value")
+        // Once a value is set, the convention is ignored
+
+        property.convention("ignored convention")
+        println("value = " + property.get())
+    }
+}

--- a/subprojects/docs/src/samples/providers/propertyConvention/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/providers/propertyConvention/kotlin/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "propertyConvention"

--- a/subprojects/docs/src/samples/providers/propertyConvention/propertyConvention.out
+++ b/subprojects/docs/src/samples/providers/propertyConvention/propertyConvention.out
@@ -1,0 +1,8 @@
+
+> Task :show
+value = convention 1
+value = convention 2
+value = value
+
+BUILD SUCCESSFUL in 0s
+1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/providers/propertyConvention/propertyConvention.sample.conf
+++ b/subprojects/docs/src/samples/providers/propertyConvention/propertyConvention.sample.conf
@@ -1,0 +1,14 @@
+# tag::cli[]
+# gradle show
+# end::cli[]
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: show
+    expected-output-file: propertyConvention.out
+}, {
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: show
+    expected-output-file: propertyConvention.out
+}]

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -25,7 +25,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
@@ -171,10 +170,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
                 generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
                 generateTask.getPublication().set(publication);
                 generateTask.getPublications().set(publications);
-                RegularFileProperty outputFile = generateTask.getOutputFile();
-                if (!outputFile.isPresent()) {
-                    outputFile.set(buildDir.file("publications/" + publicationName + "/module.json"));
-                }
+                generateTask.getOutputFile().convention(buildDir.file("publications/" + publicationName + "/module.json"));
             }
         });
         // TODO: Make lazy

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/MinimalJavaCompileOptions.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks.compile;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.DebugOptions;
@@ -62,8 +61,7 @@ public class MinimalJavaCompileOptions implements Serializable {
         this.verbose = compileOptions.isVerbose();
         this.warnings = compileOptions.isWarnings();
         this.annotationProcessorGeneratedSourcesDirectory = compileOptions.getAnnotationProcessorGeneratedSourcesDirectory();
-        DirectoryProperty headerOutputDirectory = compileOptions.getHeaderOutputDirectory();
-        this.headerOutputDirectory = headerOutputDirectory.isPresent() ? headerOutputDirectory.get().getAsFile() : null;
+        this.headerOutputDirectory = compileOptions.getHeaderOutputDirectory().getAsFile().getOrNull();
     }
 
     @Nullable

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
@@ -24,6 +24,7 @@ import org.gradle.nativeplatform.TargetMachineFactory;
 import org.gradle.nativeplatform.internal.DefaultTargetMachineFactory;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
@@ -58,9 +59,7 @@ public class Dimensions {
      * @since 5.1
      */
     public static Set<TargetMachine> setDefaultAndGetTargetMachineValues(SetProperty<TargetMachine> targetMachines, TargetMachineFactory targetMachineFactory) {
-        if (!targetMachines.isPresent()) {
-            targetMachines.empty().add(((DefaultTargetMachineFactory)targetMachineFactory).host());
-        }
+        targetMachines.convention(Collections.singleton(((DefaultTargetMachineFactory)targetMachineFactory).host()));
         targetMachines.finalizeValue();
         return targetMachines.get();
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -82,7 +82,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
 
         this.source = getTaskFileVarFactory().newInputFileCollection(this);
         this.objectFileDir = objectFactory.directoryProperty();
-        this.compilerArgs = getProject().getObjects().listProperty(String.class).empty();
+        this.compilerArgs = getProject().getObjects().listProperty(String.class);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
         this.incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes.plus(systemIncludes), macros, toolChain.map(new Transformer<Boolean, NativeToolChain>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -73,7 +73,7 @@ public class WindowsResourceCompile extends DefaultTask {
         ObjectFactory objectFactory = getProject().getObjects();
         includes = getProject().files();
         source = getProject().files();
-        this.compilerArgs = getProject().getObjects().listProperty(String.class).empty();
+        this.compilerArgs = getProject().getObjects().listProperty(String.class);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
         incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes, macros, Providers.FALSE);

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SwiftCompile.java
@@ -99,11 +99,11 @@ public class SwiftCompile extends DefaultTask {
         this.moduleName = objectFactory.property(String.class);
         this.moduleFile = objectFactory.fileProperty();
         this.modules = getProject().files();
-        this.compilerArgs = objectFactory.listProperty(String.class).empty();
+        this.compilerArgs = objectFactory.listProperty(String.class);
         this.objectFileDir = objectFactory.directoryProperty();
         this.source = getProject().files();
         this.sourceCompatibility = objectFactory.property(SwiftVersion.class);
-        this.macros = objectFactory.listProperty(String.class).empty();
+        this.macros = objectFactory.listProperty(String.class);
         this.debuggable = objectFactory.property(Boolean.class).value(false);
         this.optimize = objectFactory.property(Boolean.class).value(false);
         this.targetPlatform = objectFactory.property(NativePlatform.class);

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/plugins/CppApplicationPluginTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
 import spock.lang.Specification
 
-class   CppApplicationPluginTest extends Specification {
+class CppApplicationPluginTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     def projectDir = tmpDir.createDir("project")

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomContributor.java
@@ -17,10 +17,9 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
-
-import java.util.Map;
 
 /**
  * A contributor of a Maven publication.
@@ -70,6 +69,6 @@ public interface MavenPomContributor {
     /**
      * The properties of this contributor.
      */
-    Property<Map<String, String>> getProperties();
+    MapProperty<String, String> getProperties();
 
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloper.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/MavenPomDeveloper.java
@@ -17,10 +17,9 @@
 package org.gradle.api.publish.maven;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
-
-import java.util.Map;
 
 /**
  * A developer of a Maven publication.
@@ -75,6 +74,6 @@ public interface MavenPomDeveloper {
     /**
      * The properties of this developer.
      */
-    Property<Map<String, String>> getProperties();
+    MapProperty<String, String> getProperties();
 
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPomDeveloper.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPomDeveloper.java
@@ -17,12 +17,11 @@
 package org.gradle.api.publish.maven.internal.publication;
 
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.publish.maven.MavenPomContributor;
 import org.gradle.api.publish.maven.MavenPomDeveloper;
-
-import java.util.Map;
 
 public class DefaultMavenPomDeveloper implements MavenPomDeveloper, MavenPomContributor {
 
@@ -34,7 +33,7 @@ public class DefaultMavenPomDeveloper implements MavenPomDeveloper, MavenPomCont
     private final Property<String> organizationUrl;
     private final SetProperty<String> roles;
     private final Property<String> timezone;
-    private final Property<Map<String, String>> properties;
+    private final MapProperty<String, String> properties;
 
     public DefaultMavenPomDeveloper(ObjectFactory objectFactory) {
         id = objectFactory.property(String.class);
@@ -43,9 +42,9 @@ public class DefaultMavenPomDeveloper implements MavenPomDeveloper, MavenPomCont
         url = objectFactory.property(String.class);
         organization = objectFactory.property(String.class);
         organizationUrl = objectFactory.property(String.class);
-        roles = objectFactory.setProperty(String.class).empty();
+        roles = objectFactory.setProperty(String.class);
         timezone = objectFactory.property(String.class);
-        properties = (Property) objectFactory.property(Map.class);
+        properties = objectFactory.mapProperty(String.class, String.class);
     }
 
     @Override
@@ -89,7 +88,7 @@ public class DefaultMavenPomDeveloper implements MavenPomDeveloper, MavenPomCont
     }
 
     @Override
-    public Property<Map<String, String>> getProperties() {
+    public MapProperty<String, String> getProperties() {
         return properties;
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPomMailingList.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPomMailingList.java
@@ -36,7 +36,7 @@ public class DefaultMavenPomMailingList implements MavenPomMailingList {
         unsubscribe = objectFactory.property(String.class);
         post = objectFactory.property(String.class);
         archive = objectFactory.property(String.class);
-        otherArchives = objectFactory.setProperty(String.class).empty();
+        otherArchives = objectFactory.setProperty(String.class);
     }
 
     @Override

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
@@ -36,7 +36,7 @@ import org.gradle.api.UncheckedIOException;
 import org.gradle.api.XmlProvider;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publication.maven.internal.VersionRangeMapper;
 import org.gradle.api.publish.maven.MavenDependency;
 import org.gradle.api.publish.maven.MavenPomCiManagement;
@@ -159,7 +159,7 @@ public class MavenPomFileGenerator {
         return target;
     }
 
-    private Properties convertProperties(Property<Map<String, String>> source) {
+    private Properties convertProperties(Provider<Map<String, String>> source) {
         Properties target = new Properties();
         target.putAll(source.getOrElse(Collections.<String, String>emptyMap()));
         return target;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -25,7 +25,6 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 import org.gradle.api.file.DirectoryProperty;
-import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
@@ -211,10 +210,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
                 generateTask.setGroup(PublishingPlugin.PUBLISH_TASK_GROUP);
                 generateTask.getPublication().set(publication);
                 generateTask.getPublications().set(publications);
-                RegularFileProperty outputFile = generateTask.getOutputFile();
-                if (!outputFile.isPresent()) {
-                    outputFile.set(buildDir.file("publications/" + publication.getName() + "/module.json"));
-                }
+                generateTask.getOutputFile().convention(buildDir.file("publications/" + publication.getName() + "/module.json"));
             }
         });
         // TODO: Make lazy

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/AbstractProperty.java
@@ -27,6 +27,7 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
 
     private State state = State.Mutable;
     private Task producer;
+    private boolean hasValue;
 
     @Override
     public void attachProducer(Task task) {
@@ -62,14 +63,14 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
 
     protected abstract void makeFinal();
 
-    protected void assertReadable() {
+    protected void beforeRead() {
         if (state == State.FinalNextGet) {
             makeFinal();
             state = State.FinalLenient;
         }
     }
 
-    protected boolean assertMutable() {
+    protected boolean canMutate() {
         if (state == State.FinalStrict) {
             throw new IllegalStateException("The value for this property is final and cannot be changed any further.");
         } else if (state == State.FinalLenient) {
@@ -77,5 +78,16 @@ public abstract class AbstractProperty<T> extends AbstractMinimalProvider<T> imp
             return false;
         }
         return true;
+    }
+
+    protected void afterMutate() {
+        hasValue = true;
+    }
+
+    protected boolean shouldApplyConvention() {
+        if (!canMutate()) {
+            return false;
+        }
+        return !hasValue;
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultListProperty.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Provider;
 
 import java.util.Collection;
 import java.util.List;
@@ -35,6 +36,18 @@ public class DefaultListProperty<T> extends AbstractCollectionProperty<T, List<T
     @Override
     public ListProperty<T> empty() {
         super.empty();
+        return this;
+    }
+
+    @Override
+    public ListProperty<T> convention(Iterable<? extends T> elements) {
+        super.convention(elements);
+        return this;
+    }
+
+    @Override
+    public ListProperty<T> convention(Provider<? extends Iterable<? extends T>> provider) {
+        super.convention(provider);
         return this;
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -45,7 +45,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     private final ValueCollector<K> keyCollector;
     private final MapEntryCollector<K, V> entryCollector;
     @SuppressWarnings("unchecked")
-    private MapCollector<K, V> value = (MapCollector<K, V>) NO_VALUE;
+    private MapCollector<K, V> value = (MapCollector<K, V>) EMPTY_MAP;
     private final List<MapCollector<K, V>> collectors = new LinkedList<MapCollector<K, V>>();
 
     public DefaultMapProperty(Class<K> keyType, Class<V> valueType) {

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultMapProperty.java
@@ -32,7 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
 
-public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implements MapProperty<K, V>, PropertyInternal<Map<K, V>>, MapProviderInternal<K, V> {
+public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implements MapProperty<K, V>, MapProviderInternal<K, V> {
 
     private static final MapCollectors.EmptyMap EMPTY_MAP = new MapCollectors.EmptyMap();
     private static final MapCollectors.NoValue NO_VALUE = new MapCollectors.NoValue();
@@ -74,7 +74,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
 
     @Override
     public boolean isPresent() {
-        assertReadable();
+        beforeRead();
         if (!value.present()) {
             return false;
         }
@@ -88,7 +88,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
 
     @Override
     public Map<K, V> get() {
-        assertReadable();
+        beforeRead();
         Map<K, V> entries = new LinkedHashMap<K, V>(1 + collectors.size());
         value.collectInto(entryCollector, entries);
         for (MapCollector<K, V> collector : collectors) {
@@ -100,7 +100,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     @Nullable
     @Override
     public Map<K, V> getOrNull() {
-        assertReadable();
+        beforeRead();
         return doGetOrNull();
     }
 
@@ -150,9 +150,8 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     @Override
     @SuppressWarnings("unchecked")
     public MapProperty<K, V> empty() {
-        if (assertMutable()) {
-            value = (MapCollector<K, V>) EMPTY_MAP;
-            collectors.clear();
+        if (canMutate()) {
+            set((MapCollector<K, V>) EMPTY_MAP);
         }
         return this;
     }
@@ -173,42 +172,46 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     @Override
     @SuppressWarnings("unchecked")
     public void set(@Nullable Map<? extends K, ? extends V> entries) {
-        if (!assertMutable()) {
+        if (!canMutate()) {
             return;
         }
-        collectors.clear();
         if (entries != null) {
-            value = new MapCollectors.EntriesFromMap<K, V>(entries);
+            set(new MapCollectors.EntriesFromMap<K, V>(entries));
         } else {
-            value = (MapCollector<K, V>) NO_VALUE;
+            set((MapCollector<K, V>) NO_VALUE);
         }
     }
 
     @Override
     public void set(Provider<? extends Map<? extends K, ? extends V>> provider) {
-        if (!assertMutable()) {
+        if (!canMutate()) {
             return;
         }
         ProviderInternal<? extends Map<? extends K, ? extends V>> p = checkMapProvider(provider);
+        set(new MapCollectors.EntriesFromMapProvider<K, V>(p));
+    }
+
+    private void set(MapCollector<K, V> collector) {
         collectors.clear();
-        value = new MapCollectors.EntriesFromMapProvider<K, V>(p);
+        value = collector;
+        afterMutate();
     }
 
     @Override
     public void put(K key, V value) {
         Preconditions.checkNotNull(key, NULL_KEY_FORBIDDEN_MESSAGE);
         Preconditions.checkNotNull(value, NULL_VALUE_FORBIDDEN_MESSAGE);
-        if (!assertMutable()) {
+        if (!canMutate()) {
             return;
         }
-        collectors.add(new MapCollectors.SingleEntry<K, V>(key, value));
+        addCollector(new MapCollectors.SingleEntry<K, V>(key, value));
     }
 
     @Override
     public void put(K key, Provider<? extends V> providerOfValue) {
         Preconditions.checkNotNull(key, NULL_KEY_FORBIDDEN_MESSAGE);
         Preconditions.checkNotNull(providerOfValue, NULL_VALUE_FORBIDDEN_MESSAGE);
-        if (!assertMutable()) {
+        if (!canMutate()) {
             return;
         }
         ProviderInternal<? extends V> p = Providers.internal(providerOfValue);
@@ -216,24 +219,29 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
             throw new IllegalArgumentException(String.format("Cannot add an entry to a property of type %s with values of type %s using a provider of type %s.",
                 Map.class.getName(), valueType.getName(), p.getType().getName()));
         }
-        collectors.add(new MapCollectors.EntryWithValueFromProvider<K, V>(key, p));
+        addCollector(new MapCollectors.EntryWithValueFromProvider<K, V>(key, p));
     }
 
     @Override
     public void putAll(Map<? extends K, ? extends V> entries) {
-        if (!assertMutable()) {
+        if (!canMutate()) {
             return;
         }
-        collectors.add(new MapCollectors.EntriesFromMap<K, V>(entries));
+        addCollector(new MapCollectors.EntriesFromMap<K, V>(entries));
     }
 
     @Override
     public void putAll(Provider<? extends Map<? extends K, ? extends V>> provider) {
-        if (!assertMutable()) {
+        if (!canMutate()) {
             return;
         }
         ProviderInternal<? extends Map<? extends K, ? extends V>> p = checkMapProvider(provider);
-        collectors.add(new MapCollectors.EntriesFromMapProvider<K, V>(p));
+        addCollector(new MapCollectors.EntriesFromMapProvider<K, V>(p));
+    }
+
+    private void addCollector(MapCollector<K, V> collector) {
+        collectors.add(collector);
+        afterMutate();
     }
 
     @SuppressWarnings("unchecked")
@@ -259,6 +267,24 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
     }
 
     @Override
+    public MapProperty<K, V> convention(Map<? extends K, ? extends V> value) {
+        if (shouldApplyConvention()) {
+            this.value = new MapCollectors.EntriesFromMap<K, V>(value);
+            collectors.clear();
+        }
+        return this;
+    }
+
+    @Override
+    public MapProperty<K, V> convention(Provider<? extends Map<? extends K, ? extends V>> valueProvider) {
+        if (shouldApplyConvention()) {
+            this.value = new MapCollectors.EntriesFromMapProvider<K, V>(Providers.internal(valueProvider));
+            collectors.clear();
+        }
+        return this;
+    }
+
+    @Override
     public Provider<Set<K>> keySet() {
         return new KeySetProvider();
     }
@@ -279,14 +305,13 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
         Map<K, V> entries = doGetOrNull();
         if (entries != null) {
             if (entries.isEmpty()) {
-                value = (MapCollector<K, V>) EMPTY_MAP;
+                set((MapCollector<K, V>) EMPTY_MAP);
             } else {
-                value = new MapCollectors.EntriesFromMap<K, V>(entries);
+                set(new MapCollectors.EntriesFromMap<K, V>(entries));
             }
         } else {
-            value = (MapCollector<K, V>) NO_VALUE;
+            set((MapCollector<K, V>) NO_VALUE);
         }
-        collectors.clear();
     }
 
     private class KeySetProvider extends AbstractReadOnlyProvider<Set<K>> {
@@ -300,7 +325,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
 
         @Override
         public Set<K> get() {
-            assertReadable();
+            beforeRead();
             Set<K> keys = new LinkedHashSet<K>(1 + collectors.size());
             value.collectKeysInto(keyCollector, keys);
             for (MapCollector<K, V> collector : collectors) {
@@ -312,7 +337,7 @@ public class DefaultMapProperty<K, V> extends AbstractProperty<Map<K, V>> implem
         @Nullable
         @Override
         public Set<K> getOrNull() {
-            assertReadable();
+            beforeRead();
             Set<K> keys = new LinkedHashSet<K>(1 + collectors.size());
             if (!value.maybeCollectKeysInto(keyCollector, keys)) {
                 return null;

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultPropertyState.java
@@ -23,9 +23,10 @@ import org.gradle.api.provider.Provider;
 public class DefaultPropertyState<T> extends AbstractProperty<T> implements Property<T> {
     private final Class<T> type;
     private final ValueSanitizer<T> sanitizer;
-    private ProviderInternal<? extends T> provider = Providers.notDefined();
+    private ProviderInternal<? extends T> provider;
 
     public DefaultPropertyState(Class<T> type) {
+        applyDefaultValue();
         this.type = type;
         this.sanitizer = ValueSanitizers.forType(type);
     }
@@ -46,7 +47,7 @@ public class DefaultPropertyState<T> extends AbstractProperty<T> implements Prop
 
     @Override
     public void set(T value) {
-        if (!canMutate()) {
+        if (!beforeMutate()) {
             return;
         }
         if (value == null) {
@@ -70,7 +71,7 @@ public class DefaultPropertyState<T> extends AbstractProperty<T> implements Prop
 
     @Override
     public void set(Provider<? extends T> provider) {
-        if (!canMutate()) {
+        if (!beforeMutate()) {
             return;
         }
         if (provider == null) {
@@ -110,6 +111,11 @@ public class DefaultPropertyState<T> extends AbstractProperty<T> implements Prop
             this.provider = Providers.internal(valueProvider);
         }
         return this;
+    }
+
+    @Override
+    protected void applyDefaultValue() {
+        provider = Providers.notDefined();
     }
 
     @Override

--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/provider/DefaultSetProperty.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.provider;
 
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.SetProperty;
 
 import java.util.Collection;
@@ -35,6 +36,18 @@ public class DefaultSetProperty<T> extends AbstractCollectionProperty<T, Set<T>>
     @Override
     public SetProperty<T> empty() {
         super.empty();
+        return this;
+    }
+
+    @Override
+    public SetProperty<T> convention(Iterable<? extends T> elements) {
+        super.convention(elements);
+        return this;
+    }
+
+    @Override
+    public SetProperty<T> convention(Provider<? extends Iterable<? extends T>> provider) {
+        super.convention(provider);
         return this;
     }
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -23,13 +23,19 @@ import spock.lang.Unroll
 
 abstract class CollectionPropertySpec<C extends Collection<String>> extends PropertySpec<C> {
     @Override
-    PropertyInternal<C> propertyWithNoValue() {
+    AbstractCollectionProperty<String, C> propertyWithDefaultValue() {
+        return property()
+    }
+
+    @Override
+    AbstractCollectionProperty<String, C> propertyWithNoValue() {
         def p = property()
         p.set((Iterable) null)
         return p
     }
 
-    Provider<C> providerWithValue(C value) {
+    @Override
+    AbstractCollectionProperty<String, C> providerWithValue(C value) {
         def p = property()
         p.set(value)
         return p
@@ -49,6 +55,11 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
     @Override
     abstract Class<C> type()
+
+    @Override
+    protected void setToNull(Object property) {
+        property.set((Iterable) null)
+    }
 
     def property = property()
 
@@ -524,6 +535,41 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
         then:
         def ex = thrown(NullPointerException)
         ex.message == "Cannot add a null element to a property of type ${type().simpleName}."
+    }
+
+    def "ignores convention after element added"() {
+        expect:
+        property.add("a")
+        property.convention(["other"])
+        assertValueIs(["a"])
+    }
+
+    def "ignores convention after element added using provider"() {
+        expect:
+        property.add(Providers.of("a"))
+        property.convention(["other"])
+        assertValueIs(["a"])
+    }
+
+    def "ignores convention after elements added"() {
+        expect:
+        property.addAll(["a", "b"])
+        property.convention(["other"])
+        assertValueIs(["a", "b"])
+    }
+
+    def "ignores convention after elements added using provider"() {
+        expect:
+        property.addAll(Providers.of(["a", "b"]))
+        property.convention(["other"])
+        assertValueIs(["a", "b"])
+    }
+
+    def "ignores convention after collection made empty"() {
+        expect:
+        property.empty()
+        property.convention(["other"])
+        assertValueIs([])
     }
 
     def "cannot set to empty list after value finalized"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/CollectionPropertySpec.groovy
@@ -240,7 +240,6 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     @Unroll
     def "appends zero or more values from array #value using addAll"() {
         given:
-        property.empty()
         property.addAll(value as String[])
 
         expect:
@@ -265,7 +264,6 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     @Unroll
     def "appends zero or more values from provider #value using addAll"() {
         given:
-        property.empty()
         property.addAll(Providers.of(value))
 
         expect:
@@ -284,7 +282,6 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
         _ * provider.get() >>> [["abc"], ["def"]]
 
         expect:
-        property.empty()
         property.addAll(provider)
         assertValueIs(["abc"])
         assertValueIs(["def"])
@@ -302,7 +299,6 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     @Unroll
     def "appends zero or more values from collection #value using addAll"() {
         given:
-        property.empty()
         property.addAll(value)
 
         expect:
@@ -318,7 +314,6 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
     def "queries values of collection on every call to get()"() {
         expect:
         def value = ["abc"]
-        property.empty()
         property.addAll(value)
         assertValueIs(["abc"])
         value.add("added")
@@ -381,6 +376,15 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
         expect:
         assertValueIs(["1", "2", "3", "4"])
+    }
+
+    def "empty collection is used as value when elements added after convention set"() {
+        given:
+        property.convention(["1", "2"])
+        property.add("3")
+
+        expect:
+        assertValueIs(["3"])
     }
 
     def "property has no value when set to null and other values appended"() {
@@ -518,7 +522,6 @@ abstract class CollectionPropertySpec<C extends Collection<String>> extends Prop
 
     def "throws NullPointerException when provider returns list with null to property"() {
         given:
-        property.empty()
         property.addAll(Providers.of([null]))
 
         when:

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.provider
 
 import org.gradle.api.Transformer
 import org.gradle.api.provider.Property
-import org.gradle.api.provider.Provider
 
 class DefaultPropertyStateTest extends PropertySpec<String> {
     DefaultPropertyState<String> property() {
@@ -26,12 +25,17 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     }
 
     @Override
-    PropertyInternal<String> propertyWithNoValue() {
+    DefaultPropertyState<String> propertyWithNoValue() {
         return property()
     }
 
     @Override
-    Provider<String> providerWithValue(String value) {
+    DefaultPropertyState<String> propertyWithDefaultValue() {
+        return property()
+    }
+
+    @Override
+    DefaultPropertyState<String> providerWithValue(String value) {
         def p = property()
         p.set(value)
         return p

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultPropertyStateTest.groovy
@@ -21,13 +21,12 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
 class DefaultPropertyStateTest extends PropertySpec<String> {
-    @Override
     DefaultPropertyState<String> property() {
         return new DefaultPropertyState<String>(String)
     }
 
     @Override
-    Provider<String> providerWithNoValue() {
+    PropertyInternal<String> propertyWithNoValue() {
         return property()
     }
 
@@ -51,6 +50,21 @@ class DefaultPropertyStateTest extends PropertySpec<String> {
     @Override
     String someOtherValue() {
         return "value2"
+    }
+
+    def "has no value by default"() {
+        expect:
+        def property = property()
+        !property.present
+        property.getOrNull() == null
+        property.getOrElse(someValue()) == someValue()
+
+        when:
+        property.get()
+
+        then:
+        def e = thrown(IllegalStateException)
+        e.message == 'No value has been specified for this provider.'
     }
 
     def "toString() does not realize value"() {

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/DefaultProviderTest.groovy
@@ -20,12 +20,12 @@ import org.gradle.api.provider.Provider
 
 class DefaultProviderTest extends ProviderSpec<String> {
     @Override
-    Provider<String> providerWithNoValue() {
+    DefaultProvider<String> providerWithNoValue() {
         return new DefaultProvider<String>({ null })
     }
 
     @Override
-    Provider<String> providerWithValue(String value) {
+    DefaultProvider<String> providerWithValue(String value) {
         return new DefaultProvider<String>({ value })
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.provider
 
 import com.google.common.collect.ImmutableMap
-import org.gradle.api.provider.Provider
 import org.spockframework.util.Assert
 
 class MapPropertySpec extends PropertySpec<Map<String, String>> {
@@ -27,14 +26,19 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     }
 
     @Override
-    PropertyInternal<Map<String, String>> propertyWithNoValue() {
+    DefaultMapProperty<String, String> propertyWithDefaultValue() {
+        return property()
+    }
+
+    @Override
+    DefaultMapProperty<String, String> propertyWithNoValue() {
         def p = property()
         p.set((Map) null)
         return p
     }
 
     @Override
-    Provider<Map<String, String>> providerWithValue(Map<String, String> value) {
+    DefaultMapProperty<String, String> providerWithValue(Map<String, String> value) {
         def p = property()
         p.set(value)
         return p
@@ -53,6 +57,11 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     @Override
     Map<String, String> someOtherValue() {
         return ['k1': 'v1']
+    }
+
+    @Override
+    protected void setToNull(Object property) {
+        property.set((Map) null)
     }
 
     def property = property()
@@ -275,7 +284,7 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         property.putAll(Providers.of(['k4': 'v4']))
 
         expect:
-        assertValueIs([k1:  'v1', k2: 'v2', k3: 'v3', k4: 'v4'])
+        assertValueIs([k1: 'v1', k2: 'v2', k3: 'v3', k4: 'v4'])
     }
 
     def "property has no value when set to provider with no value and other entries added"() {
@@ -613,7 +622,7 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "keySet provider has no value when property has no value"() {
         given:
-        property.set((Map)null)
+        property.set((Map) null)
         def keySetProvider = property.keySet()
 
         expect:

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/MapPropertySpec.groovy
@@ -182,7 +182,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "appends multiple entries from map #value using putAll"() {
         given:
-        property.empty()
         property.putAll(value)
 
         expect:
@@ -197,7 +196,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "appends multiple entries from provider #value using putAll"() {
         given:
-        property.empty()
         property.putAll(Providers.of(value))
 
         expect:
@@ -210,6 +208,15 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         ['k1': 'v1', 'k2': 'v2'] | ['k1': 'v1', 'k2': 'v2']
     }
 
+    def "empty map is used when entries added after convention set"() {
+        given:
+        property.convention([k1: 'v1'])
+        property.put('k2', 'v2')
+
+        expect:
+        assertValueIs([k2:  'v2'])
+    }
+
     def "queries entries of provider on every call to get()"() {
         given:
         def provider = Stub(ProviderInternal)
@@ -217,7 +224,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
         _ * provider.present >> true
         _ * provider.get() >>> [['k1': 'v1'], ['k2': 'v2']]
         and:
-        property.empty()
         property.putAll(provider)
 
         expect:
@@ -229,7 +235,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     def "queries entries of map on every call to get()"() {
         given:
         def value = ['k1': 'v1']
-        property.empty()
         property.putAll(value)
 
         expect:
@@ -360,7 +365,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "can set null value to remove any added entries"() {
         given:
-        property.empty()
         property.put('k1', 'v1')
         property.put('k2', Providers.of('v2'))
         property.putAll(['k3': 'v3'])
@@ -378,7 +382,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "can set value to replace added entries"() {
         given:
-        property.empty()
         property.put('k1', 'v1')
         property.put('k2', Providers.of('v2'))
         property.putAll(['k3': 'v3'])
@@ -392,7 +395,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "can make empty to replace added entries"() {
         given:
-        property.empty()
         property.put('k1', 'v1')
         property.put('k2', Providers.of('v2'))
         property.putAll(['k3': 'v3'])
@@ -406,7 +408,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "throws NullPointerException when provider returns map with null key to property"() {
         given:
-        property.empty()
         property.putAll(Providers.of(Collections.singletonMap(null, 'value')))
 
         when:
@@ -418,7 +419,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
     def "throws NullPointerException when provider returns map with null value to property"() {
         given:
-        property.empty()
         property.putAll(Providers.of(['k': null]))
 
         when:
@@ -429,8 +429,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     }
 
     def "throws NullPointerException when adding an entry with a null key to the property"() {
-        given:
-        property.empty()
         when:
         property.put(null, (String) 'v')
         then:
@@ -439,8 +437,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     }
 
     def "throws NullPointerException when adding an entry with a null value to the property"() {
-        given:
-        property.empty()
         when:
         property.put('k', (String) null)
         then:
@@ -589,7 +585,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     def "entry provider tracks value of last added entry"() {
         given:
         def entryProvider = property.getting('key')
-        property.empty()
 
         when:
         property.put('key', 'v1')
@@ -636,11 +631,9 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     }
 
     def "keySet provider tracks value of property"() {
-        given:
+        when:
         def keySetProvider = property.keySet()
 
-        when:
-        property.empty()
         then:
         keySetProvider.present
         keySetProvider.get() == [] as Set
@@ -648,6 +641,7 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
 
         when:
         property.set(['k1': 'v1', 'k2': 'v2'])
+
         then:
         keySetProvider.present
         keySetProvider.get() == ['k1', 'k2'] as Set
@@ -657,7 +651,6 @@ class MapPropertySpec extends PropertySpec<Map<String, String>> {
     def "keySet provider includes keys of added entries"() {
         given:
         def keySetProvider = property.keySet()
-        property.empty()
 
         when:
         property.put('k1', 'v1')

--- a/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/api/internal/provider/PropertySpec.groovy
@@ -25,7 +25,12 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     /**
      * Returns a property with _no_ value.
      */
-    abstract PropertyInternal<T> property()
+    abstract PropertyInternal<T> propertyWithNoValue()
+
+    @Override
+    Provider<T> providerWithNoValue() {
+        return propertyWithNoValue()
+    }
 
     abstract T someValue()
 
@@ -33,24 +38,9 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     abstract Class<T> type()
 
-    def "has no value by default"() {
-        expect:
-        def property = property()
-        !property.present
-        property.getOrNull() == null
-        property.getOrElse(someValue()) == someValue()
-
-        when:
-        property.get()
-
-        then:
-        def e = thrown(IllegalStateException)
-        e.message == 'No value has been specified for this provider.'
-    }
-
     def "cannot get value when it has none"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         property.get()
@@ -69,7 +59,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "can set value"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
 
         expect:
@@ -86,7 +76,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         given:
         provider.type >> type()
 
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(provider)
 
         when:
@@ -129,7 +119,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         provider.type >> type()
         provider.get() >>> [someValue(), someOtherValue(), someValue()]
 
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(provider)
 
         expect:
@@ -140,7 +130,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "does not allow a null provider"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         property.set((Provider) null)
@@ -152,7 +142,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "can set untyped using null"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.setFromAnyValue(null)
 
         expect:
@@ -163,7 +153,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "can set untyped using value"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.setFromAnyValue(someValue())
 
         expect:
@@ -175,7 +165,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "fails when untyped value is set using incompatible type"() {
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         property.setFromAnyValue(new Thing())
@@ -193,7 +183,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
         provider.get() >> someValue()
         provider.present >> true
 
-        def property = property()
+        def property = propertyWithNoValue()
         property.setFromAnyValue(provider)
 
         when:
@@ -207,7 +197,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "can map value using a transformation"() {
         def transformer = Mock(Transformer)
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         def provider = property.map(transformer)
@@ -235,7 +225,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "transformation is provided with the current value of the property each time the value is queried"() {
         def transformer = Mock(Transformer)
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         def provider = property.map(transformer)
@@ -264,7 +254,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "can map value to some other type"() {
         def transformer = Mock(Transformer)
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         def provider = property.map(transformer)
@@ -292,7 +282,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "mapped provider has no value and transformer is not invoked when property has no value"() {
         def transformer = Mock(Transformer)
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         def provider = property.map(transformer)
@@ -312,7 +302,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "can finalize value when no value defined"() {
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         property."$method"()
@@ -326,7 +316,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "can finalize value when value set"() {
-        def property = property()
+        def property = propertyWithNoValue()
 
         when:
         property.set(someValue())
@@ -341,7 +331,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "replaces provider with fixed value when value finalized"() {
-        def property = property()
+        def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
 
@@ -366,7 +356,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "replaces provider with fixed value when value finalized on next read"() {
-        def property = property()
+        def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
 
@@ -393,7 +383,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "replaces provider with fixed value when value finalized after finalize on next read"() {
-        def property = property()
+        def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
 
@@ -421,7 +411,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "replaces provider with fixed missing value when value finalized"() {
-        def property = property()
+        def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
 
@@ -446,7 +436,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "replaces provider with fixed missing value when value finalized on next read"() {
-        def property = property()
+        def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
 
@@ -473,7 +463,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
     }
 
     def "can finalize value when already finalized"() {
-        def property = property()
+        def property = propertyWithNoValue()
         def function = Mock(Callable)
         def provider = new DefaultProvider<T>(function)
 
@@ -496,7 +486,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "cannot set value after value finalized"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValue()
 
@@ -510,7 +500,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "ignores set value after value finalized leniently"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValueOnReadAndWarnAboutChanges()
         property.get()
@@ -524,7 +514,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "cannot set value after value finalized after value finalized leniently"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValueOnReadAndWarnAboutChanges()
         property.set(someOtherValue())
@@ -540,7 +530,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "cannot set value using provider after value finalized"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValue()
 
@@ -554,7 +544,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "ignores set value using provider after value finalized leniently"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValueOnReadAndWarnAboutChanges()
         property.get()
@@ -568,7 +558,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "cannot set value using any type after value finalized"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValue()
 
@@ -589,7 +579,7 @@ abstract class PropertySpec<T> extends ProviderSpec<T> {
 
     def "ignores set value using any type after value finalized leniently"() {
         given:
-        def property = property()
+        def property = propertyWithNoValue()
         property.set(someValue())
         property.finalizeValueOnReadAndWarnAboutChanges()
         property.get()

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/AbstractLinkTask.java
@@ -85,7 +85,7 @@ public abstract class AbstractLinkTask extends DefaultTask implements ObjectFile
                 return dirProp.get();
             }
         }));
-        this.linkerArgs = getProject().getObjects().listProperty(String.class).empty();
+        this.linkerArgs = getProject().getObjects().listProperty(String.class);
         this.debuggable = objectFactory.property(Boolean.class).value(false);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/tasks/CreateStaticLibrary.java
@@ -64,7 +64,7 @@ public class CreateStaticLibrary extends DefaultTask implements ObjectFilesToBin
         ObjectFactory objectFactory = getProject().getObjects();
         this.source = getProject().files();
         this.outputFile = objectFactory.fileProperty();
-        this.staticLibArgs = getProject().getObjects().listProperty(String.class).empty();
+        this.staticLibArgs = getProject().getObjects().listProperty(String.class);
         this.targetPlatform = objectFactory.property(NativePlatform.class);
         this.toolChain = objectFactory.property(NativeToolChain.class);
     }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/GeneratePluginDescriptors.java
@@ -42,7 +42,7 @@ public class GeneratePluginDescriptors extends DefaultTask {
 
     public GeneratePluginDescriptors() {
         ObjectFactory objectFactory = getProject().getObjects();
-        declarations = objectFactory.listProperty(PluginDeclaration.class).empty();
+        declarations = objectFactory.listProperty(PluginDeclaration.class);
         outputDirectory = objectFactory.directoryProperty();
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/BasePlugin.java
@@ -87,25 +87,21 @@ public class BasePlugin implements Plugin<Project> {
         project.getTasks().withType(AbstractArchiveTask.class).configureEach(new Action<AbstractArchiveTask>() {
             public void execute(AbstractArchiveTask task) {
 
-                // This is here because the JvmComponentPlugin Jar task configuration runs before this action.
-                // It has already set the destination directory for this task. The BasePlugin needs to respect that.
-                if (!task.getDestinationDirectory().isPresent()) {
-                    Callable<String> destinationDir;
-                    if (task instanceof Jar) {
-                        destinationDir = new Callable<String>() {
-                            public String call() {
-                                return pluginConvention.getLibsDirName();
-                            }
-                        };
-                    } else {
-                        destinationDir = new Callable<String>() {
-                            public String call() {
-                                return pluginConvention.getDistsDirName();
-                            }
-                        };
-                    }
-                    task.getDestinationDirectory().set(project.getLayout().getBuildDirectory().dir(project.provider(destinationDir)));
+                Callable<String> destinationDir;
+                if (task instanceof Jar) {
+                    destinationDir = new Callable<String>() {
+                        public String call() {
+                            return pluginConvention.getLibsDirName();
+                        }
+                    };
+                } else {
+                    destinationDir = new Callable<String>() {
+                        public String call() {
+                            return pluginConvention.getDistsDirName();
+                        }
+                    };
                 }
+                task.getDestinationDirectory().convention(project.getLayout().getBuildDirectory().dir(project.provider(destinationDir)));
 
                 task.getArchiveVersion().set(project.provider(new Callable<String>() {
                     @Nullable

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -74,7 +74,7 @@ public class GenerateModuleMetadata extends DefaultTask {
     public GenerateModuleMetadata() {
         ObjectFactory objectFactory = getProject().getObjects();
         publication = objectFactory.property(Publication.class);
-        publications = objectFactory.listProperty(Publication.class).empty();
+        publications = objectFactory.listProperty(Publication.class);
         outputFile = objectFactory.fileProperty();
         // TODO - should be incremental
         getOutputs().upToDateWhen(Specs.<Task>satisfyNone());


### PR DESCRIPTION
### Context

This PR adds a `convention()` method to the property types, to allow a value to be specified that is to be used when the property has not has a value explicitly defined. Several plugins are changed to use this, but really all plugins should be changed to do so. This can happen later.

Also change the default value for collection properties and map properties created using `ObjectFactory` to an empty collection/map rather than no value, as the previous default has proven to be surprising for most people.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
