### PR TITLE
Windows native unexport main

### DIFF
--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SymbolHider.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/SymbolHider.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.swift.tasks;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+
+/**
+ * Parse and hide given symbols in on object file based on COFF format documented
+ * here: https://docs.microsoft.com/en-us/windows/desktop/debug/pe-format
+ */
+public class SymbolHider {
+    DataReader data;
+    private byte[] bytes;
+
+    class DataReader {
+        private byte[] data;
+        private int position = 0;
+
+        public DataReader(byte[] data) {
+            this.data = data;
+        }
+
+        public int getPosition() {
+            return position;
+        }
+
+        public void moveTo(int position) {
+            this.position = position;
+        }
+
+        public int readByte() {
+            return Byte.toUnsignedInt(data[position++]);
+        }
+
+        public int readWord() {
+            return readByte() | readByte() << 8;
+        }
+
+        public int readDoubleWord() {
+            return readByte() | readByte() << 8 | readByte() << 16 | readByte() << 24;
+        }
+
+        public byte[] readBytes(int count) {
+            byte[] sub = Arrays.copyOfRange(data, position, position + count);
+            position += count;
+            return sub;
+        }
+    }
+
+    class COFFHeader {
+        public int machine;
+        public int numberOfSections;
+        public int timeDateStamp;
+        public int pointerToSymbolTable;
+        public int numberOfSymbols;
+        public int sizeOfOptionalHeader;
+        public int characteristics;
+
+        public COFFHeader() {
+            machine = data.readWord();
+            numberOfSections = data.readWord();
+            timeDateStamp = data.readDoubleWord();
+            pointerToSymbolTable = data.readDoubleWord();
+            numberOfSymbols = data.readDoubleWord();
+            sizeOfOptionalHeader = data.readWord();
+            characteristics = data.readWord();
+        }
+    }
+
+    class SymbolRecord {
+        private int storageClass;
+        private byte[] name;
+        private int value;
+        private int sectionNumber;
+        private int type;
+        private int numberOfAuxSymbols;
+
+        public SymbolRecord() {
+            name = data.readBytes(8);
+            value = data.readDoubleWord();
+            sectionNumber = data.readWord();
+            type = data.readWord();
+            storageClass = data.readByte();
+            numberOfAuxSymbols = data.readByte();
+        }
+
+        public String getName() {
+            // We only need to hide "main", so only support short named symbols here.
+
+            int nullCharIndex = 0;
+            for (nullCharIndex = 0; nullCharIndex < name.length; ++nullCharIndex) {
+                if (name[nullCharIndex] == 0) {
+                    break;
+                }
+            }
+            return new String(name, 0, nullCharIndex, StandardCharsets.UTF_8);
+        }
+    }
+
+    class SymbolTable {
+        private int numberOfSymbols;
+        private static final int IMAGE_SYM_CLASS_STATIC = 0x3;
+
+        public SymbolTable(int numberOfSymbols) {
+            this.numberOfSymbols = numberOfSymbols;
+        }
+
+        public void hideSymbol(String symbolToHide) {
+            for (int i = 0; i < numberOfSymbols; ++i) {
+                SymbolRecord symbol = new SymbolRecord();
+                String name = symbol.getName();
+
+                if (name.equals(symbolToHide)) {
+                    bytes[data.getPosition() - 2] = IMAGE_SYM_CLASS_STATIC;
+                    break;
+                }
+            }
+        }
+    }
+
+    public SymbolHider(File inputFile) throws IOException {
+        bytes = Files.readAllBytes(Paths.get(inputFile.getAbsolutePath()));
+    }
+
+    public void hideSymbol(String symbolToHide) {
+
+        data = new DataReader(bytes);
+        COFFHeader coffHeader = new COFFHeader();
+
+        data.moveTo(coffHeader.pointerToSymbolTable);
+        SymbolTable symbolTable = new SymbolTable(coffHeader.numberOfSymbols);
+        symbolTable.hideSymbol(symbolToHide);
+    }
+
+    public void saveTo(File outputFile) throws IOException {
+        Files.write(Paths.get(outputFile.getAbsolutePath()), bytes);
+    }
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.UncheckedException;
 import org.gradle.process.ExecSpec;
 
 import java.io.File;
@@ -90,7 +91,7 @@ public class UnexportMainSymbol extends DefaultTask {
                     symbolHider.hideSymbol("_main");    // 32 bit
                     symbolHider.saveTo(relocatedObject);
                 } catch (IOException e) {
-                    throw new IllegalStateException("Failed to unexport a main symbol on " + OperatingSystem.current());
+                    throw UncheckedException.throwAsUncheckedException(e);
                 }   
             } else {
                 getProject().exec(new Action<ExecSpec>() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -32,6 +32,7 @@ import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.internal.UncheckedException;
+import org.gradle.language.swift.tasks.internal.SymbolHider;
 import org.gradle.process.ExecSpec;
 
 import java.io.File;

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/UnexportMainSymbol.java
@@ -86,7 +86,8 @@ public class UnexportMainSymbol extends DefaultTask {
             if (OperatingSystem.current().isWindows()) {       
                 try {
                     final SymbolHider symbolHider = new SymbolHider(file);
-                    symbolHider.hideSymbol("main");
+                    symbolHider.hideSymbol("main");     // 64 bit
+                    symbolHider.hideSymbol("_main");    // 32 bit
                     symbolHider.saveTo(relocatedObject);
                 } catch (IOException e) {
                     throw new IllegalStateException("Failed to unexport a main symbol on " + OperatingSystem.current());

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/internal/SymbolHider.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/tasks/internal/SymbolHider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.language.swift.tasks;
+package org.gradle.language.swift.tasks.internal;
 
 import java.io.File;
 import java.io.IOException;

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithApplicationIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestWithApplicationIntegrationTest.groovy
@@ -16,11 +16,6 @@
 
 package org.gradle.nativeplatform.test.cpp.plugins
 
-import org.gradle.util.Requires
-import org.gradle.util.TestPrecondition
-
-// cpp-unit-test + cpp-application don't work together on Windows yet
-@Requires(TestPrecondition.NOT_WINDOWS)
 class CppUnitTestWithApplicationIntegrationTest extends AbstractCppUnitTestIntegrationTest {
     @Override
     protected void makeSingleProject() {


### PR DESCRIPTION
### Context
This adds support for creating C++ applications with unit tests on Windows, as discussed in https://github.com/gradle/gradle-native/issues/277

Adds support for unexporting main on Windows that allows the unit test plugin to then work.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
