### PR TITLE
Support for testing mingw64 on CI

### DIFF
--- a/subprojects/docs/src/docs/userguide/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native_software.adoc
@@ -84,12 +84,12 @@ The following tool chains are supported:
 | Windows XP and later, Visual C++ 2010/2012/2013/2015/2017.
 
 | Windows
-| http://gcc.gnu.org/[GCC] with http://cygwin.com[Cygwin 32]
+| http://gcc.gnu.org/[GCC] with http://cygwin.com[Cygwin 32 and Cygwin 64]
 | Windows XP and later.
 
 | Windows
-| http://gcc.gnu.org/[GCC] with http://www.mingw.org/[MinGW]
-| Windows XP and later. http://mingw-w64.sourceforge.net[Mingw-w64] is currently not supported.
+| http://gcc.gnu.org/[GCC] with http://www.mingw.org/[MinGW] and https://mingw-w64.org/doku.php[MinGW64]
+| Windows XP and later.
 |===
 
 The following tool chains are unofficially supported. They generally work fine, but are not tested continuously:
@@ -105,10 +105,6 @@ The following tool chains are unofficially supported. They generally work fine, 
 | macOS
 | http://clang.llvm.org[Clang] from Macports
 |
-
-| Windows
-| http://gcc.gnu.org/[GCC] with http://cygwin.com[Cygwin 64]
-| Windows XP and later.
 
 | UNIX-like
 | http://gcc.gnu.org/[GCC]

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -405,7 +405,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             project(':app') {
                 apply plugin: 'cpp-application'
                 application {
-                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.os('host-family')${currentHostArchitectureDsl}]
+                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}, machines.os('host-family')]
                 }
                 dependencies {
                     implementation project(':hello')
@@ -414,7 +414,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             project(':hello') {
                 apply plugin: 'cpp-library'
                 library {
-                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}, machines.os('host-family')${currentHostArchitectureDsl}]
+                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}, machines.os('host-family')]
                 }
             }
         """
@@ -441,7 +441,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
             project(':app') {
                 apply plugin: 'cpp-application'
                 application {
-                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}]
+                    targetMachines = [machines.${currentHostOperatingSystemFamilyDsl}]
                 }
                 dependencies {
                     implementation project(':hello')

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -136,11 +136,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         result.assertTasksExecutedAndNotSkipped(getTasksToAssembleDevelopmentBinary(currentArchitecture), ":$taskNameToAssembleDevelopmentBinary")
     }
 
-    @Override
-    protected String getDefaultArchitecture() {
-        return super.defaultArchitecture
-    }
-
     protected String getCurrentHostOperatingSystemFamilyDsl() {
         String osFamily = DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
         if (osFamily == OperatingSystemFamily.MACOS) {

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.util.GUtil
-import org.junit.Assume
 
 abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
     def "can build on current operating system family and architecture when explicitly specified"() {
@@ -33,7 +32,7 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         componentUnderTest.writeToProject(testDirectory)
 
         and:
-        buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}${currentHostArchitectureDsl}")
+        buildFile << configureTargetMachines("machines.${currentHostOperatingSystemFamilyDsl}")
 
         expect:
         succeeds taskNameToAssembleDevelopmentBinary
@@ -69,8 +68,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     def "can build for current machine when multiple target machines are specified"() {
-        Assume.assumeFalse(supports32BitArchitectureOnly())
-
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -114,8 +111,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     def "can build current architecture when other, non-buildable architectures are specified"() {
-        Assume.assumeFalse(supports32BitArchitectureOnly())
-
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -129,8 +124,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     }
 
     def "ignores duplicate target machines"() {
-        Assume.assumeFalse(supports32BitArchitectureOnly())
-
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -145,7 +138,7 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
 
     @Override
     protected String getDefaultArchitecture() {
-        return supports32BitArchitectureOnly() ?  "x86" : super.defaultArchitecture
+        return super.defaultArchitecture
     }
 
     protected String getCurrentHostArchitectureDsl() {

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -141,10 +141,6 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         return super.defaultArchitecture
     }
 
-    protected String getCurrentHostArchitectureDsl() {
-        return supports32BitArchitectureOnly() ? ".x86" : ""
-    }
-
     protected String getCurrentHostOperatingSystemFamilyDsl() {
         String osFamily = DefaultNativePlatform.getCurrentOperatingSystem().toFamilyName()
         if (osFamily == OperatingSystemFamily.MACOS) {

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativePlatformSamplesIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.internal.os.OperatingSystem
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
 import org.gradle.nativeplatform.fixtures.RequiresInstalledToolChain
 import org.gradle.test.fixtures.file.TestDirectoryProvider
-import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import org.junit.Rule
@@ -29,15 +28,14 @@ import static org.gradle.nativeplatform.fixtures.ToolChainRequirement.GCC_COMPAT
 
 @Requires(TestPrecondition.CAN_INSTALL_EXECUTABLE)
 class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
-    @Rule final TestNameTestDirectoryProvider testDirProvider = new TestNameTestDirectoryProvider()
-    @Rule public final Sample cppLib = sample(testDirProvider, 'cpp-lib')
-    @Rule public final Sample cppExe = sample(testDirProvider, 'cpp-exe')
-    @Rule public final Sample multiProject = sample(testDirProvider, 'multi-project')
-    @Rule public final Sample flavors = sample(testDirProvider, 'flavors')
-    @Rule public final Sample variants = sample(testDirProvider, 'variants')
-    @Rule public final Sample toolChains = sample(testDirProvider, 'tool-chains')
-    @Rule public final Sample prebuilt = sample(testDirProvider, 'prebuilt')
-    @Rule public final Sample targetPlatforms = sample(testDirProvider, 'target-platforms')
+    @Rule public final Sample cppLib = sample(testDirectoryProvider, 'cpp-lib')
+    @Rule public final Sample cppExe = sample(testDirectoryProvider, 'cpp-exe')
+    @Rule public final Sample multiProject = sample(testDirectoryProvider, 'multi-project')
+    @Rule public final Sample flavors = sample(testDirectoryProvider, 'flavors')
+    @Rule public final Sample variants = sample(testDirectoryProvider, 'variants')
+    @Rule public final Sample toolChains = sample(testDirectoryProvider, 'tool-chains')
+    @Rule public final Sample prebuilt = sample(testDirectoryProvider, 'prebuilt')
+    @Rule public final Sample targetPlatforms = sample(testDirectoryProvider, 'target-platforms')
     @Rule public final Sample sourcesetVariant = sample(testDirectoryProvider, "sourceset-variant")
     @Rule public final Sample customCheck = sample(testDirectoryProvider, "custom-check")
 
@@ -148,14 +146,8 @@ class NativePlatformSamplesIntegrationTest extends AbstractInstalledToolChainInt
         releaseX86.assertDebugFileDoesNotExist()
         releaseX86.exec().out == "Hello world!\n"
 
-        // x86_64 binaries not supported on MinGW
-        if (toolChain.id == "mingw") {
-            debugX64.assertDoesNotExist()
-            releaseX64.assertDoesNotExist()
-        } else {
-            debugX64.arch.name == "x86_64"
-            releaseX64.arch.name == "x86_64"
-        }
+        debugX64.arch.name == "x86-64"
+        releaseX64.arch.name == "x86-64"
 
         // Itanium not built
         debugIA64.assertDoesNotExist()

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/platform/BinaryNativePlatformIntegrationTest.groovy
@@ -236,14 +236,9 @@ model {
         executable("build/exe/main/x86/main").exec().out == "i386 ${os.familyName}" * 2
         binaryInfo(objectFileFor(file("src/main/cpp/main.cpp"), "build/objs/main/x86/mainCpp")).arch.name == "x86"
 
-        // x86_64 binaries not supported on MinGW
-        if (toolChain.id == "mingw") {
-            executable("build/exe/main/x86_64/main").assertDoesNotExist()
-        } else {
-            executable("build/exe/main/x86_64/main").arch.name == "x86_64"
-            executable("build/exe/main/x86_64/main").exec().out == "amd64 ${os.familyName}" * 2
-            binaryInfo(objectFileFor(file("src/main/cpp/main.cpp"), "build/objs/main/x86_64/mainCpp")).arch.name == "x86_64"
-        }
+        executable("build/exe/main/x86_64/main").arch.name == "x86-64"
+        executable("build/exe/main/x86_64/main").exec().out == "amd64 ${os.familyName}" * 2
+        binaryInfo(objectFileFor(file("src/main/cpp/main.cpp"), "build/objs/main/x86_64/mainCpp")).arch.name == "x86-64"
 
         // ARM only supported on visualCpp 2012+
         if (toolChain.meets(ToolChainRequirement.VISUALCPP_2012_OR_NEWER)) {

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
@@ -16,7 +16,6 @@
 package org.gradle.nativeplatform.toolchain
 
 import org.gradle.nativeplatform.fixtures.AbstractInstalledToolChainIntegrationSpec
-import org.gradle.nativeplatform.fixtures.AvailableToolChains
 import org.gradle.nativeplatform.fixtures.app.CppCompilerDetectingTestApp
 
 /**
@@ -40,27 +39,17 @@ class NativeToolChainDiscoveryIntegrationTest extends AbstractInstalledToolChain
 apply plugin: 'cpp'
 model {
     toolChains {
-        tc(${toolChain.implementationClass})
+        tc(${toolChain.implementationClass}) {
+            // For software model builds, windows defaults to 32-bit target, so if we discard the toolchain init script,
+            // we need to reapply the 32-bit platform config for cygwin64 and mingw64
+            ${toolChain.platformSpecificToolChainConfiguration()}
+        }
     }
     components {
         main(NativeExecutableSpec)
     }
 }
         """
