### PR TITLE
Ignore some directories for TeamCity

### DIFF
--- a/.teamcity/Gradle_Check/configurations/StagePasses.kt
+++ b/.teamcity/Gradle_Check/configurations/StagePasses.kt
@@ -23,7 +23,10 @@ class StagePasses(model: CIBuildModel, stage: Stage, prevStage: Stage?, contains
     artifactRules = "build/build-receipt.properties"
 
     val triggerExcludes = """
-        -:design-docs
+        -:.idea
+        -:.github
+        -:.teamcity
+        -:.teamcityTest
         -:subprojects/docs/src/docs/release
     """.trimIndent()
     val masterReleaseFiler = model.masterAndReleaseBranches.joinToString(prefix = "+:", separator = "\n+:")


### PR DESCRIPTION
### Context

We don't want .idea/.github/.teamcity/.teamcityTest directory changes to trigger check builds.
This commit removes them from build trigger. Because we already have a `Hygiene` job to do the sanity check.
