### PR TITLE
Add annotation processor generated sources to SourceSetOutput

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaAnnotationProcessingIntegrationTest.groovy
@@ -110,6 +110,23 @@ class JavaAnnotationProcessingIntegrationTest extends AbstractIntegrationSpec {
         file("build/generated-sources/TestAppHelper.java").assertDoesNotExist()
     }
 
+    def "generated sources directories track task dependency"() {
+        given:
+        buildFile << """
+            dependencies {
+                compileOnly project(":annotation")
+                annotationProcessor project(":processor")
+            }
+            task sourcesJar(type: Jar) {
+                from sourceSets.main.output.generatedSourcesDirs
+            }
+        """
+
+        expect:
+        succeeds "sourcesJar"
+        ":compileJava" in executedTasks
+    }
+
     def "can model annotation processor arguments"() {
         buildFile << """                                                       
             class HelperAnnotationProcessor implements CommandLineArgumentProvider {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/tasks/DefaultSourceSetOutput.java
@@ -37,6 +37,7 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
 
     private final DefaultConfigurableFileCollection classesDirs;
     private final DefaultConfigurableFileCollection dirs;
+    private final DefaultConfigurableFileCollection generatedSourcesDirs;
     private final FileResolver fileResolver;
 
     public DefaultSourceSetOutput(String sourceSetDisplayName, final FileResolver fileResolver, TaskResolver taskResolver) {
@@ -59,6 +60,8 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
         });
 
         this.dirs = new DefaultConfigurableFileCollection("dirs", fileResolver, taskResolver);
+
+        this.generatedSourcesDirs = new DefaultConfigurableFileCollection("generatedSourcesDirs", fileResolver, taskResolver);
     }
 
     @Override
@@ -134,5 +137,10 @@ public class DefaultSourceSetOutput extends CompositeFileCollection implements S
     @Override
     public FileCollection getDirs() {
         return dirs;
+    }
+
+    @Override
+    public ConfigurableFileCollection getGeneratedSourcesDirs() {
+        return generatedSourcesDirs;
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/GroovyBasePlugin.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.Transformer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTreeElement;
@@ -34,6 +35,7 @@ import org.gradle.api.reporting.ReportingExtension;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.GroovyRuntime;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.javadoc.Groovydoc;
 
@@ -102,7 +104,6 @@ public class GroovyBasePlugin implements Plugin<Project> {
                 sourceSet.getAllJava().source(groovySourceSet.getGroovy());
                 sourceSet.getAllSource().source(groovySourceSet.getGroovy());
 
-                SourceSetUtil.configureOutputDirectoryForSourceSet(sourceSet, groovySourceSet.getGroovy(), project);
                 final Provider<GroovyCompile> compileTask = project.getTasks().register(sourceSet.getCompileTaskName("groovy"), GroovyCompile.class, new Action<GroovyCompile>() {
                     @Override
                     public void execute(GroovyCompile compile) {
@@ -112,6 +113,12 @@ public class GroovyBasePlugin implements Plugin<Project> {
                         compile.setSource(groovySourceSet.getGroovy());
                     }
                 });
+                SourceSetUtil.configureOutputDirectoryForSourceSet(sourceSet, groovySourceSet.getGroovy(), project, compileTask, compileTask.map(new Transformer<CompileOptions, GroovyCompile>() {
+                    @Override
+                    public CompileOptions transform(GroovyCompile groovyCompile) {
+                        return groovyCompile.getOptions();
+                    }
+                }));
 
 
                 // TODO: `classes` should be a little more tied to the classesDirs for a SourceSet so every plugin

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/SourceSetUtil.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/SourceSetUtil.java
@@ -17,10 +17,12 @@
 package org.gradle.api.plugins.internal;
 
 import org.gradle.api.Project;
+import org.gradle.api.Transformer;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.tasks.DefaultSourceSetOutput;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.compile.AbstractCompile;
 import org.gradle.api.tasks.compile.CompileOptions;
@@ -70,7 +72,8 @@ public class SourceSetUtil {
         });
     }
 
-    public static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target) {
+    public static void configureOutputDirectoryForSourceSet(final SourceSet sourceSet, final SourceDirectorySet sourceDirectorySet, final Project target,
+            Provider<? extends AbstractCompile> compileTask, Provider<CompileOptions> options) {
         final String sourceSetChildPath = "classes/" + sourceDirectorySet.getName() + "/" + sourceSet.getName();
         sourceDirectorySet.setOutputDir(target.provider(new Callable<File>() {
             @Override
@@ -86,5 +89,11 @@ public class SourceSetUtil {
                 return sourceDirectorySet.getOutputDir();
             }
         });
+        sourceSetOutput.getGeneratedSourcesDirs().from(options.map(new Transformer<Object, CompileOptions>() {
+            @Override
+            public Object transform(CompileOptions compileOptions) {
+                return compileOptions.getAnnotationProcessorGeneratedSourcesDirectory();
+            }
+        })).builtBy(compileTask);
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSetOutput.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.file.FileCollection;
 
 import javax.annotation.Nullable;
@@ -156,4 +157,13 @@ public interface SourceSetOutput extends FileCollection {
      * @return a new instance of registered dirs with resolved files
      */
     FileCollection getDirs();
+
+    /**
+     * Returns the directories containing generated source files (e.g. by annotation processors during compilation).
+     *
+     * @return The generated sources directories. Never returns null.
+     * @since 5.2
+     */
+    @Incubating
+    FileCollection getGeneratedSourcesDirs();
 }

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/tasks/DefaultSourceSetTest.groovy
@@ -63,6 +63,8 @@ class DefaultSourceSetTest extends Specification {
 
         assertThat(sourceSet.output.resourcesDir, nullValue())
 
+        assertThat(sourceSet.output.generatedSourcesDirs, isEmpty())
+
         assertThat(sourceSet.compileClasspath, nullValue())
 
         assertThat(sourceSet.annotationProcessorPath, nullValue())

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -126,6 +126,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         set.resources.srcDirs == toLinkedSet(project.file('src/custom/resources'))
         set.java.outputDir == new File(project.buildDir, 'classes/java/custom')
         set.output.resourcesDir == new File(project.buildDir, 'resources/custom')
+        set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/custom'))
 
         def processResources = project.tasks['processCustomResources']
         processResources.description == "Processes custom resources."
@@ -163,6 +164,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         set.resources.srcDirs == toLinkedSet(project.file('src/main/resources'))
         set.java.outputDir == new File(project.buildDir, 'classes/java/main')
         set.output.resourcesDir == new File(project.buildDir, 'resources/main')
+        set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
 
         def processResources = project.tasks.processResources
         processResources.description == "Processes main resources."
@@ -207,6 +209,19 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         def compileJava = project.tasks['compileCustomJava']
         compileJava.destinationDir == classesDir
+    }
+
+    void sourceSetReflectChangesToTasksConfiguration() {
+        def generatedSourcesDir = project.file('target/generated-sources')
+
+        when:
+        project.pluginManager.apply(JavaBasePlugin)
+        project.sourceSets.create('custom')
+        def compileJava = project.tasks['compileCustomJava']
+        compileJava.options.annotationProcessorGeneratedSourcesDirectory = generatedSourcesDir
+
+        then:
+        project.sourceSets.custom.output.generatedSourcesDirs.files == toLinkedSet(generatedSourcesDir)
     }
 
     void createsConfigurationsForNewSourceSet() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPluginTest.groovy
@@ -252,6 +252,8 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.java.outputDir == new File(project.buildDir, 'classes/java/main')
         set.output.resourcesDir == new File(project.buildDir, 'resources/main')
         set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.CLASSES_TASK_NAME ]
+        set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/main'))
+        set.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ JavaPlugin.COMPILE_JAVA_TASK_NAME ]
         set.runtimeClasspath.sourceCollections.contains(project.configurations.runtimeClasspath)
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/java/main'))
 
@@ -267,6 +269,8 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.java.outputDir == new File(project.buildDir, 'classes/java/test')
         set.output.resourcesDir == new File(project.buildDir, 'resources/test')
         set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ JavaPlugin.TEST_CLASSES_TASK_NAME ]
+        set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/test'))
+        set.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME ]
         set.runtimeClasspath.sourceCollections.contains(project.configurations.testRuntimeClasspath)
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/java/main'))
         set.runtimeClasspath.contains(new File(project.buildDir, 'classes/java/test'))
@@ -286,6 +290,8 @@ class JavaPluginTest extends AbstractProjectBuilderSpec {
         set.annotationProcessorPath.is(project.configurations.customAnnotationProcessor)
         set.java.outputDir == new File(project.buildDir, 'classes/java/custom')
         set.getOutput().getBuildDependencies().getDependencies(null)*.name == [ 'customClasses' ]
+        set.output.generatedSourcesDirs.files == toLinkedSet(new File(project.buildDir, 'generated/sources/annotationProcessor/java/custom'))
+        set.output.generatedSourcesDirs.buildDependencies.getDependencies(null)*.name == [ 'compileCustomJava' ]
         Assert.assertThat(set.runtimeClasspath, sameCollection(set.output + project.configurations.customRuntimeClasspath))
     }
 

--- a/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
+++ b/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java
@@ -23,6 +23,7 @@ import org.gradle.api.ActionConfiguration;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.ArtifactView;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
@@ -47,6 +48,7 @@ import org.gradle.api.tasks.ScalaRuntime;
 import org.gradle.api.tasks.ScalaSourceSet;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.scala.IncrementalCompileOptions;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.api.tasks.scala.ScalaDoc;
@@ -150,7 +152,6 @@ public class ScalaBasePlugin implements Plugin<Project> {
     private static void configureScalaCompile(final Project project, final SourceSet sourceSet, final Configuration incrementalAnalysis, final Usage incrementalAnalysisUsage) {
         Convention scalaConvention = (Convention) InvokerHelper.getProperty(sourceSet, "convention");
         final ScalaSourceSet scalaSourceSet = scalaConvention.findPlugin(ScalaSourceSet.class);
-        SourceSetUtil.configureOutputDirectoryForSourceSet(sourceSet, scalaSourceSet.getScala(), project);
 
         final TaskProvider<ScalaCompile> scalaCompile = project.getTasks().register(sourceSet.getCompileTaskName("scala"), ScalaCompile.class, new Action<ScalaCompile>() {
             @Override
@@ -186,6 +187,12 @@ public class ScalaBasePlugin implements Plugin<Project> {
                 }).getFiles());
             }
         });
+        SourceSetUtil.configureOutputDirectoryForSourceSet(sourceSet, scalaSourceSet.getScala(), project, scalaCompile, scalaCompile.map(new Transformer<CompileOptions, ScalaCompile>() {
+            @Override
+            public CompileOptions transform(ScalaCompile scalaCompile) {
+                return scalaCompile.getOptions();
+            }
+        }));
 
         project.getTasks().named(sourceSet.getClassesTaskName(), new Action<Task>() {
             @Override


### PR DESCRIPTION

### Context
Followup to #7551 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
