### PR TITLE
Set dirMode and fileMode for wrapper jar

### DIFF
--- a/subprojects/wrapper/wrapper.gradle
+++ b/subprojects/wrapper/wrapper.gradle
@@ -38,6 +38,8 @@ tasks.register("executableJar", Jar) {
     reproducibleFileOrder = true
     preserveFileTimestamps = false
     archiveName = 'gradle-wrapper.jar'
+    fileMode = 0644
+    dirMode = 0755
     from sourceSets.main.output
     from configurations.runtime.allDependencies.withType(ProjectDependency).collect { it.dependencyProject.sourceSets.main.output }
 }


### PR DESCRIPTION
So that the wrapper.jar does not depend on any umask settings of
the OS.

I saw differences between Windows and Linux builds in the permission settings:
Linux:
```
-rw-rw-r--  2.0 unx      779 b- defN 80-Feb-01 00:00 org/gradle/cli/ProjectPropertiesCommandLineConverter.class
```
vs
Windows:
```
-rw-r--r--  2.0 unx      779 b- defN 80-Feb-01 00:00 org/gradle/cli/ProjectPropertiesCommandLineConverter.class
```

See https://e.grdev.net/c/zsy6a6wr3t5au/thz7u5rhgvxzw/task-inputs?toggled=WzI5LDI4LDMwXQ&toggledFileChanges=WyJ4bm1rNXlqYWZxZWljLWZpbGUtaW5wdXQtMCIsIjR0Y29yaGdmaHM3dzQtZmlsZS1pbnB1dC0wIiwiZWljdnZvYWhya2NrcS1maWxlLWlucHV0LTAiLCJ4bm1rNXlqYWZxZWljLTAtMCJd#change-eicvvoahrkckq-0-0.