### PR TITLE
Transformation disambiguation

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -38,6 +38,7 @@ class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionT
         buildFile << """
 def usage = Attribute.of('usage', String)
 def artifactType = Attribute.of('artifactType', String)
+def extraAttribute = Attribute.of('extra', String)
     
 allprojects {
 
@@ -900,11 +901,15 @@ $fileSizer
                     registerTransform {
                         from.attribute(artifactType, 'custom')
                         to.attribute(artifactType, 'transformed')
+                        from.attribute(extraAttribute, 'foo')
+                        to.attribute(extraAttribute, 'bar')
                         artifactTransform(BrokenTransform)
                     }
                     registerTransform {
                         from.attribute(artifactType, 'custom')
                         to.attribute(artifactType, 'transformed')
+                        from.attribute(extraAttribute, 'foo')
+                        to.attribute(extraAttribute, 'baz')
                         artifactTransform(BrokenTransform)
                     }
                 }
@@ -1023,6 +1028,11 @@ Found the following transforms:
   - artifactType 'transformed'
   - usage 'api'
 Found the following transforms:
+  - Transform from configuration ':lib:compile' variant variant1:
+      - artifactType 'jar'
+      - buildType 'release'
+      - flavor 'free'
+      - usage 'api'
   - Transform from configuration ':lib:compile' variant variant2:
       - artifactType 'jar'
       - buildType 'release'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/DisambiguateArtifactTransformIntegrationTest.groovy
@@ -43,7 +43,6 @@ public class MyClass {
 
         buildFile << """
 def artifactType = Attribute.of('artifactType', String)
