### PR TITLE
Fix "sanityCheck" task

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -25,6 +25,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Named
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.CompileOptions
@@ -99,6 +100,23 @@ class UnitTestAndCompilePlugin : Plugin<Project> {
         configureCompile()
         configureJarTasks()
         configureTests()
+        configureLegacyConfigurations()
+    }
+
+    private
+    fun Project.configureLegacyConfigurations() {
+        // The legacy configurations should never be resolved or consumed directly.
+        // However for backwards compatibility, Gradle cannot disable this by default,
+        // but we do it for our own build, in order to catch errors early
+        listOf("compile", "runtime")
+                .map(configurations::getByName)
+                .forEach(::disableLegacyBehavior)
+    }
+
+    private
+    fun disableLegacyBehavior(c: Configuration) = c.run {
+        isCanBeConsumed = false
+        isCanBeResolved = false
     }
 
     private

--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.7")
+    implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.8")
     implementation("org.jsoup:jsoup:1.11.3")
     implementation("com.gradle:build-scan-plugin:2.1")
     implementation(project(":configuration"))


### PR DESCRIPTION
### Context

Without this change, running `sanityCheck` fails with the following error:

```
Could not determine the dependencies of task ':performance:checkstyleJmhGroovy'.
> Could not resolve all task dependencies for configuration ':performance:compile'.
   > Could not resolve project :distributionsDependencies.
     Required by:
         project :performance
      > Cannot choose between the following variants of project :distributionsDependencies:
          - apiElements
          - runtimeElements
        All of them match the consumer attributes:
          - Variant 'apiElements':
              - Found org.gradle.component.category 'platform' but wasn't required.
              - Found org.gradle.usage 'java-api' but wasn't required.
          - Variant 'runtimeElements':
              - Found org.gradle.component.category 'platform' but wasn't required.
              - Found org.gradle.usage 'java-runtime' but wasn't required.
```

It's unclear when this started to happen, but this is caused by the JMH plugin resolving the wrong configurations. A new version of the plugin has been released as part of fixing this.
