### PR TITLE
Add a "Java platform" plugin

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -873,7 +873,7 @@ include 'other'
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                String expectedVariant = GradleMetadataResolveRunner.isGradleMetadataEnabled() ? 'enforced-platform' : 'enforced-platform-runtime'
+                String expectedVariant = GradleMetadataResolveRunner.isGradleMetadataEnabled() ? 'enforcedPlatform' : 'enforced-platform-runtime'
                 module("org:platform:2.7.9:$expectedVariant") {
                     constraint('org:core:2.7.9')
                     constraint('org:databind:2.7.9')
@@ -1112,25 +1112,23 @@ include 'other'
      * @param members
      */
     void platform(RemoteRepositorySpec repo, String platformGroup, String platformName, String platformVersion, List<String> members) {
-        ['platform', 'enforced-platform'].each { kind ->
-            repo.group(platformGroup) {
-                module(platformName) {
-                    version(platformVersion) {
-                        variant(kind) {
-                            attribute('org.gradle.component.category', kind)
-                            members.each { member ->
-                                constraint(member)
-                            }
-                        }
-                        // this is used only in BOMs
+        repo.group(platformGroup) {
+            module(platformName) {
+                version(platformVersion) {
+                    variant("platform") {
+                        attribute('org.gradle.component.category', 'platform')
                         members.each { member ->
                             constraint(member)
                         }
+                    }
+                    // this is used only in BOMs
+                    members.each { member ->
+                        constraint(member)
+                    }
 
-                        withModule(MavenHttpModule) {
-                            // make it a BOM
-                            hasPackaging('pom')
-                        }
+                    withModule(MavenHttpModule) {
+                        // make it a BOM
+                        hasPackaging('pom')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.platforms
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
+
+    ResolveTestFixture resolve
+
+    def setup() {
+        settingsFile << "rootProject.name = 'test'"
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            allprojects {
+                repositories {
+                    maven { url "${mavenHttpRepo.uri}" }
+                }
+                group = 'org.test'
+                version = '1.9'
+            }
+        """
+    }
+
+    def "can get recommendations from a platform subproject"() {
+        def module = mavenHttpRepo.module("org", "foo", "1.1").publish()
+
+        given:
+        platformModule("""
+            constraints {
+                api "org:foo:1.1"
+            }
+        """)
+
+        buildFile << """
+            dependencies {
+                api platform(project(":platform"))
+                api "org:foo"
+            }
+        """
+        checkConfiguration("compileClasspath")
+
+        when:
+        module.pom.expectGet()
+        module.artifact.expectGet()
+
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", "org.test:test:1.9") {
+                project(":platform", "org.test:platform:1.9") {
+                    variant("api", ['org.gradle.usage': 'java-api', 'org.gradle.component.category': 'platform'])
+                    constraint("org:foo:1.1")
+                    noArtifacts()
+                }
+                edge('org:foo', 'org:foo:1.1') {
+                    byConstraint()
+                }
+            }
+        }
+    }
+
+    def "can get different recommendations from a platform runtime subproject"() {
+        def module1 = mavenHttpRepo.module("org", "foo", "1.1").publish()
+        def module2 = mavenHttpRepo.module("org", "foo", "1.2").publish()
+
+        given:
+        platformModule("""
+            constraints {
+                api "org:foo:1.1"
+                runtime "org:foo:1.2"
+            }
+        """)
+
+        buildFile << """
+            dependencies {
+                api platform(project(":platform"))
+                api "org:foo"
+            }
+        """
+        checkConfiguration("runtimeClasspath")
+
+        when:
+        module2.pom.expectGet()
+        module2.artifact.expectGet()
+
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", "org.test:test:1.9") {
+                project(":platform", "org.test:platform:1.9") {
+                    variant("runtime", ['org.gradle.usage': 'java-runtime', 'org.gradle.component.category': 'platform'])
+                    constraint("org:foo:1.1", "org:foo:1.2") // this is just because of the dumb test
+                    constraint("org:foo:1.2")
+                    noArtifacts()
+                }
+                edge('org:foo', 'org:foo:1.2') {
+                    configuration = "runtime"
+                    byConstraint()
+                }
+            }
+        }
+    }
+
+    def "reasonable behavior when using a regular project dependency instead of a platform dependency"() {
+        def module = mavenHttpRepo.module("org", "foo", "1.1").publish()
+
+        given:
+        platformModule("""
+            constraints {
+                api "org:foo:1.1"
+            }
+        """)
+
+        buildFile << """
+            dependencies {
+                api project(":platform")
+                api "org:foo"
+            }
+        """
+        checkConfiguration("compileClasspath")
+
+        when:
+        module.pom.expectGet()
+        module.artifact.expectGet()
+
+        run ":checkDeps"
+
+        then:
+        resolve.expectGraph {
+            root(":", "org.test:test:1.9") {
+                project(":platform", "org.test:platform:1.9") {
+                    variant("api", ['org.gradle.usage': 'java-api', 'org.gradle.component.category': 'platform'])
+                    constraint("org:foo:1.1")
+                    noArtifacts()
+                }
+                edge('org:foo', 'org:foo:1.1') {
+                    byConstraint()
+                }
+            }
+        }
+    }
+
+
+    private void checkConfiguration(String configuration) {
+        resolve = new ResolveTestFixture(buildFile, configuration)
+        resolve.expectDefaultConfiguration("compile")
+        resolve.prepare()
+    }
+
+    private void platformModule(String dependencies) {
+        settingsFile << """
+            include "platform"
+        """
+        file("platform/build.gradle") << """
+            plugins {
+                id 'java-platform'
+            }
+            
+            dependencies {
+                $dependencies
+            }
+        """
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -152,7 +152,7 @@ class DependencyManagementBuildScopeServices {
 
         return new DefaultDependencyFactory(
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileLookup, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
-            DependencyConstraintNotationParser.parser(instantiator, stringInterner),
+            DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
             new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
             projectDependencyFactory,
             attributesFactory);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies;
+
+import org.gradle.api.Action;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.MutableVersionConstraint;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+
+/**
+ * A limited use, project dependency constraint mostly aimed at publishing
+ * platforms.
+ */
+public class DefaultProjectDependencyConstraint implements DependencyConstraint {
+    private final ProjectDependency projectDependency;
+    private String reason;
+
+    public DefaultProjectDependencyConstraint(ProjectDependency projectDependency) {
+        this.projectDependency = projectDependency;
+    }
+
+    @Override
+    public void version(Action<? super MutableVersionConstraint> configureAction) {
+        throw new UnsupportedOperationException("Cannot change version constraint on a project dependency");
+    }
+
+    @Nullable
+    @Override
+    public String getReason() {
+        return reason;
+    }
+
+    @Override
+    public void because(@Nullable String reason) {
+        this.reason = reason;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return projectDependency.getAttributes();
+    }
+
+    @Override
+    public DependencyConstraint attributes(Action<? super AttributeContainer> configureAction) {
+        projectDependency.attributes(configureAction);
+        return this;
+    }
+
+    @Override
+    public VersionConstraint getVersionConstraint() {
+        return new DefaultImmutableVersionConstraint(
+                "",
+                projectDependency.getVersion(),
+                "",
+                Collections.emptyList(),
+                ""
+        );
+    }
+
+    @Override
+    public String getGroup() {
+        return projectDependency.getGroup();
+    }
+
+    @Override
+    public String getName() {
+        return projectDependency.getName();
+    }
+
+    @Nullable
+    @Override
+    public String getVersion() {
+        return projectDependency.getVersion();
+    }
+
+    @Override
+    public boolean matchesStrictly(ModuleVersionIdentifier identifier) {
+        return identifier.getModule().equals(getModule()) && identifier.getVersion().equals(projectDependency.getVersion());
+    }
+
+    @Override
+    public ModuleIdentifier getModule() {
+        String group = projectDependency.getGroup();
+        return DefaultModuleIdentifier.newId(group != null ? group : "", projectDependency.getName());
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -234,6 +234,8 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
             ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) platformDependency;
             externalModuleDependency.setForce(true);
             PlatformSupport.addPlatformAttribute(externalModuleDependency, PlatformSupport.ENFORCED_PLATFORM);
+        } else if (platformDependency instanceof HasConfigurableAttributes) {
+            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<?>) platformDependency, PlatformSupport.ENFORCED_PLATFORM);
         }
         return platformDependency;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.dsl.dependencies;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
@@ -72,5 +73,16 @@ public abstract class PlatformSupport {
             }
         }
 
+    }
+
+    public static class PreferRegularPlatform implements AttributeDisambiguationRule<String> {
+        private final static Set<String> PLATFORM_TYPES = ImmutableSet.of(REGULAR_PLATFORM, ENFORCED_PLATFORM);
+
+        @Override
+        public void execute(MultipleCandidatesDetails<String> details) {
+            if (details.getCandidateValues().equals(PLATFORM_TYPES)) {
+                details.closestMatch(REGULAR_PLATFORM);
+            }
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintNotationParser.java
@@ -17,18 +17,21 @@
 package org.gradle.api.internal.notations;
 
 import com.google.common.collect.Interner;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.internal.typeconversion.NotationParserBuilder;
 
 public class DependencyConstraintNotationParser {
-    public static NotationParser<Object, DependencyConstraint> parser(Instantiator instantiator, Interner<String> stringInterner) {
+    public static NotationParser<Object, DependencyConstraint> parser(Instantiator instantiator, DefaultProjectDependencyFactory dependencyFactory, Interner<String> stringInterner) {
         return NotationParserBuilder
             .toType(DependencyConstraint.class)
             .fromCharSequence(new DependencyStringNotationConverter<DefaultDependencyConstraint>(instantiator, DefaultDependencyConstraint.class, stringInterner))
             .converter(new DependencyMapNotationConverter<DefaultDependencyConstraint>(instantiator, DefaultDependencyConstraint.class))
+            .fromType(Project.class, new DependencyConstraintProjectNotationConverter(dependencyFactory))
             .invalidNotationMessage("Comprehensive documentation on dependency notations is available in DSL reference for DependencyHandler type.")
             .toComposite();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintProjectNotationConverter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/notations/DependencyConstraintProjectNotationConverter.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.notations;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.internal.artifacts.DefaultProjectDependencyFactory;
+import org.gradle.api.internal.artifacts.dependencies.DefaultProjectDependencyConstraint;
+import org.gradle.internal.exceptions.DiagnosticsVisitor;
+import org.gradle.internal.typeconversion.NotationConvertResult;
+import org.gradle.internal.typeconversion.NotationConverter;
+import org.gradle.internal.typeconversion.TypeConversionException;
+
+public class DependencyConstraintProjectNotationConverter implements NotationConverter<Project, DependencyConstraint> {
+
+    private final DefaultProjectDependencyFactory factory;
+
+    public DependencyConstraintProjectNotationConverter(DefaultProjectDependencyFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public void describe(DiagnosticsVisitor visitor) {
+        visitor.candidate("Projects").example("project(':some:project:path')");
+    }
+
+    public void convert(Project notation, NotationConvertResult<? super DependencyConstraint> result) throws TypeConversionException {
+        result.converted(new DefaultProjectDependencyConstraint(factory.create(notation)));
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -33,7 +33,9 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
+import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
@@ -405,6 +407,15 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                     }
                 }
                 maybeAddGeneratedDependencies(result);
+                AttributeValue<String> attributeValue = this.getAttributes().findEntry(PlatformSupport.COMPONENT_CATEGORY);
+                if (attributeValue.isPresent() && attributeValue.get().equals(PlatformSupport.ENFORCED_PLATFORM)) {
+                    // need to wrap all dependencies to force them
+                    ImmutableList<LocalOriginDependencyMetadata> rawDependencies = result.build();
+                    result = ImmutableList.builder();
+                    for (LocalOriginDependencyMetadata rawDependency : rawDependencies) {
+                        result.add(rawDependency.forced());
+                    }
+                }
                 configurationDependencies = result.build();
             }
             return configurationDependencies;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultLocalComponentMetadataTest.groovy
@@ -68,8 +68,8 @@ class DefaultLocalComponentMetadataTest extends Specification {
     def "configuration has no dependencies or artifacts when none have been added"() {
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
         when:
-        metadata.addConfiguration("super", "description", [] as Set, ImmutableSet.of("super"), false, false, null, true, true, ImmutableCapabilities.EMPTY)
-        metadata.addConfiguration("conf", "description", ["super"] as Set, ImmutableSet.of("super", "conf"), true, true, null, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration("super", "description", [] as Set, ImmutableSet.of("super"), false, false, ImmutableAttributes.EMPTY, true, true, ImmutableCapabilities.EMPTY)
+        metadata.addConfiguration("conf", "description", ["super"] as Set, ImmutableSet.of("super", "conf"), true, true, ImmutableAttributes.EMPTY, true, true, ImmutableCapabilities.EMPTY)
 
         then:
         def conf = metadata.getConfiguration('conf')

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ArtifactResolutionExpectationSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ArtifactResolutionExpectationSpec.groovy
@@ -62,6 +62,12 @@ trait ArtifactResolutionExpectationSpec<T extends Module> {
         }
     }
 
+    void noFiles() {
+        always {
+            noFiles()
+        }
+    }
+
     /**
      * Short-hand notation for expecting a list of files independently of the fact module metadata is used or not
      * @param fileNames

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -331,6 +331,7 @@ class GradleModuleMetadata {
 
             DependencyConstraint find() {
                 def depConstraint = dependencyConstraints.find { it.group == group && it.module == module && it.version == version }
+                assert depConstraint : "constraint ${group}:${module}:${version} not found in $dependencyConstraints"
                 checkedDependencyConstraints << depConstraint
                 depConstraint
             }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -185,7 +185,7 @@ class GradleModuleMetadata {
             return (values.files ?: []).collect { new File(it.name, it.url, it.size, new HashValue(it.sha1), new HashValue(it.md5)) }
         }
 
-        DependencyView dependency(String group, String module, String version, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = {}) {
+        DependencyView dependency(String group, String module, String version, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = { exists() }) {
             def view = new DependencyView(group, module, version)
             action.delegate = view
             action.resolveStrategy = Closure.DELEGATE_FIRST
@@ -193,12 +193,12 @@ class GradleModuleMetadata {
             view
         }
 
-        DependencyView dependency(String notation, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = {}) {
+        DependencyView dependency(String notation, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = { exists() }) {
             def (String group, String module, String version) = notation.split(':') as List
             dependency(group, module, version, action)
         }
 
-        DependencyConstraintView constraint(String group, String module, String version, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = {}) {
+        DependencyConstraintView constraint(String group, String module, String version, @DelegatesTo(value=DependencyView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = { exists() }) {
             def view = new DependencyConstraintView(group, module, version)
             action.delegate = view
             action.resolveStrategy = Closure.DELEGATE_FIRST
@@ -206,7 +206,7 @@ class GradleModuleMetadata {
             view
         }
 
-        DependencyConstraintView constraint(String notation, @DelegatesTo(value=DependencyConstraintView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = {}) {
+        DependencyConstraintView constraint(String notation, @DelegatesTo(value=DependencyConstraintView, strategy= Closure.DELEGATE_FIRST) Closure<Void> action = { exists() }) {
             def (String group, String module, String version) = notation.split(':') as List
             constraint(group, module, version, action)
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/SingleArtifactResolutionResultSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/SingleArtifactResolutionResultSpec.groovy
@@ -39,6 +39,10 @@ class SingleArtifactResolutionResultSpec<T extends Module> {
         expectedFileNames = fileNames.sort()
     }
 
+    void noFiles() {
+        expectedFileNames = []
+    }
+
     void shouldFail(@DelegatesTo(value = ExecutionFailure, strategy = Closure.DELEGATE_FIRST) Closure<?> onFailure) {
         expectSuccess = false
         if (onFailure == null) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -26,6 +26,7 @@ class VariantMetadataSpec {
     List<DependencyConstraintSpec> dependencyConstraints = []
     List<FileSpec> artifacts = []
     List<CapabilitySpec> capabilities = []
+    boolean useDefaultArtifacts = true
 
     VariantMetadataSpec(String name, Map<String, String> attributes = [:]) {
         this.name = name

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -17,10 +17,12 @@
 package org.gradle.test.fixtures.maven;
 
 import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
 import org.gradle.test.fixtures.GradleModuleMetadata;
 import org.gradle.test.fixtures.Module;
 import org.gradle.test.fixtures.ModuleArtifact;
 import org.gradle.test.fixtures.file.TestFile;
+import org.gradle.test.fixtures.gradle.VariantMetadataSpec;
 
 import java.util.Map;
 
@@ -206,6 +208,12 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     @Override
     public MavenModule variant(String variant, Map<String, String> attributes) {
         backingModule.variant(variant, attributes);
+        return t();
+    }
+
+    @Override
+    public MavenModule variant(String variant, Map<String, String> attributes, @DelegatesTo(value=VariantMetadataSpec.class, strategy=Closure.DELEGATE_FIRST) Closure<?> variantConfiguration) {
+        backingModule.variant(variant, attributes, variantConfiguration);
         return t();
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaPlatformModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaPlatformModule.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.maven
+
+import org.gradle.test.fixtures.PublishedJavaModule
+
+class MavenJavaPlatformModule extends DelegatingMavenModule<MavenFileModule> implements PublishedJavaModule {
+    final MavenFileModule mavenModule
+
+    MavenJavaPlatformModule(MavenFileModule mavenModule) {
+        super(mavenModule)
+        this.mavenModule = mavenModule
+    }
+
+    @Override
+    PublishedJavaModule withClassifiedArtifact(String classifier, String extension) {
+        return this
+    }
+
+    @Override
+    void assertPublishedAsJavaModule() {
+        this.assertPublished()
+    }
+
+    @Override
+    void assertPublished() {
+        super.assertPublished()
+
+        // Verify Gradle metadata particulars
+        assert mavenModule.parsedModuleMetadata.variants*.name as Set == ['api', 'runtime'] as Set
+        assert mavenModule.parsedModuleMetadata.variant('api').files.empty
+        assert mavenModule.parsedModuleMetadata.variant('runtime').files.empty
+
+        // Verify POM particulars
+        assert mavenModule.parsedPom.packaging == 'pom'
+    }
+
+    void assertNoDependencies() {
+        assert mavenModule.parsedPom.scopes.isEmpty()
+        assertApiDependencies()
+    }
+
+
+    @Override
+    void assertApiDependencies(String... expected) {
+        if (expected.length == 0) {
+            assert parsedModuleMetadata.variant('api').dependencies.empty
+            assert parsedPom.scopes.compile == null
+        } else {
+            assert parsedModuleMetadata.variant('api').dependencies*.coords as Set == expected as Set
+            assert parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            parsedPom.scopes.compile.assertDependsOn(mavenizeDependencies(expected))
+        }
+    }
+
+    @Override
+    void assertRuntimeDependencies(String... expected) {
+        if (expected.length == 0) {
+            assert parsedModuleMetadata.variant('runtime').dependencies.empty
+            assert parsedPom.scopes.runtime == null
+        } else {
+            assert parsedModuleMetadata.variant('runtime').dependencies*.coords.containsAll(expected)
+            parsedPom.scopes.runtime.assertDependsOn(mavenizeDependencies(expected))
+        }
+    }
+
+    private static String[] mavenizeDependencies(String[] input) {
+        return input.collect {it.replace("latest.integration", "LATEST").replace("latest.release", "RELEASE")}
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -18,6 +18,7 @@ package org.gradle.test.fixtures.maven
 import org.gradle.test.fixtures.Module
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.gradle.VariantMetadataSpec
 
 interface MavenModule extends Module {
     /**
@@ -75,6 +76,11 @@ interface MavenModule extends Module {
      * Define a variant with attributes. Variants are only published when using {@link #withModuleMetadata()}.
      */
     MavenModule variant(String variant, Map<String, String> attributes)
+
+    /**
+     * Define a variant with attributes. Variants are only published when using {@link #withModuleMetadata()}.
+     */
+    MavenModule variant(String variant, Map<String, String> attributes, @DelegatesTo(value= VariantMetadataSpec, strategy=Closure.DELEGATE_FIRST) Closure<?> variantConfiguration)
 
     String getPublishArtifactVersion()
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
@@ -161,4 +161,8 @@ class MavenPom {
             throw new AssertionError("Expected scope $scopeName but only found ${scopes.keySet()}")
         }
     }
+
+    void hasNoScope(String scopeName) {
+        assert scopes[scopeName] == null : "Didn't expect to find scope $scopeName"
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
@@ -150,4 +150,15 @@ class MavenPom {
         }
         scope
     }
+
+    void scope(String scopeName, @DelegatesTo(value=MavenScope, strategy=Closure.DELEGATE_FIRST) Closure<?> spec) {
+        def scope = scopes[scopeName]
+        if (scope) {
+            spec.delegate = scope
+            spec.resolveStrategy = Closure.DELEGATE_FIRST
+            spec()
+        } else {
+            throw new AssertionError("Expected scope $scopeName but only found ${scopes.keySet()}")
+        }
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenScope.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenScope.groovy
@@ -25,7 +25,15 @@ class MavenScope {
     Map<String, MavenDependency> dependencies = [:]
     Map<String, MavenDependency> dependencyManagement = [:]
 
-    void assertDependsOn(String[] expected) {
+    void assertNoDependencies() {
+        assert dependencies.isEmpty()
+    }
+
+    void assertNoDependencyManagement() {
+        assert dependencyManagement.isEmpty()
+    }
+
+    void assertDependsOn(String... expected) {
         assert dependencies.size() == expected.length
         expected.each {
             String key = StringUtils.substringBefore(it, "@")
@@ -39,7 +47,7 @@ class MavenScope {
         }
     }
 
-    void assertDependencyManagement(String[] expected) {
+    void assertDependencyManagement(String... expected) {
         assert dependencyManagement.size() == expected.length
         expected.each {
             String key = StringUtils.substringBefore(it, "@")

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaPlatformIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaPlatformIntegTest.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+
+import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.test.fixtures.maven.MavenJavaPlatformModule
+
+class MavenPublishJavaPlatformIntegTest extends AbstractMavenPublishIntegTest {
+    MavenJavaPlatformModule javaPlatform = javaPlatform(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
+
+    def "can publish java-platform with no dependencies"() {
+        createBuildScripts("""
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.javaPlatform
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaPlatform.assertPublished()
+        javaPlatform.assertNoDependencies()
+
+        and:
+        resolveArtifacts(javaPlatform) { noFiles() }
+        resolveApiArtifacts(javaPlatform) { noFiles() }
+        resolveRuntimeArtifacts(javaPlatform) { noFiles() }
+    }
+
+    def "can publish java-platform with constraints"() {
+        given:
+        javaLibrary(mavenRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
+        javaLibrary(mavenRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
+
+        createBuildScripts("""
+            dependencies {
+                constraints {
+                    api "org.test:foo:1.0"
+                    runtime "org.test:bar:1.0"
+                }
+            }
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.javaPlatform
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaPlatform.assertPublished()
+        javaPlatform.parsedModuleMetadata.variant("api") {
+            constraint("org.test:foo:1.0")
+            noMoreDependencies()
+        }
+        javaPlatform.parsedModuleMetadata.variant("runtime") {
+            constraint("org.test:foo:1.0")
+            constraint("org.test:bar:1.0")
+            noMoreDependencies()
+        }
+        javaPlatform.parsedPom.scope('compile') {
+            assertNoDependencies()
+            assertDependencyManagement("org.test:foo:1.0")
+        }
+        javaPlatform.parsedPom.scope('runtime') {
+            assertNoDependencies()
+            assertDependencyManagement("org.test:bar:1.0")
+        }
+    }
+
+    def "can define a platform with local projects"() {
+        given:
+
+        settingsFile << """
+            include "core"
+            include "utils"
+        """
+
+        createBuildScripts("""
+            dependencies {
+                constraints {
+                    api project(":core")
+                    runtime project(":utils")
+                }
+            }
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.javaPlatform
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaPlatform.assertPublished()
+        javaPlatform.parsedModuleMetadata.variant("api") {
+            constraint("org.gradle.test:core:1.9")
+            noMoreDependencies()
+        }
+        javaPlatform.parsedModuleMetadata.variant("runtime") {
+            constraint("org.gradle.test:core:1.9")
+            constraint("org.gradle.test:utils:1.9")
+            noMoreDependencies()
+        }
+        javaPlatform.parsedPom.scope('compile') {
+            assertNoDependencies()
+            assertDependencyManagement("org.gradle.test:core:1.9")
+        }
+        javaPlatform.parsedPom.scope('runtime') {
+            assertNoDependencies()
+            assertDependencyManagement("org.gradle.test:utils:1.9")
+        }
+    }
+
+
+
+    private String createBuildScripts(def append) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-platform'
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+
+            allprojects {
+                group = 'org.gradle.test'
+                version = '1.9'
+            }
+
+$append
+"""
+
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -38,6 +38,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.JavaPlatformPlugin;
 import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.publish.PublishingExtension;
@@ -291,6 +292,12 @@ public class MavenPublishPlugin implements Plugin<Project> {
                 versionMappingStrategy.usage(Usage.JAVA_RUNTIME, strategy -> {
                     DefaultVariantVersionMappingStrategy mapping = (DefaultVariantVersionMappingStrategy) strategy;
                     mapping.setTargetConfiguration(configurations.getByName(mainSourceSet.getRuntimeClasspathConfigurationName()));
+                });
+            });
+            plugins.withPlugin("org.gradle.java-platform", plugin -> {
+                versionMappingStrategy.allVariants(strategy -> {
+                    DefaultVariantVersionMappingStrategy mapping = (DefaultVariantVersionMappingStrategy) strategy;
+                    mapping.setTargetConfiguration(configurations.getByName(JavaPlatformPlugin.CLASSPATH_CONFIGURATION_NAME));
                 });
             });
         }

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -110,7 +110,8 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
 
         def externalRepo = requiresExternalDependencies?mavenCentralRepositoryDefinition():''
 
-        buildFile.text = """
+        buildFile.text = """import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
+
             apply plugin: 'java-base' // to get the standard Java library derivation strategy
             configurations {
                 resolve {
@@ -128,6 +129,11 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
             }
 
             dependencies {
+               attributesSchema { 
+                getMatchingStrategy(PlatformSupport.COMPONENT_CATEGORY)
+                   .disambiguationRules
+                   .add(PlatformSupport.PreferRegularPlatform)
+               }
                resolve($dependencyNotation) $extraArtifacts
             }
 

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -23,8 +23,9 @@ import org.gradle.test.fixtures.GradleMetadataAwarePublishingSpec
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.SingleArtifactResolutionResultSpec
 import org.gradle.test.fixtures.maven.MavenFileModule
-import org.gradle.test.fixtures.maven.MavenModule
 import org.gradle.test.fixtures.maven.MavenJavaModule
+import org.gradle.test.fixtures.maven.MavenJavaPlatformModule
+import org.gradle.test.fixtures.maven.MavenModule
 
 import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.mavenCentralRepositoryDefinition
 
@@ -36,6 +37,10 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
 
     protected static MavenJavaModule javaLibrary(MavenFileModule mavenFileModule) {
         return new MavenJavaModule(mavenFileModule)
+    }
+
+    protected static MavenJavaPlatformModule javaPlatform(MavenFileModule mavenFileModule) {
+        return new MavenJavaPlatformModule(mavenFileModule)
     }
 
     void resolveArtifacts(Object dependencyNotation, @DelegatesTo(value = MavenArtifactResolutionExpectation, strategy = Closure.DELEGATE_FIRST) Closure<?> expectationSpec) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/DefaultJavaPlatformExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/DefaultJavaPlatformExtension.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java;
+
+import org.gradle.api.plugins.JavaPlatformExtension;
+
+public class DefaultJavaPlatformExtension implements JavaPlatformExtension {
+    private boolean allowDependencies;
+
+    @Override
+    public void allowDependencies() {
+        allowDependencies = true;
+    }
+
+    public boolean isAllowDependencies() {
+        return allowDependencies;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -18,32 +18,16 @@ package org.gradle.api.internal.java;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
-import org.gradle.api.DomainObjectSet;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
-import org.gradle.api.artifacts.DependencyConstraint;
-import org.gradle.api.artifacts.DependencySet;
-import org.gradle.api.artifacts.ExcludeRule;
-import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
-import org.gradle.api.internal.artifacts.configurations.Configurations;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.internal.java.usagecontext.ConfigurationUsageContext;
 import org.gradle.api.model.ObjectFactory;
-import org.gradle.internal.hash.Hasher;
-import org.gradle.internal.isolation.Isolatable;
-import org.gradle.internal.isolation.IsolatableFactory;
 
-import javax.annotation.Nullable;
 import javax.inject.Inject;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -87,153 +71,12 @@ public class JavaLibrary implements SoftwareComponentInternal {
         return ImmutableSet.of(runtimeUsage, compileUsage);
     }
 
-    private abstract class AbstractUsageContext implements UsageContext {
-        private final Usage usage;
-        private final ImmutableAttributes attributes;
-        AbstractUsageContext(String usageName) {
-            this.usage = objectFactory.named(Usage.class, usageName);
-            this.attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, usage);
-        }
-
-        @Override
-        public AttributeContainer getAttributes() {
-            return attributes;
-        }
-
-        @Override
-        public Usage getUsage() {
-            return usage;
-        }
-
-        public Set<PublishArtifact> getArtifacts() {
-            return artifacts;
-        }
-    }
-
     private UsageContext createRuntimeUsageContext() {
-        return new ConfigurationUsageContext(Usage.JAVA_RUNTIME, "runtime", RUNTIME_ELEMENTS_CONFIGURATION_NAME);
+        return new ConfigurationUsageContext(Usage.JAVA_RUNTIME, "runtime", RUNTIME_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, objectFactory, attributesFactory);
     }
 
     private UsageContext createCompileUsageContext() {
-        return new ConfigurationUsageContext(Usage.JAVA_API, "api", API_ELEMENTS_CONFIGURATION_NAME);
+        return new ConfigurationUsageContext(Usage.JAVA_API, "api", API_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, objectFactory, attributesFactory);
     }
 
-    private class ConfigurationUsageContext extends AbstractUsageContext {
-        private final String name;
-        private final String configurationName;
-        private DomainObjectSet<ModuleDependency> dependencies;
-        private DomainObjectSet<DependencyConstraint> dependencyConstraints;
-        private Set<? extends Capability> capabilities;
-        private Set<ExcludeRule> excludeRules;
-
-
-        ConfigurationUsageContext(String usageName, String name, String configurationName) {
-            super(usageName);
-            this.name = name;
-            this.configurationName = configurationName;
-        }
-
-        @Override
-        public String getName() {
-            return name;
-        }
-
-        @Override
-        public Set<ModuleDependency> getDependencies() {
-            if (dependencies == null) {
-                dependencies = getConfiguration().getIncoming().getDependencies().withType(ModuleDependency.class);
-            }
-            return dependencies;
-        }
-
-        @Override
-        public Set<? extends DependencyConstraint> getDependencyConstraints() {
-            if (dependencyConstraints == null) {
-                dependencyConstraints = getConfiguration().getIncoming().getDependencyConstraints();
-            }
-            return dependencyConstraints;
-        }
-
-        @Override
-        public Set<? extends Capability> getCapabilities() {
-            if (capabilities == null) {
-                this.capabilities = ImmutableSet.copyOf(Configurations.collectCapabilities(getConfiguration(),
-                    Sets.<Capability>newHashSet(),
-                    Sets.<Configuration>newHashSet()));
-            }
-            return capabilities;
-        }
-
-        @Override
-        public Set<ExcludeRule> getGlobalExcludes() {
-            if (excludeRules == null) {
-                this.excludeRules = ImmutableSet.copyOf(((ConfigurationInternal) getConfiguration()).getAllExcludeRules());
-            }
-            return excludeRules;
-        }
-
-        private Configuration getConfiguration() {
-            return configurations.getByName(configurationName);
-        }
-    }
-
-    private class BackwardsCompatibilityUsageContext extends AbstractUsageContext {
-        private final DependencySet runtimeDependencies;
-
-        private BackwardsCompatibilityUsageContext(String usageName, DependencySet runtimeDependencies) {
-            super(usageName);
-            this.runtimeDependencies = runtimeDependencies;
-        }
-
-        @Override
-        public String getName() {
-            return getUsage().getName();
-        }
-
-        @Override
-        public Set<ModuleDependency> getDependencies() {
-            return runtimeDependencies.withType(ModuleDependency.class);
-        }
-
-        @Override
-        public Set<? extends DependencyConstraint> getDependencyConstraints() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<? extends Capability> getCapabilities() {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public Set<ExcludeRule> getGlobalExcludes() {
-            return Collections.emptySet();
-        }
-    }
-
-    /**
-     * This is only here to provide backward compatibility for the Shadow plugin. Remove in 5.0.
-     */
-    private static class BackwardsCompatibilityIsolatableFactory implements IsolatableFactory {
-        @Override
-        public <T> Isolatable<T> isolate(final T value) {
-            return new Isolatable<T>() {
-                @Override
-                public T isolate() {
-                    return value;
-                }
-
-                @Nullable
-                @Override
-                public <S> Isolatable<S> coerce(Class<S> type) {
-                    return null;
-                }
-
-                @Override
-                public void appendToHasher(Hasher hasher) {
-                    throw new UnsupportedOperationException();
-                }
-            };
-        }
-    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
@@ -60,11 +60,11 @@ public class JavaPlatform implements SoftwareComponentInternal {
     }
 
     private UsageContext createRuntimeUsageContext() {
-        return new JavaPlatformUsageContext(Usage.JAVA_RUNTIME, "runtime", JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+        return new JavaPlatformUsageContext(Usage.JAVA_RUNTIME, "runtime", JavaPlatformPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
     }
 
     private UsageContext createApiUsageContext() {
-        return new JavaPlatformUsageContext(Usage.JAVA_API, "api", JavaPlatformPlugin.API_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+        return new JavaPlatformUsageContext(Usage.JAVA_API, "api", JavaPlatformPlugin.API_ELEMENTS_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
     }
 
     private final static class JavaPlatformUsageContext extends ConfigurationUsageContext {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.internal.java.usagecontext.ConfigurationUsageContext;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.JavaPlatformPlugin;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Set;
+
+public class JavaPlatform implements SoftwareComponentInternal {
+    private final ObjectFactory objectFactory;
+    private final ImmutableAttributesFactory attributesFactory;
+    private final ConfigurationContainer configurations;
+    private final UsageContext api;
+    private final UsageContext runtime;
+
+    @Inject
+    public JavaPlatform(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory, ConfigurationContainer configurations) {
+        this.objectFactory = objectFactory;
+        this.attributesFactory = attributesFactory;
+        this.configurations = configurations;
+        this.api = createApiUsageContext();
+        this.runtime = createRuntimeUsageContext();
+    }
+
+    @Override
+    public Set<? extends UsageContext> getUsages() {
+        return ImmutableSet.of(api, runtime);
+    }
+
+    @Override
+    public String getName() {
+        return "javaPlatform";
+    }
+
+    private UsageContext createRuntimeUsageContext() {
+        return new JavaPlatformUsageContext(Usage.JAVA_RUNTIME, "runtime", JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+    }
+
+    private UsageContext createApiUsageContext() {
+        return new JavaPlatformUsageContext(Usage.JAVA_API, "api", JavaPlatformPlugin.API_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+    }
+
+    private final static class JavaPlatformUsageContext extends ConfigurationUsageContext {
+        private final AttributeContainer attributes;
+
+        private JavaPlatformUsageContext(String usageName,
+                                         String name,
+                                         String configurationName,
+                                         ConfigurationContainer configurations,
+                                         ObjectFactory objectFactory,
+                                         ImmutableAttributesFactory attributesFactory) {
+            super(usageName, name, configurationName, Collections.<PublishArtifact>emptySet(), configurations, objectFactory, attributesFactory);
+            AttributeContainerInternal attributes = (AttributeContainerInternal) super.getAttributes();
+            // Currently, "enforced" platforms are handled through special casing, so we don't need to publish the enforced version
+            this.attributes = attributesFactory.concat(attributes.asImmutable(), PlatformSupport.COMPONENT_CATEGORY, PlatformSupport.REGULAR_PLATFORM);
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return attributes;
+        }
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/AbstractUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/AbstractUsageContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java.usagecontext;
+
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.model.ObjectFactory;
+
+import java.util.Set;
+
+public abstract class AbstractUsageContext implements UsageContext {
+    private final Usage usage;
+    private final ImmutableAttributes attributes;
+    private final Set<PublishArtifact> artifacts;
+
+    AbstractUsageContext(String usageName, Set<PublishArtifact> artifacts, ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory) {
+        this.usage = objectFactory.named(Usage.class, usageName);
+        this.attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, usage);
+        this.artifacts = artifacts;
+    }
+
+    @Override
+    public AttributeContainer getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Usage getUsage() {
+        return usage;
+    }
+
+    public Set<PublishArtifact> getArtifacts() {
+        return artifacts;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationUsageContext.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java.usagecontext;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.configurations.Configurations;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.model.ObjectFactory;
+
+import java.util.Set;
+
+public class ConfigurationUsageContext extends AbstractUsageContext {
+    private final String name;
+    private final String configurationName;
+    private final ConfigurationContainer configurations;
+    private DomainObjectSet<ModuleDependency> dependencies;
+    private DomainObjectSet<DependencyConstraint> dependencyConstraints;
+    private Set<? extends Capability> capabilities;
+    private Set<ExcludeRule> excludeRules;
+
+
+    public ConfigurationUsageContext(String usageName,
+                                     String name,
+                                     String configurationName,
+                                     Set<PublishArtifact> artifacts,
+                                     ConfigurationContainer configurations,
+                                     ObjectFactory objectFactory,
+                                     ImmutableAttributesFactory attributesFactory) {
+        super(usageName, artifacts, objectFactory, attributesFactory);
+        this.name = name;
+        this.configurationName = configurationName;
+        this.configurations = configurations;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Set<ModuleDependency> getDependencies() {
+        if (dependencies == null) {
+            dependencies = getConfiguration().getIncoming().getDependencies().withType(ModuleDependency.class);
+        }
+        return dependencies;
+    }
+
+    @Override
+    public Set<? extends DependencyConstraint> getDependencyConstraints() {
+        if (dependencyConstraints == null) {
+            dependencyConstraints = getConfiguration().getIncoming().getDependencyConstraints();
+        }
+        return dependencyConstraints;
+    }
+
+    @Override
+    public Set<? extends Capability> getCapabilities() {
+        if (capabilities == null) {
+            this.capabilities = ImmutableSet.copyOf(Configurations.collectCapabilities(getConfiguration(),
+                Sets.<Capability>newHashSet(),
+                Sets.<Configuration>newHashSet()));
+        }
+        return capabilities;
+    }
+
+    @Override
+    public Set<ExcludeRule> getGlobalExcludes() {
+        if (excludeRules == null) {
+            this.excludeRules = ImmutableSet.copyOf(((ConfigurationInternal) getConfiguration()).getAllExcludeRules());
+        }
+        return excludeRules;
+    }
+
+    private Configuration getConfiguration() {
+        return configurations.getByName(configurationName);
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformExtension.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins;
+
+import org.gradle.api.Incubating;
+
+/**
+ * The extension to configure a Java platform project.
+ *
+ * @since 5.2
+ */
+@Incubating
+public interface JavaPlatformExtension {
+    /**
+     * Allow dependencies to be declared. By default, a platform
+     * will not allow dependencies, only constraints.
+     */
+    void allowDependencies();
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.java.DefaultJavaPlatformExtension;
 import org.gradle.api.internal.java.JavaPlatform;
 
@@ -77,11 +78,23 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     private void createConfigurations(Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration api = configurations.create(API_CONFIGURATION_NAME, AS_CONSUMABLE_CONFIGURATION);
+        declareConfigurationUsage(project, api, Usage.JAVA_API);
+        declareConfigurationCategory(api, PlatformSupport.REGULAR_PLATFORM);
         Configuration runtime = project.getConfigurations().create(RUNTIME_CONFIGURATION_NAME, AS_CONSUMABLE_CONFIGURATION);
         runtime.extendsFrom(api);
+        declareConfigurationUsage(project, runtime, Usage.JAVA_RUNTIME);
+        declareConfigurationCategory(runtime, PlatformSupport.REGULAR_PLATFORM);
         Configuration classpath = configurations.create(CLASSPATH_CONFIGURATION_NAME, AS_RESOLVABLE_CONFIGURATION);
         classpath.extendsFrom(runtime);
-        classpath.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
+        declareConfigurationUsage(project, classpath, Usage.JAVA_RUNTIME);
+    }
+
+    private void declareConfigurationCategory(Configuration configuration, String value) {
+        configuration.getAttributes().attribute(PlatformSupport.COMPONENT_CATEGORY, value);
+    }
+
+    private void declareConfigurationUsage(Project project, Configuration configuration, String usage) {
+        configuration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, usage));
     }
 
     private void configureExtension(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins;
+
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.component.SoftwareComponentInternal;
+import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.internal.java.usagecontext.ConfigurationUsageContext;
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * The Java platform plugin allows building platform components
+ * for Java, which are usually published as BOM files (for Maven)
+ * or Gradle platforms (Gradle metadata).
+ *
+ * @since 5.2
+ */
+@Incubating
+public class JavaPlatformPlugin implements Plugin<Project> {
+    public static final String API_CONFIGURATION_NAME = "api";
+    public static final String RUNTIME_CONFIGURATION_NAME = "runtime";
+    public static final String CLASSPATH_CONFIGURATION_NAME = "classpath";
+
+    private static final Action<Configuration> AS_CONSUMABLE_CONFIGURATION = new Action<Configuration>() {
+        @Override
+        public void execute(Configuration conf) {
+            conf.setCanBeResolved(false);
+            conf.setCanBeConsumed(true);
+        }
+    };
+
+    private static final Action<Configuration> AS_RESOLVABLE_CONFIGURATION = new Action<Configuration>() {
+        @Override
+        public void execute(Configuration conf) {
+            conf.setCanBeResolved(true);
+            conf.setCanBeConsumed(false);
+        }
+    };
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply(BasePlugin.class);
+        createConfigurations(project);
+        createSoftwareComponent(project);
+    }
+
+    private boolean createSoftwareComponent(Project project) {
+        return project.getComponents().add(project.getObjects().newInstance(JavaPlatformComponent.class, project.getConfigurations()));
+    }
+
+    private void createConfigurations(Project project) {
+        ConfigurationContainer configurations = project.getConfigurations();
+        Configuration api = configurations.create(API_CONFIGURATION_NAME, AS_CONSUMABLE_CONFIGURATION);
+        Configuration runtime = project.getConfigurations().create(RUNTIME_CONFIGURATION_NAME, AS_CONSUMABLE_CONFIGURATION);
+        runtime.extendsFrom(api);
+        Configuration classpath = configurations.create(CLASSPATH_CONFIGURATION_NAME, AS_RESOLVABLE_CONFIGURATION);
+        classpath.extendsFrom(runtime);
+        classpath.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
+    }
+
+    public static class JavaPlatformComponent implements SoftwareComponentInternal {
+        private final ObjectFactory objectFactory;
+        private final ImmutableAttributesFactory attributesFactory;
+        private final ConfigurationContainer configurations;
+        private final UsageContext api;
+        private final UsageContext runtime;
+
+        @Inject
+        public JavaPlatformComponent(ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory, ConfigurationContainer configurations) {
+            this.objectFactory = objectFactory;
+            this.attributesFactory = attributesFactory;
+            this.configurations = configurations;
+            this.api = createApiUsageContext();
+            this.runtime = createRuntimeUsageContext();
+        }
+
+        @Override
+        public Set<? extends UsageContext> getUsages() {
+            return ImmutableSet.of(api, runtime);
+        }
+
+        @Override
+        public String getName() {
+            return "javaPlatform";
+        }
+
+        private UsageContext createRuntimeUsageContext() {
+            return new JavaPlatformUsageContext(Usage.JAVA_RUNTIME, "runtime", RUNTIME_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+        }
+
+        private UsageContext createApiUsageContext() {
+            return new JavaPlatformUsageContext(Usage.JAVA_API, "api", API_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+        }
+    }
+
+    private final static class JavaPlatformUsageContext extends ConfigurationUsageContext {
+        private final AttributeContainer attributes;
+
+        private JavaPlatformUsageContext(String usageName,
+                                        String name,
+                                        String configurationName,
+                                        ConfigurationContainer configurations,
+                                        ObjectFactory objectFactory,
+                                        ImmutableAttributesFactory attributesFactory) {
+            super(usageName, name, configurationName, Collections.<PublishArtifact>emptySet(), configurations, objectFactory, attributesFactory);
+            AttributeContainerInternal attributes = (AttributeContainerInternal) super.getAttributes();
+            // Currently, "enforced" platforms are handled through special casing, so we don't need to publish the enforced version
+            this.attributes = attributesFactory.concat(attributes.asImmutable(), PlatformSupport.COMPONENT_CATEGORY, PlatformSupport.REGULAR_PLATFORM);
+        }
+
+        @Override
+        public AttributeContainer getAttributes() {
+            return attributes;
+        }
+    }
+}

--- a/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.java-platform.properties
+++ b/subprojects/plugins/src/main/resources/META-INF/gradle-plugins/org.gradle.java-platform.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2018 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+implementation-class=org.gradle.api.plugins.JavaPlatformPlugin

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.plugins
+
+import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
+import org.gradle.api.internal.component.UsageContext
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+
+class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
+    def "applies base plugin"() {
+        when:
+        project.pluginManager.apply(JavaPlatformPlugin)
+
+        then:
+        project.plugins.findPlugin(BasePlugin)
+    }
+
+    def "adds configurations to the project"() {
+        given:
+        project.pluginManager.apply(JavaPlatformPlugin)
+
+        when:
+        def api = project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME)
+
+        then:
+        api.canBeConsumed
+        !api.canBeResolved
+        api.extendsFrom.empty
+
+        when:
+        def runtime = project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME)
+
+        then:
+        runtime.canBeConsumed
+        !runtime.canBeResolved
+        runtime.extendsFrom == [api] as Set
+
+        when:
+        def classpath = project.configurations.getByName(JavaPlatformPlugin.CLASSPATH_CONFIGURATION_NAME)
+
+        then:
+        !classpath.canBeConsumed
+        classpath.canBeResolved
+        classpath.extendsFrom == [runtime] as Set
+        def attributes = classpath.attributes.keySet()
+        attributes.size() == 1
+        def usage = classpath.attributes.getAttribute(attributes[0])
+        usage.name == Usage.JAVA_RUNTIME
+
+    }
+
+    def "adds Java library component"() {
+        given:
+        project.pluginManager.apply(JavaPlatformPlugin)
+
+        project.dependencies.add(JavaPlatformPlugin.API_CONFIGURATION_NAME, "org:api1:1.0")
+        project.dependencies.constraints.add(JavaPlatformPlugin.API_CONFIGURATION_NAME, "org:api2:2.0")
+
+        project.dependencies.add(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME, "org:runtime1:1.0")
+        project.dependencies.constraints.add(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME, "org:runtime2:2.0")
+
+        when:
+        def javaPlatform = project.components.getByName("javaPlatform")
+        UsageContext apiUsage = javaPlatform.usages[0]
+        UsageContext runtimeUsage = javaPlatform.usages[1]
+
+        then:
+        runtimeUsage.dependencies.size() == 2
+        runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        runtimeUsage.dependencyConstraints.size() == 2
+        runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
+        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.COMPONENT_CATEGORY] as Set
+        runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
+        runtimeUsage.attributes.getAttribute(PlatformSupport.COMPONENT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
+
+        apiUsage.dependencies.size() == 1
+        apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
+        apiUsage.dependencyConstraints.size() == 1
+        apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
+        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.COMPONENT_CATEGORY] as Set
+        apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
+        apiUsage.attributes.getAttribute(PlatformSupport.COMPONENT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
+    }
+
+}

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -41,7 +41,7 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         def api = project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME)
 
         then:
-        api.canBeConsumed
+        !api.canBeConsumed
         !api.canBeResolved
         api.extendsFrom.empty
 
@@ -49,9 +49,42 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         def runtime = project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME)
 
         then:
-        runtime.canBeConsumed
+        !runtime.canBeConsumed
         !runtime.canBeResolved
         runtime.extendsFrom == [api] as Set
+
+        when:
+        def apiElements = project.configurations.getByName(JavaPlatformPlugin.API_ELEMENTS_CONFIGURATION_NAME)
+
+        then:
+        apiElements.canBeConsumed
+        !apiElements.canBeResolved
+        apiElements.extendsFrom == [api] as Set
+
+        when:
+        def runtimeElements = project.configurations.getByName(JavaPlatformPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+
+        then:
+        runtimeElements.canBeConsumed
+        !runtimeElements.canBeResolved
+        runtimeElements.extendsFrom == [runtime] as Set
+
+        when:
+        def enforcedApiElements = project.configurations.getByName(JavaPlatformPlugin.ENFORCED_API_ELEMENTS_CONFIGURATION_NAME)
+
+        then:
+        enforcedApiElements.canBeConsumed
+        !enforcedApiElements.canBeResolved
+        enforcedApiElements.extendsFrom == [api] as Set
+
+        when:
+        def enforcedRuntimeElements = project.configurations.getByName(JavaPlatformPlugin.ENFORCED_RUNTIME_ELEMENTS_CONFIGURATION_NAME)
+
+        then:
+        enforcedRuntimeElements.canBeConsumed
+        !enforcedRuntimeElements.canBeResolved
+        enforcedRuntimeElements.extendsFrom == [runtime] as Set
+
 
         when:
         def classpath = project.configurations.getByName(JavaPlatformPlugin.CLASSPATH_CONFIGURATION_NAME)
@@ -59,7 +92,7 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         then:
         !classpath.canBeConsumed
         classpath.canBeResolved
-        classpath.extendsFrom == [runtime] as Set
+        classpath.extendsFrom == [runtimeElements] as Set
         def attributes = classpath.attributes.keySet()
         attributes.size() == 1
         def usage = classpath.attributes.getAttribute(attributes[0])


### PR DESCRIPTION
### Context

This pull request introduces a Java Platform plugin. This plugin is aimed at allowing the declaration of "Java platforms" from Gradle. A Java platform is a set of constraints or dependencies for consumption by other Java components.

The plugin supports producing BOM files as well as Gradle metadata, however, the model is richer with Gradle metadata as we support both "api" and "runtime" constraints, and a Gradle platform may also include _dependencies_.

### Usage

```
plugins {
    id "java-platform" // for declaring a platform
    id "maven-publish" // to publish it as a BOM or Gradle metadata
}

dependencies {
    constraints {
       api("org:foo:1.0") // for dependencies needed at compile time
       api(project(":local-component")) // for local components
       runtime("org:bar:1.0") // for dependencies needed at run time
    }
}

publishing {
   publications {
       myPlatform(MavenPublication) {
           from components.javaPlatform
       }
   }
}
```
In order to reduce the risks of user errors, adding dependencies to a platform is disabled by default, and needs to be explicitly enabled by an extension call:

```
javaPlatform {
   allowDependencies() // allow declaring dependencies in addition to constraints
}
```