### PR TITLE
Assemble should fail when cpp component cannot be built

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppIntegrationTest.groovy
@@ -54,4 +54,9 @@ abstract class AbstractCppIntegrationTest extends AbstractCppComponentIntegratio
     protected String getTaskNameToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
         return ":assembleDebug${architecture.capitalize()}"
     }
+
+    @Override
+    protected String getComponentName() {
+        return "main"
+    }
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/AbstractSwiftIntegrationTest.groovy
@@ -166,6 +166,11 @@ abstract class AbstractSwiftIntegrationTest extends AbstractSwiftComponentIntegr
     }
 
     @Override
+    String getComponentName() {
+        return "main"
+    }
+
+    @Override
     List<String> getTasksToAssembleDevelopmentBinaryOfComponentUnderTest() {
         return getTasksToAssembleDevelopmentBinary()
     }

--- a/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithTargetMachines.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/ComponentWithTargetMachines.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.nativeplatform.TargetMachine;
+
+/**
+ * Represents a component that targets multiple target machines.
+ *
+ * @since 5.2
+ */
+@Incubating
+public interface ComponentWithTargetMachines {
+    /**
+     * Specifies the target machines this component should be built for.  The "machines" extension property (see {@link org.gradle.nativeplatform.TargetMachineFactory}) can be used to construct common operating system and architecture combinations.
+     *
+     * <p>For example:</p>
+     * <pre>
+     * targetMachines = [machines.linux.x86_64, machines.windows.x86_64]
+     * </pre>
+     *
+     * @since 5.2
+     */
+    SetProperty<TargetMachine> getTargetMachines();
+}

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/CppComponent.java
@@ -23,11 +23,10 @@ import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.SetProperty;
 import org.gradle.language.BinaryCollection;
 import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.ComponentWithDependencies;
-import org.gradle.nativeplatform.TargetMachine;
+import org.gradle.language.ComponentWithTargetMachines;
 
 /**
  * Configuration for a C++ component, such as a library or executable, defining the source files and private header directories that make up the component. Private headers are those that are visible only to the source files of the component.
@@ -39,7 +38,7 @@ import org.gradle.nativeplatform.TargetMachine;
  * @since 4.2
  */
 @Incubating