-//attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_API))
 
 allprojects {
     repositories {
@@ -122,6 +121,126 @@ class FileSizer extends ArtifactTransform {
         output.count("Transforming main to main.txt") == 1
         output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 1
         output.count("Transforming test-1.3.jar.txt to test-1.3.jar.txt.txt") == 1
+    }
+
+    def "disambiguates A -> B -> C and D -> C by selecting the later iff attributes match"() {
+        def m1 = mavenRepo.module("test", "test", "1.3").publish()
+        m1.artifactFile.text = "1234"
+
+        given:
+        settingsFile << """
+            rootProject.name = 'root'
+            include 'lib'
+            include 'app'
+        """
+
+        file('lib/src/main/java/test/MyClass.java') << """
+package test;
+
+public class MyClass {
+    public static void main(String[] args) {
+        System.out.println("Hello world!");
+    }
+}
+"""
+
+        buildFile << """
+def artifactType = Attribute.of('artifactType', String)
+def extraAttribute = Attribute.of('extra', String)
+
+allprojects {
+    repositories {
+        maven { url "${mavenRepo.uri}" }
+    }
+}
+project(':lib') {
+    apply plugin: 'java-library'
+}
+
+project(':app') {
+    apply plugin: 'java'
+
+    dependencies {
+        implementation 'test:test:1.3'
+        implementation project(':lib')
+    }
+
+    dependencies {
+        registerTransform {
+            from.attribute(artifactType, 'java-classes-directory')
+            to.attribute(artifactType, 'final')
+            
+            if (project.hasProperty('extraAttribute')) {
+                from.attribute(extraAttribute, 'whatever')
+                to.attribute(extraAttribute, 'value1')
+            }
+            
+            artifactTransform(TestTransform)
+        }
+        registerTransform {
+            from.attribute(artifactType, 'jar')
+            to.attribute(artifactType, 'magic-jar')
+
+            if (project.hasProperty('extraAttribute')) {
+                from.attribute(extraAttribute, 'whatever')
+                to.attribute(extraAttribute, 'value2')
+            }
+            
+            artifactTransform(TestTransform)
+        }
+        registerTransform {
+            from.attribute(artifactType, 'magic-jar')
+            to.attribute(artifactType, 'final')
+            artifactTransform(TestTransform)
+        }
+    }
+
+    task resolve(type: Copy) {
+        def artifacts = configurations.compileClasspath.incoming.artifactView {
+            attributes { it.attribute(artifactType, 'final') }
+            if (project.hasProperty("lenient")) {
+                lenient(true)
+            }
+        }.artifacts
+        from artifacts.artifactFiles
+        into "\${buildDir}/libs"
+        doLast {
+            println "files: " + artifacts.collect { it.file.name }
+            println "ids: " + artifacts.collect { it.id }
+            println "components: " + artifacts.collect { it.id.componentIdentifier }
+            println "variants: " + artifacts.collect { it.variant.attributes }
+        }
+    }
+}
+
+class TestTransform extends ArtifactTransform {
+    List<File> transform(File input) {
+        assert outputDirectory.directory && outputDirectory.list().length == 0
+        def output = new File(outputDirectory, input.name + ".txt")
+        println "Transforming \${input.name} to \${output.name}"
+        output.text = String.valueOf(input.length())
+        return [output]
+    }
+}
+
+"""
+
+
+
+        when:
+        run "resolve"
+
+        then:
+        output.count("Transforming") == 3
+        output.count("Transforming main to main.txt") == 1
+        output.count("Transforming test-1.3.jar to test-1.3.jar.txt") == 1
+        output.count("Transforming test-1.3.jar.txt to test-1.3.jar.txt.txt") == 1
+
+        when:
+        fails 'resolve', '-PextraAttribute'
+
+        then:
+        failureCauseContains('Found multiple transforms')
     }
 
     def "transform with two attributes will not confuse"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -32,7 +32,10 @@ import org.gradle.internal.component.VariantSelectionException;
 import org.gradle.internal.component.model.AttributeMatcher;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 class AttributeMatchingVariantSelector implements VariantSelector {
     private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
@@ -95,7 +98,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             }
         }
         if (candidates.size() > 1) {
-            candidates = tryDisambiguate(candidates);
+            candidates = tryDisambiguate(matcher, candidates);
         }
         if (candidates.size() == 1) {
             Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> result = candidates.get(0);
@@ -115,24 +118,60 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         throw new NoMatchingVariantSelectionException(producer.asDescribable().getDisplayName(), componentRequested, producer.getVariants(), matcher);
     }
 
-    private List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> tryDisambiguate(List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates) {
-        List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> shortestTransforms = Lists.newArrayListWithExpectedSize(candidates.size());
+    private List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> tryDisambiguate(AttributeMatcher matcher, List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates) {
+        if (candidates.size() == 2) {
+            // Short circuit logic when only 2 candidates
+            return compareCandidates(matcher, candidates.get(0), candidates.get(1))
+                .map(Collections::singletonList)
+                .orElse(candidates);
+        }
 
-        for (Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> candidate : candidates) {
-            boolean newCandidate = true;
-            for (int i = 0; i < shortestTransforms.size(); i++) {
-                Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> shorterTransform = shortestTransforms.get(i);
-                if (shorterTransform.right.transformation.endsWith(candidate.right.transformation)) {
-                    newCandidate = false;
-                    shortestTransforms.set(i, candidate);
-                } else if (candidate.right.transformation.endsWith(shorterTransform.right.transformation)) {
-                    newCandidate = false;
-                }
+        List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> shortestTransforms = Lists.newArrayListWithExpectedSize(candidates.size());
+        candidates.sort(Comparator.comparingInt(candidate -> candidate.right.depth));
+
+        // Need to remember if a further element was matched by an earlier one, no need to consider it then
+        boolean[] hasBetterMatch = new boolean[candidates.size()];
+
+        for (int i = 0; i < candidates.size(); i++) {
+            if (hasBetterMatch[i]) {
+                continue;
             }
-            if (newCandidate) {
-                shortestTransforms.add(candidate);
+            boolean candidateIsDifferent = true;
+            Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> current = candidates.get(i);
+            for (int j = i + 1; j < candidates.size(); j++) {
+                if (hasBetterMatch[j]) {
+                    continue;
+                }
+                int index = j; // Needed to use inside lambda below
+                candidateIsDifferent = compareCandidates(matcher, current, candidates.get(index)).map(candidate -> {
+                    if (candidate != current) {
+                        // The other is better, current is not part of result
+                        return false;
+                    } else {
+                        // The other is disambiguated by current, never consider other again
+                        hasBetterMatch[index] = true;
+                    }
+                    return true;
+                }).orElse(true);
+            }
+            if (candidateIsDifferent) {
+                shortestTransforms.add(current);
             }
         }
         return shortestTransforms;
+    }
+
+    private Optional<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> compareCandidates(AttributeMatcher matcher,
+                                                                                                          Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> firstCandidate,
+                                                                                                          Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> secondCandidate) {
+
+        if (matcher.isMatching(firstCandidate.right.attributes, secondCandidate.right.attributes)) {
+            if (firstCandidate.right.depth >= secondCandidate.right.depth) {
+                return Optional.of(secondCandidate);
+            } else {
+                return Optional.of(firstCandidate);
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExecutionGraphDependenciesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExecutionGraphDependenciesResolver.java
@@ -80,7 +80,7 @@ public class DefaultExecutionGraphDependenciesResolver implements ExecutionGraph
         VisitedArtifactSet visitedArtifacts = results.getVisitedArtifacts();
         SelectedArtifactSet artifacts = visitedArtifacts.select(Specs.satisfyAll(), transformer.getFromAttributes(), element -> {
             return dependencies.contains(element);
-        }, true);
+        }, false);
         ResolvedFilesCollectingVisitor visitor = new ResolvedFilesCollectingVisitor();
         artifacts.visitArtifacts(visitor, false);
         if (!visitor.getFailures().isEmpty()) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -1,0 +1,423 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform
+
+import org.gradle.api.Task
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet
+import org.gradle.api.internal.attributes.AttributesSchemaInternal
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory
+import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.internal.Describables
+import org.gradle.internal.component.AmbiguousVariantSelectionException
+import org.gradle.internal.component.model.AttributeMatcher
+import org.gradle.util.AttributeTestUtil
+import spock.lang.Specification
+
+class AttributeMatchingVariantSelectorSpec extends Specification {
+
+    def consumerProvidedVariantFinder = Mock(ConsumerProvidedVariantFinder)
+    def attributeMatcher = Mock(AttributeMatcher)
+    def attributesSchema = Mock(AttributesSchemaInternal) {
+        withProducer(_) >> attributeMatcher
+    }
+    def attributesFactory = Mock(ImmutableAttributesFactory) {
+        concat(_, _) >> { args -> return args[0]}
+    }
+    def requestedAttributes = AttributeTestUtil.attributes(['artifactType' : 'jar'])
+    def variantAttributes = AttributeTestUtil.attributes(['artifactType': 'jar'])
+    def otherVariantAttributes = AttributeTestUtil.attributes(['artifactType': 'classes'])
+    def dependenciesResolverFactory = Mock(ExtraExecutionGraphDependenciesResolverFactory)
+    def variant = Mock(ResolvedVariant) {
+        getAttributes() >> variantAttributes
+        asDescribable() >> Describables.of("mock resolved variant")
+    }
+    def variantSet = Mock(ResolvedVariantSet) {
+        asDescribable() >> Describables.of("mock producer")
+        getVariants() >> [variant]
+    }
+
+    def 'direct match on variant means no finder interaction'() {
+        given:
+        def resolvedArtifactSet = Mock(ResolvedArtifactSet)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(variantSet)
+
+        then:
+        result == resolvedArtifactSet
+        1 * attributeMatcher.matches(_, _) >> [variant]
+        1 * variant.getArtifacts() >> resolvedArtifactSet
+        0 * consumerProvidedVariantFinder._
+    }
+
+    def 'multiple match on variant results in ambiguous exception'() {
+        given:
+        def otherResolvedVariant = Mock(ResolvedVariant) {
+            asDescribable() >> Describables.of('other mocked variant')
+            getAttributes() >> otherVariantAttributes
+        }
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(variantSet)
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                throw new AssertionError("Expected an exception")
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                assert failure instanceof AmbiguousVariantSelectionException
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> [variant, otherResolvedVariant]
+        0 * consumerProvidedVariantFinder._
+    }
+
+    def 'selecting a transform results in added DefaultTransformationDependency'() {
+        given:
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(variantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                assert dependency instanceof DefaultTransformationDependency
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                throw failure
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, Mock(Transformation), 1)
+        }
+    }
+
+    def 'can disambiguate sub chains'() {
+        given:
+        def otherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> otherVariantAttributes
+            asDescribable() >> Describables.of("mock other resolved variant")
+        }
+        def multiVariantSet = Mock(ResolvedVariantSet) {
+            asDescribable() >> Describables.of("mock multi producer")
+            getVariants() >> [variant, otherVariant]
+        }
+        def transform1 = Mock(Transformation)
+        def transform2 = Mock(Transformation)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(multiVariantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                assert dependency instanceof DefaultTransformationDependency
+                assert dependency.transformation == transform1
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                throw failure
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        1 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >> true
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform1, 2)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform2, 3)
+        }
+    }
+
+    def 'can disambiguate 2 equivalent chains by picking shortest'() {
+        given:
+        def otherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> otherVariantAttributes
+            asDescribable() >> Describables.of("mock other resolved variant")
+        }
+        def multiVariantSet = Mock(ResolvedVariantSet) {
+            asDescribable() >> Describables.of("mock multi producer")
+            getVariants() >> [variant, otherVariant]
+        }
+        def transform1 = Mock(Transformation)
+        def transform2 = Mock(Transformation)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(multiVariantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                assert dependency instanceof DefaultTransformationDependency
+                assert dependency.transformation == transform1
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                throw failure
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        1 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >> true
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform1, 2)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform2, 3)
+        }
+    }
+
+    def 'can disambiguate between three chains when one subset of both others'() {
+        given:
+        def yetAnotherVariantAttributes = AttributeTestUtil.attributes(['artifactType': 'foo'])
+        def otherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> otherVariantAttributes
+            asDescribable() >> Describables.of("mock other resolved variant")
+        }
+        def yetAnotherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> yetAnotherVariantAttributes
+            asDescribable() >> Describables.of("mock another resolved variant")
+        }
+        def multiVariantSet = Mock(ResolvedVariantSet) {
+            asDescribable() >> Describables.of("mock multi producer")
+            getVariants() >> [variant, otherVariant, yetAnotherVariant]
+        }
+        def transform1 = Mock(Transformation)
+        def transform2 = Mock(Transformation)
+        def transform3 = Mock(Transformation)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(multiVariantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                assert dependency instanceof DefaultTransformationDependency
+                assert dependency.transformation == transform3
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                throw failure
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        2 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >> true
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform1, 3)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform2, 3)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(yetAnotherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform3, 2)
+        }
+    }
+
+    def 'can disambiguate 3 equivalent chains by picking shortest'() {
+        given:
+        def yetAnotherVariantAttributes = AttributeTestUtil.attributes(['artifactType': 'foo'])
+        def otherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> otherVariantAttributes
+            asDescribable() >> Describables.of("mock other resolved variant")
+        }
+        def yetAnotherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> yetAnotherVariantAttributes
+            asDescribable() >> Describables.of("mock another resolved variant")
+        }
+        def multiVariantSet = Mock(ResolvedVariantSet) {
+            asDescribable() >> Describables.of("mock multi producer")
+            getVariants() >> [variant, otherVariant, yetAnotherVariant]
+        }
+        def transform1 = Mock(Transformation)
+        def transform2 = Mock(Transformation)
+        def transform3 = Mock(Transformation)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(multiVariantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                assert dependency instanceof DefaultTransformationDependency
+                assert dependency.transformation == transform2
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                throw failure
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        2 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >> true
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform1, 3)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform2, 2)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(yetAnotherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform3, 3)
+        }
+    }
+
+    def 'cannot disambiguate 3 chains when 2 different'() {
+        given:
+        def yetAnotherVariantAttributes = AttributeTestUtil.attributes(['artifactType': 'foo'])
+        def otherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> otherVariantAttributes
+            asDescribable() >> Describables.of("mock other resolved variant")
+        }
+        def yetAnotherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> yetAnotherVariantAttributes
+            asDescribable() >> Describables.of("mock another resolved variant")
+        }
+        def multiVariantSet = Mock(ResolvedVariantSet) {
+            asDescribable() >> Describables.of("mock multi producer")
+            getVariants() >> [variant, otherVariant, yetAnotherVariant]
+        }
+        def transform1 = Mock(Transformation)
+        def transform2 = Mock(Transformation)
+        def transform3 = Mock(Transformation)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(multiVariantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                throw new AssertionError("Expected an exception")
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                assert failure instanceof AmbiguousTransformException
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        2 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >>> [false, true]
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform1, 3)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform2, 2)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(yetAnotherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform3, 3)
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces further disambiguation for artifact transforms.
We now consider that candidates resulting in a matching set of
attributes are equivalent and prefer the shortest chain in that case.

The commit also fixes the limited logic that prevented disambiguation
when there were more than 2 candidates.