### PR TITLE
Fix typo in Project Report Plugin docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/project_report_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/project_report_plugin.adoc
@@ -39,7 +39,7 @@ The project report plugin defines the following tasks:
 `dependencyReport` — link:{groovyDslPath}/org.gradle.api.tasks.diagnostics.DependencyReportTask.html[DependencyReportTask]::
 Generates the project dependency report.
 
-`dependencyReport` — link:{groovyDslPath}/org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.html[HtmlDependencyReportTask]::
+`htmlDependencyReport` — link:{groovyDslPath}/org.gradle.api.reporting.dependencies.HtmlDependencyReportTask.html[HtmlDependencyReportTask]::
 Generates an HTML dependency and dependency insight report for the project or a set of projects.
 
 `propertyReport` — link:{groovyDslPath}/org.gradle.api.tasks.diagnostics.PropertyReportTask.html[PropertyReportTask]::


### PR DESCRIPTION
### Context
This is just a simple typo fix in the Project Report Plugin docs. `dependencyReport` task was listed twice in the doc and the 2nd one should be `htmlDependencyReport`. That's what this PR fixes.

(I created this PR by clicking the "Edit this page" link in the manual and that's why I think that the ordinary PR checklists don't apply to this simple change.)