### PR TITLE
Fixed environment variable issues on process level isolated worker task.

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/ProcessBuilderFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ProcessBuilderFactory.java
@@ -34,7 +34,6 @@ public class ProcessBuilderFactory {
         processBuilder.redirectErrorStream(processSettings.getRedirectErrorStream());
 
         Map<String, String> environment = processBuilder.environment();
-        environment.clear();
         environment.putAll(processSettings.getEnvironment());
 
         return processBuilder;


### PR DESCRIPTION
### Context
When using `WorkerExecutor` with `IsolationMode.PROCESS`, we cannot get environment variable such as `PATH` from inside a task. This PR will fix this issue.
