### PR TITLE
Publish platform project dependency properly

### DIFF
--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -334,6 +334,7 @@ class DefaultMavenPublicationTest extends Specification {
 
         and:
         projectDependency.excludeRules >> []
+        projectDependency.getAttributes() >> ImmutableAttributes.EMPTY
         projectDependencyResolver.resolve(ModuleVersionIdentifier, projectDependency) >> DefaultModuleVersionIdentifier.newId("pub-group", "pub-name", "pub-version")
 
         when:


### PR DESCRIPTION
When a project depends on a `java-platform` using the `platform` or
`enforcedPlatform` and is published using `maven-publish` the dependency
needs to be declared as a `dependencyManagement` with scope `import`
entry.