### PR TITLE
Support for env variables in TestKit

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -90,6 +90,7 @@ See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn 
 We would like to thank the following community members for making contributions to this release of Gradle.
 
  - [Thomas Broyer](https://github.com/tbroyer) - Provide default value for annotationProcessorGeneratedSourcesDirectory (gradle/gradle#7551)
+ - [Szczepan Faber](https://github.com/mockitoguy) - User can specify environment variables in TestKit runner (gradle/gradle#8089)
  - [Stefan M.](https://github.com/StefMa) - Deprecate ProjectBuilder constructor (gradle/gradle#7444)
  - [Roberto Perez Alcolea](https://github.com/rpalcolea) - Ignore ProjectBuilder deprecation warning when using builder (gradle/gradle#8067)
  - [Ian Kerins](https://github.com/isker) - Fix links to CreateStartScripts DSL docs in Application Plugin user manual chapter (gradle/gradle#7938)

--- a/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerEnvironmentVariablesIntegrationTest.groovy
+++ b/subprojects/test-kit/src/integTest/groovy/org/gradle/testkit/runner/GradleRunnerEnvironmentVariablesIntegrationTest.groovy
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testkit.runner
+
+import org.gradle.testkit.runner.fixtures.CustomDaemonDirectory
+import org.gradle.testkit.runner.fixtures.NoDebug
+
+class GradleRunnerEnvironmentVariablesIntegrationTest extends BaseGradleRunnerIntegrationTest {
+
+    @CustomDaemonDirectory //avoid the daemon to be reused to avoid leaking env variable
+    @NoDebug //avoid in-process execution so that we can set the env variable
+    def "use can provide environment variables"() {
+        given:
+        buildScript "file('env.txt') << System.getenv('dummyEnvVar')"
+
+        when:
+        runner().withEnvironment(dummyEnvVar: "env var OK").build()
+
+        then:
+        file('env.txt').text == "env var OK"
+    }
+}

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
@@ -18,10 +18,12 @@ package org.gradle.testkit.runner;
 
 import org.gradle.testkit.runner.internal.DefaultGradleRunner;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Writer;
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Executes a Gradle build, allowing inspection of the outcome.
@@ -296,6 +298,26 @@ public abstract class GradleRunner {
      * @since 2.9
      */
     public abstract GradleRunner withDebug(boolean flag);
+
+    /**
+     * Environment variables for the build.
+     * {@code null} is valid and indicates the build will use system environment.
+     *
+     * @return environment variables
+     * @since 5.2
+     */
+    @Nullable
+    public abstract Map<String, String> getEnvironment();
+
+    /**
+     * Sets the environment variables for the build.
+     * {@code null} is permitted and will make the build use system environment.
+     *
+     * @param environmentVariables the variables to use, null ok.
+     * @return this
+     * @since 5.2
+     */
+    public abstract GradleRunner withEnvironment(Map<String, String> environmentVariables);
 
     /**
      * Configures the runner to forward standard output from builds to the given writer.

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/GradleRunner.java
@@ -283,6 +283,9 @@ public abstract class GradleRunner {
      * Debug support is off (i.e. {@code false}) by default.
      * It can be enabled by setting the system property {@code org.gradle.testkit.debug} to {@code true} for the test process,
      * or by using the {@link #withDebug(boolean)} method.
+     * <p>
+     * When {@link #withEnvironment(Map)} is specified, running with debug is not allowed.
+     * Debug mode runs "in process" and we need to fork a separate process to pass environment variables.
      *
      * @return whether the build should be executed in the same process
      * @since 2.9
@@ -312,6 +315,8 @@ public abstract class GradleRunner {
     /**
      * Sets the environment variables for the build.
      * {@code null} is permitted and will make the build use system environment.
+     * When environment is specified, running with {@link #isDebug()} is not allowed.
+     * Debug mode runs "in process" and we need to fork a separate process to pass environment variables.
      *
      * @param environmentVariables the variables to use, null ok.
      * @return this

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
@@ -290,6 +290,12 @@ public class DefaultGradleRunner extends GradleRunner {
             throw new InvalidRunnerConfigurationException("Please specify a project directory before executing the build");
         }
 
+        if (environment != null && debug) {
+            throw new InvalidRunnerConfigurationException("Debug mode is not allowed when environment variables are specified. " +
+                "Debug mode runs 'in process' but we need to fork a separate process to pass environment variables. " +
+                "To run with debug mode, please remove environment variables.");
+        }
+
         File testKitDir = createTestKitDir(testKitDirProvider);
 
         GradleProvider effectiveDistribution = gradleProvider == null ? findGradleInstallFromGradleRunner() : gradleProvider;

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/DefaultGradleRunner.java
@@ -61,6 +61,7 @@ public class DefaultGradleRunner extends GradleRunner {
     private OutputStream standardError;
     private InputStream standardInput;
     private boolean forwardingSystemStreams;
+    private Map<String, String> environment;
 
     public DefaultGradleRunner() {
         this(new ToolingApiGradleExecutor(), calculateTestKitDirProvider(SystemProperties.getInstance()));
@@ -184,6 +185,17 @@ public class DefaultGradleRunner extends GradleRunner {
     }
 
     @Override
+    public Map<String, String> getEnvironment() {
+        return environment;
+    }
+
+    @Override
+    public GradleRunner withEnvironment(Map<String, String> environment) {
+        this.environment = environment;
+        return this;
+    }
+
+    @Override
     public GradleRunner forwardStdOutput(Writer writer) {
         if (forwardingSystemStreams) {
             forwardingSystemStreams = false;
@@ -292,7 +304,8 @@ public class DefaultGradleRunner extends GradleRunner {
             debug,
             standardOutput,
             standardError,
-            standardInput
+            standardInput,
+            environment
         ));
 
         resultVerification.execute(execResult);

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/GradleExecutionParameters.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/GradleExecutionParameters.java
@@ -18,10 +18,12 @@ package org.gradle.testkit.runner.internal;
 
 import org.gradle.internal.classpath.ClassPath;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Map;
 
 public class GradleExecutionParameters {
 
@@ -35,6 +37,7 @@ public class GradleExecutionParameters {
     private final OutputStream standardOutput;
     private final OutputStream standardError;
     private final InputStream standardInput;
+    private final Map<String, String> environment;
 
     public GradleExecutionParameters(
         GradleProvider gradleProvider,
@@ -46,8 +49,8 @@ public class GradleExecutionParameters {
         boolean embedded,
         OutputStream standardOutput,
         OutputStream standardError,
-        InputStream standardInput
-    ) {
+        InputStream standardInput,
+        Map<String, String> environment) {
         this.gradleProvider = gradleProvider;
         this.gradleUserHome = gradleUserHome;
         this.projectDir = projectDir;
@@ -58,6 +61,7 @@ public class GradleExecutionParameters {
         this.standardOutput = standardOutput;
         this.standardError = standardError;
         this.standardInput = standardInput;
+        this.environment = environment;
     }
 
     public GradleProvider getGradleProvider() {
@@ -98,5 +102,10 @@ public class GradleExecutionParameters {
 
     public InputStream getStandardInput() {
         return standardInput;
+    }
+
+    @Nullable
+    public Map<String, String> getEnvironment() {
+        return environment;
     }
 }

--- a/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
+++ b/subprojects/test-kit/src/main/java/org/gradle/testkit/runner/internal/ToolingApiGradleExecutor.java
@@ -57,7 +57,12 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.gradle.testkit.runner.TaskOutcome.*;
+import static org.gradle.testkit.runner.TaskOutcome.FAILED;
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE;
+import static org.gradle.testkit.runner.TaskOutcome.NO_SOURCE;
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED;
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
 
 public class ToolingApiGradleExecutor implements GradleExecutor {
 
@@ -119,6 +124,7 @@ public class ToolingApiGradleExecutor implements GradleExecutor {
 
             launcher.withArguments(parameters.getBuildArgs().toArray(new String[0]));
             launcher.setJvmArguments(parameters.getJvmArgs().toArray(new String[0]));
+            launcher.setEnvironmentVariables(parameters.getEnvironment());
 
             if (!parameters.getInjectedClassPath().isEmpty()) {
                 if (targetGradleVersion.compareTo(TestKitFeature.PLUGIN_CLASSPATH_INJECTION.getSince()) < 0) {

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildLauncher.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/internal/consumer/DefaultBuildLauncher.java
@@ -79,7 +79,6 @@ public class DefaultBuildLauncher extends AbstractLongRunningOperation<DefaultBu
 
     public void run(final ResultHandler<? super Void> handler) {
         final ConsumerOperationParameters operationParameters = getConsumerOperationParameters();
-
         connection.run(new ConsumerAction<Void>() {
             public ConsumerOperationParameters getParameters() {
                 return operationParameters;


### PR DESCRIPTION
This PR is ready to review and hopefully merge. I incorporated @oehme's feedback.

Fixes #6070

Tested by:
- running ```./gradlew testKit:check```
- Travis CI failure seems to be unrelated

Notes:
- it is ok to pass 'null' env variables to the launcher because it will handle them correctly [org/gradle/tooling/internal/provider/ProviderConnection.java:269](https://github.com/gradle/gradle/blob/master/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/ProviderConnection.java#L269).
- there is already coverage for env variables in tooling API: [BuildEnvironmentCrossVersionSpec](https://github.com/gradle/gradle/blob/master/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r35/BuildEnvironmentCrossVersionSpec.groovy)
- daemon uses System.getenv() by default and this PR does not change it. References:
    - [org/gradle/launcher/daemon/configuration/DaemonParameters.java:72](https://github.com/gradle/gradle/blob/master/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java#L72)
    - [org/gradle/launcher/daemon/configuration/DaemonParameters.java:167](https://github.com/gradle/gradle/blob/master/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java#L167)
