### PR TITLE
Use lifecycle task compileAllBuild

### DIFF
--- a/.teamcity/Gradle_Check/configurations/CompileAll.kt
+++ b/.teamcity/Gradle_Check/configurations/CompileAll.kt
@@ -23,7 +23,7 @@ class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model,
     applyDefaults(
         model,
         this,
-        ":createBuildReceipt -PignoreIncomingBuildReceipt=true compileAll",
+        "compileAllBuild -PignoreIncomingBuildReceipt=true",
         extraParameters = buildScanTag("CompileAll")
     )
 


### PR DESCRIPTION
### Context

Previously we ran `:createBuildReceipt compileAll` instead of the unified `compileAllBuild` task. Now all branches should contain the change so let's switch to that task.