### PR TITLE
expand include path to solve messy header issue

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractExternalModuleDependency.java
@@ -30,6 +30,7 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     private final ModuleIdentifier moduleIdentifier;
     private boolean changing;
     private boolean force;
+    private static boolean expandIncludePath;
     private final DefaultMutableVersionConstraint versionConstraint;
 
     public AbstractExternalModuleDependency(ModuleIdentifier module, String version, String configuration) {
@@ -39,6 +40,7 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
         }
         this.moduleIdentifier = module;
         this.versionConstraint = new DefaultMutableVersionConstraint(version);
+        this.expandIncludePath = false;
     }
 
     protected void copyTo(AbstractExternalModuleDependency target) {
@@ -73,6 +75,15 @@ public abstract class AbstractExternalModuleDependency extends AbstractModuleDep
     public boolean isForce() {
         return force;
     }
+
+    public static boolean getExpandIncludePath() {
+        return expandIncludePath;
+    }
+
+    public void setExpandIncludePath(Boolean ex) {
+        this.expandIncludePath=ex;
+    }
+
 
     public ExternalModuleDependency setForce(boolean force) {
         validateMutation(this.force, force);


### PR DESCRIPTION
 ### Context
gradle/gradle-native/issues/869

This PR is a solution for consuming a lib with messy headers.  I don't know if this would work transitively or not.  Also, added a flag to `AbstractExternalModuleDependency` to support the following DSL to turn the expansion of include paths on/off:  This may not work if there are multiple dependencies declared this way because the static instance may not be bound to the same runtime instance when checking the static variable expandIncludePath
```
application {
   dependencies {
      implementation ('cpp-lib:foo:1.5') {
         expandIncludePath=true
      }
   }
}
```
I need help figuring out how to do integration testing on this thing, but this code works on a local build sample where the exported libs public headers are
```
foo/bar/foobar.h
```
The consumer of the lib then can reference the include any number of ways like
```
#include foobar.h
#include bar/foobar.h
#include foo/bar/foobar.h
```
The code takes the baseline include path, then recursively checks to see if additional directories reside in the include path, and for each directory encountered, it is added as an include path as follows.
```
/path/to/gradle/cache/lib
/path/to/gradle/cache/lib/foo
/path/to/gradle/cache/lib/foo/bar
```
### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