-
-        // For software model builds, windows defaults to 32-bit target, so if we discard the toolchain init script,
-        // we need to reapply the 32-bit platform config for cygwin64
-        if (toolChain instanceof AvailableToolChains.InstalledCygwinGcc) {
-            buildFile << """
-                model {
-                    toolChains {
-                        tc { 
-                            ${AvailableToolChains.InstalledCygwinGcc.platform32Configuration()}
-                        }
-                    }
-                }
-            """
-        }
 
         and:
         helloWorldApp.writeSources(file("src/main"))

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/toolchain/NativeToolChainDiscoveryIntegrationTest.groovy
@@ -50,12 +50,12 @@ model {
 
         // For software model builds, windows defaults to 32-bit target, so if we discard the toolchain init script,
         // we need to reapply the 32-bit platform config for cygwin64
-        if (toolChain instanceof AvailableToolChains.InstalledCygwinGcc64) {
+        if (toolChain instanceof AvailableToolChains.InstalledCygwinGcc) {
             buildFile << """
                 model {
                     toolChains {
                         tc { 
-                            ${AvailableToolChains.InstalledCygwinGcc64.platform32Configuration()}
+                            ${AvailableToolChains.InstalledCygwinGcc.platform32Configuration()}
                         }
                     }
                 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -53,15 +53,6 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
                 }
             }
         """
-        if (supports32BitArchitectureOnly()) {
-            initScript << """
-                allprojects { p ->
-                    components.withType(CppComponent) { component ->
-                        component.targetMachines.set([machines.host().x86])        
-                    }            
-                }
-            """
-        }
         executer.beforeExecute({
             usingInitScript(initScript)
         })
@@ -191,10 +182,6 @@ abstract class AbstractInstalledToolChainIntegrationSpec extends AbstractIntegra
     }
 
     protected String getCurrentArchitecture() {
-        return supports32BitArchitectureOnly() ? Architectures.X86.canonicalName : DefaultNativePlatform.currentArchitecture.name
-    }
-
-    protected boolean supports32BitArchitectureOnly() {
-        return toolChain.meets(ToolChainRequirement.SUPPORTS_32) && !toolChain.meets(ToolChainRequirement.SUPPORTS_32_AND_64)
+        return DefaultNativePlatform.currentArchitecture.name
     }
 }

--- a/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
+++ b/subprojects/platform-native/src/testFixtures/groovy/org/gradle/nativeplatform/fixtures/AbstractInstalledToolChainIntegrationSpec.groovy
@@ -24,7 +24,6 @@ import org.gradle.integtests.fixtures.SourceFile
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.internal.time.Time
 import org.gradle.nativeplatform.internal.CompilerOutputFileNamingSchemeFactory
-import org.gradle.nativeplatform.platform.internal.Architectures
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.gradle.test.fixtures.file.TestFile
 import org.junit.experimental.categories.Category

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestDependentComponentsIntegrationSpec.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestDependentComponentsIntegrationSpec.groovy
@@ -89,13 +89,13 @@ class GoogleTestDependentComponentsIntegrationSpec extends AbstractInstalledTool
                         if (targetPlatform.operatingSystem.linux) {
                             cppCompiler.args '-pthread'
                             linker.args '-pthread'
+                        }
                         
-                            if (toolChain instanceof Gcc || toolChain instanceof Clang) {
-                                // Use C++03 with the old ABIs, as this is what the googletest binaries were built with
-                                // Later, Gradle's dependency management will understand ABI
-                                cppCompiler.args '-std=c++03', '-D_GLIBCXX_USE_CXX11_ABI=0'
-                                linker.args '-std=c++03'
-                            }
+                        if ((toolChain instanceof Gcc || toolChain instanceof Clang) && ${!toolChain.displayName.startsWith("gcc cygwin")}) {
+                            // Use C++03 with the old ABIs, as this is what the googletest binaries were built with
+                            // Later, Gradle's dependency management will understand ABI
+                            cppCompiler.args '-std=c++03', '-D_GLIBCXX_USE_CXX11_ABI=0'
+                            linker.args '-std=c++03'
                         }
                     }
                 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/googletest/GoogleTestIntegrationTest.groovy
@@ -93,13 +93,12 @@ model {
             if (targetPlatform.operatingSystem.linux) {
                 cppCompiler.args '-pthread'
                 linker.args '-pthread'
-           
-                if (toolChain instanceof Gcc || toolChain instanceof Clang) {
-                    // Use C++03 with the old ABIs, as this is what the googletest binaries were built with
-                    // Later, Gradle's dependency management will understand ABI
-                    cppCompiler.args '-std=c++03', '-D_GLIBCXX_USE_CXX11_ABI=0'
-                    linker.args '-std=c++03'
-                }
+            }
+            if ((toolChain instanceof Gcc || toolChain instanceof Clang) && ${!toolChain.displayName.startsWith("gcc cygwin")}) {
+                // Use C++03 with the old ABIs, as this is what the googletest binaries were built with
+                // Later, Gradle's dependency management will understand ABI
+                cppCompiler.args '-std=c++03', '-D_GLIBCXX_USE_CXX11_ABI=0'
+                linker.args '-std=c++03'
             }
         }
     }


### PR DESCRIPTION
Adds support for testing mingw64 on windows CI servers.  See https://github.com/gradle/gradle-native/issues/419.