### PR TITLE
Don't clean up buildSrc

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -115,14 +115,6 @@ fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTas
 
     buildType.steps {
         gradleWrapper {
-            name = "CLEAN_BUILD_SRC"
-            tasks = "clean"
-            gradleParams = gradleParameterString
-            workingDir = "buildSrc"
-            gradleWrapperPath = ".."
-            buildFile = "build.gradle.kts"
-        }
-        gradleWrapper {
             name = "GRADLE_RUNNER"
             tasks = "clean $gradleTasks"
             gradleParams = (


### PR DESCRIPTION
`buildSrc` cleanup happens automatically. We can now track the cache
misses, so we should fix any problems we encounter.
