### PR TITLE
Synchronize access to java.home system property in DefaultSslContextFactory

### DIFF
--- a/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultSslContextFactory.java
+++ b/subprojects/resources-http/src/main/java/org/gradle/internal/resource/transport/http/DefaultSslContextFactory.java
@@ -62,8 +62,12 @@ public class DefaultSslContextFactory implements SslContextFactory {
         for (String prop : SSL_SYSTEM_PROPERTIES) {
             currentProperties.put(prop, System.getProperty(prop));
         }
-        currentProperties.put("java.home", SystemProperties.getInstance().getJavaHomeDir().getPath());
+        currentProperties.put("java.home", getJavaHomeDir());
         return currentProperties;
+    }
+
+    private String getJavaHomeDir() {
+        return SystemProperties.getInstance().withSystemProperties(() -> SystemProperties.getInstance().getJavaHomeDir().getPath());
     }
 
     private static class SslContextCacheLoader extends CacheLoader<Map<String, String>, SSLContext> {

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpClientConfigurerTest.groovy
@@ -15,14 +15,23 @@
  */
 package org.gradle.internal.resource.transport.http
 
+import com.google.common.util.concurrent.UncheckedExecutionException
 import org.apache.http.auth.AuthScope
 import org.apache.http.impl.client.HttpClientBuilder
 import org.apache.http.ssl.SSLContexts
 import org.gradle.api.artifacts.repositories.PasswordCredentials
+import org.gradle.internal.SystemProperties
 import org.gradle.internal.authentication.AllSchemesAuthentication
 import org.gradle.internal.credentials.DefaultHttpHeaderCredentials
 import org.gradle.internal.resource.UriTextResource
 import spock.lang.Specification
+
+import javax.net.ssl.SSLContext
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 class HttpClientConfigurerTest extends Specification {
     HttpClientBuilder httpClientBuilder = HttpClientBuilder.create()
@@ -44,6 +53,46 @@ class HttpClientConfigurerTest extends Specification {
         createSslContext() >> SSLContexts.createDefault()
     }
     HttpClientConfigurer configurer = new HttpClientConfigurer(httpSettings)
+
+    def "forces java.home racecondition"() {
+        final sslContextFactory = new DefaultSslContextFactory()
+        def goodSSLContext = sslContextFactory.createSslContext()
+        AtomicReference<UncheckedExecutionException> exceptionRef = new AtomicReference<>()
+        AtomicBoolean endBarrierTimedOut = new AtomicBoolean(false)
+        CyclicBarrier startBarrier = new CyclicBarrier(2)
+        CountDownLatch endBarrier = new CountDownLatch(1)
+
+        when:
+        def thread = new Thread({ ->
+            SystemProperties.getInstance().withJavaHome(new File('/foo/bar'), { ->
+                startBarrier.await(1, TimeUnit.SECONDS)
+                try {
+                    // This is expected to fail because of the bad path set above. Does not block with synchronization because in same thread.
+                    sslContextFactory.createSslContext()
+                } catch(UncheckedExecutionException e) {
+                    exceptionRef.set(e)
+                }
+                // endBarrier must time out in a proper solution, because the main thread blocks in sslContextFactory.createSslContext() below.
+                endBarrierTimedOut.set( !endBarrier.await(100, TimeUnit.MILLISECONDS) )
+            })
+        })
+        thread.start()
+        startBarrier.await(1, TimeUnit.SECONDS)
+        SSLContext interestingSSLContext = null
+        try {
+            // This should not get the bad path because it cannot be executed simultanously with the "withJavaHome" closure above.
+            interestingSSLContext = sslContextFactory.createSslContext()
+        } finally {
+            endBarrier.countDown()
+            thread.join(1000)
+        }
+
+        then:
+        endBarrierTimedOut.get()
+        interestingSSLContext != null
+        interestingSSLContext == goodSSLContext
+        exceptionRef.get().message ==~ /.*foo.bar.lib.security.cacerts.*/
+    }
 
     def "configures http client with no credentials or proxy"() {
         httpSettings.authenticationSettings >> []


### PR DESCRIPTION
Make access to System Property "java.home" synchronized via SystemProperties when getting java home directory for retrieving ssl certificates.

### Context
Fixes the sporadically occurring problem with `org.apache.http.ssl.SSLInitializationException: <JDK_HOME>/lib/security/cacerts (No such file or directory)`
Issue: #8039

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