-public interface CppComponent extends ComponentWithBinaries, ComponentWithDependencies {
+public interface CppComponent extends ComponentWithBinaries, ComponentWithDependencies, ComponentWithTargetMachines {
     /**
      * Specifies the base name for this component. This name is used to calculate various output file names. The default value is calculated from the project name.
      */
@@ -95,16 +94,4 @@ public interface CppComponent extends ComponentWithBinaries, ComponentWithDepend
      * @since 4.5
      */
     BinaryCollection<? extends CppBinary> getBinaries();
-
-    /**
-     * Specifies the target machines this component should be built for.  The "machines" extension property (see {@link org.gradle.nativeplatform.TargetMachineFactory}) can be used to construct common operating system and architecture combinations.
-     *
-     * <p>For example:</p>
-     * <pre>
-     * targetMachines = [machines.linux.x86_64, machines.windows.x86_64]
-     * </pre>
-     *
-     * @since 5.1
-     */
-    SetProperty<TargetMachine> getTargetMachines();
 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/plugins/NativeBasePlugin.java
@@ -166,7 +166,7 @@ public class NativeBasePlugin implements Plugin<Project> {
                 project.getGradle().getTaskGraph().whenReady(taskExecutionGraph -> {
                     TaskIdentity<Task> assembleIdentity = TaskIdentity.create(LifecycleBasePlugin.ASSEMBLE_TASK_NAME, null, (ProjectInternal)project);
                     if (taskExecutionGraph.hasTask(assembleIdentity.identityPath.getPath()) && component.getBinaries().get().isEmpty()) {
-                        throw new IllegalArgumentException("The component '" + component.getName() + "' does not target this operating system.");
+                        throw new IllegalArgumentException("The " + component.getName() + " component does not target this operating system.");
                     }
                 });
             }

--- a/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/swift/SwiftComponent.java
@@ -22,11 +22,10 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
-import org.gradle.api.provider.SetProperty;
 import org.gradle.language.ComponentWithBinaries;
 import org.gradle.language.BinaryCollection;
 import org.gradle.language.ComponentWithDependencies;
-import org.gradle.nativeplatform.TargetMachine;
+import org.gradle.language.ComponentWithTargetMachines;
 
 /**
  * Configuration for a Swift component, such as a library or executable, defining the source files that make up the component plus other settings.
@@ -38,7 +37,7 @@ import org.gradle.nativeplatform.TargetMachine;
  * @since 4.2
  */
 @Incubating
-public interface SwiftComponent extends ComponentWithBinaries, ComponentWithDependencies {
+public interface SwiftComponent extends ComponentWithBinaries, ComponentWithDependencies, ComponentWithTargetMachines {
     /**
      * Defines the Swift module for this component. The default value is calculated from the project name.
      */
@@ -79,11 +78,4 @@ public interface SwiftComponent extends ComponentWithBinaries, ComponentWithDepe
      * @since 4.6
      */
     Property<SwiftVersion> getSourceCompatibility();
-
-    /**
-     * Specifies the target machines this component should be built for.
-     *
-     * @since 5.1
-     */
-    SetProperty<TargetMachine> getTargetMachines();
 }

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -51,7 +51,7 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         fails taskNameToAssembleDevelopmentBinary
 
         and:
-        failure.assertHasDescription("The component 'main' does not target this operating system.")
+        failure.assertHasDescription("The ${componentName} component does not target this operating system.")
     }
 
     def "does not fail when current operating system family is excluded but assemble is not invoked"() {
@@ -165,6 +165,8 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
     protected abstract String getTaskNameToAssembleDevelopmentBinary()
 
     protected abstract String getTaskNameToAssembleDevelopmentBinaryWithArchitecture(String architecture)
+
+    protected abstract String getComponentName()
 
     protected configureTargetMachines(String targetMachines) {
         return """

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -39,7 +39,7 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         result.assertTasksExecutedAndNotSkipped(tasksToAssembleDevelopmentBinary, ":$taskNameToAssembleDevelopmentBinary")
     }
 
-    def "ignores compile and link tasks when current operating system family is excluded"() {
+    def "assemble fails when current operating system family is excluded"() {
         given:
         makeSingleProject()
         componentUnderTest.writeToProject(testDirectory)
@@ -48,9 +48,22 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         buildFile << configureTargetMachines("machines.os('some-other-family')")
 
         expect:
-        succeeds taskNameToAssembleDevelopmentBinary
-        result.assertTasksExecuted(":$taskNameToAssembleDevelopmentBinary")
-        result.assertTasksSkipped(":$taskNameToAssembleDevelopmentBinary")
+        fails taskNameToAssembleDevelopmentBinary
+
+        and:
+        failure.assertHasDescription("The component 'main' does not target this operating system.")
+    }
+
+    def "does not fail when current operating system family is excluded but assemble is not invoked"() {
+        given:
+        makeSingleProject()
+        componentUnderTest.writeToProject(testDirectory)
+
+        and:
+        buildFile << configureTargetMachines("machines.os('some-other-family')")
+
+        expect:
+        succeeds "help"
     }
 
     def "fails configuration when no target machine is configured"() {

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/cpp/AbstractCppComponentIntegrationTest.groovy
@@ -51,7 +51,8 @@ abstract class AbstractCppComponentIntegrationTest extends AbstractNativeLanguag
         fails taskNameToAssembleDevelopmentBinary
 
         and:
-        failure.assertHasDescription("The ${componentName} component does not target this operating system.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':${taskNameToAssembleDevelopmentBinary}'")
+        failure.assertHasCause("The ${componentName} component does not target this operating system.")
     }
 
     def "does not fail when current operating system family is excluded but assemble is not invoked"() {

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -184,7 +184,7 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
         fails taskNameToAssembleDevelopmentBinary
 
         and:
-        failure.assertHasDescription("The component 'main' does not target this operating system.")
+        failure.assertHasDescription("The ${componentName} component does not target this operating system.")
     }
 
     def "does not fail when current operating system family is excluded but assemble is not invoked"() {
@@ -231,6 +231,8 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
     abstract String getTaskNameToAssembleDevelopmentBinary()
 
     abstract List<String> getTasksToAssembleDevelopmentBinaryOfComponentUnderTest()
+
+    abstract String getComponentName()
 
     protected configureTargetMachines(String targetMachines) {
         return """

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.nativeplatform.fixtures.ToolChainRequirement
 import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 
+import static org.gradle.util.Matchers.matchesRegexp
+
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLanguageComponentIntegrationTest {
     def "binaries have the right Swift version"() {
@@ -172,7 +174,7 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
         result.assertTasksExecuted(tasksToAssembleDevelopmentBinaryOfComponentUnderTest, ":$taskNameToAssembleDevelopmentBinary")
     }
 
-    def "assemble fails when current operating system family is excluded"() {
+    def "assemble task fails when current operating system family is excluded"() {
         given:
         makeSingleProject()
         swift4Component.writeToProject(testDirectory)
@@ -186,6 +188,22 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
         and:
         failure.assertHasDescription("Could not determine the dependencies of task ':${taskNameToAssembleDevelopmentBinary}'")
         failure.assertHasCause("The ${componentName} component does not target this operating system.")
+    }
+
+    def "build task fails when current operating system family is excluded"() {
+        given:
+        makeSingleProject()
+        swift4Component.writeToProject(testDirectory)
+
+        and:
+        buildFile << configureTargetMachines("machines.os('some-other-family')")
+
+        expect:
+        fails "build"
+
+        and:
+        failure.assertHasDescription("Could not determine the dependencies of task")
+        failure.assertThatCause(matchesRegexp("The \\w+ component does not target this operating system."))
     }
 
     def "does not fail when current operating system family is excluded but assemble is not invoked"() {

--- a/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
+++ b/subprojects/language-native/src/testFixtures/groovy/org/gradle/language/swift/AbstractSwiftComponentIntegrationTest.groovy
@@ -184,7 +184,8 @@ abstract class AbstractSwiftComponentIntegrationTest extends AbstractNativeLangu
         fails taskNameToAssembleDevelopmentBinary
 
         and:
-        failure.assertHasDescription("The ${componentName} component does not target this operating system.")
+        failure.assertHasDescription("Could not determine the dependencies of task ':${taskNameToAssembleDevelopmentBinary}'")
+        failure.assertHasCause("The ${componentName} component does not target this operating system.")
     }
 
     def "does not fail when current operating system family is excluded but assemble is not invoked"() {

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/AbstractCppUnitTestComponentIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/AbstractCppUnitTestComponentIntegrationTest.groovy
@@ -32,4 +32,9 @@ abstract class AbstractCppUnitTestComponentIntegrationTest extends AbstractCppCo
     protected String getTaskNameToAssembleDevelopmentBinaryWithArchitecture(String architecture) {
         return ":runTest${architecture.capitalize()}"
     }
+
+    @Override
+    protected String getComponentName() {
+        return "test"
+    }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/AbstractCppUnitTestComponentIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/cpp/AbstractCppUnitTestComponentIntegrationTest.groovy
@@ -19,6 +19,22 @@ package org.gradle.nativeplatform.test.cpp
 import org.gradle.language.cpp.AbstractCppComponentIntegrationTest
 
 abstract class AbstractCppUnitTestComponentIntegrationTest extends AbstractCppComponentIntegrationTest {
+    def "check task fails when current operating system family is excluded"() {
+        given:
+        makeSingleProject()
+        componentUnderTest.writeToProject(testDirectory)
+
+        and:
+        buildFile << configureTargetMachines("machines.os('some-other-family')")
+
+        expect:
+        fails "check"
+
+        and:
+        failure.assertHasDescription("Could not determine the dependencies of task ':${taskNameToAssembleDevelopmentBinary}'")
+        failure.assertHasCause("The ${componentName} component does not target this operating system.")
+    }
+
     @Override
     protected String getComponentUnderTestDsl() {
         return 'unitTest'

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
@@ -59,4 +59,9 @@ abstract class AbstractSwiftXCTestComponentIntegrationTest extends AbstractSwift
     List<String> getTasksToAssembleDevelopmentBinaryOfComponentUnderTest() {
         return [":compileTestSwift", ":linkTest", ":installTest", ":xcTest"]
     }
+
+    @Override
+    String getComponentName() {
+        return "test"
+    }
 }

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/AbstractSwiftXCTestComponentIntegrationTest.groovy
@@ -30,6 +30,22 @@ abstract class AbstractSwiftXCTestComponentIntegrationTest extends AbstractSwift
         Assume.assumeFalse(OperatingSystem.current().isMacOsX() && toolChain.version.major == 3)
     }
 
+    def "check task fails when current operating system family is excluded"() {
+        given:
+        makeSingleProject()
+        swift4Component.writeToProject(testDirectory)
+
+        and:
+        buildFile << configureTargetMachines("machines.os('some-other-family')")
+
+        expect:
+        fails "check"
+
+        and:
+        failure.assertHasDescription("Could not determine the dependencies of task ':${taskNameToAssembleDevelopmentBinary}'")
+        failure.assertHasCause("The ${componentName} component does not target this operating system.")
+    }
+
     @Override
     protected String getComponentUnderTestDsl() {
         return "xctest"

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/plugins/NativeTestingBasePlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/plugins/NativeTestingBasePlugin.java
@@ -20,8 +20,6 @@ import org.gradle.api.Incubating;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.project.ProjectInternal;
-import org.gradle.api.internal.project.taskfactory.TaskIdentity;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
@@ -70,12 +68,12 @@ public class NativeTestingBasePlugin implements Plugin<Project> {
 
         project.getComponents().withType(TestSuiteComponent.class, testSuiteComponent -> {
             if (TEST_COMPONENT_NAME.equals(testSuiteComponent.getName())) {
-                project.getGradle().getTaskGraph().whenReady(taskExecutionGraph -> {
-                    TaskIdentity<Task> testTaskIdentity = TaskIdentity.create(TEST_TASK_NAME, null, (ProjectInternal) project);
-                    if (taskExecutionGraph.hasTask(testTaskIdentity.identityPath.getPath()) && !testSuiteComponent.getTestBinary().isPresent()) {
+                test.configure(task -> task.dependsOn((Callable) () -> {
+                    if (!testSuiteComponent.getTestBinary().isPresent()) {
                         throw new IllegalArgumentException("The " + testSuiteComponent.getName() + " component does not target this operating system.");
                     }
-                });
+                    return null;
+                }));
             }
         });
 


### PR DESCRIPTION
This changes the behavior of assemble when a cpp component does not target the current operating system such that it will fail rather than doing nothing (and succeeding).
