### PR TITLE
Support dependencies on multiple variants of the same component

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedComponentResult.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.internal.scan.UsedByScanPlugin;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -75,7 +76,21 @@ public interface ResolvedComponentResult extends ComponentResult {
      * @return the resolved variant for this component
      *
      * @since 4.6
+     *
+     * @deprecated Use {@link #getVariants()} instead}
      */
     @Incubating
+    @Deprecated
     ResolvedVariantResult getVariant();
+
+    /**
+     * Returns the variants that were selected for this component. When Gradle metadata is not used, this usually only refers to the target
+     * "configuration" (for an Ivy dependency) or "scope" (for a Maven dependency).
+     *
+     * @return the resolved variants for this component
+     *
+     * @since 5.2
+     */
+    @Incubating
+    List<ResolvedVariantResult> getVariants();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.dependencies;
 
+import com.google.common.base.Objects;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
@@ -153,6 +154,9 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
             return false;
         }
         if (this.buildProjectDependencies != that.buildProjectDependencies) {
+            return false;
+        }
+        if (!Objects.equal(getAttributes(), that.getAttributes())) {
             return false;
         }
         return true;

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDependencyResolutionTest {
+
+    ResolveTestFixture resolve
+
+    def setup() {
+        buildFile << """
+            allprojects {
+                apply plugin: 'java-library'
+            }
+        """
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.prepare()
+    }
+
+    def "can select both main variant and test fixtures with project dependencies"() {
+        given:
+        settingsFile << "include 'lib'"
+
+        file("lib/build.gradle") << """
+            configurations {
+                testFixtures {
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'test-fixtures'))
+                    }
+                }
+            }
+
+            artifacts {
+                testFixtures file("lib-test-fixtures.jar")
+            }
+        """
+
+        buildFile << """
+            dependencies {
+                implementation project(':lib')
+                implementation (project(':lib')) {
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'test-fixtures'))
+                    }
+                }
+            }
+        """
+
+        when:
+        succeeds ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                project(":lib", "test:lib:") {
+                    variant "apiElements", ['org.gradle.usage':'java-api']
+                    artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
+                }
+                project(":lib", "test:lib:") {
+                    variant "testFixtures", ['org.gradle.usage':'test-fixtures']
+                    artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
+                }
+            }
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -48,6 +48,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'test-fixtures'))
                     }
+                    outgoing.capability('org:lib-fixtures:1.0')
                 }
             }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -1030,58 +1030,6 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         'c2'                        | 'c1'                      | 'c2'                      | 'runtime'             | 'api'                      | 'runtime'                  | 'runtime'
     }
 
