### PR TITLE
Silence unrecognized annotation processor option during incremental processing

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/IsolatingIncrementalAnnotationProcessingIntegrationTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.language.fixtures.HelperProcessorFixture
 import org.gradle.language.fixtures.NonIncrementalProcessorFixture
 import org.gradle.language.fixtures.ServiceRegistryProcessorFixture
 import org.gradle.util.TextUtil
+import spock.lang.Issue
 
 import static org.gradle.api.internal.tasks.compile.CompileJavaBuildOperationType.Result.AnnotationProcessorDetails.Type.ISOLATING
 
@@ -272,6 +273,27 @@ class IsolatingIncrementalAnnotationProcessingIntegrationTest extends AbstractIn
 
         and:
         outputContains("Full recompilation is required because the generated type 'ServiceRegistry' must have exactly one originating element, but had 2.")
+    }
+
+    @Issue(["https://github.com/gradle/gradle/issues/8128", "https://bugs.openjdk.java.net/browse/JDK-8162455"])
+    def "incremental processing doesn't trigger unmatched processor option warning"() {
+        buildFile << """
+            dependencies {
+                compileOnly project(":annotation")
+                annotationProcessor project(":processor")
+            }
+            compileJava.options.compilerArgs += [ "-Werror", "-Amessage=fromOptions" ]
+        """
+        java "@Helper class A {}"
+
+        outputs.snapshot { succeeds "compileJava" }
+
+        when:
+        java "class B {}"
+
+        then:
+        succeeds "compileJava"
+        outputs.recompiledClasses("B")
     }
 
     def "reports isolating processor in build operation"() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SupportedOptionsCollectingProcessor.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/SupportedOptionsCollectingProcessor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.compile.processing;
+
+import javax.annotation.processing.AbstractProcessor;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.TypeElement;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Collects all registered processors' supported options.
+ *
+ * <p>This is a workaround for https://bugs.openjdk.java.net/browse/JDK-8162455, which
+ * will be triggered a lot more during incremental compilations, and can fail builds
+ * when combined with {@code -Werror}.
+ *
+ * <p>This processor needs to be added last to make sure that all other processors
+ * have been {@linkplain Processor#init(ProcessingEnvironment) initialized} when
+ * {@link #getSupportedOptions()} is called.
+ */
+public class SupportedOptionsCollectingProcessor extends AbstractProcessor {
+    private final List<Processor> processors = new ArrayList<Processor>();
+
+    public void addProcessor(Processor processor) {
+        processors.add(processor);
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Collections.singleton("*");
+    }
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        Set<String> supportedOptions = new HashSet<String>();
+        for (Processor processor : processors) {
+            supportedOptions.addAll(processor.getSupportedOptions());
+        }
+        return supportedOptions;
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> set, RoundEnvironment roundEnvironment) {
+        return false;
+    }
+}

--- a/subprojects/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/HelperProcessorFixture.groovy
+++ b/subprojects/language-java/src/testFixtures/groovy/org/gradle/language/fixtures/HelperProcessorFixture.groovy
@@ -82,14 +82,19 @@ for (Element element : elements) {
     @Override
     protected String getSupportedOptionsBlock() {
         if (declaredType == IncrementalAnnotationProcessorType.DYNAMIC) {
-                """
-                @Override
-                public Set<String> getSupportedOptions() {
-                    return Collections.singleton("${IncrementalAnnotationProcessorType.ISOLATING.processorOption}");
-                }
+            """
+            @Override
+            public Set<String> getSupportedOptions() {
+                return new HashSet<String>(Arrays.asList("message", "${IncrementalAnnotationProcessorType.ISOLATING.processorOption}"));
+            }
             """
         } else {
-            ""
+            """
+            @Override
+            public Set<String> getSupportedOptions() {
+                return Collections.singleton("message");
+            }
+            """
         }
     }
 }


### PR DESCRIPTION
### Context
See #8128 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
