### PR TITLE
Add StartReleaseCycleTest configuration

### DIFF
--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_StartReleaseCycleTest.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_StartReleaseCycleTest.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="355487d7-45b9-4387-9fc5-713e7683e6d0"
+            xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
+    <name>Master - Start Release Cycle Test</name>
+    <description>Run daily to test Start Release Cycle job</description>
+    <settings>
+        <options>
+            <option name="artifactRules" value="incoming-build-receipt/build-receipt.properties =&gt; incoming-build-receipt&#xA;promote-projects/gradle/build/reports/jdiff =&gt; jdiff"/>
+            <option name="checkoutMode" value="ON_SERVER"/>
+        </options>
+        <parameters>
+            <param name="confirmationCode" value="" spec="text description='Enter the value |'startCycle|' (no quotes) to confirm the promotion' display='prompt' label='Confirmation Code'"/>
+            <param name="gitUserEmail" value=""
+                   spec="text description='Enter the git |'user.email|' configuration to commit change under' label='Git user.email Configuration' validationMode='any' display='prompt'"/>
+            <param name="gitUserName" value=""
+                   spec="text description='Enter the git |'user.name|' configuration to commit change under' label='Git user.name Configuration' validationMode='any' display='prompt'"/>
+        </parameters>
+        <build-runners>
+            <runner id="RUNNER_9" name="Promote" type="gradle-runner">
+                <parameters>
+                    <param name="org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration" value="GLOBAL"/>
+                    <param name="teamcity.coverage.emma.include.source" value="true"/>
+                    <param name="teamcity.coverage.emma.instr.parameters" value="-ix -*Test*"/>
+                    <param name="teamcity.coverage.idea.includePatterns" value="*"/>
+                    <param name="teamcity.step.mode" value="default"/>
+                    <param name="ui.gradleRunner.additional.gradle.cmd.params" value="-PuseBuildReceipt -PconfirmationCode=startCycle -Igradle/buildScanInit.gradle -PtestRun=1"/>
+                    <param name="ui.gradleRunner.gradle.tasks.names" value="clean promoteStartReleaseCycle"/>
+                    <param name="ui.gradleRunner.gradle.wrapper.useWrapper" value="true"/>
+                </parameters>
+            </runner>
+        </build-runners>
+        <vcs-settings>
+            <vcs-entry-ref root-id="Gradle_Promotion_GradlePromotionBranches"/>
+        </vcs-settings>
+        <requirements>
+            <contains id="RQ_28" name="teamcity.agent.jvm.os.name" value="Linux"/>
+        </requirements>
+        <build-triggers>
+            <build-trigger id="TRIGGER_12" type="schedulingTrigger">
+                <parameters>
+                    <param name="cronExpression_dm" value="*"/>
+                    <param name="cronExpression_dw" value="?"/>
+                    <param name="cronExpression_hour" value="*"/>
+                    <param name="cronExpression_min" value="0"/>
+                    <param name="cronExpression_month" value="*"/>
+                    <param name="cronExpression_sec" value="0"/>
+                    <param name="cronExpression_year" value="*"/>
+                    <param name="dayOfWeek" value="Sunday"/>
+                    <param name="enableQueueOptimization" value="true"/>
+                    <param name="hour" value="0"/>
+                    <param name="minute" value="0"/>
+                    <param name="schedulingPolicy" value="daily"/>
+                </parameters>
+            </build-trigger>
+            <build-trigger id="vcsTrigger" type="vcsTrigger">
+                <parameters>
+                    <param name="enableQueueOptimization" value="true"/>
+                    <param name="quietPeriodMode" value="DO_NOT_USE"/>
+                </parameters>
+            </build-trigger>
+        </build-triggers>
+        <artifact-dependencies>
+            <dependency id="ARTIFACT_DEPENDENCY_9" sourceBuildTypeId="Gradle_Check_Stage_ReadyforNightly_Trigger" cleanDestination="true">
+                <revisionRule name="lastSuccessful" revision="latest.lastSuccessful" branch="master"/>
+                <artifact sourcePath="build-receipt.properties =&gt; incoming-build-receipt/"/>
+            </dependency>
+        </artifact-dependencies>
+        <cleanup/>
+    </settings>
+</build-type>
+

--- a/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_StartReleaseCycleTest.xml
+++ b/.teamcity/Gradle_Promotion/buildTypes/Gradle_Promotion_StartReleaseCycleTest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="355487d7-45b9-4387-9fc5-713e7683e6d0"
+<build-type xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" uuid="355487d7-45b9-4387-9fc5-713e7683e6d1"
             xsi:noNamespaceSchemaLocation="http://www.jetbrains.com/teamcity/schemas/2018.1/project-config.xsd">
     <name>Master - Start Release Cycle Test</name>
     <description>Run daily to test Start Release Cycle job</description>


### PR DESCRIPTION
### Context

Also see https://github.com/gradle/gradle-private/issues/1708 and https://github.com/gradle/gradle-promote/pull/24

Previously we have little tests for promotion pipelines. This PR adds a separate pipeline to run `Start Release Cycle Test` with `-PtestRun=1`. It has two triggers:

- Once per day.
- Monitor all `gradle-promote` branch changes.

@jjohannes I'm not quite familiar with TC XML configurations, esp. when it has artifact dependencies. Can you take a look at it?