### PR TITLE
Exclude virtual platform from resolution results

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AbstractAlignmentSpec.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AbstractAlignmentSpec.groovy
@@ -187,7 +187,7 @@ abstract class AbstractAlignmentSpec extends AbstractModuleDependencyResolveTest
 
     }
 
-    protected void "a rule which infers module set from group and version"() {
+    protected void "a rule which infers module set from group and version"(boolean virtual = true) {
         buildFile << """
             dependencies {
                 components.all(InferModuleSetFromGroupAndVersion)
@@ -196,7 +196,7 @@ abstract class AbstractAlignmentSpec extends AbstractModuleDependencyResolveTest
             class InferModuleSetFromGroupAndVersion implements ComponentMetadataRule {
                 void execute(ComponentMetadataContext ctx) {
                     ctx.details.with {
-                        belongsTo("\${id.group}:platform:\${id.version}")
+                        belongsTo("\${id.group}:platform:\${id.version}", ${virtual})
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -1085,11 +1085,6 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 edge("org:foo:1.0", "org:foo:1.1") {
                     byConstraint("belongs to platform org:platform:1.1")
                 }
-                constraint("org:platform:1.1", "org:platform:1.1") {
-                    noArtifacts()
-                    constraint('org:foo:1.1')
-                    byConstraint("belongs to platform org:platform:1.1")
-                }
             }
             virtualConfiguration("org:platform:1.1")
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -683,13 +683,6 @@ include 'other'
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                module('org:platform:2.7.9:default') {
-                    noArtifacts()
-                    constraint('org:core:2.7.9')
-                    constraint('org:databind:2.7.9')
-                    constraint('org:annotations:2.7.9')
-                    constraint('org:kotlin:2.7.9')
-                }
             }
         }
 
@@ -742,15 +735,6 @@ include 'other'
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                constraint('org:platform:2.7.9', 'org:platform:2.7.9') {
-                    noArtifacts()
-                    byConstraint("belongs to platform org:platform:2.7.9")
-                    forced()
-                    constraint('org:core:2.7.9')
-                    constraint('org:databind:2.7.9')
-                    constraint('org:annotations:2.7.9')
-                    constraint('org:kotlin:2.7.9')
-                }
             }
             virtualConfiguration('org:platform:2.7.9')
         }
@@ -802,14 +786,6 @@ include 'other'
                     module('org:core:2.9.4.1')
                     module('org:annotations:2.9.4.1')
                 }
-                constraint('org:platform:2.9.4.1', 'org:platform:2.9.4.1') {
-                    noArtifacts()
-                    byConstraint("belongs to platform org:platform:2.9.4.1")
-                    constraint('org:core:2.9.4.1')
-                    constraint('org:databind:2.9.4.1')
-                    constraint('org:annotations:2.9.4.1')
-                    constraint('org:kotlin:2.9.4.1')
-                }
             }
             virtualConfiguration('org:platform:2.9.4.1')
         }
@@ -852,7 +828,7 @@ include 'other'
         """
 
         and:
-        "a rule which infers module set from group and version"()
+        "a rule which infers module set from group and version"(false)
 
         when:
         allowAllRepositoryInteractions()
@@ -943,15 +919,6 @@ include 'other'
                     module('org:core:2.7.9')
                     module('org:annotations:2.7.9')
                 }
-                constraint('org:platform:2.7.9', 'org:platform:2.7.9') {
-                    noArtifacts()
-                    byConstraint("belongs to platform org:platform:2.7.9")
-                    forced()
-                    constraint('org:core:2.7.9')
-                    constraint('org:databind:2.7.9')
-                    constraint('org:annotations:2.7.9')
-                    constraint('org:kotlin:2.7.9')
-                }
             }
             virtualConfiguration('org:platform:2.7.9')
         }
@@ -1010,17 +977,6 @@ include 'other'
                 if (forceNotation.contains("force = true")) {
                     module("org:databind:2.8.11.1")
                 }
-                if (forceNotation.contains('enforcedPlatform')) {
-                    module("org:platform:2.8.11.1:default") {
-                        noArtifacts()
-                        byConstraint("belongs to platform org:platform:2.8.11.1")
-                        forced()
-                        constraint('org:core:2.8.10')
-                        constraint('org:databind:2.8.11.1')
-                        constraint('org:annotations:2.8.10')
-                        constraint('org:cbor:2.8.10')
-                    }
-                }
             }
         }
 
