### PR TITLE
 Introduce @RequiresNonFinalSubClasses

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/api/RequiresNonFinalSubClasses.java
+++ b/subprojects/base-services/src/main/java/org/gradle/api/RequiresNonFinalSubClasses.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Marks a type as requiring non-final subclasses.
+ *
+ * Types decorated by the Gradle runtime need to be non-final. This annotation allows
+ * linters, IDEs, DSLs, compiler plugins to validate them or make them non-final.
+ *
+ * @since 5.1
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Incubating
+public @interface RequiresNonFinalSubClasses {
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -28,6 +28,7 @@ import org.gradle.api.AntBuilder;
 import org.gradle.api.Describable;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
+import org.gradle.api.RequiresNonFinalSubClasses;
 import org.gradle.api.Task;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
@@ -88,6 +89,7 @@ import java.util.concurrent.Callable;
 
 import static org.gradle.util.GUtil.uncheckedCall;
 
+@RequiresNonFinalSubClasses
 public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
     private static final Logger BUILD_LOGGER = Logging.getLogger(Task.class);
     private static final ThreadLocal<TaskInfo> NEXT_INSTANCE = new ThreadLocal<TaskInfo>();


### PR DESCRIPTION
 Marks a type as requiring non-final subclasses.

Types decorated by the Gradle runtime need to be non-final. This annotation allows
linters, IDEs, DSLs, compiler plugins to validate them or make them non-final.

See https://github.com/gradle/kotlin-dsl/issues/390