### PR TITLE
Make Gradle's own build reproducible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -400,3 +400,10 @@ tasks.register<Zip>("allIncubationReportsZip") {
 }
 
 fun Project.collectAllIncubationReports() = subprojects.flatMap { it.tasks.withType(IncubatingApiReportTask::class) }
+
+allprojects {
+    tasks.withType<AbstractArchiveTask>() {
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+    }
+}

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/ClasspathManifestPatcher.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/ClasspathManifestPatcher.kt
@@ -13,6 +13,7 @@ import org.objectweb.asm.commons.Remapper
 import java.io.File
 
 import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.zipTo
 
 
 // Map of internal APIs that have been renamed since the last release
@@ -100,9 +101,7 @@ open class ClasspathManifestPatcher(
 
     private
     fun pack(baseDir: File, destFile: File): Unit = project.run {
-        ant.withGroovyBuilder {
-            "zip"("basedir" to baseDir, "destfile" to destFile)
-        }
+        zipTo(destFile, baseDir)
     }
 
     private

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/JarPatcher.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/modules/JarPatcher.kt
@@ -19,6 +19,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 
 import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.zipTo
 
 import java.io.File
 
@@ -93,8 +94,6 @@ class JarPatcher(
                 }
             }
         }
-        ant.withGroovyBuilder {
-            "zip"("basedir" to baseDir, "destfile" to destFile)
-        }
+        zipTo(destFile, baseDir)
     }
 }


### PR DESCRIPTION
When running two builds of the same sources of Gradle,
outputs were not binary equivalent, this was primarily
due to zip files not being equivalent due to both
file ordering and timestamps in the file metadata.

This changes makes it so that running two gradle builds
with the same buildTimestamp
(e.g. -PbuildTimestamp="20181220000000-0800") produce the same output.

Having a reproducible build will make it easier to verify that
the official distributions match the sources on github.

Following changes were needed:

* switch to the kotlin-dsl provided zipTo methods instead of Ant's
  zip helper for the tasks that package the kotlin-dsl dependencies as zipTo
  correctly ignores file metadata
* set all AbstractArchiveTasks preserveFileTimestamp=false
  & reproducibleFileOrder=true to ensure jars created do not have file ordering
  or metadata changes from build to build

### Context
A chain of custody from source to binary is a great thing to have so people can verify for themselves that the distribution matches the sources.

### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
