### PR TITLE
Enable lib selection for static/shared library

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -31,6 +31,7 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     private boolean changing;
     private boolean force;
     private final DefaultMutableVersionConstraint versionConstraint;
+    private static String linkageDesignation;
 
     public AbstractExternalModuleDependency(ModuleIdentifier module, String version, String configuration) {
         super(configuration);
@@ -39,6 +40,14 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
         }
         this.moduleIdentifier = module;
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
+    }
+
+    public static String getLinkageDesignation() {
+        return linkageDesignation;
+    }
+
+    public void setLinkageDesignation(String linkageDesignation) {
+        AbstractExternalModuleDependency.linkageDesignation = linkageDesignation;
     }
 
     protected void copyTo(AbstractExternalModuleDependency target) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFile;
+import org.gradle.api.internal.artifacts.dependencies.AbstractExternalModuleDependency;
 import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.PublishingExtension;
@@ -410,8 +411,13 @@ public class NativeBasePlugin implements Plugin<Project> {
     static class LinkageSelectionRule implements AttributeDisambiguationRule<Linkage> {
         @Override
         public void execute(MultipleCandidatesDetails<Linkage> details) {
-            if (details.getCandidateValues().contains(Linkage.SHARED)) {
-                details.closestMatch(Linkage.SHARED);
+            if (details.getCandidateValues().contains(Linkage.SHARED) && details.getCandidateValues().contains(Linkage.STATIC)) {
+                String linkage = (AbstractExternalModuleDependency.getLinkageDesignation()!=null)? AbstractExternalModuleDependency.getLinkageDesignation(): "SHARED";
+                if(Linkage.STATIC.getName().equals(linkage)) {
+                    details.closestMatch(Linkage.STATIC);
+                } else {
+                    details.closestMatch(Linkage.SHARED);
+                }
             }
         }
     }


### PR DESCRIPTION
### Context

gradle/gradle-native/issues/923

The solution to this issue lies on how to let the NativeBasePlugin.LinkageSelectionRule know which lib to select.  Currently I found that it is hard wired to use the Linkage.SHARED variant.  I couldn't figure out how to let this class know which variant to select without modifying the dependency api, `AbstractExternalModuleDependency` with an additional attribute like `linkageDesignation` below with a static `getter` method to be used directly in the `LinkageSelectionRule`:

```
application {
    dependencies {
        implementation ('cpp-lib:foo:1.5') {
            linkageDesignation=Linkage.SHARED   
        }
    }
}
```
So this PR includes a code modification in `dependency-management` subproject.  This may not work if there are multiple dependencies declared this way because the instance may not be bound to the same runtime instance when checking the static variable `linkageDesignation`.

However, I found that it is possible to add a new linkage selection rule directly in the build.gradle (like below), but I couldn't get it to work unless I disabled the linkage selection rule defined in the NativeBasePlugin which required a re-compile of the gradle source code.
```
application {
   dependencies {
      implementation ('cpp-lib:foo:1.5') {
         project.getDependencies().getAttributesSchema()
           .attribute(Attribute.of("linkage", Linkage.class))
           .getDisambiguationRules()
           .add(MyStaticLinkageSelectionRule.class)
       }
      implementation ('cpp-lib:bar:1.5') {
         project.getDependencies().getAttributesSchema()
           .attribute(Attribute.of("linkage", Linkage.class))
           .getDisambiguationRules()
           .add(MySharedLinkageSelectionRule.class)
       }
   }
}
static class MyStaticLinkageSelectionRule implements AttributeDisambiguationRule<Linkage> {
   @Override
   public void execute(MultipleCandidatesDetails<Linkage> details) {
      details.closestMatch(Linkage.STATIC)
   }
}
static class MySharedLinkageSelectionRule implements AttributeDisambiguationRule<Linkage> {
   @Override
   public void execute(MultipleCandidatesDetails<Linkage> details) {
      details.closestMatch(Linkage.SHARED)
   }
}

```

And furthermore, the code is lacking integration tests.  I haven't been able to get around to adding those due to the complexity of the integration tests.  It seems for every line of code in gradle, there are a hundred lines of test code to go with it.  So that said, I'm hoping with some collaboration that this solution or a variant of the above would aid in solving the issue.

<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
