### PR TITLE
Restore previous package for DefaultConvention

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
+++ b/subprojects/model-core/src/main/java/org/gradle/api/internal/plugins/DefaultConvention.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.plugins;
+
+import org.gradle.internal.reflect.Instantiator;
+
+/**
+ * Compatibility class since the type is used at least by IntelliJ IDEA Gradle integration
+ * See https://youtrack.jetbrains.com/issue/IDEA-204971
+ */
+@Deprecated
+public class DefaultConvention extends org.gradle.internal.extensibility.DefaultConvention {
+    public DefaultConvention(Instantiator instantiator) {
+        super(instantiator);
+    }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ExtensibleDynamicObject.java
@@ -53,11 +53,11 @@ public class ExtensibleDynamicObject extends MixInClosurePropertiesAsMethodsDyna
     private DynamicObject extraPropertiesDynamicObject;
 
     public ExtensibleDynamicObject(Object delegate, Class<?> publicType, Instantiator instantiator) {
-        this(delegate, createDynamicObject(delegate, publicType), new DefaultConvention(instantiator));
+        this(delegate, createDynamicObject(delegate, publicType), new org.gradle.api.internal.plugins.DefaultConvention(instantiator));
     }
 
     public ExtensibleDynamicObject(Object delegate, AbstractDynamicObject dynamicDelegate, Instantiator instantiator) {
-        this(delegate, dynamicDelegate, new DefaultConvention(instantiator));
+        this(delegate, dynamicDelegate, new org.gradle.api.internal.plugins.DefaultConvention(instantiator));
     }
 
     public ExtensibleDynamicObject(Object delegate, AbstractDynamicObject dynamicDelegate, Convention convention) {


### PR DESCRIPTION
This internal API is used by the IntelliJ IDEA integration plugin and
breaks it if moved to a different package.