### PR TITLE
Fix documentation example for maven-publish

### DIFF
--- a/subprojects/docs/src/samples/maven-publish/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/maven-publish/quickstart/kotlin/build.gradle.kts
@@ -1,7 +1,7 @@
 
 // tag::use-plugin[]
 plugins {
-    `maven-publish`
+    "maven-publish"
 // end::use-plugin[]
     java
 // tag::use-plugin[]
@@ -30,4 +30,3 @@ publishing {
     }
 }
 // end::repositories[]
-


### PR DESCRIPTION
### Context
The `maven-publish` quickstart example has backticks, it should have double quotes.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
