### PR TITLE
Remove blank lines to get rid of flakiness

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/LogContent.java
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures.executer;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang.StringUtils;
 import org.fusesource.jansi.AnsiOutputStream;
 import org.gradle.api.Action;
 import org.gradle.api.UncheckedIOException;
@@ -31,6 +32,7 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 public class LogContent {
     private final static Pattern DEBUG_PREFIX = Pattern.compile("\\d{2}:\\d{2}:\\d{2}\\.\\d{3} \\[\\w+] \\[.+?] ");
@@ -226,16 +228,11 @@ public class LogContent {
     }
 
     /**
-     * Remove all empty lines.
+     * Remove all blank lines.
      */
-    public LogContent removeEmptyLines() {
-        List<String> nonEmptyLines = new ArrayList<String>();
-        for (String line : lines) {
-            if (!line.isEmpty()) {
-                nonEmptyLines.add(line);
-            }
-        }
-        return new LogContent(ImmutableList.copyOf(nonEmptyLines), definitelyNoDebugPrefix, rawContent);
+    public LogContent removeBlankLines() {
+        List<String> nonBlankLines = lines.stream().filter(StringUtils::isNotBlank).collect(Collectors.toList());
+        return new LogContent(ImmutableList.copyOf(nonBlankLines), definitelyNoDebugPrefix, rawContent);
     }
 
     public static String stripWorkInProgressArea(String output) {

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleBuildResultFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleBuildResultFunctionalTest.groovy
@@ -124,7 +124,7 @@ BUILD SUCCESSFUL in \\d+s\\n?
         // Check that the failure text appears either stdout or stderr
         def outputWithFailure = errorsShouldAppearOnStdout() ? failure.output : failure.error
         def outputWithoutFailure = errorsShouldAppearOnStdout() ? failure.error : failure.output
-        def outputWithFailureAndNoDebugging = LogContent.of(outputWithFailure).removeEmptyLines().removeAnsiChars().removeDebugPrefix().withNormalizedEol()
+        def outputWithFailureAndNoDebugging = LogContent.of(outputWithFailure).removeBlankLines().removeAnsiChars().removeDebugPrefix().withNormalizedEol()
 
         outputWithFailure.contains("Build failed with an exception.")
         outputWithFailureAndNoDebugging.contains("""


### PR DESCRIPTION
### Context

We saw several flaky occurrences: https://builds.gradle.org/viewLog.html?buildId=18727332&buildTypeId=Gradle_Check_Platform_Java11_Openjdk_Windows_logging

It seems that we need to remove blank lines instead of empty lines to get rid of flakiness.

@adammurdoch can you please take a look at this?