### PR TITLE
ignore ProjectBuilder deprecation warning when using builder

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -18,6 +18,7 @@ package org.gradle.testfixtures;
 import org.gradle.util.SingleMessageLogger;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.internal.ProjectBuilderImpl;
+import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
 
@@ -67,7 +68,12 @@ public class ProjectBuilder {
      * @return The builder
      */
     public static ProjectBuilder builder() {
-        return new ProjectBuilder();
+        return DeprecationLogger.whileDisabled(new Factory<ProjectBuilder>() {
+                  @Override
+                  public ProjectBuilder create() {
+                      return new ProjectBuilder();
+                  }
+              });
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/testfixtures/ProjectBuilder.java
@@ -17,6 +17,7 @@ package org.gradle.testfixtures;
 
 import org.gradle.util.SingleMessageLogger;
 import org.gradle.api.Project;
+import org.gradle.internal.Factory;
 import org.gradle.testfixtures.internal.ProjectBuilderImpl;
 import org.gradle.util.DeprecationLogger;
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -67,8 +67,8 @@ See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn 
 We would like to thank the following community members for making contributions to this release of Gradle.
 
  - [Thomas Broyer](https://github.com/tbroyer) - Provide default value for annotationProcessorGeneratedSourcesDirectory (gradle/gradle#7551)
-
  - [Stefan M.](https://github.com/StefMa) - Deprecate ProjectBuilder constructor (gradle/gradle#7444)
+ - [Roberto Perez Alcolea](https://github.com/rpalcolea) - Ignore ProjectBuilder deprecation warning when using builder (gradle/gradle#8067)
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 


### PR DESCRIPTION
Hi @marcphilipp ,

https://github.com/gradle/gradle/pull/7444/files introduced deprecation warning for `ProjectBuilder` constructor usage, but since the `builder()` uses it, builds get the deprecation anyway