### PR TITLE
Fix incorrect return in build step scripts

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -41,7 +41,7 @@ val m2CleanScriptUnixLike = """
         tree ${'$'}REPO
         rm -rf ${'$'}REPO
         echo "${'$'}REPO was polluted during the build"
-        return 1
+        exit 1
     else
         echo "${'$'}REPO does not exist"
     fi

--- a/.teamcity/Gradle_Util/buildTypes/Gradle_Util_AdHocFunctionalTestLinux.xml
+++ b/.teamcity/Gradle_Util/buildTypes/Gradle_Util_AdHocFunctionalTestLinux.xml
@@ -37,7 +37,7 @@ if [ -e $REPO ] ; then
     tree $REPO
     rm -rf $REPO
     echo "$REPO was polluted during the build"
-    return 1
+    exit 1
 else
     echo "$REPO does not exist"
 fi]]></param>

--- a/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_AdHocPerformanceScenarioLinux.xml
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_AdHocPerformanceScenarioLinux.xml
@@ -45,7 +45,7 @@
 if [ -e $REPO ] ; then
 rm -rf $REPO
 echo "$REPO was polluted during the build"
-return 1
+exit 1
 else
 echo "$REPO does not exist"
 fi]]></param>

--- a/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_PerformanceTestCoordinatorLinux.xml
+++ b/.teamcity/Gradle_Util_Performance/buildTypes/Gradle_Util_Performance_PerformanceTestCoordinatorLinux.xml
@@ -40,7 +40,7 @@ if [ -e $REPO ] ; then
     tree $REPO
     rm -rf $REPO
     echo "$REPO was polluted during the build"
-    return 1
+    exit 1
 else
     echo "$REPO does not exist"
 fi]]></param>


### PR DESCRIPTION
### Context

Previously we had wrong `return` statements in build step scripts. This results in some errors (see https://github.com/gradle/gradle-private/issues/1749). Now we change all these `return`s to `exit`s.