### PR TITLE
Fix typo in Organizing Gradle Projects documentation

### DIFF
--- a/subprojects/docs/src/docs/userguide/organizing_gradle_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/organizing_gradle_projects.adoc
@@ -269,7 +269,7 @@ Remember to run a full build regularly or at least when you're done, though.
 
 == Declare properties in `gradle.properties` file
 
-In Gradle, properties can be define in the build script, in a `gradle.properties` file or as parameters on the command line.
+In Gradle, properties can be defined in the build script, in a `gradle.properties` file or as parameters on the command line.
 
 It's common to declare properties on the command line for ad-hoc scenarios.
 For example you may want to pass in a specific property value to control runtime behavior just for this one invocation of the build.


### PR DESCRIPTION
### Context
Fixes super minor typo in the Organizing Gradle Projects documentation

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
