### PR TITLE
Property handle UNC paths for the wrapper path.

### DIFF
--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperGenerationIntegrationTest.groovy
@@ -71,7 +71,7 @@ class WrapperGenerationIntegrationTest extends AbstractIntegrationSpec {
         executer.inDirectory(file("second")).withTasks("wrapper").run()
 
         then: "the checksum should be constant (unless there are code changes)"
-        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "76b12da7f4a7cdd025e5996811a2e49bf5df0fb62d72554ab555c0e434b63aae"
+        sha256(file("first/gradle/wrapper/gradle-wrapper.jar")).asHexString() == "963ca8f92fb943ea0b8e17232fa18862b94358bc2723ecb14a163880cdc3e505"
 
         and:
         file("first/gradle/wrapper/gradle-wrapper.jar").md5Hash == file("second/gradle/wrapper/gradle-wrapper.jar").md5Hash

--- a/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUNCIntegrationTest.groovy
+++ b/subprojects/wrapper/src/integTest/groovy/org/gradle/integtests/WrapperUNCIntegrationTest.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests
+
+import org.gradle.util.Requires
+import org.gradle.util.TestPrecondition
+import spock.lang.Ignore
+
+class WrapperUNCIntegrationTest extends AbstractWrapperIntegrationSpec {
+    @Requires(TestPrecondition.WINDOWS)
+    @Ignore("Test Framework does not support UNC Paths")
+    def "wrapper propertly supports UNC paths on windows"() {
+        given:
+        file("build.gradle") << """
+        task hello {
+            println 'hello'
+        }
+        """
+        file('settings.gradle') << ''
+
+        prepareWrapper()
+
+        def exec = wrapperExecuter
+
+        def workingDir = exec.workingDir
+
+        exec.inDirectory(new File('\\\\?\\' + workingDir))
+
+        exec.withTasks("hello")
+
+        when:
+        def success = exec.run()
+
+        then:
+        success.output.contains('BUILD SUCCESSFUL')
+    }
+}

--- a/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
+++ b/subprojects/wrapper/src/main/java/org/gradle/wrapper/GradleWrapperMain.java
@@ -23,6 +23,7 @@ import org.gradle.cli.SystemPropertiesCommandLineConverter;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Properties;
 
@@ -88,7 +89,11 @@ public class GradleWrapperMain {
         if (!location.getScheme().equals("file")) {
             throw new RuntimeException(String.format("Cannot determine classpath for wrapper Jar from codebase '%s'.", location));
         }
-        return new File(location.getPath());
+        try {
+            return Paths.get(location).toFile();
+        } catch (NoClassDefFoundError e) {
+            return new File(location.getPath());
+        }
     }
 
     private static File gradleUserHome(ParsedCommandLine options) {


### PR DESCRIPTION
File::getPath() does not have the correct behavior specifically for network paths, but has the same behavior for all other types

### Context
This is useful if a system has folder redirection set up, like in a domain, where it will work with the wrapper.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
