### PR TITLE
Fix incorrect commit version comparison behavior

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy
@@ -179,7 +179,7 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
             }
             def releasedVersion = findRelease(releases, version)
             def versionObject = GradleVersion.version(version)
-            if (minimumVersion != null && versionObject < GradleVersion.version(minimumVersion)) {
+            if (minimumVersion != null && targetVersionLowerThanMinimumRequirement(versionObject, GradleVersion.version(minimumVersion))) {
                 //this version is not supported by this scenario, as it uses features not yet available in this version of Gradle
                 continue
             }
@@ -204,9 +204,21 @@ class CrossVersionPerformanceTestRunner extends PerformanceTestSpec {
         baselineVersions
     }
 
+    private static boolean targetVersionLowerThanMinimumRequirement(GradleVersion target, GradleVersion minimum) {
+        if (isCommitVersion(target)) {
+            return target.getBaseVersion() < minimum.getBaseVersion()
+        } else {
+            return target < minimum
+        }
+    }
+
     private static boolean isRcVersion(GradleVersion versionObject) {
         // there is no public API for checking for RC version, this is an internal way
         versionObject.stage.stage == 3
+    }
+
+    private static boolean isCommitVersion(GradleVersion version) {
+        return version.toString().contains("-commit-")
     }
 
     private static Iterable<String> resolveOverriddenVersions(String overrideBaselinesProperty, List<String> targetVersions) {


### PR DESCRIPTION
### Context

Previously the comparison between `5.2-commit-1a2b3c` and normal nightly `5.2-20181221000038+0000` wasn't clearly defined, which caused some issues. For example, when running `GradleInceptionPerformanceTest`, `5.2-commit-1a2b3c` will be compared to `5.2-20181221000038+0000` and return negative number:

https://github.com/gradle/gradle/blob/8c5db3e2408e7adcd68aba42ad7197680c53aefd/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy#L182

This results in an empty "target version set" and as a fallback, the latest released version will be added as baseline:

https://github.com/gradle/gradle/blob/8c5db3e2408e7adcd68aba42ad7197680c53aefd/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/fixture/CrossVersionPerformanceTestRunner.groovy#L199

This isn't expected behavior. Latest released version is released from `release` branch and might be too old. We want `5.2-commit-1a2b3c` to be target baseline version.

This PR fixes this issue by adding an extra `if` to handle `5.2-commit-1a2b3c`. TBH this is not a perfect solution, but it works before we decide how to compare commit version and nightly version.