-    @RequiredFeatures(
-            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
-    void "can select distinct variants of the same component by using different attributes"() {
-        given:
-        repository {
-            'org:test:1.0' {
-                variant('api') {
-                    attribute('custom', 'c1')
-                }
-                variant('runtime') {
-                    attribute('custom', 'c2')
-                }
-            }
-        }
-
-        buildFile << """
-            dependencies {
-                conf('org:test:1.0') {
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, 'c1')
-                    }
-                }
-                conf('org:test:1.0') {
-                    attributes {
-                        attribute(CUSTOM_ATTRIBUTE, 'c2')
-                    }
-                }
-            }
-        """
-
-        when:
-        repositoryInteractions {
-            'org:test:1.0' {
-                expectResolve()
-            }
-        }
-        succeeds 'checkDeps'
-
-        then:
-        resolve.expectGraph {
-            root(":", ":test:") {
-                module('org:test:1.0') {
-                    variant('api', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1'])
-                }
-                module('org:test:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2'])
-                }
-            }
-        }
-    }
-
     static Closure<String> defaultStatus() {
         { -> GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release' }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -107,7 +107,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects variant #expectedVariant using custom attribute value #attributeValue")
     def "attribute value is used during selection"() {
@@ -158,7 +158,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects variant #expectedVariant using typed attribute value #attributeValue")
     @Issue("gradle/gradle#5232")
@@ -218,7 +218,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Issue("gradle/gradle#5232")
     def "Serializes and reads back failed resolution when failure comes from an unmatched typed attribute"() {
@@ -270,7 +270,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     def "Merges consumer configuration attributes with dependency attributes"() {
         given:
@@ -317,7 +317,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     def "Fails resolution because consumer configuration attributes and dependency attributes conflict"() {
         given:
@@ -365,7 +365,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects variant #expectedVariant using custom attribute value #dependencyValue overriding configuration attribute #configurationValue")
     def "dependency attribute value overrides configuration attribute"() {
@@ -418,7 +418,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects variant #expectedVariant using custom attribute value #dependencyValue overriding configuration attribute #configurationValue using dependency constraint")
     def "dependency attribute value overrides configuration attribute using dependency constraint"() {
@@ -478,7 +478,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     def "Fails resolution because consumer configuration attributes and constraint attributes conflict"() {
         given:
@@ -529,54 +529,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
-    )
-    def "Fails resolution because dependency attributes and constraint attributes conflict"() {
-        given:
-        repository {
-            'org:test:1.0' {
-                variant('api') {
-                    attribute('custom', 'c1')
-                }
-                variant('runtime') {
-                    attribute('custom', 'c2')
-                }
-            }
-        }
-
-        buildFile << """
-            dependencies {
-                constraints {
-                    conf('org:test:1.0') {
-                        attributes {
-                            attribute(CUSTOM_ATTRIBUTE, 'c2')
-                        }
-                    }
-                }
-                conf('org:test') {
-                   attributes {
-                      attribute(CUSTOM_ATTRIBUTE, 'c1')
-                   }
-                }
-            }
-        """
-
-        when:
-        repositoryInteractions {
-            'org:test:1.0' {
-                expectGetMetadata()
-            }
-        }
-        fails 'checkDeps'
-
-        then:
-        failure.assertHasCause("""Cannot select a variant of 'org:test' because different values for attribute 'custom' are requested:
-  - Dependency path ':test:unspecified' wants 'org:test' with attribute custom = c1
-  - Constraint path ':test:unspecified' wants 'org:test:1.0' with attribute custom = c2""")
-    }
-
-    @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects variant #expectedVariant using dependency attribute value #attributeValue set in a metadata rule")
     def "attribute value set by metadata rule is used during selection"() {
@@ -708,7 +661,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects variant #expectedVariant using transitive dependency attribute value #attributeValue set in a metadata rule")
     def "attribute value set by metadata rule on transitive dependency is used during selection"() {
@@ -857,7 +810,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects direct=#expectedDirectVariant, transitive=[#expectedTransitiveVariantA, #expectedTransitiveVariantB], leaf=#expectedLeafVariant making sure dependency attribute value doesn't leak to transitives")
     def "Attribute value on dependency only affects selection of this dependency (using component metadata rules)"() {
@@ -981,7 +934,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
     @Unroll("Selects direct=#expectedDirectVariant, transitive=[#expectedTransitiveVariantA, #expectedTransitiveVariantB], leaf=#expectedLeafVariant making sure dependency attribute value doesn't leak to transitives (using published metadata)")
     def "Attribute value on dependency only affects selection of this dependency (using published metadata)"() {
@@ -1078,36 +1031,12 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
     }
 
     @RequiredFeatures(
-        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
     )
-    def "fails when 2 transitive dependencies requires a different attribute value"() {
+    void "can select distinct variants of the same component by using different attributes"() {
         given:
         repository {
-            'org:directA:1.0' {
-                variant('api') {
-                    dependsOn('org:transitive:1.0') {
-                        attribute('custom', 'c1')
-                    }
-                }
-                variant('runtime') {
-                    dependsOn('org:transitive:1.0') {
-                        attribute('custom', 'c1')
-                    }
-                }
-            }
-            'org:directB:1.0' {
-                variant('api') {
-                    dependsOn('org:transitive:1.0') {
-                        attribute('custom', 'c2')
-                    }
-                }
-                variant('runtime') {
-                    dependsOn('org:transitive:1.0') {
-                        attribute('custom', 'c2')
-                    }
-                }
-            }
-            'org:transitive:1.0' {
+            'org:test:1.0' {
                 variant('api') {
                     attribute('custom', 'c1')
                 }
@@ -1119,29 +1048,38 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         buildFile << """
             dependencies {
-               conf('org:directA:1.0')
-               conf('org:directB:1.0')
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c1')
+                    }
+                }
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c2')
+                    }
+                }
             }
         """
 
         when:
         repositoryInteractions {
-            'org:directA:1.0' {
-                expectGetMetadata()
-            }
-            'org:directB:1.0' {
-                expectGetMetadata()
-            }
-            'org:transitive:1.0' {
-                expectGetMetadata()
+            'org:test:1.0' {
+                expectResolve()
             }
         }
-        fails 'checkDeps'
+        succeeds 'checkDeps'
 
         then:
-        failure.assertHasCause("""Cannot select a variant of 'org:transitive' because different values for attribute 'custom' are requested:
-  - Dependency path ':test:unspecified' --> 'org:directA:1.0' wants 'org:transitive:1.0' with attribute custom = c1
-  - Dependency path ':test:unspecified' --> 'org:directB:1.0' wants 'org:transitive:1.0' with attribute custom = c2""")
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:test:1.0') {
+                    variant('api', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1'])
+                }
+                module('org:test:1.0') {
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2'])
+                }
+            }
+        }
     }
 
     static Closure<String> defaultStatus() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def setup() {
+        buildFile << """
+            def CUSTOM_ATTRIBUTE = Attribute.of('custom', String)
+            dependencies.attributesSchema.attribute(CUSTOM_ATTRIBUTE)
+        """
+    }
+
+    @RequiredFeatures(
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    void "can select distinct variants of the same component by using different attributes"() {
+        given:
+        repository {
+            'org:test:1.0' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c1')
+                    }
+                }
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c2')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:test:1.0') {
+                    variant('api', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1'])
+                }
+                module('org:test:1.0') {
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2'])
+                }
+            }
+        }
+    }
+
+    @RequiredFeatures(
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "selects 2 variants of the same component when transitive dependency"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                    artifact('c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                    artifact('c2')
+                }
+            }
+            'org:foo:1.1' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                    artifact('c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                    artifact('c2')
+                }
+            }
+            'org:bar:1.0' {
+                variant('api') {
+                    dependsOn('org:foo:1.1') {
+                        attributes.custom = 'c1'
+                    }
+                }
+                variant('runtime') {
+                    dependsOn('org:foo:1.1') {
+                        attributes.custom = 'c1'
+                    }
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c2')
+                    }
+                }
+                conf('org:bar:1.0')
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:bar:1.0' {
+                expectResolve()
+            }
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
+            'org:foo:1.1' {
+                expectGetMetadata()
+                expectGetVariantArtifacts('api')
+                expectGetVariantArtifacts('runtime')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:foo:1.0', 'org:foo:1.1') {
+                    byConflictResolution('between versions 1.0 and 1.1')
+                    // the following assertion is true but limitations to the test fixtures make it hard to check
+                    //variant('api',[custom:'c1', 'org.gradle.status':'integration', 'org.gradle.usage':'java-api'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c1'
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c2'
+                }
+                module('org:bar:1.0') {
+                    module('org:foo:1.1')
+                }
+            }
+        }
+
+    }
+
+    @RequiredFeatures(
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "selects a single variant of the same component when asking for a consumer specific attribute"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                    artifact('c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                    artifact('c2')
+                }
+            }
+            'org:foo:1.1' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                    artifact('c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                    artifact('c2')
+                }
+            }
+            'org:bar:1.0' {
+                variant('api') {
+                    dependsOn('org:foo:1.1') {
+                        attributes.custom = 'c2'
+                    }
+                }
+                variant('runtime') {
+                    dependsOn('org:foo:1.1') {
+                        attributes.custom = 'c2'
+                    }
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0') {
+                    attributes {
+                        attribute(Attribute.of("other", String), 'unused')
+                    }
+                }
+                conf('org:bar:1.0')
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:bar:1.0' {
+                expectResolve()
+            }
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
+            'org:foo:1.1' {
+                expectGetMetadata()
+                expectGetVariantArtifacts('runtime')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:foo:1.0', 'org:foo:1.1') {
+                    byConflictResolution('between versions 1.0 and 1.1')
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c2'
+                }
+                module('org:bar:1.0') {
+                    module('org:foo:1.1')
+                }
+            }
+        }
+    }
+
+    @RequiredFeatures(
+            @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+    )
+    def "can select both main variant and test fixtures of a single component"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {}
+                variant('runtime') {}
+                variant('test-fixtures') {
+                    attribute('test-fixtures', 'true')
+                    artifact('test-fixtures')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0')
+                conf('org:foo:1.0') {
+                    attributes {
+                        // This setup is for tests only. Do not assume this is the right
+                        // way to define test fixtures
+                        attribute(Attribute.of("test-fixtures", String), 'true')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectResolve()
+                expectGetVariantArtifacts('test-fixtures')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:foo:1.0') {
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0'
+                }
+                module('org:foo:1.0') {
+                    variant('test-fixtures', ['org.gradle.status': defaultStatus(), 'test-fixtures': 'true'])
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'test-fixtures'
+                }
+            }
+        }
+    }
+
+    static Closure<String> defaultStatus() {
+        { -> GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release' }
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyModuleResolveIntegrationTest.groovy
@@ -362,7 +362,8 @@ task retrieve(type: Sync) {
             root(":", "org.test:test:1.0") {
                 module("ivy.configuration:projectA:1.2:a") {
                     module("ivy.configuration:projectB:1.5") {
-                        variant('a+c', ['org.gradle.status': 'integration']) // b, parent are redundant
+                        variant('a', ['org.gradle.status': 'integration']) // b, parent are redundant
+                        variant('c', ['org.gradle.status': 'integration']) // b, parent are redundant
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -195,8 +195,8 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                         } else {
                             if (GradleMetadataResolveRunner.useIvy()) {
                                 // Ivy doesn't derive any variant
-                                expectedTargetVariant = 'default+customVariant'
-                                expectedAttributes = ['org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
+                                expectedTargetVariant = 'customVariant'
+                                expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                             } else {
                                 // for Maven, we derive variants for compile/runtime. Variants are then used during selection, and are subject
                                 // to metadata rules. In this case, we have multiple variants (default, runtime, compile), but only the "compile"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ConflictResolverDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ConflictResolverDetails.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 import javax.annotation.Nullable;
 import java.util.Collection;
 
-public interface ConflictResolverDetails<T extends ComponentResolutionState> {
+public interface ConflictResolverDetails<T> {
     Collection<? extends T> getCandidates();
 
     void select(T candidate);
@@ -27,8 +27,6 @@ public interface ConflictResolverDetails<T extends ComponentResolutionState> {
 
     @Nullable
     T getSelected();
-
-    boolean isRestart();
 
     @Nullable
     Throwable getFailure();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/LatestModuleConflictResolver.java
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-class LatestModuleConflictResolver implements ModuleConflictResolver {
+class LatestModuleConflictResolver<T extends ComponentResolutionState> implements ModuleConflictResolver<T> {
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
 
@@ -37,7 +37,7 @@ class LatestModuleConflictResolver implements ModuleConflictResolver {
     }
 
     @Override
-    public <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details) {
+    public void select(ConflictResolverDetails<T> details) {
         // Find the candidates with the highest base version
         Version baseVersion = null;
         Map<Version, T> matches = new LinkedHashMap<Version, T>();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ModuleConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ModuleConflictResolver.java
@@ -15,12 +15,11 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine;
 
-public interface ModuleConflictResolver {
+public interface ModuleConflictResolver<T> {
     /**
      * Selects matching candidate. Returns null if this implementation of the resolver is not able to select a candidate.
      *
      * @param details the conflict resolution details
-     * @param <T> the candidate type
      */
-    <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details);
+    void select(ConflictResolverDetails<T> details);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ProjectDependencyForcingResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/ProjectDependencyForcingResolver.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-class ProjectDependencyForcingResolver implements ModuleConflictResolver {
+class ProjectDependencyForcingResolver<T extends ComponentResolutionState> implements ModuleConflictResolver<T> {
     private final ModuleConflictResolver delegate;
 
     ProjectDependencyForcingResolver(ModuleConflictResolver delegate) {
@@ -32,7 +32,7 @@ class ProjectDependencyForcingResolver implements ModuleConflictResolver {
     }
 
     @Override
-    public <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details) {
+    public void select(ConflictResolverDetails<T> details) {
         // the collection will only be initialized if more than one project candidate is found
         Collection<T> projectCandidates = null;
         T foundProjectCandidate = null;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/DependencyGraphNode.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 
@@ -49,4 +50,8 @@ public interface DependencyGraphNode {
     Set<? extends LocalFileDependencyMetadata> getOutgoingFileEdges();
 
     ConfigurationMetadata getMetadata();
+
+    boolean isSelected();
+
+    ComponentResolutionState getComponent();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedGraphComponent.java
@@ -19,10 +19,9 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
-import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * The final representation of a component in the resolved dependency graph.
@@ -51,22 +50,10 @@ public interface ResolvedGraphComponent {
     ComponentSelectionReason getSelectionReason();
 
     /**
-     * Returns the name of the resolved variant. This can currently be 2 different things: for legacy components,
-     * it's going to be the name of a "configuration" (either a project configuration, an Ivy configuration name or a Maven "scope").
-     * For components with variants, it's going to be the name of the variant. This name is going to be used for reporting purposes.
-     */
-    DisplayName getVariantName();
-
-    /**
-     * Returns the attributes of the resolved variant. This is going to be used for reporting purposes. In practice, variant attributes
-     * should effectively be what defines the _identity_ of the variant. In practice, because we have multiple kind of components, it's
-     * not necessarily the case.
-     */
-    AttributeContainer getVariantAttributes();
-
-    /**
      * Returns the name of the repository used to source this component, or {@code null} if this component was not resolved from a repository.
      */
     @Nullable
     String getRepositoryName();
+
+    List<ResolvedVariantDetails> getResolvedVariants();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedVariantDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedVariantDetails.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
+
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.internal.DisplayName;
+
+public interface ResolvedVariantDetails {
+    /**
+     * Returns the name of the resolved variant. This can currently be 2 different things: for legacy components,
+     * it's going to be the name of a "configuration" (either a project configuration, an Ivy configuration name or a Maven "scope").
+     * For components with variants, it's going to be the name of the variant. This name is going to be used for reporting purposes.
+     */
+    DisplayName getVariantName();
+
+    /**
+     * Returns the attributes of the resolved variant. This is going to be used for reporting purposes. In practice, variant attributes
+     * should effectively be what defines the _identity_ of the variant. In practice, because we have multiple kind of components, it's
+     * not necessarily the case.
+     */
+    AttributeContainer getVariantAttributes();
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 
 import java.util.Set;
 
@@ -59,6 +60,14 @@ abstract class AttributeDesugaring {
             if (!moduleAttributes.isEmpty()) {
                 ImmutableAttributes attributes = ((AttributeContainerInternal) moduleAttributes).asImmutable();
                 return DefaultModuleComponentSelector.newSelector(module.getModuleIdentifier(), module.getVersionConstraint(), desugar(attributes, attributesFactory));
+            }
+        }
+        if (selector instanceof DefaultProjectComponentSelector) {
+            DefaultProjectComponentSelector project = (DefaultProjectComponentSelector) selector;
+            AttributeContainer projectAttributes = project.getAttributes();
+            if (!projectAttributes.isEmpty()) {
+                ImmutableAttributes attributes = ((AttributeContainerInternal) projectAttributes).asImmutable();
+                return new DefaultProjectComponentSelector(project.getBuildIdentifier(), project.getIdentityPath(), project.projectPath(), project.getProjectName(), desugar(attributes, attributesFactory));
             }
         }
         return selector;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -27,12 +27,12 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.RepositoryChainModuleSource;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.DependencyGraphComponent;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.VersionConflictResolutionDetails;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionDescriptorInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasonInternal;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapability;
@@ -45,6 +45,7 @@ import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.DefaultBuildableComponentResolveResult;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -251,25 +252,32 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     }
 
     @Override
-    public DisplayName getVariantName() {
-        DisplayName name = null;
-        List<String> names = null;
+    public List<ResolvedVariantDetails> getResolvedVariants() {
+        List<ResolvedVariantDetails> result = null;
+        ResolvedVariantDetails cur = null;
         for (NodeState node : nodes) {
             if (node.isSelected()) {
-                if (names == null) {
-                    names = Lists.newArrayListWithCapacity(nodes.size());
+                DisplayName name = Describables.of(node.getMetadata().getName());
+                AttributeContainer attributes = AttributeDesugaring.desugar(node.getMetadata().getAttributes(), node.getAttributesFactory());
+                ResolvedVariantDetails details = new DefaultVariantDetails(name, attributes);
+                if (result != null) {
+                    result.add(details);
+                } else if (cur != null) {
+                    result = Lists.newArrayList();
+                    result.add(cur);
+                    result.add(details);
+                } else {
+                    cur = details;
                 }
-                names.add(node.getMetadata().getName());
             }
         }
-        name = variantNameBuilder.getVariantName(names);
-        return name == null ? UNKNOWN_VARIANT : name;
-    }
-
-    @Override
-    public AttributeContainer getVariantAttributes() {
-        NodeState selected = getSelectedNode();
-        return selected == null ? ImmutableAttributes.EMPTY : AttributeDesugaring.desugar(selected.getMetadata().getAttributes(), selected.getAttributesFactory());
+        if (result != null) {
+            return result;
+        }
+        if (cur != null) {
+            return Collections.singletonList(cur);
+        }
+        return Collections.emptyList();
     }
 
     /**
@@ -422,4 +430,5 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         }
         return null;
     }
+
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -389,11 +389,28 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         }
     }
 
+    Capability getImplicitCapability() {
+        return implicitCapability;
+    }
+
     Capability findCapability(String group, String name) {
         if (id.getGroup().equals(group) && id.getName().equals(name)) {
             return implicitCapability;
         }
         return null;
+    }
+
+    boolean hasMoreThanOneSelectedNodeUsingVariantAwareResolution() {
+        int count = 0;
+        for (NodeState node : nodes) {
+            if (node.isSelectedByVariantAwareResolution()) {
+                count++;
+                if (count == 2) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -53,12 +53,9 @@ import java.util.Set;
  * Resolution state for a given component
  */
 public class ComponentState implements ComponentResolutionState, DependencyGraphComponent {
-    private static final DisplayName UNKNOWN_VARIANT = Describables.of("unknown");
-
     private final ComponentIdentifier componentIdentifier;
     private final ModuleVersionIdentifier id;
     private final ComponentMetaDataResolver resolver;
-    private final VariantNameBuilder variantNameBuilder;
     private final List<NodeState> nodes = Lists.newLinkedList();
     private final Long resultId;
     private final ModuleResolveState module;
@@ -75,13 +72,12 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
     private boolean rejected;
     private boolean root;
 
-    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver, VariantNameBuilder variantNameBuilder) {
+    ComponentState(Long resultId, ModuleResolveState module, ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier, ComponentMetaDataResolver resolver) {
         this.resultId = resultId;
         this.module = module;
         this.id = id;
         this.componentIdentifier = componentIdentifier;
         this.resolver = resolver;
-        this.variantNameBuilder = variantNameBuilder;
         this.implicitCapability = new ImmutableCapability(id.getGroup(), id.getName(), id.getVersion());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import com.google.common.collect.Lists;
-import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -390,39 +389,9 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         }
     }
 
-
-    public void forEachCapability(Action<? super Capability> action) {
-        // check conflict for each target node
-        for (NodeState target : nodes) {
-            List<? extends Capability> capabilities = target.getMetadata().getCapabilities().getCapabilities();
-            // The isEmpty check is not required, might look innocent, but Guava's performance bad for an empty immutable list
-            // because it still creates an inner class for an iterator, which delegates to an Array iterator, which does... nothing.
-            // so just adding this check has a significant impact because most components do not declare any capability
-            if (!capabilities.isEmpty()) {
-                for (Capability capability : capabilities) {
-                    action.execute(capability);
-                }
-            }
-        }
-    }
-
-    public Capability findCapability(String group, String name) {
+    Capability findCapability(String group, String name) {
         if (id.getGroup().equals(group) && id.getName().equals(name)) {
             return implicitCapability;
-        }
-        return findCapabilityOnTarget(group, name);
-    }
-
-    private Capability findCapabilityOnTarget(String group, String name) {
-        for (NodeState target : nodes) {
-            List<? extends Capability> capabilities = target.getMetadata().getCapabilities().getCapabilities();
-            if (!capabilities.isEmpty()) { // Not required, but Guava's performance bad for an empty immutable list
-                for (Capability capability : capabilities) {
-                    if (capability.getGroup().equals(group) && capability.getName().equals(name)) {
-                        return capability;
-                    }
-                }
-            }
         }
         return null;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultVariantDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultVariantDetails.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails;
+import org.gradle.internal.DisplayName;
+
+public class DefaultVariantDetails implements ResolvedVariantDetails {
+    private final DisplayName name;
+    private final AttributeContainer attributes;
+
+    public DefaultVariantDetails(DisplayName name, AttributeContainer attributes) {
+        this.name = name;
+        this.attributes = attributes;
+    }
+
+    @Override
+    public DisplayName getVariantName() {
+        return name;
+    }
+
+    @Override
+    public AttributeContainer getVariantAttributes() {
+        return attributes;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -196,7 +196,7 @@ public class DependencyGraphBuilder {
                         for (ComponentState version : versions) {
                             List<NodeState> nodes = version.getNodes();
                             for (NodeState nodeState : nodes) {
-                                if (nodeState.isSelected()) {
+                                if (nodeState.isSelected() && doesNotDeclareExplicitCapability(nodeState)) {
                                     implicitProvidersForCapability.add(nodeState);
                                 }
                             }
@@ -210,6 +210,10 @@ public class DependencyGraphBuilder {
                 if (c.conflictExists()) {
                     c.withParticipatingModules(resolveState.getDeselectVersionAction());
                 }
+            }
+
+            private boolean doesNotDeclareExplicitCapability(NodeState nodeState) {
+                return nodeState.getMetadata().getCapabilities().getCapabilities().isEmpty();
             }
         });
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -162,7 +162,7 @@ public class DependencyGraphBuilder {
                 LOGGER.debug("Visiting configuration {}.", node);
 
                 // Register capabilities for this node
-                registerCapabilities(resolveState, node.getComponent());
+                registerCapabilities(resolveState, node);
 
                 // Initialize and collect any new outgoing edges of this node
                 dependencies.clear();
@@ -180,23 +180,32 @@ public class DependencyGraphBuilder {
         }
     }
 
-    private void registerCapabilities(final ResolveState resolveState, final ComponentState moduleRevision) {
-        moduleRevision.forEachCapability(new Action<Capability>() {
+    private void registerCapabilities(final ResolveState resolveState, final NodeState node) {
+        node.forEachCapability(new Action<Capability>() {
             @Override
             public void execute(Capability capability) {
                 // This is a performance optimization. Most modules do not declare capabilities. So, instead of systematically registering
                 // an implicit capability for each module that we see, we only consider modules which _declare_ capabilities. If they do,
                 // then we try to find a module which provides the same capability. It that module has been found, then we register it.
                 // Otherwise, we have nothing to do. This avoids most of registrations.
-                Collection<ComponentState> implicitProvidersForCapability = Collections.emptyList();
+                Collection<NodeState> implicitProvidersForCapability = Collections.emptyList();
                 for (ModuleResolveState state : resolveState.getModules()) {
                     if (state.getId().getGroup().equals(capability.getGroup()) && state.getId().getName().equals(capability.getName())) {
-                        implicitProvidersForCapability = state.getVersions();
+                        Collection<ComponentState> versions = state.getVersions();
+                        implicitProvidersForCapability = Lists.newArrayListWithExpectedSize(versions.size());
+                        for (ComponentState version : versions) {
+                            List<NodeState> nodes = version.getNodes();
+                            for (NodeState nodeState : nodes) {
+                                if (nodeState.isSelected()) {
+                                    implicitProvidersForCapability.add(nodeState);
+                                }
+                            }
+                        }
                         break;
                     }
                 }
                 PotentialConflict c = capabilitiesConflictHandler.registerCandidate(
-                    DefaultCapabilitiesConflictHandler.candidate(moduleRevision, capability, implicitProvidersForCapability)
+                    DefaultCapabilitiesConflictHandler.candidate(node, capability, implicitProvidersForCapability)
                 );
                 if (c.conflictExists()) {
                     c.withParticipatingModules(resolveState.getDeselectVersionAction());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -164,7 +164,7 @@ class EdgeState implements DependencyGraphEdge {
 
     public ImmutableAttributes getAttributes() {
         ModuleResolveState module = selector.getTargetModule();
-        return module.getMergedSelectorAttributes();
+        return module.mergedConstraintsAttributes(dependencyState.getRequested().getAttributes());
     }
 
     private void calculateTargetConfigurations(ComponentState targetComponent) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -81,7 +81,7 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         if (targetComponent instanceof LenientPlatformResolveMetadata) {
             LenientPlatformResolveMetadata platformMetadata = (LenientPlatformResolveMetadata) targetComponent;
-            return Collections.<ConfigurationMetadata>singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.getPlatformState(), platformId));
+            return Collections.singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.getPlatformState(), platformId));
         }
         // the target component exists, so we need to fallback to the traditional selection process
         return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -57,7 +57,6 @@ class ModuleResolveState implements CandidateModule {
     private final List<EdgeState> unattachedDependencies = new LinkedList<EdgeState>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<ModuleVersionIdentifier, ComponentState>();
     private final List<SelectorState> selectors = Lists.newArrayListWithExpectedSize(4);
-    private final VariantNameBuilder variantNameBuilder;
     private final ImmutableAttributesFactory attributesFactory;
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
@@ -74,7 +73,6 @@ class ModuleResolveState implements CandidateModule {
     ModuleResolveState(IdGenerator<Long> idGenerator,
                        ModuleIdentifier id,
                        ComponentMetaDataResolver metaDataResolver,
-                       VariantNameBuilder variantNameBuilder,
                        ImmutableAttributesFactory attributesFactory,
                        Comparator<Version> versionComparator,
                        VersionParser versionParser,
@@ -83,7 +81,6 @@ class ModuleResolveState implements CandidateModule {
         this.idGenerator = idGenerator;
         this.id = id;
         this.metaDataResolver = metaDataResolver;
-        this.variantNameBuilder = variantNameBuilder;
         this.attributesFactory = attributesFactory;
         this.versionComparator = versionComparator;
         this.versionParser = versionParser;
@@ -262,7 +259,7 @@ class ModuleResolveState implements CandidateModule {
     public ComponentState getVersion(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier) {
         ComponentState moduleRevision = versions.get(id);
         if (moduleRevision == null) {
-            moduleRevision = new ComponentState(idGenerator.generateId(), this, id, componentIdentifier, metaDataResolver, variantNameBuilder);
+            moduleRevision = new ComponentState(idGenerator.generateId(), this, id, componentIdentifier, metaDataResolver);
             versions.put(id, moduleRevision);
         }
         return moduleRevision;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -77,7 +77,7 @@ public class NodeState implements DependencyGraphNode {
     // In opposite to outgoing edges, virtual edges are for now pretty rare, so they are created lazily
     private List<EdgeState> virtualEdges;
     private boolean queued;
-    private boolean excluded;
+    private boolean evicted;
 
     public NodeState(Long resultId, ResolvedConfigurationIdentifier id, ComponentState component, ResolveState resolveState, ConfigurationMetadata md) {
         this.resultId = resultId;
@@ -389,8 +389,8 @@ public class NodeState implements DependencyGraphNode {
         return !incomingEdges.isEmpty();
     }
 
-    public void exclude() {
-        excluded = true;
+    public void evict() {
+        evicted = true;
         restartIncomingEdges();
     }
 
@@ -464,7 +464,7 @@ public class NodeState implements DependencyGraphNode {
         // If this configuration belongs to the select version, queue ourselves up for traversal.
         // If not, then remove our incoming edges, which triggers them to be moved across to the selected configuration
         if (component == selected) {
-            if (!excluded) {
+            if (!evicted) {
                 resolveState.onMoreSelected(this);
             }
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ReplaceSelectionWithConflictResultAction.java
@@ -28,13 +28,24 @@ class ReplaceSelectionWithConflictResultAction implements Action<ConflictResolut
     }
 
     public void execute(final ConflictResolutionResult result) {
-        final ComponentState selected = result.getSelected();
+        Object selected = result.getSelected();
+        final ComponentState component = findComponent(selected);
         result.withParticipatingModules(new Action<ModuleIdentifier>() {
             public void execute(ModuleIdentifier moduleIdentifier) {
                 // Restart each configuration. For the evicted configuration, this means moving incoming dependencies across to the
                 // matching selected configuration. For the select configuration, this mean traversing its dependencies.
-                resolveState.getModule(moduleIdentifier).restart(selected);
+                resolveState.getModule(moduleIdentifier).restart(component);
             }
         });
+    }
+
+    private ComponentState findComponent(Object selected) {
+        if (selected instanceof ComponentState) {
+            return (ComponentState) selected;
+        }
+        if (selected instanceof NodeState) {
+            return ((NodeState) selected).getComponent();
+        }
+        return null;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ResolveState.java
@@ -70,7 +70,6 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     private final ComponentSelectorConverter componentSelectorConverter;
     private final ImmutableAttributesFactory attributesFactory;
     private final DependencySubstitutionApplicator dependencySubstitutionApplicator;
-    private final VariantNameBuilder variantNameBuilder = new VariantNameBuilder();
     private final VersionSelectorScheme versionSelectorScheme;
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
@@ -128,7 +127,7 @@ class ResolveState implements ComponentStateFactory<ComponentState> {
     public ModuleResolveState getModule(ModuleIdentifier id) {
         ModuleResolveState module = modules.get(id);
         if (module == null) {
-            module = new ModuleResolveState(idGenerator, id, metaDataResolver, variantNameBuilder, attributesFactory, versionComparator, versionParser, selectorStateResolver, resolveOptimizations);
+            module = new ModuleResolveState(idGenerator, id, metaDataResolver, attributesFactory, versionComparator, versionParser, selectorStateResolver, resolveOptimizations);
             modules.put(id, module);
         }
         return module;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
@@ -17,15 +17,15 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
 
 import java.util.Collection;
 
 public interface CapabilitiesConflictHandler extends ConflictHandler<CapabilitiesConflictHandler.Candidate, ConflictResolutionResult, CapabilitiesConflictHandler.Resolver> {
     interface Candidate {
-        ComponentState getComponent();
+        NodeState getNode();
         Capability getCapability();
-        Collection<ComponentState> getImplicitCapabilityProviders();
+        Collection<NodeState> getImplicitCapabilityProviders();
     }
 
     interface ResolutionDetails extends ConflictResolutionResult {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CompositeConflictResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CompositeConflictResolver.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver;
 
@@ -25,12 +24,12 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 
-class CompositeConflictResolver implements ModuleConflictResolver {
+class CompositeConflictResolver<T> implements ModuleConflictResolver<T> {
 
     private final List<ModuleConflictResolver> resolvers = new LinkedList<ModuleConflictResolver>();
 
     @Override
-    public <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details) {
+    public void select(ConflictResolverDetails<T> details) {
         CompositeDetails<T> composite = new CompositeDetails<T>(details);
         for (ModuleConflictResolver r : resolvers) {
             r.select(composite);
@@ -46,7 +45,7 @@ class CompositeConflictResolver implements ModuleConflictResolver {
         resolvers.add(0, conflictResolver);
     }
 
-    private static class CompositeDetails<T extends ComponentResolutionState> implements ConflictResolverDetails<T> {
+    private static class CompositeDetails<T> implements ConflictResolverDetails<T> {
         private final ConflictResolverDetails<T> delegate;
         private boolean hasResult;
 
@@ -74,11 +73,6 @@ class CompositeConflictResolver implements ModuleConflictResolver {
         @Override
         public T getSelected() {
             return delegate.getSelected();
-        }
-
-        @Override
-        public boolean isRestart() {
-            return delegate.isRestart();
         }
 
         @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/ConflictResolutionResult.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 
 public interface ConflictResolutionResult {
 
@@ -31,6 +30,6 @@ public interface ConflictResolutionResult {
     /**
      * The actual selected version.
      */
-    <T extends ComponentResolutionState> T getSelected();
+    <T> T getSelected();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -198,7 +198,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
 
                             @Override
                             public void evict() {
-                                node.exclude();
+                                node.evict();
                                 evicted.add(node);
                             }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolutionResult.java
@@ -18,15 +18,14 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 
 import java.util.Collection;
 
-class DefaultConflictResolutionResult implements ConflictResolutionResult {
+class DefaultConflictResolutionResult<T> implements ConflictResolutionResult {
     private final Collection<? extends ModuleIdentifier> participatingModules;
-    private final ComponentResolutionState selected;
+    private final T selected;
 
-    public DefaultConflictResolutionResult(Collection<? extends ModuleIdentifier> participatingModules, ComponentResolutionState selected) {
+    public DefaultConflictResolutionResult(Collection<? extends ModuleIdentifier> participatingModules, T selected) {
         this.participatingModules = participatingModules;
         this.selected = selected;
     }
@@ -37,7 +36,7 @@ class DefaultConflictResolutionResult implements ConflictResolutionResult {
         }
     }
 
-    public ComponentResolutionState getSelected() {
+    public T getSelected() {
         return selected;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolverDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultConflictResolverDetails.java
@@ -15,17 +15,15 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
 
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
 
-public class DefaultConflictResolverDetails<T extends ComponentResolutionState> implements ConflictResolverDetails<T> {
+public class DefaultConflictResolverDetails<T> implements ConflictResolverDetails<T> {
     private final Collection<? extends T> participants;
     private T selected;
     private Throwable failure;
-    private boolean restart;
 
     public DefaultConflictResolverDetails(Collection<? extends T> participants) {
         this.participants = participants;
@@ -38,9 +36,6 @@ public class DefaultConflictResolverDetails<T extends ComponentResolutionState> 
 
     @Override
     public void select(T candidate) {
-        if (restart) {
-            throw new IllegalStateException("Cannot select a candidate if another candidate has been queued for restart");
-        }
         selected = candidate;
     }
 
@@ -52,11 +47,6 @@ public class DefaultConflictResolverDetails<T extends ComponentResolutionState> 
     @Override
     public T getSelected() {
         return selected;
-    }
-
-    @Override
-    public boolean isRestart() {
-        return restart;
     }
 
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/PotentialConflictFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/PotentialConflictFactory.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
 
 import java.util.Set;
 
@@ -26,7 +25,7 @@ class PotentialConflictFactory {
 
     private static final PotentialConflict NO_CONFLICT = new NoConflict();
 
-    static PotentialConflict potentialConflict(final ConflictContainer<ModuleIdentifier, ? extends ComponentResolutionState>.Conflict conflict) {
+    static <T> PotentialConflict potentialConflict(final ConflictContainer<ModuleIdentifier, T>.Conflict conflict) {
         if (conflict == null) {
             return NO_CONFLICT;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
@@ -23,11 +24,15 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionIdentifierSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.DefaultVariantDetails;
+import org.gradle.internal.Describables;
 import org.gradle.internal.serialize.Decoder;
 import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.Serializer;
 
 import java.io.IOException;
+import java.util.List;
 
 public class ComponentResultSerializer implements Serializer<ResolvedGraphComponent> {
 
@@ -48,10 +53,20 @@ public class ComponentResultSerializer implements Serializer<ResolvedGraphCompon
         ModuleVersionIdentifier id = idSerializer.read(decoder);
         ComponentSelectionReason reason = reasonSerializer.read(decoder);
         ComponentIdentifier componentId = componentIdSerializer.read(decoder);
-        String variantName = decoder.readString();
-        AttributeContainer attributes = attributeContainerSerializer.read(decoder);
+        List<ResolvedVariantDetails> resolvedVariants = readResolvedVariants(decoder);
         String repositoryName = decoder.readNullableString();
-        return new DetachedComponentResult(resultId, id, reason, componentId, variantName, attributes, repositoryName);
+        return new DetachedComponentResult(resultId, id, reason, componentId, resolvedVariants, repositoryName);
+    }
+
+    private List<ResolvedVariantDetails> readResolvedVariants(Decoder decoder) throws IOException {
+        int size = decoder.readSmallInt();
+        ImmutableList.Builder<ResolvedVariantDetails> builder = ImmutableList.builderWithExpectedSize(size);
+        for (int i=0; i<size; i++) {
+            String variantName = decoder.readString();
+            AttributeContainer attributes = attributeContainerSerializer.read(decoder);
+            builder.add(new DefaultVariantDetails(Describables.of(variantName), attributes));
+        }
+        return builder.build();
     }
 
     public void write(Encoder encoder, ResolvedGraphComponent value) throws IOException {
@@ -59,8 +74,15 @@ public class ComponentResultSerializer implements Serializer<ResolvedGraphCompon
         idSerializer.write(encoder, value.getModuleVersion());
         reasonSerializer.write(encoder, value.getSelectionReason());
         componentIdSerializer.write(encoder, value.getComponentId());
-        encoder.writeString(value.getVariantName().getDisplayName());
-        attributeContainerSerializer.write(encoder, value.getVariantAttributes());
+        writeSelectedVariantDetails(encoder, value.getResolvedVariants());
         encoder.writeNullableString(value.getRepositoryName());
+    }
+
+    private void writeSelectedVariantDetails(Encoder encoder, List<ResolvedVariantDetails> variants) throws IOException {
+        encoder.writeSmallInt(variants.size());
+        for (ResolvedVariantDetails variant : variants) {
+            encoder.writeString(variant.getVariantName().getDisplayName());
+            attributeContainerSerializer.write(encoder, variant.getVariantAttributes());
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.UnresolvedDependency;
@@ -30,17 +31,19 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails;
 import org.gradle.api.internal.artifacts.result.DefaultResolutionResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedComponentResult;
 import org.gradle.api.internal.artifacts.result.DefaultResolvedVariantResult;
-import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Describables;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -50,7 +53,7 @@ public class DefaultResolutionResultBuilder {
 
     public static ResolutionResult empty(ModuleVersionIdentifier id, ComponentIdentifier componentIdentifier) {
         DefaultResolutionResultBuilder builder = new DefaultResolutionResultBuilder();
-        builder.visitComponent(new DetachedComponentResult(0L, id, ComponentSelectionReasons.root(), componentIdentifier, "<empty>", ImmutableAttributes.EMPTY, null));
+        builder.visitComponent(new DetachedComponentResult(0L, id, ComponentSelectionReasons.root(), componentIdentifier, Collections.emptyList(), null));
         return builder.complete(0L);
     }
 
@@ -62,8 +65,13 @@ public class DefaultResolutionResultBuilder {
         create(component.getResultId(), component.getModuleVersion(), component.getSelectionReason(), component.getComponentId(), variantDetails(component), component.getRepositoryName());
     }
 
-    private static ResolvedVariantResult variantDetails(ResolvedGraphComponent component) {
-        return new DefaultResolvedVariantResult(component.getVariantName(), component.getVariantAttributes());
+    private static List<ResolvedVariantResult> variantDetails(ResolvedGraphComponent component) {
+        List<ResolvedVariantDetails> resolvedVariants = component.getResolvedVariants();
+        ImmutableList.Builder<ResolvedVariantResult> builder = ImmutableList.builderWithExpectedSize(resolvedVariants.size());
+        for (ResolvedVariantDetails resolvedVariant : resolvedVariants) {
+            builder.add(new DefaultResolvedVariantResult(resolvedVariant.getVariantName(), resolvedVariant.getVariantAttributes()));
+        }
+        return builder.build();
     }
 
     public void visitOutgoingEdges(Long fromComponent, Collection<? extends ResolvedGraphDependency> dependencies) {
@@ -81,9 +89,9 @@ public class DefaultResolutionResultBuilder {
         }
     }
 
-    private void create(Long id, ModuleVersionIdentifier moduleVersion, ComponentSelectionReason selectionReason, ComponentIdentifier componentId, ResolvedVariantResult variant, String repoName) {
+    private void create(Long id, ModuleVersionIdentifier moduleVersion, ComponentSelectionReason selectionReason, ComponentIdentifier componentId, List<ResolvedVariantResult> variants, String repoName) {
         if (!modules.containsKey(id)) {
-            modules.put(id, new DefaultResolvedComponentResult(moduleVersion, selectionReason, componentId, variant, repoName));
+            modules.put(id, new DefaultResolvedComponentResult(moduleVersion, selectionReason, componentId, variants, repoName));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DesugaredAttributeContainerSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DesugaredAttributeContainerSerializer.java
@@ -69,7 +69,7 @@ public class DesugaredAttributeContainerSerializer extends AbstractSerializer<At
                 encoder.writeByte(BOOLEAN_ATTRIBUTE);
                 encoder.writeBoolean((Boolean) container.getAttribute(attribute));
             } else {
-                assert attribute.getType().equals(String.class);
+                assert attribute.getType().equals(String.class) : "Unexpected attribute type " + attribute.getType() + " : should be " + String.class.getSimpleName();
                 encoder.writeByte(STRING_ATTRIBUTE);
                 encoder.writeString((String) container.getAttribute(attribute));
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedComponentResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DetachedComponentResult.java
@@ -19,10 +19,10 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
-import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent;
-import org.gradle.internal.Describables;
-import org.gradle.internal.DisplayName;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails;
+
+import java.util.List;
 
 /**
  * A {@link ResolvedGraphComponent} implementation that is detached from the original resolution process.
@@ -33,17 +33,15 @@ public class DetachedComponentResult implements ResolvedGraphComponent {
     private final ModuleVersionIdentifier id;
     private final ComponentSelectionReason reason;
     private final ComponentIdentifier componentIdentifier;
-    private final DisplayName variantName;
-    private final AttributeContainer variantAttributes;
+    private final List<ResolvedVariantDetails> resolvedVariants;
     private final String repositoryName;
 
-    public DetachedComponentResult(Long resultId, ModuleVersionIdentifier id, ComponentSelectionReason reason, ComponentIdentifier componentIdentifier, String variantName, AttributeContainer variantAttributes, String repositoryName) {
+    public DetachedComponentResult(Long resultId, ModuleVersionIdentifier id, ComponentSelectionReason reason, ComponentIdentifier componentIdentifier, List<ResolvedVariantDetails> resolvedVariants, String repositoryName) {
         this.resultId = resultId;
         this.id = id;
         this.reason = reason;
         this.componentIdentifier = componentIdentifier;
-        this.variantName = Describables.of(variantName);
-        this.variantAttributes = variantAttributes;
+        this.resolvedVariants = resolvedVariants;
         this.repositoryName = repositoryName;
     }
 
@@ -65,17 +63,12 @@ public class DetachedComponentResult implements ResolvedGraphComponent {
     }
 
     @Override
-    public DisplayName getVariantName() {
-        return variantName;
-    }
-
-    @Override
-    public AttributeContainer getVariantAttributes() {
-        return variantAttributes;
-    }
-
-    @Override
     public String getRepositoryName() {
         return repositoryName;
+    }
+
+    @Override
+    public List<ResolvedVariantDetails> getResolvedVariants() {
+        return resolvedVariants;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -22,11 +22,17 @@ import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.VariantNameBuilder;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.Describables;
+import org.gradle.internal.DisplayName;
 
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class DefaultResolvedComponentResult implements ResolvedComponentResultInternal {
     private final ModuleVersionIdentifier moduleVersion;
@@ -34,18 +40,18 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     private final Set<ResolvedDependencyResult> dependents = new LinkedHashSet<ResolvedDependencyResult>();
     private final ComponentSelectionReason selectionReason;
     private final ComponentIdentifier componentId;
-    private final ResolvedVariantResult variant;
+    private final List<ResolvedVariantResult> variants;
     private final String repositoryName;
 
-    public DefaultResolvedComponentResult(ModuleVersionIdentifier moduleVersion, ComponentSelectionReason selectionReason, ComponentIdentifier componentId, ResolvedVariantResult variant, String repositoryName) {
+    public DefaultResolvedComponentResult(ModuleVersionIdentifier moduleVersion, ComponentSelectionReason selectionReason, ComponentIdentifier componentId, List<ResolvedVariantResult> variants, String repositoryName) {
         assert moduleVersion != null;
         assert selectionReason != null;
-        assert variant != null;
+        assert variants != null;
 
         this.moduleVersion = moduleVersion;
         this.selectionReason = selectionReason;
         this.componentId = componentId;
-        this.variant = variant;
+        this.variants = variants;
         this.repositoryName = repositoryName;
     }
 
@@ -93,11 +99,24 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
 
     @Override
     public ResolvedVariantResult getVariant() {
-        return variant;
+        if (variants.isEmpty()) {
+            return new DefaultResolvedVariantResult(Describables.of("<empty>"), ImmutableAttributes.EMPTY);
+        }
+        // Returns an approximation of a composite variant
+        List<String> parts = variants.stream()
+                .map(ResolvedVariantResult::getDisplayName)
+                .collect(Collectors.toList());
+        DisplayName variantName = new VariantNameBuilder().getVariantName(parts);
+        return new DefaultResolvedVariantResult(variantName, variants.get(0).getAttributes());
     }
 
     @Override
     public String toString() {
         return getId().getDisplayName();
+    }
+
+    @Override
+    public List<ResolvedVariantResult> getVariants() {
+        return variants;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -39,7 +39,11 @@ public abstract class AttributeConfigurationSelector {
         }
         List<ConfigurationMetadata> matches = attributeMatcher.matches(consumableConfigurations, consumerAttributes, fallbackConfiguration);
         if (matches.size() == 1) {
-            return matches.get(0);
+            ConfigurationMetadata match = matches.get(0);
+            if (variantsForGraphTraversal.isPresent()) {
+                return SelectedByVariantMatchingConfigurationMetadata.of(match);
+            }
+            return match;
         } else if (!matches.isEmpty()) {
             throw new AmbiguousConfigurationSelectionException(consumerAttributes, attributeMatcher, matches, targetComponent, variantsForGraphTraversal.isPresent());
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingConfigurationMetadata.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.internal.DisplayName;
+
+import java.util.List;
+import java.util.Set;
+
+public class DefaultSelectedByVariantMatchingConfigurationMetadata implements SelectedByVariantMatchingConfigurationMetadata {
+
+    private final ConfigurationMetadata delegate;
+
+    DefaultSelectedByVariantMatchingConfigurationMetadata(ConfigurationMetadata delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public ImmutableSet<String> getHierarchy() {
+        return delegate.getHierarchy();
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public DisplayName asDescribable() {
+        return delegate.asDescribable();
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return delegate.getAttributes();
+    }
+
+    @Override
+    public List<? extends DependencyMetadata> getDependencies() {
+        return delegate.getDependencies();
+    }
+
+    @Override
+    public List<? extends ComponentArtifactMetadata> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+
+    @Override
+    public Set<? extends VariantResolveMetadata> getVariants() {
+        return delegate.getVariants();
+    }
+
+    @Override
+    public ImmutableList<ExcludeMetadata> getExcludes() {
+        return delegate.getExcludes();
+    }
+
+    @Override
+    public boolean isTransitive() {
+        return delegate.isTransitive();
+    }
+
+    @Override
+    public boolean isVisible() {
+        return delegate.isVisible();
+    }
+
+    @Override
+    public boolean isCanBeConsumed() {
+        return delegate.isCanBeConsumed();
+    }
+
+    @Override
+    public boolean isCanBeResolved() {
+        return delegate.isCanBeResolved();
+    }
+
+    @Override
+    public ComponentArtifactMetadata artifact(IvyArtifactName artifact) {
+        return delegate.artifact(artifact);
+    }
+
+    @Override
+    public CapabilitiesMetadata getCapabilities() {
+        return delegate.getCapabilities();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        DefaultSelectedByVariantMatchingConfigurationMetadata that = (DefaultSelectedByVariantMatchingConfigurationMetadata) o;
+        return Objects.equal(delegate, that.delegate);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(delegate);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingLocalConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultSelectedByVariantMatchingLocalConfigurationMetadata.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import org.gradle.internal.component.local.model.LocalComponentArtifactMetadata;
+import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
+import org.gradle.internal.component.local.model.LocalFileDependencyMetadata;
+
+import java.util.List;
+import java.util.Set;
+
+public class DefaultSelectedByVariantMatchingLocalConfigurationMetadata extends DefaultSelectedByVariantMatchingConfigurationMetadata implements LocalConfigurationMetadata {
+    private final LocalConfigurationMetadata delegate;
+
+    DefaultSelectedByVariantMatchingLocalConfigurationMetadata(ConfigurationMetadata delegate) {
+        super(delegate);
+        this.delegate = (LocalConfigurationMetadata) delegate;
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public Set<String> getExtendsFrom() {
+        return delegate.getExtendsFrom();
+    }
+
+    @Override
+    public Set<LocalFileDependencyMetadata> getFiles() {
+        return delegate.getFiles();
+    }
+
+    public List<? extends LocalOriginDependencyMetadata> getDependencies() {
+        return delegate.getDependencies();
+    }
+
+    @Override
+    public List<? extends LocalComponentArtifactMetadata> getArtifacts() {
+        return delegate.getArtifacts();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/SelectedByVariantMatchingConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/SelectedByVariantMatchingConfigurationMetadata.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component.model;
+
+import org.gradle.internal.component.local.model.LocalConfigurationMetadata;
+
+/**
+ * A class which only delegates to another configuration, used by the dependency
+ * management engine to recognize that a configuration was selected via variant-aware
+ * selection.
+ */
+public interface SelectedByVariantMatchingConfigurationMetadata extends ConfigurationMetadata {
+
+    static SelectedByVariantMatchingConfigurationMetadata of(ConfigurationMetadata delegate) {
+        if (delegate instanceof LocalConfigurationMetadata) {
+            return new DefaultSelectedByVariantMatchingLocalConfigurationMetadata(delegate);
+        }
+        return new DefaultSelectedByVariantMatchingConfigurationMetadata(delegate);
+    }
+
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandlerTest.groovy
@@ -18,11 +18,15 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.capabilities.CapabilitiesMetadata
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
+import org.gradle.api.internal.artifacts.ResolvedConfigurationIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState
 import org.gradle.internal.component.external.model.CapabilityInternal
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
+import org.gradle.internal.component.model.ConfigurationMetadata
 import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Subject
@@ -31,6 +35,8 @@ class DefaultCapabilitiesConflictHandlerTest extends Specification {
 
     @Subject
     DefaultCapabilitiesConflictHandler handler = new DefaultCapabilitiesConflictHandler()
+
+    private long id
 
     @Issue("gradle/gradle#5920")
     def "order of components should be preserved"() {
@@ -78,7 +84,7 @@ class DefaultCapabilitiesConflictHandlerTest extends Specification {
 
     CapabilitiesConflictHandler.Candidate candidate(CapabilityInternal cap, ComponentState co) {
         Mock(CapabilitiesConflictHandler.Candidate) {
-            getComponent() >> co
+            getNode() >> node(co)
             getCapability() >> cap
             getImplicitCapabilityProviders() >> []
         }
@@ -98,6 +104,19 @@ class DefaultCapabilitiesConflictHandlerTest extends Specification {
         Mock(CapabilityInternal) {
             getGroup() >> group
             getName() >> name
+        }
+    }
+
+    NodeState node(ComponentState cs) {
+        return new NodeState(id++, Mock(ResolvedConfigurationIdentifier), cs, null, Mock(ConfigurationMetadata) {
+            getCapabilities() >> Mock(CapabilitiesMetadata) {
+                getCapabilities() >> []
+            }
+        }) {
+            @Override
+            boolean isSelected() {
+                return true;
+            }
         }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -272,9 +272,9 @@ class SelectorStateResolverTest extends Specification {
         }
     }
 
-    static class FailingConflictResolver implements ModuleConflictResolver {
+    static class FailingConflictResolver<T> implements ModuleConflictResolver<T> {
         @Override
-        <T extends ComponentResolutionState> void select(ConflictResolverDetails<T> details) {
+        void select(ConflictResolverDetails<T> details) {
             assert false : "Unexpected conflict resolution: " + details.candidates.collect {it.id}
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilderSpec.groovy
@@ -20,12 +20,11 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
 import org.gradle.api.artifacts.result.ComponentSelectionReason
-import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphComponent
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedGraphDependency
-import org.gradle.internal.DisplayName
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector
 import org.gradle.internal.resolve.ModuleVersionResolveException
@@ -269,9 +268,8 @@ class DefaultResolutionResultBuilderSpec extends Specification {
         ModuleVersionIdentifier moduleVersion
         ComponentSelectionReason selectionReason
         ComponentIdentifier componentId
-        DisplayName variantName
-        AttributeContainer variantAttributes
         String repositoryName
+        List<ResolvedVariantDetails> resolvedVariants = []
     }
 
     class DummyInternalDependencyResult implements ResolvedGraphDependency {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -135,7 +135,7 @@ class DefaultResolutionResultTest extends Specification {
         def dep = new DefaultUnresolvedDependencyResult(
             Stub(ComponentSelector), false,
             Stub(ComponentSelectionReason),
-            new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, Stub(ResolvedVariantResult), null),
+            new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, [Stub(ResolvedVariantResult)], null),
             new ModuleVersionNotFoundException(Stub(ModuleComponentSelector), "too bad")
         )
         def edge = new UnresolvedDependencyEdge(dep)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -44,7 +44,7 @@ class ResolutionResultDataBuilder {
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1', ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested(), ResolvedVariantResult variant = newVariant(), String repoId = null) {
-        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), variant, repoId)
+        new DefaultResolvedComponentResult(newId(group, module, version), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, module), version), [variant], repoId)
     }
 
     static DefaultResolvedDependencyResult newDependency(ComponentSelector componentSelector, String group='a', String module='a', String selectedVersion='1') {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1704,7 +1704,10 @@ org:leaf2:1.0
         then:
         outputContains """
 project :
-   variant "compile+runtimeElements"
+   variant "compile"
+   variant "runtimeElements" [
+      org.gradle.usage = java-runtime-jars (not requested)
+   ]
 
 project :
 \\--- project :impl

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/DependencyInsightReportTask.java
@@ -167,6 +167,7 @@ public class DependencyInsightReportTask extends DefaultTask {
      * Tells if the report should only display a single path to each dependency, which
      * can be useful when the graph is large. This is false by default, meaning that for
      * each dependency, the report will display all paths leading to it.
+     *
      * @since 4.9
      */
     @Option(option = "singlepath", description = "Show at most one path to each dependency")
@@ -244,12 +245,12 @@ public class DependencyInsightReportTask extends DefaultTask {
     private void assertValidTaskConfiguration(Configuration configuration) {
         if (configuration == null) {
             throw new InvalidUserDataException("Dependency insight report cannot be generated because the input configuration was not specified. "
-                + "\nIt can be specified from the command line, e.g: '" + getPath() + " --configuration someConf --dependency someDep'");
+                    + "\nIt can be specified from the command line, e.g: '" + getPath() + " --configuration someConf --dependency someDep'");
         }
 
         if (dependencySpec == null) {
             throw new InvalidUserDataException("Dependency insight report cannot be generated because the dependency to show was not specified."
-                + "\nIt can be specified from the command line, e.g: '" + getPath() + " --dependency someDep'");
+                    + "\nIt can be specified from the command line, e.g: '" + getPath() + " --dependency someDep'");
         }
     }
 
@@ -365,8 +366,8 @@ public class DependencyInsightReportTask extends DefaultTask {
         }
 
         private void printVariantDetails(StyledTextOutput out, RenderableDependency dependency) {
-            ResolvedVariantResult resolvedVariant = dependency.getResolvedVariant();
-            if (resolvedVariant != null) {
+            List<ResolvedVariantResult> resolvedVariants = dependency.getResolvedVariants();
+            for (ResolvedVariantResult resolvedVariant : resolvedVariants) {
                 out.println();
                 out.withStyle(Description).text("   variant \"" + resolvedVariant.getDisplayName() + "\"");
                 AttributeContainer attributes = resolvedVariant.getAttributes();
@@ -387,8 +388,8 @@ public class DependencyInsightReportTask extends DefaultTask {
 
         private AttributeContainer concat(AttributeContainer configAttributes, AttributeContainer dependencyAttributes) {
             return attributesFactory.concat(
-                ((AttributeContainerInternal) configAttributes).asImmutable(),
-                ((AttributeContainerInternal) dependencyAttributes).asImmutable());
+                    ((AttributeContainerInternal) configAttributes).asImmutable(),
+                    ((AttributeContainerInternal) dependencyAttributes).asImmutable());
         }
 
         private void writeAttributeBlock(StyledTextOutput out, AttributeContainer attributes, AttributeContainer requested) {

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableDependency.java
@@ -42,8 +42,8 @@ public abstract class AbstractRenderableDependency implements RenderableDependen
     }
 
     @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return null;
+    public List<ResolvedVariantResult> getResolvedVariants() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableModuleResult.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/AbstractRenderableModuleResult.java
@@ -20,6 +20,8 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
+import java.util.List;
+
 public abstract class AbstractRenderableModuleResult extends AbstractRenderableDependency {
 
     protected final ResolvedComponentResult module;
@@ -39,8 +41,8 @@ public abstract class AbstractRenderableModuleResult extends AbstractRenderableD
     }
 
     @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return module.getVariant();
+    public List<ResolvedVariantResult> getResolvedVariants() {
+        return module.getVariants();
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyEdge.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.result.ComponentSelectionReason;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
+import java.util.List;
 import java.util.Set;
 
 public interface DependencyEdge {
@@ -34,7 +35,7 @@ public interface DependencyEdge {
 
     ComponentSelectionReason getReason();
 
-    ResolvedVariantResult getSelectedVariant();
+    List<ResolvedVariantResult> getSelectedVariants();
 
     Set<? extends RenderableDependency> getChildren();
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/DependencyReportHeader.java
@@ -29,13 +29,13 @@ import java.util.List;
 public class DependencyReportHeader extends AbstractRenderableDependency implements HasAttributes {
     private final DependencyEdge dependency;
     private final String description;
-    private final ResolvedVariantResult selectedVariant;
+    private final List<ResolvedVariantResult> selectedVariants;
     private final List<Section> extraDetails;
 
-    public DependencyReportHeader(DependencyEdge dependency, String description, ResolvedVariantResult resolvedVariantResult, List<Section> extraDetails) {
+    public DependencyReportHeader(DependencyEdge dependency, String description, List<ResolvedVariantResult> resolvedVariants, List<Section> extraDetails) {
         this.dependency = dependency;
         this.description = description;
-        this.selectedVariant = resolvedVariantResult;
+        this.selectedVariants = resolvedVariants;
         this.extraDetails = extraDetails;
     }
 
@@ -60,8 +60,8 @@ public class DependencyReportHeader extends AbstractRenderableDependency impleme
     }
 
     @Override
-    public ResolvedVariantResult getResolvedVariant() {
-        return selectedVariant;
+    public List<ResolvedVariantResult> getResolvedVariants() {
+        return selectedVariants;
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/RenderableDependency.java
@@ -30,7 +30,7 @@ public interface RenderableDependency {
     Object getId();
     String getName();
     String getDescription();
-    ResolvedVariantResult getResolvedVariant();
+    List<ResolvedVariantResult> getResolvedVariants();
     ResolutionState getResolutionState();
     Set<? extends RenderableDependency> getChildren();
     List<Section> getExtraDetails();

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/ResolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/ResolvedDependencyEdge.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.result.ResolvedDependencyResult;
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class ResolvedDependencyEdge implements DependencyEdge {
@@ -48,8 +49,8 @@ public class ResolvedDependencyEdge implements DependencyEdge {
     }
 
     @Override
-    public ResolvedVariantResult getSelectedVariant() {
-        return dependency.getSelected().getVariant();
+    public List<ResolvedVariantResult> getSelectedVariants() {
+        return dependency.getSelected().getVariants();
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/graph/nodes/UnresolvedDependencyEdge.java
@@ -28,6 +28,7 @@ import org.gradle.internal.component.local.model.DefaultProjectComponentSelector
 import org.gradle.internal.component.local.model.OpaqueComponentIdentifier;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 public class UnresolvedDependencyEdge implements DependencyEdge {
@@ -73,8 +74,8 @@ public class UnresolvedDependencyEdge implements DependencyEdge {
     }
 
     @Override
-    public ResolvedVariantResult getSelectedVariant() {
-        return null;
+    public List<ResolvedVariantResult> getSelectedVariants() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporter.java
@@ -114,8 +114,8 @@ public class DependencyInsightReporter {
         }
 
         buildFailureSection(dependency, alreadyReportedErrors, extraDetails);
-        ResolvedVariantResult selectedVariant = dependency.getSelectedVariant();
-        return new DependencyReportHeader(dependency, reasonShortDescription, selectedVariant, extraDetails);
+        List<ResolvedVariantResult> selectedVariants = dependency.getSelectedVariants();
+        return new DependencyReportHeader(dependency, reasonShortDescription, selectedVariants, extraDetails);
     }
 
     private RequestedVersion newRequestedVersion(LinkedList<RenderableDependency> out, DependencyEdge dependency) {

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -190,11 +190,11 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private static DefaultResolvedDependencyResult dep(String group, String name, String requested, String selected = requested, ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested()) {
-        def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant(), "repoId")
+        def selectedModule = new DefaultResolvedComponentResult(newId(group, name, selected), selectionReason, new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), [defaultVariant()], "repoId")
         new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId(group, name), requested),
                 false,
                 selectedModule,
-                new DefaultResolvedComponentResult(newId("a", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), defaultVariant(), "repoId"))
+                new DefaultResolvedComponentResult(newId("a", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId(group, name), selected), [defaultVariant()], "repoId"))
     }
 
     private static DefaultResolvedVariantResult defaultVariant() {
@@ -202,10 +202,10 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private static DefaultResolvedDependencyResult path(String path) {
-        DefaultResolvedComponentResult from = new DefaultResolvedComponentResult(newId("group", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("group", "root"), "1"), defaultVariant(), "repoId")
+        DefaultResolvedComponentResult from = new DefaultResolvedComponentResult(newId("group", "root", "1"), ComponentSelectionReasons.requested(), new DefaultModuleComponentIdentifier(DefaultModuleIdentifier.newId("group", "root"), "1"), [defaultVariant()], "repoId")
         List<DefaultResolvedDependencyResult> pathElements = (path.split(' -> ') as List).reverse().collect {
             def (name, version) = it.split(':')
-            def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), ComponentSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('group', name), version), defaultVariant(), "repoId")
+            def componentResult = new DefaultResolvedComponentResult(newId('group', name, version), ComponentSelectionReasons.requested(), DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId('group', name), version), [defaultVariant()], "repoId")
             def result = new DefaultResolvedDependencyResult(newSelector(DefaultModuleIdentifier.newId("group", name), version), false, componentResult, from)
             from = componentResult
             result

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures.resolve
 
 import com.google.common.base.Joiner
+import groovy.transform.Canonical
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ModuleVersionIdentifier
@@ -109,7 +110,15 @@ allprojects {
         def expectedRoot = "[id:${graph.root.id}][mv:${graph.root.moduleVersionId}][reason:${graph.root.reason}]".toString()
         assert actualRoot.startsWith(expectedRoot)
 
-        def expectedFirstLevel = graph.root.deps.findAll { !it.constraint }.collect { "[${it.selected.moduleVersionId}:${it.selected.configuration}]" } as Set
+        def expectedFirstLevel = graph.root.deps.findAll { !it.constraint }.collect { d ->
+            def configs = d.selected.configurations.collect {
+                "[${d.selected.moduleVersionId}:${it}]"
+            }
+            if (configs.empty) {
+                configs = ["[${d.selected.moduleVersionId}:$defaultConfig"]
+            }
+            configs
+        }.flatten() as Set
 
         def actualFirstLevel = findLines(configDetails, 'first-level')
         compare("first level dependencies", actualFirstLevel, expectedFirstLevel)
@@ -124,13 +133,19 @@ allprojects {
         compare("lenient filtered first level dependencies", actualFirstLevel, expectedFirstLevel)
 
         def actualConfigurations = findLines(configDetails, 'configuration') as Set
-        def expectedConfigurations = graph.nodesWithoutRoot.collect { "[${it.moduleVersionId}]".toString() } - graph.virtualConfigurations.collect { "[${it}]".toString() }
+        def expectedConfigurations = graph.nodesWithoutRoot.collect { "[${it.moduleVersionId}]".toString() } - graph.virtualConfigurations.collect { "[${it}]".toString() } as Set
         compare("configurations in graph", actualConfigurations, expectedConfigurations)
 
         def actualComponents = findLines(configDetails, 'component')
-        def expectedComponents = graph.nodes.collect {
-            def variantDetails = it.checkVariant ? "[variant:name:${it.variantName} attributes:${it.variantAttributes}]" : ''
-            "[id:${it.id}][mv:${it.moduleVersionId}][reason:${it.reason}]$variantDetails"
+        def expectedComponents = graph.nodes.collect { baseNode ->
+            def variantDetails = ''
+            def variants = baseNode.variants.collect { variant ->
+                "variant:name:${variant.name} attributes:${variant.attributes}"
+            }
+            if (variants) {
+                variantDetails = "[${variants.join('@@')}]"
+            }
+            "[id:${baseNode.id}][mv:${baseNode.moduleVersionId}][reason:${baseNode.reason}]$variantDetails"
         }
         compareNodes("components in graph", parseNodes(actualComponents), parseNodes(expectedComponents))
 
@@ -222,28 +237,31 @@ allprojects {
             throw new IllegalArgumentException("Missing reasons in '$line'")
         }
         List<String> reasons = line.substring(start, idx).split('!!') as List<String>
+        Set<Variant> variants = []
         start = idx + 15
-        String variant = null
-        Map<String, String> attributes = [:]
-        if (start<line.length()) {
+        while (start < line.length()) {
             idx = line.indexOf(' attributes:', start) // [variant name:
-            variant = line.substring(start, idx)
+            String variant = line.substring(start, idx)
             start = idx + 12
-            idx = line.indexOf(']', start) // attributes:
-            attributes = line.substring(start, idx)
-                .split(',') // attributes are separated by commas
-                .findAll() // only keep non empty entries (thank you, split!)
-                .collectEntries { it.split('=') as List }
+            idx = line.indexOf('@@', start)
+            if (idx < 0) {
+                idx = line.indexOf(']', start) // attributes:
+            }
+            Map<String, String> attributes = line.substring(start, idx)
+                    .split(',') // attributes are separated by commas
+                    .findAll() // only keep non empty entries (thank you, split!)
+                    .collectEntries { it.split('=') as List }
+            start = idx + 15 // '@@'
+            variants << new Variant(name: variant, attributes: attributes)
         }
-        new ParsedNode(id: id, module:module, reasons: reasons, variant: variant, attributes: attributes)
+        new ParsedNode(id: id, module: module, reasons: reasons, variants: variants)
     }
 
     static class ParsedNode {
         String id
         String module
         List<String> reasons
-        String variant
-        Map<String, String> attributes
+        Set<Variant> variants = []
 
         boolean diff(ParsedNode actual, StringBuilder sb) {
             List<String> errors = []
@@ -260,12 +278,14 @@ allprojects {
                     }
                 }
             }
-            if (variant) {
-                if (variant != actual.variant) {
-                    errors << "Expected variant name $variant, but was: $actual.variant"
-                }
-                if (attributes != actual.attributes) {
-                    errors << "Expected variant attributes $attributes, but was: $actual.attributes"
+            variants.each { variant ->
+                def actualVariant = actual.variants.find { it.name == variant.name }
+                if (!actualVariant) {
+                    errors << "Expected variant name $variant, but wasn't found in: $actual.variants.name"
+                } else {
+                    if (variant.attributes != actualVariant.attributes) {
+                        errors << "On variant $variant.name, expected attributes $variant.attributes, but was: $actualVariant.attributes"
+                    }
                 }
             }
 
@@ -280,7 +300,7 @@ allprojects {
         }
 
         String toString() {
-            "id: $id, module: $module, reasons: ${reasons}${variant?', variant ' + variant:''}${attributes?', variant attributes' + attributes:''}"
+            "id: $id, module: $module, reasons: ${reasons}${variants}"
         }
     }
 
@@ -299,11 +319,11 @@ allprojects {
             }
         }
         actualSorted.each { node ->
-            if (!expectedSorted.find { it.id == node.id } ) {
+            if (!expectedSorted.find { it.id == node.id }) {
                 errors.append("Found unexpected node $node")
             }
         }
-        if (errors.length()>0) {
+        if (errors.length() > 0) {
             throw new AssertionError("Result contains unexpected $compType\n${errors}\nMatched $compType:\n${matched}")
         }
     }
@@ -326,7 +346,7 @@ allprojects {
     }
 
     static class GraphBuilder {
-        private final Map<String, NodeBuilder> nodes = new LinkedHashMap<>()
+        private final Map<String, NodeBuilder> nodes = [:]
         private NodeBuilder root
         private String defaultConfig
 
@@ -458,11 +478,11 @@ allprojects {
         def node(String id, String moduleVersion, Map attrs) {
             def node = nodes[moduleVersion]
             if (!node) {
-                if (!attrs.configuration) {
-                    attrs.configuration = defaultConfig
-                }
                 node = new NodeBuilder(id, moduleVersion, attrs, this)
                 nodes[moduleVersion] = node
+            }
+            if (attrs.configuration) {
+                node.configuration(attrs.configuration)
             }
             return node
         }
@@ -515,6 +535,16 @@ allprojects {
         }
     }
 
+    @Canonical
+    static class Variant {
+        String name
+        String attributes
+
+        String toString() {
+            "variant $name, variant attributes $attributes"
+        }
+    }
+
     static class NodeBuilder {
         final List<EdgeBuilder> deps = []
         private final GraphBuilder graph
@@ -523,13 +553,12 @@ allprojects {
         final String group
         final String module
         final String version
-        String configuration
+        final Set<String> configurations = []
         private boolean implicitArtifact = true
         final List<String> files = []
         private final Set<ExpectedArtifact> artifacts = new LinkedHashSet<>()
         private final Set<String> reasons = new TreeSet<String>()
-        String variantName
-        String variantAttributes
+        Set<Variant> variants = []
 
         boolean checkVariant
 
@@ -538,11 +567,11 @@ allprojects {
             this.group = attrs.group
             this.module = attrs.module
             this.version = attrs.version
-            this.configuration = attrs.configuration
             this.moduleVersionId = moduleVersionId
             this.id = id
-            this.variantName = attrs.variantName
-            this.variantAttributes = attrs.variantAttributes
+            if (attrs.variantName) {
+                variant(attrs.variantName, attrs.variantAttributes)
+            }
         }
 
         Set<ExpectedArtifact> getArtifacts() {
@@ -587,7 +616,7 @@ allprojects {
             def (group, name, version) = parts
             def attrs = [group: group, module: name, version: version]
             def node = graph.node(id, moduleVersionId, attrs)
-            deps << new EdgeBuilder(this, requestedVersion?"${group}:${name}:${requestedVersion}":moduleVersionId, node)
+            deps << new EdgeBuilder(this, requestedVersion ? "${group}:${name}:${requestedVersion}" : moduleVersionId, node)
             return node
         }
 
@@ -749,13 +778,24 @@ allprojects {
         }
 
         NodeBuilder variant(String name, Map<String, ?> attributes = [:]) {
+            configuration(name)
             checkVariant = true
-            variantName = name
-            variantAttributes = attributes.collect { "$it.key=$it.value" }.sort().join(',')
+            String variantName = name
+            String variantAttributes = attributes.collect { "$it.key=$it.value" }.sort().join(',')
             if (id.startsWith("project ")) {
                 configuration = variantName
             }
+            variants << new Variant(name: variantName, attributes: variantAttributes)
             this
+        }
+
+        void setConfiguration(String configuration) {
+            configurations.clear()
+            configurations.add(configuration)
+        }
+
+        void configuration(String configuration) {
+            configurations << configuration
         }
     }
 
@@ -802,7 +842,7 @@ class GenerateGraphTask extends DefaultTask {
                 writer.println("component:${formatComponent(it)}")
             }
             configuration.incoming.resolutionResult.allDependencies.each {
-                writer.println("dependency:${it.constraint ? '[constraint]' : '' }[from:${it.from.id}][${it.requested}->${it.selected.id}]")
+                writer.println("dependency:${it.constraint ? '[constraint]' : ''}[from:${it.from.id}][${it.requested}->${it.selected.id}]")
             }
             if (buildArtifacts) {
                 configuration.files.each {
@@ -866,7 +906,10 @@ class GenerateGraphTask extends DefaultTask {
     }
 
     def formatComponent(ResolvedComponentResult result) {
-        return "[id:${result.id}][mv:${result.moduleVersion}][reason:${formatReason(result.selectionReason)}][variant:${formatVariant(result.variant)}]"
+        String variants = result.variants.collect { variant ->
+            "variant:${formatVariant(variant)}"
+        }.join('@@')
+        "[id:${result.id}][mv:${result.moduleVersion}][reason:${formatReason(result.selectionReason)}][$variants]"
     }
 
     def formatVariant(ResolvedVariantResult variant) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -513,6 +513,7 @@ allprojects {
         String classifier
         String type
         String name
+        boolean noType
 
         String getType() {
             return type ?: 'jar'
@@ -527,11 +528,11 @@ allprojects {
         }
 
         String getArtifactName() {
-            return "${getName()}${classifier ? '-' + classifier : ''}.${getType()}"
+            return "${getName()}${classifier ? '-' + classifier : ''}${noType ? '' : '.' + getType()}"
         }
 
         String getFileName() {
-            return "${getName()}${version ? '-' + version : ''}${classifier ? '-' + classifier : ''}.${getType()}"
+            return "${getName()}${version ? '-' + version : ''}${classifier ? '-' + classifier : ''}${noType ? '' : '.' + getType()}"
         }
     }
 
@@ -698,7 +699,7 @@ allprojects {
          * Specifies an artifact for this node. A default is assumed when none specified
          */
         NodeBuilder artifact(Map attributes) {
-            def artifact = new ExpectedArtifact(group: group, module: module, version: version, name: attributes.name, classifier: attributes.classifier, type: attributes.type)
+            def artifact = new ExpectedArtifact(group: group, module: module, version: version, name: attributes.name, classifier: attributes.classifier, type: attributes.type, noType: attributes.noType?:false)
             artifacts << artifact
             return this
         }
@@ -782,9 +783,6 @@ allprojects {
             checkVariant = true
             String variantName = name
             String variantAttributes = attributes.collect { "$it.key=$it.value" }.sort().join(',')
-            if (id.startsWith("project ")) {
-                configuration = variantName
-            }
             variants << new Variant(name: variantName, attributes: variantAttributes)
             this
         }
@@ -884,13 +882,13 @@ class GenerateGraphTask extends DefaultTask {
             }
 
             configuration.resolvedConfiguration.resolvedArtifacts.each {
-                writer.println("artifact:[${it.moduleVersion.id}][${it.name}${it.classifier ? "-" + it.classifier : ""}.${it.extension}]")
+                writer.println("artifact:[${it.moduleVersion.id}][${it.name}${it.classifier ? "-" + it.classifier : ""}${it.extension?'.' + it.extension : ''}]")
             }
             configuration.resolvedConfiguration.lenientConfiguration.artifacts.each {
-                writer.println("lenient-artifact:[${it.moduleVersion.id}][${it.name}${it.classifier ? "-" + it.classifier : ""}.${it.extension}]")
+                writer.println("lenient-artifact:[${it.moduleVersion.id}][${it.name}${it.classifier ? "-" + it.classifier : ""}${it.extension?'.' + it.extension : ''}]")
             }
             configuration.resolvedConfiguration.lenientConfiguration.getArtifacts { true }.each {
-                writer.println("filtered-lenient-artifact:[${it.moduleVersion.id}][${it.name}${it.classifier ? "-" + it.classifier : ""}.${it.extension}]")
+                writer.println("filtered-lenient-artifact:[${it.moduleVersion.id}][${it.name}${it.classifier ? "-" + it.classifier : ""}${it.extension?'.' + it.extension : ''}]")
             }
         }
     }


### PR DESCRIPTION
### Context

This pull request adds support for having multiple dependencies to the same component, but on different variants. Previously to this change, if 2 dependencies were found on the same component but that the attributes didn't match, then we would fail. This means that this PR doesn't introduce a breaking change, but rather improves on an error case. It's worth noting that after initial review feedback, this behavior is **only allowed if variants provide different capabilities**.

This is the first step towards supporting "optional dependencies" as variants.

