### PR TITLE
Spelling

### DIFF
--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/MinifyPlugin.kt
@@ -69,7 +69,7 @@ open class MinifyPlugin : Plugin<Project> {
                     /*
                      * Some of our projects still depend on matching the default
                      * configuration. As soon as any attribute is added, the default
-                     * configuraiton is no longer a valid match. To work around this
+                     * configuration is no longer a valid match. To work around this
                      * we only add the "minified" attribute in places where we already
                      * use other attributes.
                      */

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/service/DefaultServiceRegistryTest.groovy
@@ -969,8 +969,8 @@ class DefaultServiceRegistryTest extends Specification {
 
     def closeInvokesCloseMethodOnEachServiceCreatedFromImplementationClass() {
         given:
-        registry.register({ registration -> registration.add(ClosableService) } as Action)
-        def service = registry.get(ClosableService)
+        registry.register({ registration -> registration.add(CloseableService) } as Action)
+        def service = registry.get(CloseableService)
 
         when:
         registry.close()
@@ -1000,22 +1000,22 @@ class DefaultServiceRegistryTest extends Specification {
     def closeClosesServicesInDependencyOrder() {
         def service1 = Mock(TestCloseService)
         def service2 = Mock(TestStopService)
-        def service3 = Mock(ClosableService)
+        def service3 = Mock(CloseableService)
         def registry = new DefaultServiceRegistry()
 
         given:
         registry.addProvider(new Object() {
-            ClosableService createService3() {
+            CloseableService createService3() {
                 return service3
             }
 
-            TestStopService createService2(ClosableService b) {
+            TestStopService createService2(CloseableService b) {
                 return service2
             }
 
         })
         registry.addProvider(new Object() {
-            TestCloseService createService1(TestStopService a, ClosableService b) {
+            TestCloseService createService1(TestStopService a, CloseableService b) {
                 return service1
             }
         })
@@ -1073,13 +1073,13 @@ class DefaultServiceRegistryTest extends Specification {
     def closeContinuesToCloseServicesAfterFailingToStopSomeService() {
         def service1 = Mock(TestCloseService)
         def service2 = Mock(TestStopService)
-        def service3 = Mock(ClosableService)
+        def service3 = Mock(CloseableService)
         def failure = new RuntimeException()
         def registry = new DefaultServiceRegistry()
 
         given:
         registry.addProvider(new Object() {
-            TestStopService createService2(ClosableService b) {
+            TestStopService createService2(CloseableService b) {
                 return service2
             }
 
@@ -1087,7 +1087,7 @@ class DefaultServiceRegistryTest extends Specification {
                 return service1
             }
 
-            ClosableService createService3() {
+            CloseableService createService3() {
                 return service3
             }
         })
@@ -1185,7 +1185,7 @@ class DefaultServiceRegistryTest extends Specification {
         given:
         def parentService = Mock(TestCloseService)
         registry.addProvider(new Object(){
-            Closeable createClosableService() {
+            Closeable createCloseableService() {
                 parentService
             }
         })
@@ -1193,7 +1193,7 @@ class DefaultServiceRegistryTest extends Specification {
         def child = new DefaultServiceRegistry(registry)
         def childService = Mock(TestStopService)
         child.addProvider(new Object() {
-            Stoppable createClosableService(Closeable dependency) {
+            Stoppable createCloseableService(Closeable dependency) {
                 childService
             }
         })
@@ -1216,23 +1216,23 @@ class DefaultServiceRegistryTest extends Specification {
     def "closes services in dependency order even when child requested them first"() {
         def service1 = Mock(TestCloseService)
         def service2 = Mock(TestStopService)
-        def service3 = Mock(ClosableService)
+        def service3 = Mock(CloseableService)
         def parent = new DefaultServiceRegistry()
         def child = new DefaultServiceRegistry(parent)
 
         given:
         parent.addProvider(new Object() {
-            ClosableService createService3() {
+            CloseableService createService3() {
                 return service3
             }
 
-            TestStopService createService2(ClosableService b) {
+            TestStopService createService2(CloseableService b) {
                 return service2
             }
         })
 
         child.addProvider(new Object() {
-            TestCloseService createService1(TestStopService a, ClosableService b) {
+            TestCloseService createService1(TestStopService a, CloseableService b) {
                 return service1
             }
         })
@@ -1645,7 +1645,7 @@ class DefaultServiceRegistryTest extends Specification {
         }
     }
 
-    static class ClosableService implements Closeable {
+    static class CloseableService implements Closeable {
         boolean closed
 
         void close() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractNamedDomainObjectContainer.java
@@ -62,7 +62,7 @@ public abstract class AbstractNamedDomainObjectContainer<T> extends DefaultNamed
     @Deprecated
     protected AbstractNamedDomainObjectContainer(Class<T> type, Instantiator instantiator) {
         this(type, instantiator, CollectionCallbackActionDecorator.NOOP);
-        DeprecationLogger.nagUserOfDeprecated("Internal API constructor FactoryNamedDomainObjectContaineronstructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator)", "Don't use internal API");
+        DeprecationLogger.nagUserOfDeprecated("Internal API constructor FactoryNamedDomainObjectContainerConstructor AbstractNamedDomainObjectContainer(Class<T>, Instantiator)", "Don't use internal API");
     }
 
     /**

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/BuildScopeServicesTest.groovy
@@ -80,7 +80,7 @@ class BuildScopeServicesTest extends Specification {
     StartParameter startParameter = new StartParameter()
     ServiceRegistry sessionServices = Mock()
     Factory<CacheFactory> cacheFactoryFactory = Mock()
-    ClosableCacheFactory cacheFactory = Mock()
+    CloseableCacheFactory cacheFactory = Mock()
     ClassLoaderRegistry classLoaderRegistry = Mock()
     ListenerManager listenerManager = new DefaultListenerManager()
 
@@ -261,7 +261,7 @@ class BuildScopeServicesTest extends Specification {
         t
     }
 
-    public interface ClosableCacheFactory extends CacheFactory {
+    public interface CloseableCacheFactory extends CacheFactory {
         void close()
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/EnumFromCharSequenceNotationParserSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/typeconversion/EnumFromCharSequenceNotationParserSpec.groovy
@@ -32,7 +32,7 @@ class EnumFromCharSequenceNotationParserSpec extends Specification {
         TestEnum.ENUM_4_1 == parser.parseNotation("enum_4_1")
     }
 
-    def "reports available values for non convertable strings"() {
+    def "reports available values for non convertible strings"() {
         when:
         parser.parseNotation(value)
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultModuleVersionIdentifier.java
@@ -38,7 +38,7 @@ public class DefaultModuleVersionIdentifier implements ModuleVersionIdentifier {
         assert version != null : "version cannot be null";
         this.id = id;
         this.version = version;
-        // pre-compule the hashcode as it's going to be used anyway, and this object
+        // pre-compute the hashcode as it's going to be used anyway, and this object
         // is used as a key in several hash maps
         this.hashCode = 31 * id.hashCode() ^ version.hashCode();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -129,7 +129,7 @@ public class StartParameterResolutionOverride {
         return original;
     }
 
-    public ExternalResourceConnector overrideExternalResourceConnnector(ExternalResourceConnector original) {
+    public ExternalResourceConnector overrideExternalResourceConnector(ExternalResourceConnector original) {
         if (startParameter.isOffline()) {
             return new OfflineExternalResourceConnector();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/RepositoryTransportFactory.java
@@ -116,7 +116,7 @@ public class RepositoryTransportFactory {
         ResourceConnectorSpecification connectionDetails = new DefaultResourceConnectorSpecification(authentications);
 
         ExternalResourceConnector resourceConnector = connectorFactory.createResourceConnector(connectionDetails);
-        resourceConnector = startParameterResolutionOverride.overrideExternalResourceConnnector(resourceConnector);
+        resourceConnector = startParameterResolutionOverride.overrideExternalResourceConnector(resourceConnector);
 
         ExternalResourceCachePolicy cachePolicy = new DefaultExternalResourceCachePolicy();
         cachePolicy = startParameterResolutionOverride.overrideExternalResourceCachePolicy(cachePolicy);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -45,7 +45,7 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
     private ImmutableAttributes computedAttributes;
     private CapabilitiesMetadata computedCapabilities;
 
-    // Fields used for performance optimizations: we avoid computing the derived dependencies (withConstraints, withoutContrainsts, ...)
+    // Fields used for performance optimizations: we avoid computing the derived dependencies (withConstraints, withoutConstraints, ...)
     // eagerly because it's very likely that those methods would only be called on the selected variant. Therefore it's a waste of time
     // to compute them eagerly when those filtering methods are called. We cannot use a dedicated, lazy wrapper over configuration metadata
     // because we need the attributes to be computes lazily too, because of component metadata rules.

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/reporting/dependencies/HtmlDependencyReportTaskIntegrationTest.groovy
@@ -165,7 +165,7 @@ class HtmlDependencyReportTaskIntegrationTest extends AbstractIntegrationSpec {
         json.project.configurations[0].dependencies[1].resolvable == 'FAILED'
     }
 
-    def "conflictual dependencies are marked as such"() {
+    def "conflicting dependencies are marked as such"() {
         given:
         mavenRepo.module("foo", "bar", "1.0").publish()
         mavenRepo.module("foo", "bar", "2.0").publish()

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/ProjectPageRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependencies/internal/ProjectPageRenderer.java
@@ -65,7 +65,7 @@ public class ProjectPageRenderer extends ReportRenderer<Project, HtmlPageBuilder
                         div().classAttr("breadcrumbs");
                             a().href("index.html").text("Projects").end();
                             text(" > ");
-                            span().id("projectBreacrumb").end();
+                            span().id("projectBreadcrumb").end();
                         end();
                         div().id("insight").end();
                         div().id("dependencies").end();

--- a/subprojects/diagnostics/src/main/resources/org/gradle/api/tasks/diagnostics/htmldependencyreport/script.js
+++ b/subprojects/diagnostics/src/main/resources/org/gradle/api/tasks/diagnostics/htmldependencyreport/script.js
@@ -192,7 +192,7 @@ function initializeProjectPage(report) {
             $(this).toggleClass('closed');
         });
 
-        $('#projectBreacrumb').text(project.name);
+        $('#projectBreadcrumb').text(project.name);
         populateFooter(report);
     });
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/reporting/model/ModelReportNodeBuilderTest.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/reporting/model/ModelReportNodeBuilderTest.groovy
@@ -34,7 +34,7 @@ class ModelReportNodeBuilderTest extends Specification {
         node.'**'.childTwo.@anotherValue[0] == 'somethingElse'
     }
 
-    def "can accept an empty closue"() {
+    def "can accept an empty closure"() {
         def node = ModelReportNodeBuilder.fromDsl {}.get()
         expect:
         node == null

--- a/subprojects/docs/src/docs/userguide/dependency_management_attribute_based_matching.adoc
+++ b/subprojects/docs/src/docs/userguide/dependency_management_attribute_based_matching.adoc
@@ -158,7 +158,7 @@ However, there are cases where a provider may not have _exactly_ what the consum
 For example, if the consumer is asking for the API of a library, there's a possibility that the producer doesn't have such a variant, but only a _runtime_ variant.
 This is typical of libraries published on external repositories.
 In this case, we know that even if we don't have an exact match (API), we can still compile against the runtime variant (it contains _more_ than what we need to compile but it's still ok to use).
-To deal with this, Gradle provides link:{javadocPath}/org/gradle/api/attributes/AttributeCompatibilityRule.html[attribute compatibilty rules].
+To deal with this, Gradle provides link:{javadocPath}/org/gradle/api/attributes/AttributeCompatibilityRule.html[attribute compatibility rules].
 The role of a compatibility rule is to explain what variants are _compatible_ with what the consumer asked for.
 
 Attribute compatibility rules have to be registered via the link:{javadocPath}/org/gradle/api/attributes/AttributeMatchingStrategy.html[attribute matching strategy] that you can obtain from the link:{javadocPath}/org/gradle/api/attributes/AttributesSchema.html[attributes schema].

--- a/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/Util.h
+++ b/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/Util.h
@@ -125,7 +125,7 @@ CU_EXPORT void CU_trim(char *szString);
 
 CU_EXPORT size_t CU_number_width(int number);
 /**< 
- *  Calulates the number of places required to display 
+ *  Calculates the number of places required to display 
  *  number in decimal.
  */
 

--- a/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/Util.h
+++ b/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/Util.h
@@ -24,7 +24,7 @@
  *
  *  13/Oct/2001   Moved some of the generic functions declarations from
  *                other files to this one so as to use the functions 
- *                consitently. This file is not included in the distribution 
+ *                consistently. This file is not included in the distribution 
  *                headers because it is used internally by CUnit. (AK)
  *
  *  20-Jul-2004   New interface, support for deprecated version 1 names. (JDS)

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
@@ -1081,7 +1081,7 @@ inline void FlushInfoLog() { fflush(NULL); }
 // const Foo*).  When you use ImplicitCast_, the compiler checks that
 // the cast is safe.  Such explicit ImplicitCast_s are necessary in
 // surprisingly many situations where C++ demands an exact type match
-// instead of an argument type convertable to a target type.
+// instead of an argument type convertible to a target type.
 //
 // The syntax for using ImplicitCast_ is the same as for static_cast:
 //

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/groovy/settings.gradle
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-rootProject.name = "declaring-capabitilies"
+rootProject.name = "declaring-capabilities"

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/kotlin/settings.gradle.kts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-rootProject.name = "declaring-capabitilies"
+rootProject.name = "declaring-capabilities"

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r211/ToolingApiIdeaModelCrossVersionSpec.groovy
@@ -156,7 +156,7 @@ class ToolingApiIdeaModelCrossVersionSpec extends ToolingApiSpecification {
     }
 
     @TargetGradleVersion("=2.11")
-    def "explicit idea project language level overrules sourceCompatiblity settings"() {
+    def "explicit idea project language level overrules sourceCompatibility settings"() {
         given:
         settingsFile << "\ninclude 'root', 'child1', 'child2', 'child3'"
         buildFile << """

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpecs.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/TaskOrderSpecs.java
@@ -58,8 +58,8 @@ import java.util.Set;
  */
 public class TaskOrderSpecs {
 
-    public static TaskOrderSpec any(Object[] contraints) {
-        return new AnyOrderSpec(Arrays.asList(contraints));
+    public static TaskOrderSpec any(Object[] constraints) {
+        return new AnyOrderSpec(Arrays.asList(constraints));
     }
 
     public static TaskOrderSpec exact(Object[] constraints) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/plugin/PluginBuilder.groovy
@@ -182,7 +182,7 @@ class PluginBuilder {
         this
     }
 
-    PluginBuilder addNonConstructablePlugin(String id = "test-plugin", String className = "TestPlugin") {
+    PluginBuilder addNonConstructiblePlugin(String id = "test-plugin", String className = "TestPlugin") {
         addPluginSource(id, className, """
             package $packageName
 

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -599,7 +599,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
     }
 
     @Unroll
-    def "recompiles outermost class when #visibility inner class constains constant reference"() {
+    def "recompiles outermost class when #visibility inner class contains constant reference"() {
         java api: [
             "class A { public static final int EVIL = 666; }",
         ], impl: [

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/sourceparser/PreprocessingReaderTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/nativeplatform/internal/incremental/sourceparser/PreprocessingReaderTest.groovy
@@ -148,7 +148,7 @@ line comments.
 
         where:
         description | testIn | testOut
-        "line comment" | "// Commment on first line\nAnother line" | "\nAnother line"
+        "line comment" | "// Comment on first line\nAnother line" | "\nAnother line"
         "inline comment" | "/* inline comment at the start */of the line" | " of the line"
         "line continuation" | "${BN} at the start of the content" | " at the start of the content"
     }

--- a/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
+++ b/subprojects/launcher/src/main/java/org/gradle/tooling/internal/provider/TestExecutionRequestAction.java
@@ -44,7 +44,7 @@ public class TestExecutionRequestAction extends SubscribableBuildAction {
         this.internalJvmTestRequests = internalJvmTestRequests;
     }
 
-    // Unpacks the request to serialize across to the daemon and craetes instance of
+    // Unpacks the request to serialize across to the daemon and creates instance of
     // TestExecutionRequestAction
     public static TestExecutionRequestAction create(BuildClientSubscriptions clientSubscriptions, StartParameterInternal startParameter, ProviderInternalTestExecutionRequest testExecutionRequest) {
         final Collection<String> testClassNames = testExecutionRequest.getTestClassNames();

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultColorMapTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultColorMapTest.groovy
@@ -65,7 +65,7 @@ class DefaultColorMapTest extends Specification {
         1 * ansi.fg(Color.CYAN)
         1 * ansi.a(Attribute.ITALIC)
 
-        when: 'A color is requested for FailureHeader which defaults to combinging Failure and Header'
+        when: 'A color is requested for FailureHeader which defaults to combining Failure and Header'
         color = map.getColourFor(Style.FailureHeader)
         color.on(ansi)
 

--- a/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/Conf2ScopeMappingContainer.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/artifacts/maven/Conf2ScopeMappingContainer.java
@@ -35,7 +35,7 @@ public interface Conf2ScopeMappingContainer {
      * Maven scope. A configuration can be mapped to one and only one scope. If this method is called
      * more than once for a particular configuration, the last call wins.</p>
      *
-     * See {@link #getMapping(java.util.Collection)} for the rules how a scope is choosen from a set of mappings.
+     * See {@link #getMapping(java.util.Collection)} for the rules how a scope is chosen from a set of mappings.
      *
      * @param priority a number that is used for comparison with the priority of other scopes.
      * @param configuration a Gradle configuration name (must not be null).

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/pom/DefaultExcludeRuleConverter.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/pom/DefaultExcludeRuleConverter.java
@@ -20,7 +20,7 @@ import org.gradle.api.artifacts.ExcludeRule;
 
 class DefaultExcludeRuleConverter implements ExcludeRuleConverter {
     public Exclusion convert(ExcludeRule excludeRule) {
-        if (isConvertable(excludeRule)) {
+        if (isConvertible(excludeRule)) {
             Exclusion exclusion = new Exclusion();
             exclusion.setGroupId(determineExclusionExpression(excludeRule.getGroup()));
             exclusion.setArtifactId(determineExclusionExpression(excludeRule.getModule()));
@@ -29,7 +29,7 @@ class DefaultExcludeRuleConverter implements ExcludeRuleConverter {
         return null;
     }
 
-    private boolean isConvertable(ExcludeRule excludeRule) {
+    private boolean isConvertible(ExcludeRule excludeRule) {
         return excludeRule.getGroup()!= null || excludeRule.getModule()!= null;
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/util/ClosureBackedAction.java
+++ b/subprojects/model-core/src/main/java/org/gradle/util/ClosureBackedAction.java
@@ -28,7 +28,7 @@ public class ClosureBackedAction<T> implements Action<T> {
 
     private final Closure closure;
     private final int resolveStrategy;
-    private final boolean configureableAware;
+    private final boolean configurableAware;
 
     public static <T> ClosureBackedAction<T> of(Closure<?> closure) {
         return new ClosureBackedAction<T>(closure);
@@ -42,10 +42,10 @@ public class ClosureBackedAction<T> implements Action<T> {
         this(closure, resolveStrategy, false);
     }
 
-    public ClosureBackedAction(Closure closure, int resolveStrategy, boolean configureableAware) {
+    public ClosureBackedAction(Closure closure, int resolveStrategy, boolean configurableAware) {
         this.closure = closure;
         this.resolveStrategy = resolveStrategy;
-        this.configureableAware = configureableAware;
+        this.configurableAware = configurableAware;
     }
 
     public static <T> void execute(T delegate, Closure<?> closure) {
@@ -58,7 +58,7 @@ public class ClosureBackedAction<T> implements Action<T> {
         }
 
         try {
-            if (configureableAware && delegate instanceof Configurable) {
+            if (configurableAware && delegate instanceof Configurable) {
                 ((Configurable) delegate).configure(closure);
             } else {
                 Closure copy = (Closure) closure.clone();
@@ -92,7 +92,7 @@ public class ClosureBackedAction<T> implements Action<T> {
         }
 
         ClosureBackedAction that = (ClosureBackedAction) o;
-        return configureableAware == that.configureableAware
+        return configurableAware == that.configurableAware
             && resolveStrategy == that.resolveStrategy
             && closure.equals(that.closure);
     }
@@ -100,7 +100,7 @@ public class ClosureBackedAction<T> implements Action<T> {
     @Override
     public int hashCode() {
         int result = closure.hashCode();
-        result = 31 * result + (configureableAware ? 1 : 0);
+        result = 31 * result + (configurableAware ? 1 : 0);
         result = 31 * result + resolveStrategy;
         return result;
     }

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-port.h
@@ -1081,7 +1081,7 @@ inline void FlushInfoLog() { fflush(NULL); }
 // const Foo*).  When you use ImplicitCast_, the compiler checks that
 // the cast is safe.  Such explicit ImplicitCast_s are necessary in
 // surprisingly many situations where C++ demands an exact type match
-// instead of an argument type convertable to a target type.
+// instead of an argument type convertible to a target type.
 //
 // The syntax for using ImplicitCast_ is the same as for static_cast:
 //

--- a/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/ToolSearchBuildAbilityTest.groovy
+++ b/subprojects/platform-base/src/test/groovy/org/gradle/platform/base/internal/ToolSearchBuildAbilityTest.groovy
@@ -32,7 +32,7 @@ class ToolSearchBuildAbilityTest extends Specification {
         ability.isBuildable()
     }
 
-    def "is not builadble when tool search is not successful" () {
+    def "is not buildable when tool search is not successful" () {
         when:
         result.isAvailable() >> false
 

--- a/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
+++ b/subprojects/platform-native/src/integTest/groovy/org/gradle/nativeplatform/NativeDependentComponentsReportIntegrationTest.groovy
@@ -95,7 +95,7 @@ class NativeDependentComponentsReportIntegrationTest extends AbstractIntegration
     }
 
     @Unroll
-    def "hide non-buidable dependents by default #nonBuildables"() {
+    def "hide non-buildable dependents by default #nonBuildables"() {
         given:
         buildScript simpleCppBuild()
         nonBuildables.each { nonBuildable ->

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/NonDeclarativePluginUseIntegrationSpec.groovy
@@ -269,7 +269,7 @@ class NonDeclarativePluginUseIntegrationSpec extends AbstractIntegrationSpec {
     def "failure due to plugin instantiation throwing"() {
         when:
         pluginBuilder.with {
-            addNonConstructablePlugin(PLUGIN_ID, "OtherPlugin")
+            addNonConstructiblePlugin(PLUGIN_ID, "OtherPlugin")
             publishAs(GROUP, ARTIFACT, VERSION, pluginRepo, executer).allowAll()
         }
 

--- a/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PostPluginResolutionFailuresIntegrationSpec.groovy
+++ b/subprojects/plugin-use/src/integTest/groovy/org/gradle/plugin/use/PostPluginResolutionFailuresIntegrationSpec.groovy
@@ -55,7 +55,7 @@ class PostPluginResolutionFailuresIntegrationSpec extends AbstractIntegrationSpe
     }
 
     def "error creating plugin"() {
-        pluginBuilder.addNonConstructablePlugin(PLUGIN_ID)
+        pluginBuilder.addNonConstructiblePlugin(PLUGIN_ID)
         pluginBuilder.publishAs(GROUP, ARTIFACT, VERSION, pluginRepo, executer).allowAll()
 
         buildScript applyPlugin()

--- a/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceAccessorTest.groovy
+++ b/subprojects/resources-http/src/test/groovy/org/gradle/internal/resource/transport/http/HttpResourceAccessorTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 class HttpResourceAccessorTest extends Specification {
     URI uri = new URI("http://somewhere")
 
-    def "should call close() on ClosableHttpResource when getMetaData is called"() {
+    def "should call close() on CloseableHttpResource when getMetaData is called"() {
         def response = Mock(CloseableHttpResponse)
         def http = Mock(HttpClientHelper) {
             performHead(uri.toString(), _) >> new HttpClientResponse("GET", uri, response)

--- a/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsContinuousIntegrationTest.groovy
+++ b/subprojects/testing-base/src/integTest/groovy/org/gradle/testing/TestExecutionBuildOperationsContinuousIntegrationTest.groovy
@@ -27,7 +27,7 @@ import org.junit.Rule
 
 import static org.gradle.testing.TestExecutionBuildOperationTestUtils.assertJunit
 
-class TestExecutionBuildOperationsContinousIntegrationTest extends AbstractContinuousIntegrationTest {
+class TestExecutionBuildOperationsContinuousIntegrationTest extends AbstractContinuousIntegrationTest {
 
     final List<Action<GradleExecuter>> afterExecute = []
 

--- a/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuterTest.groovy
+++ b/subprojects/tooling-api/src/test/groovy/org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuterTest.groovy
@@ -79,7 +79,7 @@ class DefaultPhasedBuildActionExecuterTest extends ConcurrentSpec {
         def handler = Mock(ResultHandler)
 
         given:
-        asyncConnection.run(!null, !null) >> { def consummerAction, ResultHandlerVersion1 adaptedHandler ->
+        asyncConnection.run(!null, !null) >> { def consumerAction, ResultHandlerVersion1 adaptedHandler ->
             start {
                 thread.blockUntil.dispatched
                 instant.resultAvailable
@@ -104,7 +104,7 @@ class DefaultPhasedBuildActionExecuterTest extends ConcurrentSpec {
 
     def "run() blocks until result is available"() {
         given:
-        asyncConnection.run(!null, !null) >> { def consummerAction, ResultHandlerVersion1 adaptedHandler ->
+        asyncConnection.run(!null, !null) >> { def consumerAction, ResultHandlerVersion1 adaptedHandler ->
             start {
                 thread.block()
                 instant.resultAvailable


### PR DESCRIPTION
### Context
Misspellings make it harder to search for things; they make it harder for people to understand code and descriptions; and sometimes they result in bugs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

I'm happy to drop files/directories if they're not yours -- I can't figure out if `subprojects/` is third party content.
I'm happy to split into, e.g. API, docs, code as requested.

--
Generated by https://github.com/jsoref/spelling `f` -- this is the misspelled `a` family

In short, my tool identifies candidates, I manually select and inspect candidates, and corrections are chosen by me manually (although I often let Google suggest the correction instead of typing it myself as it has a lower typo rate).

This is part 2 (part one was #8147)