### PR TITLE
Downgrade javadoc to HTML 4

### DIFF
--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/docbook/JavadocConverterTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/docbook/JavadocConverterTest.groovy
@@ -318,7 +318,7 @@ literal code</programlisting><para> does something.
     }
 
     def convertsTTElementToALiteralElement() {
-        _ * classMetaData.rawCommentText >> '<code>text</code>'
+        _ * classMetaData.rawCommentText >> '<tt>text</tt>'
 
         when:
         def result = parser.parse(classMetaData, listener)

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CheckstyleExtension.java
@@ -130,7 +130,7 @@ public class CheckstyleExtension extends CodeQualityExtension {
 
     /**
      * The maximum number of errors that are tolerated before breaking the build
-     * or setting the failure property. Defaults to <code>0</code>.
+     * or setting the failure property. Defaults to <tt>0</tt>.
      * <p>
      * Example: maxErrors = 42
      *
@@ -153,7 +153,7 @@ public class CheckstyleExtension extends CodeQualityExtension {
 
     /**
      * The maximum number of warnings that are tolerated before breaking the build
-     * or setting the failure property. Defaults to <code>Integer.MAX_VALUE</code>.
+     * or setting the failure property. Defaults to <tt>Integer.MAX_VALUE</tt>.
      * <p>
      * Example: maxWarnings = 1000
      *
@@ -175,7 +175,7 @@ public class CheckstyleExtension extends CodeQualityExtension {
     }
 
     /**
-     * Whether rule violations are to be displayed on the console. Defaults to <code>true</code>.
+     * Whether rule violations are to be displayed on the console. Defaults to <tt>true</tt>.
      *
      * Example: showViolations = false
      */
@@ -184,7 +184,7 @@ public class CheckstyleExtension extends CodeQualityExtension {
     }
 
     /**
-     * Whether rule violations are to be displayed on the console. Defaults to <code>true</code>.
+     * Whether rule violations are to be displayed on the console. Defaults to <tt>true</tt>.
      *
      * Example: showViolations = false
      */

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeNarcExtension.java
@@ -119,14 +119,14 @@ public class CodeNarcExtension extends CodeQualityExtension {
     }
 
     /**
-     * The format type of the CodeNarc report. One of <code>html</code>, <code>xml</code>, <code>text</code>, <code>console</code>.
+     * The format type of the CodeNarc report. One of <tt>html</tt>, <tt>xml</tt>, <tt>text</tt>, <tt>console</tt>.
      */
     public String getReportFormat() {
         return reportFormat;
     }
 
     /**
-     * The format type of the CodeNarc report. One of <code>html</code>, <code>xml</code>, <code>text</code>, <code>console</code>.
+     * The format type of the CodeNarc report. One of <tt>html</tt>, <tt>xml</tt>, <tt>text</tt>, <tt>console</tt>.
      */
     public void setReportFormat(String reportFormat) {
         if (REPORT_FORMATS.contains(reportFormat)) {

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeQualityExtension.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/CodeQualityExtension.java
@@ -45,14 +45,14 @@ public abstract class CodeQualityExtension {
     }
 
     /**
-     * The source sets to be analyzed as part of the <code>check</code> and <code>build</code> tasks.
+     * The source sets to be analyzed as part of the <tt>check</tt> and <tt>build</tt> tasks.
      */
     public Collection<SourceSet> getSourceSets() {
         return sourceSets;
     }
 
     /**
-     * The source sets to be analyzed as part of the <code>check</code> and <code>build</code> tasks.
+     * The source sets to be analyzed as part of the <tt>check</tt> and <tt>build</tt> tasks.
      */
     public void setSourceSets(Collection<SourceSet> sourceSets) {
         this.sourceSets = sourceSets;

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/FindBugsPlugin.java
@@ -35,8 +35,8 @@ import java.util.concurrent.Callable;
  * A plugin for the <a href="http://findbugs.sourceforge.net">FindBugs</a> byte code analyzer.
  *
  * <p>
- * Declares a <code>findbugs</code> configuration which needs to be configured with the FindBugs library to be used.
- * Additional plugins can be added to the <code>findbugsPlugins</code> configuration.
+ * Declares a <tt>findbugs</tt> configuration which needs to be configured with the FindBugs library to be used.
+ * Additional plugins can be added to the <tt>findbugsPlugins</tt> configuration.
  *
  * <p>
  * For projects that have the Java (base) plugin applied, a {@link FindBugs} task is

--- a/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
+++ b/subprojects/code-quality/src/main/groovy/org/gradle/api/plugins/quality/PmdPlugin.java
@@ -37,11 +37,11 @@ import java.util.concurrent.Callable;
 /**
  * A plugin for the <a href="http://pmd.sourceforge.net/">PMD</a> source code analyzer.
  * <p>
- * Declares a <code>pmd</code> configuration which needs to be configured with the PMD library to be used.
+ * Declares a <tt>pmd</tt> configuration which needs to be configured with the PMD library to be used.
  * <p>
  * For each source set that is to be analyzed, a {@link Pmd} task is created and configured to analyze all Java code.
  * <p>
- * All PMD tasks (including user-defined ones) are added to the <code>check</code> lifecycle task.
+ * All PMD tasks (including user-defined ones) are added to the <tt>check</tt> lifecycle task.
  *
  * @see PmdExtension
  * @see Pmd

--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -115,7 +115,7 @@ import java.util.concurrent.Callable;
  * Plugins can be applied using the {@link PluginAware#apply(java.util.Map)} method, or by using the {@link org.gradle.plugin.use.PluginDependenciesSpec} plugins script block.
  * </p>
  *
- * <a id="properties"></a> <h3>Properties</h3>
+ * <a name="properties"></a> <h3>Properties</h3>
  *
  * <p>Gradle executes the project's build file against the <code>Project</code> instance to configure the project. Any
  * property or method which your script uses is delegated through to the associated <code>Project</code> object.  This
@@ -163,7 +163,7 @@ import java.util.concurrent.Callable;
  * <p>When writing a property, the project searches the above scopes in order, and sets the property in the first scope
  * it finds the property in. If not found, an exception is thrown. See {@link #setProperty(String, Object)} for more details.</p>
  *
- * <a id="extraproperties"></a> <h4>Extra Properties</h4>
+ * <a name="extraproperties"></a> <h4>Extra Properties</h4>
  *
  * All extra properties must be defined through the &quot;ext&quot; namespace. Once an extra property has been defined,
  * it is available directly on the owning object (in the below case the Project, Task, and sub-projects respectively) and can

--- a/subprojects/core-api/src/main/java/org/gradle/api/Task.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Task.java
@@ -76,7 +76,7 @@ import java.util.Set;
  * next task by throwing a {@link org.gradle.api.tasks.StopExecutionException}. Using these exceptions allows you to
  * have precondition actions which skip execution of the task, or part of the task, if not true.</p>
  *
- * <a id="dependencies"></a><h3>Task Dependencies and Task Ordering</h3>
+ * <a name="dependencies"></a><h3>Task Dependencies and Task Ordering</h3>
  *
  * <p>A task may have dependencies on other tasks or might be scheduled to always run after another task.
  * Gradle ensures that all task dependencies and ordering rules are honored when executing tasks, so that the task is executed after
@@ -119,7 +119,7 @@ import java.util.Set;
  *
  * <h3>Using a Task in a Build File</h3>
  *
- * <a id="properties"></a> <h4>Dynamic Properties</h4>
+ * <a name="properties"></a> <h4>Dynamic Properties</h4>
  *
  * <p>A {@code Task} has 4 'scopes' for properties. You can access these properties by name from the build file or by
  * calling the {@link #property(String)} method. You can change the value of these properties by calling the {@link #setProperty(String, Object)} method.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -39,8 +39,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * The following parameter are accepted as keys for the map:
      *
-     * <table>
-     * <caption>Shows property keys and associated values</caption>
+     * <table summary="Shows property keys and associated values">
      * <tr><th>Key</th>
      *     <th>Description of Associated Value</th></tr>
      * <tr><td><code>name</code></td>
@@ -139,8 +138,7 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      *
      * <p>The following parameter are accepted as keys for the map:
      *
-     * <table>
-     * <caption>Shows property keys and associated values</caption>
+     * <table summary="Shows property keys and associated values">
      * <tr><th>Key</th>
      *     <th>Description of Associated Value</th></tr>
      * <tr><td><code>name</code></td>

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/CopySpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/CopySpec.java
@@ -103,14 +103,14 @@ public interface CopySpec extends CopySourceSpec, CopyProcessingSpec, PatternFil
     /**
      * Tells if empty target directories will be included in the copy.
      *
-     * @return <code>true</code> if empty target directories will be included in the copy, <code>false</code> otherwise
+     * @return <tt>true</tt> if empty target directories will be included in the copy, <tt>false</tt> otherwise
      */
     boolean getIncludeEmptyDirs();
 
     /**
      * Controls if empty target directories should be included in the copy.
      *
-     * @param includeEmptyDirs <code>true</code> if empty target directories should be included in the copy, <code>false</code> otherwise
+     * @param includeEmptyDirs <tt>true</tt> if empty target directories should be included in the copy, <tt>false</tt> otherwise
      */
     void setIncludeEmptyDirs(boolean includeEmptyDirs);
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/file/ReproducibleFileVisitor.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/ReproducibleFileVisitor.java
@@ -25,7 +25,7 @@ public interface ReproducibleFileVisitor extends FileVisitor {
     /**
      * Whether the {@link FileVisitor} should receive the files in a reproducible order independent of the underlying file system.
      *
-     * @return <code>true</code> if files should be walked in a reproducible order.
+     * @return <tt>true</tt> if files should be walked in a reproducible order.
      */
     boolean isReproducibleFileOrder();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -416,11 +416,11 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     /**
      * Specifies whether file timestamps should be preserved in the archive.
      * <p>
-     * If <code>false</code> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
+     * If <tt>false</tt> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
      * </p>
      *
      * @since 3.4
-     * @return <code>true</code> if file timestamps should be preserved for archive entries
+     * @return <tt>true</tt> if file timestamps should be preserved for archive entries
      */
     @Input
     public boolean isPreserveFileTimestamps() {
@@ -430,11 +430,11 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     /**
      * Specifies whether file timestamps should be preserved in the archive.
      * <p>
-     * If <code>false</code> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
+     * If <tt>false</tt> this ensures that archive entries have the same time for builds between different machines, Java versions and operating systems.
      * </p>
      *
      * @since 3.4
-     * @param preserveFileTimestamps <code>true</code> if file timestamps should be preserved for archive entries
+     * @param preserveFileTimestamps <tt>true</tt> if file timestamps should be preserved for archive entries
      */
     public void setPreserveFileTimestamps(boolean preserveFileTimestamps) {
         this.archivePreserveFileTimestamps.set(preserveFileTimestamps);
@@ -449,7 +449,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * </p>
      *
      * @since 3.4
-     * @return <code>true</code> if the files should read from disk in a reproducible order.
+     * @return <tt>true</tt> if the files should read from disk in a reproducible order.
      */
     @Input
     public boolean isReproducibleFileOrder() {
@@ -464,7 +464,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * </p>
      *
      * @since 3.4
-     * @param reproducibleFileOrder <code>true</code> if the files should read from disk in a reproducible order.
+     * @param reproducibleFileOrder <tt>true</tt> if the files should read from disk in a reproducible order.
      */
     public void setReproducibleFileOrder(boolean reproducibleFileOrder) {
         this.archiveReproducibleFileOrder.set(reproducibleFileOrder);

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/ports/DefaultPortDetector.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/ports/DefaultPortDetector.groovy
@@ -22,7 +22,7 @@ class DefaultPortDetector implements PortDetector {
      * Checks to see if a specific port is available.
      *
      * @param port the port to check for availability
-     * @return <code>true</code> if the port is available, <code>false</code> otherwise
+     * @return <tt>true</tt> if the port is available, <tt>false</tt> otherwise
      */
     public boolean isAvailable(int port) {
         try {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriter.java
@@ -234,9 +234,9 @@ public class DefaultIvyModuleDescriptorWriter implements IvyModuleDescriptorWrit
     }
 
     /**
-     * Writes the specified <code>Map</code> containing the extra attributes to the given <code>PrintWriter</code>.
+     * Writes the specified <tt>Map</tt> containing the extra attributes to the given <tt>PrintWriter</tt>.
      *
-     * @param extra the extra attributes, can be <code>null</code>
+     * @param extra the extra attributes, can be <tt>null</tt>
      * @param writer the writer to use
      */
     private static void printExtraAttributes(Map<String, ?> extra, SimpleXmlWriter writer) throws IOException {

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -305,8 +305,9 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
     options.encoding = 'utf-8'
     options.docEncoding = 'utf-8'
     options.charSet = 'utf-8'
-    if (BuildEnvironment.javaVersion.isJava8Compatible()) {
-        options.addStringOption 'Xdoclint:syntax,html,reference', '-quiet'
+    options.addStringOption 'Xdoclint:syntax,html,reference', '-quiet'
+    if (BuildEnvironment.javaVersion.isJava11Compatible()) {
+        options.addBooleanOption('html4', true)
     }
     options.addStringOption "stylesheetfile", stylesheetFile.absolutePath
     source ProjectGroups.INSTANCE.getPublicJavaProjects(project).collect { project -> project.sourceSets.main.allJava }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Dependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/Dependency.java
@@ -24,14 +24,14 @@ import org.gradle.api.Incubating;
 public interface Dependency {
 
     /**
-     * The scope of this library. If <code>null</code>, the scope attribute is not added.
+     * The scope of this library. If <tt>null</tt>, the scope attribute is not added.
      * @since 4.5
      */
     @Incubating
     String getScope();
 
     /**
-     * The scope of this library. If <code>null</code>, the scope attribute is not added.
+     * The scope of this library. If <tt>null</tt>, the scope attribute is not added.
      * @since 4.5
      */
     @Incubating

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/IdeaModule.java
@@ -195,17 +195,17 @@ public class IdeaModule {
      * <p>
      * <b>since</b> 1.0-milestone-2
      * <p>
-     * If your project has problems with unique names it is recommended to always run <code>gradle idea</code> from the
+     * If your project has problems with unique names it is recommended to always run <tt>gradle idea</tt> from the
      * root, i.e. for all subprojects.
      * If you run the generation of the IDEA module only for a single subproject then you may have different results
      * because the unique names are calculated based on IDEA modules that are involved in the specific build run.
      * <p>
-     * If you update the module names then make sure you run <code>gradle idea</code> from the root, e.g. for all
+     * If you update the module names then make sure you run <tt>gradle idea</tt> from the root, e.g. for all
      * subprojects, including generation of IDEA project.
      * The reason is that there may be subprojects that depend on the subproject with amended module name.
      * So you want them to be generated as well because the module dependencies need to refer to the amended project
      * name.
-     * Basically, for non-trivial projects it is recommended to always run <code>gradle idea</code> from the root.
+     * Basically, for non-trivial projects it is recommended to always run <tt>gradle idea</tt> from the root.
      * <p>
      * For example see docs for {@link IdeaModule}
      */

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/ModuleLibrary.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/idea/model/ModuleLibrary.java
@@ -93,7 +93,7 @@ public class ModuleLibrary implements Dependency {
     }
 
     /**
-     * The scope of this library. If <code>null</code>, the scope attribute is not added.
+     * The scope of this library. If <tt>null</tt>, the scope attribute is not added.
      */
     public String getScope() {
         return scope;

--- a/subprojects/maven/src/main/java/org/gradle/api/plugins/MavenRepositoryHandlerConvention.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/plugins/MavenRepositoryHandlerConvention.java
@@ -62,8 +62,7 @@ public interface MavenRepositoryHandlerConvention {
      *
      * The following parameter are accepted as keys for the map:
      *
-     * <table>
-     * <caption>Shows property keys and associated values</caption>
+     * <table summary="Shows property keys and associated values">
      * <tr><th>Key</th>
      *     <th>Description of Associated Value</th></tr>
      * <tr><td><code>name</code></td>
@@ -132,8 +131,7 @@ public interface MavenRepositoryHandlerConvention {
      *
      * The following parameter are accepted as keys for the map:
      *
-     * <table>
-     * <caption>Shows property keys and associated values</caption>
+     * <table summary="Shows property keys and associated values">
      * <tr><th>Key</th>
      *     <th>Description of Associated Value</th></tr>
      * <tr><td><code>name</code></td>

--- a/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/FileSystem.java
+++ b/subprojects/native/src/main/java/org/gradle/internal/nativeintegration/filesystem/FileSystem.java
@@ -34,15 +34,15 @@ public interface FileSystem extends Chmod, Stat {
     /**
      * Tells whether the file system is case sensitive.
      *
-     * @return <code>true</code> if the file system is case sensitive, <code>false</code> otherwise
+     * @return <tt>true</tt> if the file system is case sensitive, <tt>false</tt> otherwise
      */
     boolean isCaseSensitive();
 
     /**
      * Tells if the file system can create symbolic links. If the answer cannot be determined accurately,
-     * <code>false</code> is returned.
+     * <tt>false</tt> is returned.
      *
-     * @return <code>true</code> if the file system can create symbolic links, <code>false</code> otherwise
+     * @return <tt>true</tt> if the file system can create symbolic links, <tt>false</tt> otherwise
      */
     boolean canCreateSymbolicLink();
 


### PR DESCRIPTION
### Context

By default, JDK 11 generates HTML5 Javadoc, so when we upgraded build JDK to 11 last December, we fixed some Javadoc tags to make it HTML5-compatible. However, it broke some DSL documentation: https://docs.gradle.org/5.1/dsl/org.gradle.api.Project.html#N14DA6

Now given that we're going to release 5.1.1, I think we should downgrade Javadoc to HTML4 for now. This PR reverts previous change and enables `-html4` option for Javadoc. 

