### PR TITLE
Make AsciidoctorTask cacheable again

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,7 +45,7 @@ base.archivesBaseName = "gradle"
 
 buildTypes {
     create("compileAllBuild") {
-        tasks(":createBuildReceipt", "compileAll")
+        tasks(":createBuildReceipt", "compileAll", ":docs:distDocs")
         projectProperties("ignoreIncomingBuildReceipt" to true)
     }
 

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -2,7 +2,6 @@ dependencies {
     api("com.google.guava:guava:26.0-jre")
     api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2")
     implementation("org.asciidoctor:asciidoctorj:1.5.8.1")
-    implementation("org.jruby:jruby-complete:9.2.5.0")
     implementation(project(":buildPlatform"))
     implementation("commons-lang:commons-lang:2.6")
     implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16")

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -4,6 +4,7 @@ dependencies {
     api("com.google.guava:guava:26.0-jre")
     implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16")
     implementation("org.asciidoctor:asciidoctorj:1.5.8.1")
+    implementation("org.jruby:jruby-complete:9.2.5.0")
     implementation("org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2")
     implementation("com.github.javaparser:javaparser-core")
 }

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -2,8 +2,8 @@ dependencies {
     implementation(project(":buildPlatform"))
     implementation("commons-lang:commons-lang:2.6")
     api("com.google.guava:guava:26.0-jre")
-    implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.11")
-    implementation("org.asciidoctor:asciidoctorj:1.5.5")
-    implementation("org.asciidoctor:asciidoctor-gradle-plugin:1.5.3")
+    implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16")
+    implementation("org.asciidoctor:asciidoctorj:1.5.8.1")
+    implementation("org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2")
     implementation("com.github.javaparser:javaparser-core")
 }

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    implementation(project(":buildPlatform"))
-    implementation("commons-lang:commons-lang:2.6")
     api("com.google.guava:guava:26.0-jre")
-    implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16")
+    api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2")
     implementation("org.asciidoctor:asciidoctorj:1.5.8.1")
     implementation("org.jruby:jruby-complete:9.2.5.0")
-    implementation("org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2")
+    implementation(project(":buildPlatform"))
+    implementation("commons-lang:commons-lang:2.6")
+    implementation("org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16")
     implementation("com.github.javaparser:javaparser-core")
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/BuildReceipt.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/BuildReceipt.groovy
@@ -32,6 +32,7 @@ class BuildReceipt extends DefaultTask {
     private static final SimpleDateFormat TIMESTAMP_FORMAT = new java.text.SimpleDateFormat('yyyyMMddHHmmssZ')
     private static final SimpleDateFormat ISO_TIMESTAMP_FORMAT = new java.text.SimpleDateFormat('yyyy-MM-dd HH:mm:ss z')
     static {
+        TIMESTAMP_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
         ISO_TIMESTAMP_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
     }
     private static final String UNKNOWN_TIMESTAMP = "unknown"

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -35,11 +35,6 @@ import java.nio.file.Paths
 
 @CacheableTask
 class CacheableAsciidoctorTask extends AsciidoctorTask {
-    /** Returns the current set of Asciidoctor attributes
-     *
-     * @since 1.5.1
-     */
-    @Optional
     @Input
     @Override
     Map getAttributes() {
@@ -52,7 +47,7 @@ class CacheableAsciidoctorTask extends AsciidoctorTask {
         }
 
         Map copy = new HashMap(attributes)
-        copy.put('sample-dir', relativize(sampleDir))
+        copy.put('samples-dir', relativize(sampleDir))
         return Collections.unmodifiableMap(copy)
     }
 

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -32,12 +32,6 @@ import org.gradle.api.tasks.util.PatternSet
 
 @CacheableTask
 class CacheableAsciidoctorTask extends AsciidoctorTask {
-    @Optional
-    @Input
-    Map getAttributes() {
-        println("attrs: " + super.getAttributes())
-        super.getAttributes()
-    }
 
     @Internal
     @Override

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -43,7 +43,6 @@ class CacheableAsciidoctorTask extends AsciidoctorTask {
         Map attributes = super.getAttributes()
         String sampleDir = attributes['samples-dir']
         if (sampleDir == null) {
-            println("attributes: ${attributes.toString()}")
             return attributes
         }
 

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -43,11 +43,13 @@ class CacheableAsciidoctorTask extends AsciidoctorTask {
         Map attributes = super.getAttributes()
         String sampleDir = attributes['samples-dir']
         if (sampleDir == null) {
+            println("attributes: ${attributes.toString()}")
             return attributes
         }
 
         Map copy = new HashMap(attributes)
         copy.put('samples-dir', relativize(sampleDir))
+        println("attributes: ${copy.toString()}")
         return Collections.unmodifiableMap(copy)
     }
 

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -15,7 +15,6 @@
  */
 package org.gradle.build.docs
 
-import org.asciidoctor.gradle.AsciidoctorProxy
 import org.asciidoctor.gradle.AsciidoctorTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -32,6 +32,13 @@ import org.gradle.api.tasks.util.PatternSet
 
 @CacheableTask
 class CacheableAsciidoctorTask extends AsciidoctorTask {
+    @Optional
+    @Input
+    Map getAttributes() {
+        println("attrs: " + super.getAttributes())
+        super.getAttributes()
+    }
+
     @Internal
     @Override
     List<Object> getAsciidoctorExtensions() {

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -30,38 +30,8 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.util.PatternSet
 
-import java.nio.file.Path
-import java.nio.file.Paths
-
 @CacheableTask
 class CacheableAsciidoctorTask extends AsciidoctorTask {
-    @Input
-    @Override
-    Map getAttributes() {
-        // attribute "samples-dir" is absolute path and breaks cachability, see subprojects/docs/docs.gradle
-        // hacks to make the attribute relative
-        Map attributes = super.getAttributes()
-        String sampleDir = attributes['samples-dir']
-        if (sampleDir == null) {
-            return attributes
-        }
-
-        Map copy = new HashMap(attributes)
-        copy.put('samples-dir', relativize(sampleDir))
-        return Collections.unmodifiableMap(copy)
-    }
-
-    private String relativize(String absolutePath) {
-        Path targetPath = Paths.get(absolutePath)
-        Path projectPath = project.getProjectDir().toPath()
-
-        if (targetPath.startsWith(projectPath)) {
-            return projectPath.relativize(targetPath).toString().replace('\\', '/')
-        } else {
-            return targetPath
-        }
-    }
-
     @Internal
     @Override
     List<Object> getAsciidoctorExtensions() {

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -49,7 +49,6 @@ class CacheableAsciidoctorTask extends AsciidoctorTask {
 
         Map copy = new HashMap(attributes)
         copy.put('samples-dir', relativize(sampleDir))
-        println("attributes: ${copy.toString()}")
         return Collections.unmodifiableMap(copy)
     }
 
@@ -58,7 +57,7 @@ class CacheableAsciidoctorTask extends AsciidoctorTask {
         Path projectPath = project.getProjectDir().toPath()
 
         if (targetPath.startsWith(projectPath)) {
-            return projectPath.relativize(targetPath).toString()
+            return projectPath.relativize(targetPath).toString().replace('\\', '/')
         } else {
             return targetPath
         }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/CacheableAsciidoctorTask.groovy
@@ -17,7 +17,6 @@ package org.gradle.build.docs
 
 import org.asciidoctor.gradle.AsciidoctorProxy
 import org.asciidoctor.gradle.AsciidoctorTask
-import org.asciidoctor.gradle.ResourceCopyProxy
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.FileCollection
@@ -34,12 +33,6 @@ import org.gradle.api.tasks.util.PatternSet
 
 @CacheableTask
 class CacheableAsciidoctorTask extends AsciidoctorTask {
-
-    @Internal
-    @Override
-    AsciidoctorProxy getAsciidoctor() {
-        return super.getAsciidoctor()
-    }
 
     @Internal
     @Override
@@ -98,12 +91,6 @@ class CacheableAsciidoctorTask extends AsciidoctorTask {
     @Internal
     Set<File> getOutputDirectories() {
         super.getOutputDirectories()
-    }
-
-    @Internal
-    @Override
-    ResourceCopyProxy getResourceCopyProxy() {
-        return super.getResourceCopyProxy()
     }
 
     /**

--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
     implementation(project(":plugins"))
+    implementation(project(":build"))
 }
 
 gradlePlugin {

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -94,10 +94,16 @@ open class BuildScanPlugin : Plugin<Project> {
     fun Task.isCacheMiss() = !state.skipped && (isCompileCacheMiss() || isAsciidoctorCacheMiss())
 
     private
-    fun Task.isCompileCacheMiss() = isTaskType(AbstractCompile::class.java, ClasspathManifest::class.java) && !isExpectedCompileCacheMiss()
+    fun Task.isCompileCacheMiss() = isMonitoredCompileTask() && !isExpectedCompileCacheMiss()
 
     private
-    fun Task.isAsciidoctorCacheMiss() = isTaskType(CacheableAsciidoctorTask::class.java) && !isExpectedAsciidoctorCacheMiss()
+    fun Task.isAsciidoctorCacheMiss() = isMonitoredAsciidoctorTask() && !isExpectedAsciidoctorCacheMiss()
+
+    private
+    fun Task.isMonitoredCompileTask() = this is AbstractCompile || this is ClasspathManifest
+
+    private
+    fun Task.isMonitoredAsciidoctorTask() = this is CacheableAsciidoctorTask
 
     private
     fun Task.isExpectedAsciidoctorCacheMiss() =
@@ -112,9 +118,6 @@ open class BuildScanPlugin : Plugin<Project> {
     // 2. Gradleception which re-builds Gradle with a new Gradle version
     // 3. buildScanPerformance test, which doesn't depend on compileAll
         isInBuild("Gradle_Check_CompileAll", "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux", "Gradle_Check_Gradleception")
-
-    private
-    fun Task.isTaskType(vararg classes: Class<*>) = this.javaClass in classes
 
     private
     fun Task.isInBuild(vararg buildTypeIds: String) = System.getenv("BUILD_TYPE_ID") in buildTypeIds

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -24,6 +24,7 @@ import org.gradle.api.plugins.quality.CodeNarc
 import org.gradle.api.reporting.Reporting
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.build.ClasspathManifest
+import org.gradle.build.docs.CacheableAsciidoctorTask
 import org.gradle.gradlebuild.BuildEnvironment.isCiServer
 import org.gradle.gradlebuild.BuildEnvironment.isTravis
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
@@ -80,7 +81,7 @@ open class BuildScanPlugin : Plugin<Project> {
     private
     fun Project.monitorUnexpectedCacheMisses() {
         gradle.taskGraph.afterTask {
-            if (isCacheMiss() && !isExpectedCacheMiss() && isNotTaggedYet()) {
+            if (isCacheMiss() && isNotTaggedYet()) {
                 buildScan.tag("CACHE_MISS")
             }
         }
@@ -90,18 +91,33 @@ open class BuildScanPlugin : Plugin<Project> {
     fun isNotTaggedYet() = cacheMissTagged.compareAndSet(false, true)
 
     private
-    fun Task.isCacheMiss() = !state.skipped && isMonitoredForCacheMiss()
+    fun Task.isCacheMiss() = !state.skipped && (isCompileCacheMiss() || isAsciidoctorCacheMiss())
 
     private
-    fun Task.isMonitoredForCacheMiss() = this is AbstractCompile || this is ClasspathManifest
+    fun Task.isCompileCacheMiss() = isTaskType(AbstractCompile::class.java, ClasspathManifest::class.java) && !isExpectedCompileCacheMiss()
 
     private
-    fun Project.isExpectedCacheMiss() =
+    fun Task.isAsciidoctorCacheMiss() = isTaskType(CacheableAsciidoctorTask::class.java) && !isExpectedAsciidoctorCacheMiss()
+
+    private
+    fun Task.isExpectedAsciidoctorCacheMiss() =
+    // Expected cache-miss for asciidoctor task:
+    // Gradle_Check_BuildDistributions is the seed build
+        isInBuild("Gradle_Check_BuildDistributions")
+
+    private
+    fun Task.isExpectedCompileCacheMiss() =
     // Expected cache-miss:
-    // 1. compileAll is seed build
+    // 1. CompileAll is the seed build
     // 2. Gradleception which re-builds Gradle with a new Gradle version
     // 3. buildScanPerformance test, which doesn't depend on compileAll
-        System.getenv("BUILD_TYPE_ID") in listOf("Gradle_Check_CompileAll", "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux", "Gradle_Check_Gradleception")
+        isInBuild("Gradle_Check_CompileAll", "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux", "Gradle_Check_Gradleception")
+
+    private
+    fun Task.isTaskType(vararg classes: Class<*>) = this.javaClass in classes
+
+    private
+    fun Task.isInBuild(vararg buildTypeIds: String) = System.getenv("BUILD_TYPE_ID") in buildTypeIds
 
     private
     fun Project.extractCheckstyleAndCodenarcData() {

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -108,8 +108,9 @@ open class BuildScanPlugin : Plugin<Project> {
     private
     fun Task.isExpectedAsciidoctorCacheMiss() =
     // Expected cache-miss for asciidoctor task:
-    // Gradle_Check_BuildDistributions is the seed build
-        isInBuild("Gradle_Check_BuildDistributions")
+    // 1. CompileAll is the seed build for docs:distDocs
+    // 2. Gradle_Check_BuildDistributions is the seed build for other asciidoctor tasks
+        isInBuild("Gradle_Check_CompileAll", "Gradle_Check_BuildDistributions")
 
     private
     fun Task.isExpectedCompileCacheMiss() =

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -88,8 +88,7 @@ configurations {
 }
 
 dependencies {
-    asciidoctor("org.gradle:docs-asciidoctor-extensions:0.4.0")
-    asciidoctor("org.jruby:jruby-complete:9.2.5.0")
+    asciidoctor "org.gradle:docs-asciidoctor-extensions:0.4.0"
     asciidoctor project.files("src/main/resources")
 
     userGuideTask 'xalan:xalan:2.7.1', 'xerces:xercesImpl:2.11.0'

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -87,34 +87,9 @@ configurations {
     }
 }
 
-//class AsciidoctorJSelectRule implements ComponentMetadataRule {
-//    @Override
-//    void execute(ComponentMetadataContext context) {
-//        context.details.allVariants {
-//            withDependencies {
-//                it.each { metadata ->
-//                    if (metadata.name == 'asciidoctorj') {
-//                        metadata.version { require('v1.6.0-RC.2') }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//}
-
 dependencies {
     asciidoctor("org.gradle:docs-asciidoctor-extensions:0.4.0")
-    asciidoctor("org.asciidoctor:asciidoctorj-groovy-dsl:1.0.0.Alpha3")
     asciidoctor("org.jruby:jruby-complete:9.2.5.0")
-
-//    withLibraryDependencies("org.gradle:sample-discovery", DependencyRemovalByNameRule::class, setOf("asciidoctorj", "asciidoctorj-api"))
-//    components {
-//        withModule("org.asciidoctor:asciidoctorj", DependencyRemovalByNameRule, {
-//            params(["jruby-complete"] as Set)
-//        })
-//        withModule("org.gradle:docs-asciidoctor-extensions", AsciidoctorJSelectRule)
-//        withModule("org.asciidoctor:asciidoctorj-groovy-dsl", AsciidoctorJSelectRule)
-//    }
     asciidoctor project.files("src/main/resources")
 
     userGuideTask 'xalan:xalan:2.7.1', 'xerces:xercesImpl:2.11.0'
@@ -374,9 +349,9 @@ tasks.withType(CacheableAsciidoctorTask).configureEach {
     separateOutputDirs = false
     options doctype: 'book'
 
-    inputs.file "$srcDocsDir/css/manual.css"
-    inputs.dir file("src/main/resources")
-    inputs.dir samplesSrcDir
+    inputs.file("$srcDocsDir/css/manual.css").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(file("src/main/resources")).withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir(samplesSrcDir).withPathSensitivity(PathSensitivity.RELATIVE)
 
     attributes stylesdir           : '../css/',
         stylesheet          : 'manual.css',

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -373,7 +373,8 @@ tasks.withType(CacheableAsciidoctorTask).configureEach {
         docsUrl             : 'https://docs.gradle.org',
         guidesUrl           : 'https://guides.gradle.org',
         gradleVersion       : version,
-        samplesPath         : "../../samples"
+        samplesPath         : "../../samples",
+        'samples-dir'       : 'src/samples'
 }
 
 def userguideMultiPage = tasks.register("userguideMultiPage", CacheableAsciidoctorTask) {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -373,8 +373,7 @@ tasks.withType(CacheableAsciidoctorTask).configureEach {
         docsUrl             : 'https://docs.gradle.org',
         guidesUrl           : 'https://guides.gradle.org',
         gradleVersion       : version,
-        samplesPath         : "../../samples",
-        'samples-dir'       : "$projectDir/src/samples"
+        samplesPath         : "../../samples"
 }
 
 def userguideMultiPage = tasks.register("userguideMultiPage", CacheableAsciidoctorTask) {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 import org.apache.tools.ant.filters.ReplaceTokens
-import org.asciidoctor.gradle.AsciidoctorTask
+import org.gradle.build.docs.CacheableAsciidoctorTask
 import org.gradle.build.docs.Docbook2Xhtml
 import org.gradle.build.docs.UserGuideTransformTask
 import org.gradle.build.docs.dsl.docbook.AssembleDslDocTask
@@ -87,8 +87,34 @@ configurations {
     }
 }
 
+//class AsciidoctorJSelectRule implements ComponentMetadataRule {
+//    @Override
+//    void execute(ComponentMetadataContext context) {
+//        context.details.allVariants {
+//            withDependencies {
+//                it.each { metadata ->
+//                    if (metadata.name == 'asciidoctorj') {
+//                        metadata.version { require('v1.6.0-RC.2') }
+//                    }
+//                }
+//            }
+//        }
+//    }
+//}
+
 dependencies {
-    asciidoctor "org.gradle:docs-asciidoctor-extensions:0.4.0"
+    asciidoctor("org.gradle:docs-asciidoctor-extensions:0.4.0")
+    asciidoctor("org.asciidoctor:asciidoctorj-groovy-dsl:1.0.0.Alpha3")
+    asciidoctor("org.jruby:jruby-complete:9.2.5.0")
+
+//    withLibraryDependencies("org.gradle:sample-discovery", DependencyRemovalByNameRule::class, setOf("asciidoctorj", "asciidoctorj-api"))
+//    components {
+//        withModule("org.asciidoctor:asciidoctorj", DependencyRemovalByNameRule, {
+//            params(["jruby-complete"] as Set)
+//        })
+//        withModule("org.gradle:docs-asciidoctor-extensions", AsciidoctorJSelectRule)
+//        withModule("org.asciidoctor:asciidoctorj-groovy-dsl", AsciidoctorJSelectRule)
+//    }
     asciidoctor project.files("src/main/resources")
 
     userGuideTask 'xalan:xalan:2.7.1', 'xerces:xercesImpl:2.11.0'
@@ -279,7 +305,7 @@ def dslHtml = tasks.register("dslHtml", Docbook2Xhtml) {
     ext.entryPoint = "$destDir/index.html"
 }
 
-def userguideSinglePage = tasks.register("userguideSinglePage", AsciidoctorTask) {
+def userguideSinglePage = tasks.register("userguideSinglePage", CacheableAsciidoctorTask) {
     sourceDir = userguideSrcDir
     sources { include 'userguide_single.adoc' }
     outputDir = userguideSinglePageOutputDir
@@ -331,7 +357,7 @@ tasks.register("checkstyleApi", Checkstyle) {
     reports.xml.destination = file("$checkstyle.reportsDir/checkstyle-api.xml")
 }
 
-def distDocs = tasks.register("distDocs", AsciidoctorTask) {
+def distDocs = tasks.register("distDocs", CacheableAsciidoctorTask) {
     sourceDir = userguideSrcDir
     outputDir = distDocsDir
     sources { include 'getting-started.adoc' }
@@ -340,10 +366,9 @@ def distDocs = tasks.register("distDocs", AsciidoctorTask) {
 
 asciidoctorj {
     noDefaultRepositories = true
-    version = '1.5.7'
 }
 
-tasks.withType(AsciidoctorTask).configureEach {
+tasks.withType(CacheableAsciidoctorTask).configureEach {
     dependsOn css, samples, defaultImports
 
     separateOutputDirs = false
@@ -377,7 +402,7 @@ tasks.withType(AsciidoctorTask).configureEach {
         'samples-dir'       : "$projectDir/src/samples"
 }
 
-def userguideMultiPage = tasks.register("userguideMultiPage", AsciidoctorTask) {
+def userguideMultiPage = tasks.register("userguideMultiPage", CacheableAsciidoctorTask) {
     sourceDir = userguideSrcDir
 
     sources {


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/1741

This PR does:

- Re-enables `CacheableAsciidoctorTask` 
- Updates everything to the latest version. 
- Fixes several broken cacheability issues.
- Tag the build `CACHE_MISS` upon unexpected cache-miss.

See https://e.grdev.net/s/sjnd7kktpskfk/timeline?taskFilter=userguid for cache-hit and https://e.grdev.net/s/27fe263mgh4sk/timeline?typeFilter=org.gradle.build.docs.CacheableAsciidoctorTask for cache-miss examples

One question is, which does `docs:distDocs` do? Which build should be the seed build of `docs:distDocs`?