### PR TITLE
Disallow '-J' flags in `CompilerOptions.compilerArgs`

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/api/tasks/compile/JavaCompileIntegrationTest.groovy
@@ -817,6 +817,23 @@ class JavaCompileIntegrationTest extends AbstractPluginIntegrationTest {
         failureHasCause("Cannot specify -processorpath or --processor-path via `CompileOptions.compilerArgs`. Use the `CompileOptions.annotationProcessorPath` property instead.")
     }
 
+    def "fails when a -J (compiler JVM) flag is set on compilerArgs"() {
+        buildFile << '''
+            apply plugin: 'java'
+
+            compileJava {
+                options.compilerArgs = ['-J-Xdiag']
+            }
+        '''
+        file('src/main/java/Square.java') << 'public class Square extends Rectangle {}'
+
+        when:
+        fails 'compileJava'
+
+        then:
+        failureHasCause("Cannot specify -J flags via `CompileOptions.compilerArgs`. Use the `CompileOptions.forkOptions.jvmArgs` property instead.")
+    }
+
     @Requires(adhoc = { AvailableJavaHomes.getJdk7() && AvailableJavaHomes.getJdk8() && TestPrecondition.NOT_JDK_IBM.fulfilled && TestPrecondition.FIX_TO_WORK_ON_JAVA9.fulfilled })
     def "bootclasspath can be set"() {
         def jdk7 = AvailableJavaHomes.getJdk7()

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -91,13 +91,21 @@ public class JavaCompilerArgumentsBuilder {
     }
 
     private void validateCompilerArgs(List<String> compilerArgs) {
-        if (compilerArgs.contains("-sourcepath") || compilerArgs.contains("--source-path")) {
-            throw new InvalidUserDataException("Cannot specify -sourcepath or --source-path via `CompileOptions.compilerArgs`. " +
-                "Use the `CompileOptions.sourcepath` property instead.");
-        }
-        if (compilerArgs.contains("-processorpath") || compilerArgs.contains("--processor-path")) {
-            throw new InvalidUserDataException("Cannot specify -processorpath or --processor-path via `CompileOptions.compilerArgs`. " +
-                "Use the `CompileOptions.annotationProcessorPath` property instead.");
+        for (String arg : compilerArgs) {
+            if ("-sourcepath".equals(arg) || "--source-path".equals(arg)) {
+                throw new InvalidUserDataException("Cannot specify -sourcepath or --source-path via `CompileOptions.compilerArgs`. " +
+                    "Use the `CompileOptions.sourcepath` property instead.");
+            }
+
+            if ("-processorpath".equals(arg) || "--processor-path".equals(arg)) {
+                throw new InvalidUserDataException("Cannot specify -processorpath or --processor-path via `CompileOptions.compilerArgs`. " +
+                    "Use the `CompileOptions.annotationProcessorPath` property instead.");
+            }
+
+            if (arg != null && arg.startsWith("-J")) {
+                throw new InvalidUserDataException("Cannot specify -J flags via `CompileOptions.compilerArgs`. " +
+                    "Use the `CompileOptions.forkOptions.jvmArgs` property instead.");
+            }
         }
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilderTest.groovy
@@ -357,6 +357,8 @@ class JavaCompilerArgumentsBuilderTest extends Specification {
         '--source-path'    | 'CompileOptions.sourcepath'
         '-processorpath'   | 'CompileOptions.annotationProcessorPath'
         '--processor-path' | 'CompileOptions.annotationProcessorPath'
+        '-J'               | 'CompileOptions.forkOptions.jvmArgs'
+        '-J-Xdiag'         | 'CompileOptions.forkOptions.jvmArgs'
     }
 
     def "removes sourcepath when module-source-path is provided"() {


### PR DESCRIPTION
`javac` already fails if -J flags (i.e. those affecting the JVM that is running
the compiler) appear in command-line argument files as opposed to directly on
the command line, but does so with a particularly useless error message.

This validation thus mainly serves to improve the error messaging, offering the
right alternative API for supplying such flags.

Signed-off-by: Ian Kerins <ianskerins@gmail.com>


### Context
See #8163, which this closes.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
