### PR TITLE
Remove Implementation-Version from Wrapper JAR manifest

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -20,6 +20,9 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.gradle.util.TextUtil
 
+import java.util.jar.Attributes
+import java.util.jar.Manifest
+
 import static org.gradle.internal.hash.HashUtil.sha256
 
 class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
@@ -68,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "353aba77db94b53b3a6a72980246e23197af3e62549942aee91657c3878fdf42"
+        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "76b12da7f4a7cdd025e5996811a2e49bf5df0fb62d72554ab555c0e434b63aae"
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash
@@ -130,5 +133,21 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         file("gradle/wrapper/gradle-wrapper.properties").text.contains("distributionSha256Sum=somehash")
+    }
+
+    def "wrapper JAR does not contain version in manifest"() {
+        when:
+        run "wrapper"
+
+        then:
+        def contents = file('contents')
+        file("gradle/wrapper/gradle-wrapper.jar").unzipTo(contents)
+
+        Manifest manifest = contents.file('META-INF/MANIFEST.MF').withInputStream { new Manifest(it) } as Manifest
+        with(manifest.mainAttributes) {
+            size() == 2
+            getValue(Attributes.Name.MANIFEST_VERSION) == '1.0'
+            getValue(Attributes.Name.IMPLEMENTATION_TITLE) == 'Gradle Wrapper'
+        }
     }
 }

--- a/subprojects/wrapper/wrapper.gradle
+++ b/subprojects/wrapper/wrapper.gradle
@@ -1,3 +1,4 @@
+import java.util.jar.Attributes
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 
 /*
@@ -40,6 +41,10 @@ tasks.register("executableJar", Jar) {
     archiveName = 'gradle-wrapper.jar'
     fileMode = 0644
     dirMode = 0755
+    manifest {
+        attributes.remove(Attributes.Name.IMPLEMENTATION_VERSION.toString())
+        attributes([(Attributes.Name.IMPLEMENTATION_TITLE.toString()): "Gradle Wrapper"])
+    }
     from sourceSets.main.output
     from configurations.runtime.allDependencies.withType(ProjectDependency).collect { it.dependencyProject.sourceSets.main.output }
 }


### PR DESCRIPTION
In order to make it reproducible across versions the Wrapper JAR no longer contains the `Implementation-Version` manifest entry.

Related issue: #6632.