### PR TITLE
Add usage attribute to buildscript classpath

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassPathIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/BuildScriptClassPathIntegrationTest.groovy
@@ -90,4 +90,17 @@ task foo {
         then:
         outputDoesNotContain('Original bar')
     }
+
+    def 'buildscript classpath has proper usage attribute'() {
+        buildFile << """
+buildscript {
+    configurations.classpath {
+        def value = attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
+        assert value.name == Usage.JAVA_RUNTIME
+    }
+}
+"""
+        expect:
+        succeeds()
+    }
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/InitScriptExecutionIntegrationTest.groovy
@@ -228,6 +228,21 @@ rootProject {
         }
     }
 
+    def 'init script classpath configuration has proper usage attribute'() {
+        def initScript = file('init.gradle')
+        initScript << """
+initscript {
+    configurations.classpath {
+        def value = attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
+        assert value.name == Usage.JAVA_RUNTIME
+    }
+}
+"""
+        expect:
+        executer.withArguments('--init-script', initScript.absolutePath)
+        succeeds()
+    }
+
     private def createExternalJar() {
         ArtifactBuilder builder = artifactBuilder()
         builder.sourceFile('org/gradle/test/BuildClass.java') << '''

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/SettingsDslIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/SettingsDslIntegrationSpec.groovy
@@ -127,4 +127,17 @@ class SettingsDslIntegrationSpec extends AbstractIntegrationSpec {
         succeeds('help')
     }
 
+    def 'settings script classpath has proper usage attribute'() {
+        settingsFile << """
+buildscript {
+    configurations.classpath {
+        def value = attributes.getAttribute(Usage.USAGE_ATTRIBUTE)
+        assert value.name == Usage.JAVA_RUNTIME
+    }
+}    
+"""
+        expect:
+        succeeds()
+    }
+
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementServices.java
@@ -28,7 +28,7 @@ public interface DependencyManagementServices {
     /**
      * Registers the dependency management DSL services.
      */
-    void addDslServices(ServiceRegistration registration);
+    void addDslServices(ServiceRegistration registration, DomainObjectContext domainObjectContext);
 
     DependencyResolutionServices create(FileResolver resolver, DependencyMetaDataProvider dependencyMetaDataProvider,
                                         ProjectFinder projectFinder, DomainObjectContext domainObjectContext);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -20,9 +20,11 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.groovy.scripts.ScriptSource;
@@ -107,6 +109,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
+            classpathConfiguration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -114,7 +114,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         register(new Action<ServiceRegistration>() {
             public void execute(ServiceRegistration registration) {
                 registration.add(DomainObjectContext.class, project);
-                parent.get(DependencyManagementServices.class).addDslServices(registration);
+                parent.get(DependencyManagementServices.class).addDslServices(registration, project);
                 for (PluginServiceRegistry pluginServiceRegistry : parent.getAll(PluginServiceRegistry.class)) {
                     pluginServiceRegistry.registerProjectServices(registration);
                 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -19,7 +19,9 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
+import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.classpath.ClassPath
 import org.gradle.util.ConfigureUtil
@@ -38,6 +40,7 @@ class DefaultScriptHandlerTest extends Specification {
     }
     def classpathResolver = Mock(ScriptClassPathResolver)
     def handler = new DefaultScriptHandler(scriptSource, depMgmtServices, classLoaderScope, classpathResolver)
+    def attributes = Mock(AttributeContainerInternal)
 
     def "adds classpath configuration when configuration container is queried"() {
         when:
@@ -47,6 +50,8 @@ class DefaultScriptHandlerTest extends Specification {
         then:
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
+        1 * configuration.attributes >> attributes
+        1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         0 * configurationContainer._
         0 * depMgmtServices._
     }
@@ -59,6 +64,8 @@ class DefaultScriptHandlerTest extends Specification {
         then:
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
+        1 * configuration.attributes >> attributes
+        1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         0 * configurationContainer._
         0 * depMgmtServices._
@@ -89,6 +96,8 @@ class DefaultScriptHandlerTest extends Specification {
         and:
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
+        1 * configuration.attributes >> attributes
+        1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * classpathResolver.resolveClassPath(configuration) >> classpath
     }
 
@@ -115,6 +124,9 @@ class DefaultScriptHandlerTest extends Specification {
         then:
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         1 * depMgmtServices.configurationContainer >> configurationContainer
+        1 * configurationContainer.create('classpath') >> configuration
+        1 * configuration.attributes >> attributes
+        1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * dependencyHandler.add('config', 'dep')
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.ClassGenerator
 import org.gradle.api.internal.CollectionCallbackActionDecorator
+import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.artifacts.DependencyManagementServices
@@ -169,7 +170,7 @@ class ProjectScopeServicesTest extends Specification {
         service.is(testDslService)
 
         and:
-        1 * dependencyManagementServices.addDslServices(_) >> { ServiceRegistration registration ->
+        1 * dependencyManagementServices.addDslServices(_, _) >> { ServiceRegistration registration, DomainObjectContext context ->
             registration.add(Runnable, testDslService)
         }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ClasspathDependenciesAttributesIntegrationTest.groovy
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+import org.gradle.test.fixtures.file.TestFile
+import org.objectweb.asm.ClassWriter
+import org.objectweb.asm.Opcodes
+import org.objectweb.asm.tree.ClassNode;
+
+class ClasspathDependenciesAttributesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def 'buildscript classpath resolves java-runtime variant'() {
+        def otherSettings = file('other/settings.gradle')
+        def otherBuild = file('other/build.gradle')
+
+        otherSettings << """
+rootProject.name = 'other'
+"""
+        otherBuild << """
+group = 'org.other'
+version = '1.0'
+configurations {
+    conf {
+        canBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+        }
+    }
+    badConf {
+        canBeConsumed = true
+        attributes {
+            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'not-good'))
+        }
+    }
+}
+"""
+
+        buildFile << """
+buildscript {
+    dependencies {
+        classpath 'org.other:other:1.0'
+    }
+}
+"""
+
+        expect:
+        executer.withArguments('--include-build', 'other')
+        succeeds()
+    }
+
+    @RequiredFeatures([
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "false"),
+        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
+    ])
+    def 'show that settings classpath respects attributes and thus will use the default java-runtime value'() {
+        given:
+        def jarFile = file('build/lib/foo.jar')
+        createJarFile(jarFile)
+        def foo = mavenRepo.module('org', 'foo')
+        foo.publish()
+        foo.artifact.file.bytes = jarFile.bytes
+        mavenRepo.module('org', 'bar').dependsOn(['scope': 'runtime'], foo).publish()
+
+        settingsFile << """
+import org.gradle.api.internal.model.NamedObjectInstantiator
+buildscript {
+    $repositoryDeclaration
+
+    configurations.classpath {
+        attributes.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage, Usage.JAVA_API))
+    }
+    
+    dependencies {
+        classpath 'org:bar:1.0'
+    }
+}    
+    Class.forName('org.gradle.MyClass')
+"""
+
+        repositoryInteractions {
+            'org:bar:1.0' {
+                expectResolve()
+            }
+        }
+        when:
+        fails()
+
+        then:
+        failure.assertHasCause("org.gradle.MyClass")
+    }
+
+    private void createJarFile(TestFile jar) {
+        TestFile contents = file('contents')
+        TestFile classFile = contents.createFile('org/gradle/MyClass.class')
+
+        ClassNode classNode = new ClassNode()
+        classNode.version = Opcodes.V1_6
+        classNode.access = Opcodes.ACC_PUBLIC
+        classNode.name = 'org/gradle/MyClass'
+        classNode.superName = 'java/lang/Object'
+
+        ClassWriter cw = new ClassWriter(0)
+        classNode.accept(cw)
+
+        classFile.withDataOutputStream {
+            it.write(cw.toByteArray())
+        }
+
+        contents.zipTo(jar)
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -36,6 +36,7 @@ import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentMetadataHandler;
 import org.gradle.api.internal.artifacts.dsl.DefaultComponentModuleMetadataHandler;
@@ -98,6 +99,7 @@ import org.gradle.internal.build.BuildState;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.component.external.ivypublish.DefaultArtifactPublisher;
 import org.gradle.internal.component.external.ivypublish.DefaultIvyModuleDescriptorWriter;
+import org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.component.model.ComponentAttributeMatcher;
 import org.gradle.internal.event.ListenerManager;
@@ -160,12 +162,12 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         services.add(ProjectFinder.class, projectFinder);
         services.add(DomainObjectContext.class, domainObjectContext);
         services.addProvider(new ArtifactTransformResolutionGradleUserHomeServices());
-        services.addProvider(new DependencyResolutionScopeServices());
+        services.addProvider(new DependencyResolutionScopeServices(domainObjectContext));
         return services.get(DependencyResolutionServices.class);
     }
 
-    public void addDslServices(ServiceRegistration registration) {
-        registration.addProvider(new DependencyResolutionScopeServices());
+    public void addDslServices(ServiceRegistration registration, DomainObjectContext domainObjectContext) {
+        registration.addProvider(new DependencyResolutionScopeServices(domainObjectContext));
     }
 
     private static class ArtifactTransformResolutionGradleUserHomeServices {
@@ -228,6 +230,12 @@ public class DefaultDependencyManagementServices implements DependencyManagement
     }
 
     private static class DependencyResolutionScopeServices {
+
+        private final DomainObjectContext domainObjectContext;
+
+        public DependencyResolutionScopeServices(DomainObjectContext domainObjectContext) {
+            this.domainObjectContext = domainObjectContext;
+        }
 
         AttributesSchemaInternal createConfigurationAttributesSchema(InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory) {
             return instantiatorFactory.decorate().newInstance(DefaultAttributesSchema.class, new ComponentAttributeMatcher(), instantiatorFactory, isolatableFactory);
@@ -455,7 +463,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         DependencyResolutionServices createDependencyResolutionServices(ServiceRegistry services) {
-            return new DefaultDependencyResolutionServices(services);
+            return new DefaultDependencyResolutionServices(services, domainObjectContext);
         }
 
         ArtifactResolutionQueryFactory createArtifactResolutionQueryFactory(ConfigurationContainerInternal configurationContainer, RepositoryHandler repositoryHandler,
@@ -470,9 +478,11 @@ public class DefaultDependencyManagementServices implements DependencyManagement
     private static class DefaultDependencyResolutionServices implements DependencyResolutionServices {
 
         private final ServiceRegistry services;
+        private final DomainObjectContext domainObjectContext;
 
-        private DefaultDependencyResolutionServices(ServiceRegistry services) {
+        private DefaultDependencyResolutionServices(ServiceRegistry services, DomainObjectContext domainObjectContext) {
             this.services = services;
+            this.domainObjectContext = domainObjectContext;
         }
 
         public RepositoryHandler getResolveRepositoryHandler() {
@@ -484,7 +494,11 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         public DependencyHandler getDependencyHandler() {
-            return services.get(DependencyHandler.class);
+            DependencyHandler dependencyHandler = services.get(DependencyHandler.class);
+            if (domainObjectContext.isScript()) {
+                ((ComponentMetadataHandlerInternal) dependencyHandler.getComponents()).setVariantDerivationStrategy(new JavaEcosystemVariantDerivationStrategy());
+            }
+            return dependencyHandler;
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultDependencyManagementServicesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/DefaultDependencyManagementServicesTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts
 import org.gradle.api.Action
 import org.gradle.api.artifacts.dsl.ArtifactHandler
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
+import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.InstantiatorFactory
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer
 import org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler
@@ -39,6 +40,7 @@ import java.lang.reflect.ParameterizedType
 class DefaultDependencyManagementServicesTest extends Specification {
     final ServiceRegistry parent = Mock()
     final DefaultDependencyManagementServices services = new DefaultDependencyManagementServices(parent)
+    def domainObjectContext = Mock(DomainObjectContext)
 
     def setup() {
         _ * parent.get(Instantiator) >> TestUtil.instantiatorFactory().decorate()
@@ -53,7 +55,7 @@ class DefaultDependencyManagementServicesTest extends Specification {
         def registry = new DefaultServiceRegistry(parent)
 
         when:
-        registry.register({ ServiceRegistration registration -> services.addDslServices(registration) } as Action)
+        registry.register({ ServiceRegistration registration -> services.addDslServices(registration, domainObjectContext) } as Action)
         def resolutionServices = registry.get(DependencyResolutionServices)
 
         then:
@@ -70,7 +72,7 @@ class DefaultDependencyManagementServicesTest extends Specification {
         def registry = new DefaultServiceRegistry(parent)
 
         when:
-        registry.register({ ServiceRegistration registration -> services.addDslServices(registration) } as Action)
+        registry.register({ ServiceRegistration registration -> services.addDslServices(registration, domainObjectContext) } as Action)
         def publishServices = registry.get(ArtifactPublicationServices)
 
         then:
@@ -84,7 +86,7 @@ class DefaultDependencyManagementServicesTest extends Specification {
         def registry = new DefaultServiceRegistry(parent)
 
         when:
-        registry.register({ ServiceRegistration registration -> services.addDslServices(registration) } as Action)
+        registry.register({ ServiceRegistration registration -> services.addDslServices(registration, domainObjectContext) } as Action)
         def publishServices = registry.get(ArtifactPublicationServices)
 
         then:


### PR DESCRIPTION
The classpath configuration used by build and init scripts to build
their classpath was lacking the `Usage` attribute.
It is now properly configured to be `java-runtime` given the role of
this configuration.