@@ -1076,17 +1032,6 @@ include 'other'
                 }
                 if (forceNotation.contains("force = true")) {
                     module("org:databind:2.6.7.1")
-                }
-                if (forceNotation.contains('enforcedPlatform')) {
-                    module("org:platform:2.6.7.1:default") {
-                        noArtifacts()
-                        byConstraint("belongs to platform org:platform:2.6.7.1")
-                        forced()
-                        constraint('org:core:2.6.7')
-                        constraint('org:databind:2.6.7.1')
-                        constraint('org:annotations:2.6.7')
-                        constraint('org:cbor:2.6.7')
-                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphEdge.java
@@ -48,4 +48,6 @@ public interface DependencyGraphEdge extends ResolvedGraphDependency {
     @Nullable
     Dependency getOriginalDependency();
 
+    boolean isTargetVirtualPlatform();
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -396,7 +396,7 @@ public class DependencyGraphBuilder {
 
         // Visit the nodes prior to visiting the edges
         for (NodeState nodeState : resolveState.getNodes()) {
-            if (nodeState.isSelected()) {
+            if (nodeState.shouldIncludedInGraphResult()) {
                 visitor.visitNode(nodeState);
             }
         }
@@ -404,7 +404,7 @@ public class DependencyGraphBuilder {
         // Collect the components to sort in consumer-first order
         List<ComponentState> queue = Lists.newArrayListWithExpectedSize(resolveState.getNodeCount());
         for (ModuleResolveState module : resolveState.getModules()) {
-            if (module.getSelected() != null) {
+            if (module.getSelected() != null && !module.isVirtualPlatform()) {
                 queue.add(module.getSelected());
             }
         }
@@ -421,7 +421,7 @@ public class DependencyGraphBuilder {
                     }
                     for (EdgeState edge : node.getIncomingEdges()) {
                         ComponentState owner = edge.getFrom().getOwner();
-                        if (owner.getVisitState() == VisitState.NotSeen) {
+                        if (owner.getVisitState() == VisitState.NotSeen && !owner.getModule().isVirtualPlatform()) {
                             queue.add(pos, owner);
                             pos++;
                         } // else, already visited or currently visiting (which means a cycle), skip

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -239,6 +239,12 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     @Override
+    public boolean isTargetVirtualPlatform() {
+        ComponentState selectedComponent = getSelectedComponent();
+        return selectedComponent != null && selectedComponent.getModule().isVirtualPlatform();
+    }
+
+    @Override
     public ComponentSelectionReason getReason() {
         return selector.getSelectionReason();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -375,6 +375,10 @@ class NodeState implements DependencyGraphNode {
         return !incomingEdges.isEmpty();
     }
 
+    public boolean shouldIncludedInGraphResult() {
+        return isSelected() && !component.getModule().isVirtualPlatform();
+    }
+
     private ModuleExclusion getModuleResolutionFilter(List<EdgeState> incomingEdges) {
         ModuleExclusions moduleExclusions = resolveState.getModuleExclusions();
         ModuleExclusion nodeExclusions = moduleExclusions.excludeAny(metaData.getExcludes());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/StreamingResolutionResultBuilder.java
@@ -49,6 +49,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.gradle.internal.UncheckedException.throwAsUncheckedException;
 
@@ -121,7 +122,9 @@ public class StreamingResolutionResultBuilder implements DependencyGraphVisitor 
     @Override
     public void visitEdges(DependencyGraphNode node) {
         final Long fromComponent = node.getOwner().getResultId();
-        final Collection<? extends DependencyGraphEdge> dependencies = node.getOutgoingEdges();
+        final Collection<? extends DependencyGraphEdge> dependencies = node.getOutgoingEdges().stream()
+            .filter(dep -> !dep.isTargetVirtualPlatform())
+            .collect(Collectors.toList());
         if (!dependencies.isEmpty()) {
             store.write(new BinaryStore.WriteAction() {
                 public void write(Encoder encoder) throws IOException {


### PR DESCRIPTION
When using a virtual platform, it cannot appear in the
`ResolutionResult` so it is filtered when the resulting graph is saved.

However this does not resolve the publication issue.