### PR TITLE
Support for cygwin64 on CI infrastructure

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/AbstractNativeLanguageIncrementalBuildIntegrationTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.language
 
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
-import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.IncrementalHelloWorldApp
@@ -46,8 +45,8 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     TestFile commonHeaderFile
     List<TestFile> librarySourceFiles = []
 
-    boolean isCanBuildForMultiplePlatforms() {
-        return !(toolChain instanceof AvailableToolChains.InstalledWindowsGcc)
+    boolean languageBuildsOnMultiplePlatforms() {
+        return true
     }
 
     abstract IncrementalHelloWorldApp getHelloWorldApp()
@@ -323,7 +322,7 @@ abstract class AbstractNativeLanguageIncrementalBuildIntegrationTest extends Abs
     @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
     @RequiresInstalledToolChain(SUPPORTS_32_AND_64)
     def "rebuilds binary with target platform change"() {
-        Assume.assumeTrue(canBuildForMultiplePlatforms)
+        Assume.assumeTrue(languageBuildsOnMultiplePlatforms())
         given:
         buildFile << """
     model {

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/objectivec/ObjectiveCLanguageIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/objectivec/ObjectiveCLanguageIncrementalBuildIntegrationTest.groovy
@@ -32,8 +32,8 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPAT
 class ObjectiveCLanguageIncrementalBuildIntegrationTest extends AbstractNativeLanguageIncrementalBuildIntegrationTest {
 
     @Override
-    boolean isCanBuildForMultiplePlatforms() {
-        false
+    boolean languageBuildsOnMultiplePlatforms() {
+        return false
     }
 
     @Ignore("Demos a problem with clang on ubuntu creating randomly different object files")

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -67,9 +67,9 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         failure.assertHasDescription("A problem occurred configuring root project '${testDirectory.name}'.")
         failure.assertHasCause("A target machine needs to be specified for the ${GUtil.toWords(componentUnderTestDsl, (char) ' ')}.")
     }
-    
+
     def "can build for current machine when multiple target machines are specified"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
+        Assume.assumeFalse(supports32BitArchitectureOnly())
 
         given:
         makeSingleProject()
@@ -114,14 +114,14 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     def "can build current architecture when other, non-buildable architectures are specified"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
+        Assume.assumeFalse(supports32BitArchitectureOnly())
 
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
 
         and:
-        buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}.architecture('foo'), machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}")
+        buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}.architecture('foo'), machines.${currentHostOperatingSystemFamilyDsl}")
 
         expect:
         succeeds taskNameToAssembleDevelopmentBinary
@@ -129,14 +129,14 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     def "ignores duplicate target machines"() {
-        Assume.assumeFalse(toolChain.meets(ToolChainRequirement.WINDOWS_GCC))
+        Assume.assumeFalse(supports32BitArchitectureOnly())
 
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
 
         and:
-        buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}.architecture('foo'), machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}")
+        buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}.architecture('foo'), machines.${currentHostOperatingSystemFamilyDsl}, machines.${currentHostOperatingSystemFamilyDsl}")
 
         expect:
         succeeds taskNameToAssembleDevelopmentBinary
@@ -145,11 +145,11 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
 
     @Override
     protected String getDefaultArchitecture() {
-        return toolChain.meets(ToolChainRequirement.WINDOWS_GCC) ? "x86" : super.defaultArchitecture
+        return supports32BitArchitectureOnly() ?  "x86" : super.defaultArchitecture
     }
 
     protected String getCurrentHostArchitectureDsl() {
-        return toolChain.meets(ToolChainRequirement.WINDOWS_GCC) ? ".x86" : ""
+        return supports32BitArchitectureOnly() ? ".x86" : ""
     }
 
     protected String getCurrentHostOperatingSystemFamilyDsl() {

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -148,7 +148,7 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         releaseX86.assertDebugFileDoesNotExist()
         releaseX86.exec().out == "Hello world!\n"
 
-        // x86_64 binaries not supported on MinGW or cygwin
+        // x86_64 binaries not supported on MinGW
         if (toolChain.id == "mingw") {
             debugX64.assertDoesNotExist()
             releaseX64.assertDoesNotExist()

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -149,7 +149,7 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         releaseX86.exec().out == "Hello world!\n"
 
         // x86_64 binaries not supported on MinGW or cygwin
-        if (toolChain.id == "mingw" || toolChain.id == "gcccygwin") {
+        if (toolChain.id == "mingw") {
             debugX64.assertDoesNotExist()
             releaseX64.assertDoesNotExist()
         } else {

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -236,7 +236,7 @@ model {
         executable("build/exe/main/x86/main").exec().out == "i386 ${os.familyName}" * 2
         binaryInfo(objectFileFor(file("src/main/cpp/main.cpp"), "build/objs/main/x86/mainCpp")).arch.name == "x86"
 
-        // x86_64 binaries not supported on MinGW or cygwin
+        // x86_64 binaries not supported on MinGW
         if (toolChain.id == "mingw") {
             executable("build/exe/main/x86_64/main").assertDoesNotExist()
         } else {

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -237,7 +237,7 @@ model {
         binaryInfo(objectFileFor(file("src/main/cpp/main.cpp"), "build/objs/main/x86/mainCpp")).arch.name == "x86"
 
         // x86_64 binaries not supported on MinGW or cygwin
-        if (toolChain.id == "mingw" || toolChain.id == "gcccygwin") {
+        if (toolChain.id == "mingw") {
             executable("build/exe/main/x86_64/main").assertDoesNotExist()
         } else {
             executable("build/exe/main/x86_64/main").arch.name == "x86_64"

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
@@ -16,6 +16,7 @@
 package org.gradle.nativeplatform.toolchain
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
+import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.app.CppCompilerDetectingTestApp
 
 /**
@@ -32,7 +33,7 @@ class NativeToolChainDiscoveryIntegrationTest extends AbstractInstalledToolChain
 
     def "can discover tool chain in environment"() {
         given:
-        toolChain.initialiseEnvironment();
+        toolChain.initialiseEnvironment()
 
         and:
         buildFile << """
@@ -47,6 +48,20 @@ model {
 }
         """
 
+        // For software model builds, windows defaults to 32-bit target, so if we discard the toolchain init script,
+        // we need to reapply the 32-bit platform config for cygwin64
+        if (toolChain instanceof AvailableToolChains.InstalledCygwinGcc64) {
+            buildFile << """
+                model {
+                    toolChains {
+                        tc { 
+                            ${AvailableToolChains.InstalledCygwinGcc64.platform32Configuration()}
+                        }
+                    }
+                }
+            """
+        }
+
         and:
         helloWorldApp.writeSources(file("src/main"))
 
@@ -59,7 +74,7 @@ model {
         mainExecutable.exec().out == helloWorldApp.expectedOutput(toolChain)
 
         cleanup:
-        toolChain.resetEnvironment();
+        toolChain.resetEnvironment()
     }
 
     def "uses correct tool chain when explicitly configured"() {

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -53,7 +53,7 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
                 }
             }
         """
-        if (toolChain.meets(ToolChainRequirement.WINDOWS_GCC)) {
+        if (!toolChain.meets(ToolChainRequirement.SUPPORTS_32_AND_64)) {
             initScript << """
                 allprojects { p ->
                     components.withType(CppComponent) { component ->
@@ -191,6 +191,10 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
     }
 
     protected String getCurrentArchitecture() {
-        return toolChain.meets(ToolChainRequirement.WINDOWS_GCC) ? Architectures.X86.canonicalName : DefaultNativePlatform.currentArchitecture.name
+        return supports32BitArchitectureOnly() ? Architectures.X86.canonicalName : DefaultNativePlatform.currentArchitecture.name
+    }
+
+    protected boolean supports32BitArchitectureOnly() {
+        return toolChain.meets(ToolChainRequirement.SUPPORTS_32) && !toolChain.meets(ToolChainRequirement.SUPPORTS_32_AND_64)
     }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -53,7 +53,7 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
                 }
             }
         """
-        if (!toolChain.meets(ToolChainRequirement.SUPPORTS_32_AND_64)) {
+        if (supports32BitArchitectureOnly()) {
             initScript << """
                 allprojects { p ->
                     components.withType(CppComponent) { component ->

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -207,17 +207,11 @@ public class AvailableToolChains {
                 File cygwin32RuntimePath = new File(compiler32Exe.getParentFile().getParentFile(), "usr/i686-pc-cygwin/sys-root/usr/bin");
                 return new InstalledCygwinGcc64(ToolFamily.CYGWIN_GCC_64, VersionNumber.UNKNOWN).inPath(compiler64Exe.getParentFile(), cygwin32RuntimePath);
             } else {
-                return new UnavailableToolChain(ToolFamily.CYGWIN_GCC);
+                return new UnavailableToolChain(ToolFamily.CYGWIN_GCC_64);
             }
         }
 
-        // Fall back to just 32-bit toolchain if available
-        File compilerExe = new File("C:/cygwin/bin/g++.exe");
-        if (compilerExe.isFile()) {
-            return new InstalledWindowsGcc(ToolFamily.CYGWIN_GCC, VersionNumber.UNKNOWN).inPath(compilerExe.getParentFile());
-        }
-
-        return new UnavailableToolChain(ToolFamily.CYGWIN_GCC);
+        return new UnavailableToolChain(ToolFamily.CYGWIN_GCC_64);
     }
 
     static private List<ToolChainCandidate> findGccs(boolean mustFind) {
@@ -297,7 +291,6 @@ public class AvailableToolChains {
         CLANG("clang"),
         VISUAL_CPP("visual c++"),
         MINGW_GCC("mingw"),
-        CYGWIN_GCC("gcc cygwin"),
         CYGWIN_GCC_64("gcc cygwin"),
         SWIFTC("swiftc");
 
@@ -603,19 +596,19 @@ public class AvailableToolChains {
 
         @Override
         public String getBuildScriptConfig() {
-            String config =  String.format("%s_32(%s) {\n", getId(), getImplementationClass());
+            String config =  String.format("%s(%s) {\n", getId(), getImplementationClass());
             for (File pathEntry : getPathEntries()) {
-                config += String.format("path file('%s')\n", pathEntry.toURI());
+                config += String.format("     path file('%s')\n", pathEntry.toURI());
             }
-            config += "eachPlatform { platformToolChain ->\n";
-            config += "if (platformToolChain.platform.architecture.isI386()) {\n";
-            config += "platformToolChain.cCompiler.executable='i686-pc-cygwin-gcc.exe'\n";
-            config += "platformToolChain.cppCompiler.executable='i686-pc-cygwin-g++.exe'\n";
-            config += "platformToolChain.linker.executable='i686-pc-cygwin-g++.exe'\n";
-            config += "platformToolChain.assembler.executable='i686-pc-cygwin-gcc.exe'\n";
-            config += "platformToolChain.staticLibArchiver.executable='i686-pc-cygwin-ar.exe'\n";
-            config += "}\n";
-            config += "}\n";
+            config += "     eachPlatform { platformToolChain ->\n";
+            config += "         if (platformToolChain.platform.architecture.isI386()) {\n";
+            config += "             platformToolChain.cCompiler.executable='i686-pc-cygwin-gcc.exe'\n";
+            config += "             platformToolChain.cppCompiler.executable='i686-pc-cygwin-g++.exe'\n";
+            config += "             platformToolChain.linker.executable='i686-pc-cygwin-g++.exe'\n";
+            config += "             platformToolChain.assembler.executable='i686-pc-cygwin-gcc.exe'\n";
+            config += "             platformToolChain.staticLibArchiver.executable='i686-pc-cygwin-ar.exe'\n";
+            config += "         }\n";
+            config += "     }\n";
             config += "}\n";
             return config;
         }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -600,8 +600,14 @@ public class AvailableToolChains {
             for (File pathEntry : getPathEntries()) {
                 config += String.format("     path file('%s')\n", pathEntry.toURI());
             }
-            config += "     eachPlatform { platformToolChain ->\n";
-            config += "         if (platformToolChain.platform.architecture.isI386()) {\n";
+            config += platform32Configuration();
+            config += "}\n";
+            return config;
+        }
+
+        public static String platform32Configuration() {
+            String config = "     eachPlatform { platformToolChain ->\n";
+            config += "         if (platformToolChain.platform.architecture.isI386() || platformToolChain.platform.architecture.isArm()) {\n";
             config += "             platformToolChain.cCompiler.executable='i686-pc-cygwin-gcc.exe'\n";
             config += "             platformToolChain.cppCompiler.executable='i686-pc-cygwin-g++.exe'\n";
             config += "             platformToolChain.linker.executable='i686-pc-cygwin-g++.exe'\n";
@@ -609,7 +615,6 @@ public class AvailableToolChains {
             config += "             platformToolChain.staticLibArchiver.executable='i686-pc-cygwin-ar.exe'\n";
             config += "         }\n";
             config += "     }\n";
-            config += "}\n";
             return config;
         }
 

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -200,7 +200,12 @@ public class AvailableToolChains {
 
     static private ToolChainCandidate findCygwin() {
         // Search in the standard installation locations
-        File compilerExe = new File("C:/cygwin/bin/g++.exe");
+        File compilerExe = new File("C:/cygwin64/bin/g++.exe");
+        if (compilerExe.isFile()) {
+            return new InstalledWindowsGcc(ToolFamily.CYGWIN_GCC_64, VersionNumber.UNKNOWN).inPath(compilerExe.getParentFile());
+        }
+
+        compilerExe = new File("C:/cygwin/bin/g++.exe");
         if (compilerExe.isFile()) {
             return new InstalledWindowsGcc(ToolFamily.CYGWIN_GCC, VersionNumber.UNKNOWN).inPath(compilerExe.getParentFile());
         }
@@ -286,6 +291,7 @@ public class AvailableToolChains {
         VISUAL_CPP("visual c++"),
         MINGW_GCC("mingw"),
         CYGWIN_GCC("gcc cygwin"),
+        CYGWIN_GCC_64("gcc cygwin64"),
         SWIFTC("swiftc");
 
         private final String displayName;
@@ -571,7 +577,7 @@ public class AvailableToolChains {
                 case WINDOWS_GCC:
                     return true;
                 case SUPPORTS_32_AND_64:
-                    return false;
+                    return getFamily() == ToolFamily.CYGWIN_GCC_64;
                 default:
                     return super.meets(requirement);
             }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AvailableToolChains.java
@@ -205,13 +205,13 @@ public class AvailableToolChains {
             File compiler32Exe = new File("C:/cygwin64/bin/i686-pc-cygwin-gcc.exe");
             if (compiler32Exe.isFile()) {
                 File cygwin32RuntimePath = new File(compiler32Exe.getParentFile().getParentFile(), "usr/i686-pc-cygwin/sys-root/usr/bin");
-                return new InstalledCygwinGcc64(ToolFamily.CYGWIN_GCC_64, VersionNumber.UNKNOWN).inPath(compiler64Exe.getParentFile(), cygwin32RuntimePath);
+                return new InstalledCygwinGcc64(ToolFamily.CYGWIN_GCC, VersionNumber.UNKNOWN).inPath(compiler64Exe.getParentFile(), cygwin32RuntimePath);
             } else {
-                return new UnavailableToolChain(ToolFamily.CYGWIN_GCC_64);
+                return new UnavailableToolChain(ToolFamily.CYGWIN_GCC);
             }
         }
 
-        return new UnavailableToolChain(ToolFamily.CYGWIN_GCC_64);
+        return new UnavailableToolChain(ToolFamily.CYGWIN_GCC);
     }
 
     static private List<ToolChainCandidate> findGccs(boolean mustFind) {
@@ -291,7 +291,7 @@ public class AvailableToolChains {
         CLANG("clang"),
         VISUAL_CPP("visual c++"),
         MINGW_GCC("mingw"),
-        CYGWIN_GCC_64("gcc cygwin"),
+        CYGWIN_GCC("gcc cygwin"),
         SWIFTC("swiftc");
 
         private final String displayName;


### PR DESCRIPTION
This adds support for detecting a cygwin64 toolchain in our test infrastructure code and configuring it for both 64 and 32-bit compilation.