### PR TITLE
Misc changes around platforms and publishing

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -86,6 +86,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
 
             $dependencies            
 """)
+        executer.expectDeprecationWarning()
 
         when:
         run "publish"

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -44,6 +44,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.java.JavaLibraryPlatform;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
@@ -69,6 +70,7 @@ import org.gradle.internal.DisplayName;
 import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
@@ -212,6 +214,9 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
             throw new InvalidUserDataException(String.format("Ivy publication '%s' cannot include multiple components", name));
         }
         this.component = (SoftwareComponentInternal) component;
+        if (component instanceof JavaLibraryPlatform) {
+            DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("components.javaLibraryPlatform", "Use the 'java-platform' plugin instead.");
+        }
         artifactsOverridden = false;
         updateModuleDescriptorArtifact();
     }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -506,6 +506,7 @@ class MavenPublishJavaIntegTest extends AbstractMavenPublishIntegTest {
                 }
             }
 """)
+        executer.expectDeprecationWarning()
 
         when:
         run "publish"

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -1058,17 +1058,10 @@ include(':platform')
             }
             project(':platform') {
                 apply plugin: 'java-platform'
-                apply plugin: 'maven-publish'
 
                 group = 'org.gradle.test'
                 version = '1.9'
 
-                publishing {
-                    repositories {
-                        maven { url "${mavenRepo.uri}" }
-                    }
-                }
-                
                 dependencies {
                     constraints {
                         api 'org.test:bar:1.0'

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -49,6 +49,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
+import org.gradle.api.internal.java.JavaLibraryPlatform;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.publish.VersionMappingStrategy;
@@ -74,6 +75,7 @@ import org.gradle.internal.Factory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.typeconversion.NotationParser;
 import org.gradle.util.CollectionUtils;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 
 import javax.annotation.Nullable;
@@ -227,6 +229,9 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
             throw new InvalidUserDataException(String.format("Maven publication '%s' cannot include multiple components", name));
         }
         this.component = (SoftwareComponentInternal) component;
+        if (component instanceof JavaLibraryPlatform) {
+            DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("components.javaLibraryPlatform", "Use the 'java-platform' plugin instead.");
+        }
         artifactsOverridden = false;
         updateModuleDescriptorArtifact();
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibraryPlatform.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibraryPlatform.java
@@ -21,6 +21,12 @@ import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
 
+/**
+ * Represents an attempt at providing a Java platform definition.
+ *
+ * @deprecated Replaced by the {@code java-platform} plugin
+ */
+@Deprecated
 public class JavaLibraryPlatform extends JavaLibrary {
     @Inject
     public JavaLibraryPlatform(ObjectFactory objectFactory, ConfigurationContainer configurations, ImmutableAttributesFactory attributesFactory) {


### PR DESCRIPTION
* Added a test showing that `dependency` nodes from the XML can be
filtered out through `pom.withXml`. In this case it applies to a virtual
platform.
* Deprecate `JavaLibraryPlatform`. This is now replaced by the `java-platform` plugin.
* Enable multi module Java platform test