### PR TITLE
Fix windows follow symlinks on delete

### DIFF
--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/Symlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/Symlink.java
@@ -19,7 +19,7 @@ package org.gradle.internal.nativeintegration.filesystem;
 import java.io.File;
 
 public interface Symlink {
-    boolean isSymlinkSupported();
+    boolean isSymlinkCreationSupported();
 
     void symlink(File link, File target) throws Exception;
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
@@ -51,10 +51,7 @@ public class Jdk7Symlink implements Symlink {
 
     @Override
     public boolean isSymlink(File suspect) {
-        if (isSymlinkSupported()) {
-            return Files.isSymbolicLink(suspect.toPath());
-        }
-        return false;
+        return Files.isSymbolicLink(suspect.toPath());
     }
 
     private static boolean doesSystemSupportSymlinks() {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
@@ -78,11 +78,11 @@ public class Jdk7Symlink implements Symlink {
             return false;
         } finally {
             try {
-                if (sourceFile != null && sourceFile.toFile().exists()) {
-                    Files.delete(sourceFile);
+                if (sourceFile != null) {
+                    Files.deleteIfExists(sourceFile);
                 }
-                if (linkFile != null && linkFile.toFile().exists()) {
-                    Files.delete(linkFile);
+                if (linkFile != null) {
+                    Files.deleteIfExists(linkFile);
                 }
             } catch (IOException e) {
                 // We don't really need to handle this.

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7Symlink.java
@@ -28,19 +28,19 @@ import java.nio.file.Path;
 public class Jdk7Symlink implements Symlink {
     private static final Logger LOGGER = LoggerFactory.getLogger(Jdk7Symlink.class);
 
-    private final boolean symlinksSupported;
+    private final boolean symlinkCreationSupported;
 
     public Jdk7Symlink() {
         this(doesSystemSupportSymlinks());
     }
 
-    protected Jdk7Symlink(boolean symlinksSupported) {
-        this.symlinksSupported = symlinksSupported;
+    protected Jdk7Symlink(boolean symlinkCreationSupported) {
+        this.symlinkCreationSupported = symlinkCreationSupported;
     }
 
     @Override
-    public boolean isSymlinkSupported() {
-        return symlinksSupported;
+    public boolean isSymlinkCreationSupported() {
+        return symlinkCreationSupported;
     }
 
     @Override

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/GenericFileSystem.java
@@ -96,7 +96,7 @@ class GenericFileSystem implements FileSystem {
         this.stat = stat;
         this.symlink = symlink;
         this.chmod = chmod;
-        canCreateSymbolicLink = symlink.isSymlinkSupported();
+        canCreateSymbolicLink = symlink.isSymlinkCreationSupported();
     }
 
     private void initializeCaseSensitive() {

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedSymlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/NativePlatformBackedSymlink.java
@@ -31,7 +31,7 @@ class NativePlatformBackedSymlink implements Symlink {
     }
 
     @Override
-    public boolean isSymlinkSupported() {
+    public boolean isSymlinkCreationSupported() {
         return true;
     }
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/UnsupportedSymlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/UnsupportedSymlink.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 
 class UnsupportedSymlink implements Symlink {
     @Override
-    public boolean isSymlinkSupported() {
+    public boolean isSymlinkCreationSupported() {
         return false;
     }
 

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/WindowsSymlink.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/services/WindowsSymlink.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 
 class WindowsSymlink implements Symlink {
     @Override
-    public boolean isSymlinkSupported() {
+    public boolean isSymlinkCreationSupported() {
         return false;
     }
 

--- a/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7SymlinkTest.groovy
+++ b/subprojects/native/src/test/groovy/org/gradle/internal/nativeintegration/filesystem/jdk7/Jdk7SymlinkTest.groovy
@@ -32,13 +32,13 @@ class Jdk7SymlinkTest extends Specification {
     @Requires(TestPrecondition.SYMLINKS)
     def 'on symlink supporting system, it will return true for supported symlink'() {
         expect:
-        new Jdk7Symlink().isSymlinkSupported()
+        new Jdk7Symlink().isSymlinkCreationSupported()
     }
 
     @Requires(TestPrecondition.NO_SYMLINKS)
     def 'on non symlink supporting system, it will return false for supported symlink'() {
         expect:
-        !new WindowsJdk7Symlink().isSymlinkSupported()
+        !new WindowsJdk7Symlink().isSymlinkCreationSupported()
     }
 
     @Requires(TestPrecondition.SYMLINKS)


### PR DESCRIPTION
### Context
This PR fixes "Delete task always follows symlinks on Windows" #6478, therefore avoiding bad surprises when you (have to) work with symlinks on Windows.

- https://github.com/gradle/gradle/issues/6478
- https://github.com/gradle/gradle/issues/4065
- https://github.com/gradle/gradle/issues/8119

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
