### PR TITLE
Document AbstractArchiveTask deprecations

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -101,7 +101,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
 
     /**
      * Returns the archive name. If the name has not been explicitly set, the pattern for the name is:
-     * <code>[baseName]-[appendix]-[version]-[classifier].[extension]</code>
+     * <code>[archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]</code>
      *
      * @return the archive name.
      * @deprecated Use {@link #getArchiveFileName()}
@@ -125,7 +125,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
 
     /**
      * Returns the archive name. If the name has not been explicitly set, the pattern for the name is:
-     * <code>[baseName]-[appendix]-[version]-[classifier].[extension]</code>
+     * <code>[archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]</code>
      *
      * @return the archive name.
      * @since 5.1
@@ -136,7 +136,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
     }
 
     /**
-     * The path where the archive is constructed. The path is simply the {@code destinationDir} plus the {@code archiveName}.
+     * The path where the archive is constructed. The path is simply the {@code destinationDirectory} plus the {@code archiveFileName}.
      *
      * @return a File object with the path to the archive
      * @deprecated Use {@link #getArchiveFile()}
@@ -149,7 +149,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
 
     /**
      * The {@link RegularFile} where the archive is constructed.
-     * The path is simply the {@code destinationDir} plus the {@code archiveName}.
+     * The path is simply the {@code destinationDirectory} plus the {@code archiveFileName}.
      *
      * @return a {@link RegularFile} object with the path to the archive
      * @since 5.1

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
@@ -9,12 +9,24 @@
                 </tr>
             </thead>
             <tr>
+                <td>archiveFileName</td>
+                <td><literal><replaceable>${archiveBaseName}</replaceable>-<replaceable>${archiveAppendix}</replaceable>-<replaceable>${archiveVersion}</replaceable>-<replaceable>${archiveClassifier}</replaceable>.<replaceable>${archiveExtension}</replaceable></literal></td>
+            </tr>
+            <tr>
                 <td>archiveName</td>
-                <td><literal><replaceable>${baseName}</replaceable>-<replaceable>${appendix}</replaceable>-<replaceable>${version}</replaceable>-<replaceable>${classifier}</replaceable>.<replaceable>${extension}</replaceable></literal></td>
+                <td><literal><replaceable>${archiveBaseName}</replaceable>-<replaceable>${archiveAppendix}</replaceable>-<replaceable>${archiveVersion}</replaceable>-<replaceable>${archiveClassifier}</replaceable>.<replaceable>${archiveExtension}</replaceable></literal></td>
+            </tr>
+            <tr>
+                <td>archiveFile</td>
+                <td><literal><replaceable>${destinationDirectory}</replaceable>/<replaceable>${archiveFileName}</replaceable></literal></td>
             </tr>
             <tr>
                 <td>archivePath</td>
-                <td><literal><replaceable>${destinationDir}</replaceable>/<replaceable>${archiveName}</replaceable></literal></td>
+                <td><literal><replaceable>${destinationDirectory}</replaceable>/<replaceable>${archiveFileName}</replaceable></literal></td>
+            </tr>
+            <tr>
+                <td>archiveAppendix</td>
+                <td><literal>null</literal></td>
             </tr>
             <tr>
                 <td>appendix</td>
@@ -26,7 +38,7 @@
             </tr>
             <tr>
                 <td>archiveBaseName</td>
-                <td/>
+                <td><literal>project.archivesBaseName</literal></td>
             </tr>
             <tr>
                 <td>version</td>
@@ -34,7 +46,7 @@
             </tr>
             <tr>
                 <td>archiveVersion</td>
-                <td/>
+                <td><literal>project.version</literal></td>
             </tr>
             <tr>
                 <td>extension</td>
@@ -43,6 +55,10 @@
             <tr>
                 <td>archiveExtension</td>
                 <td/>
+            </tr>
+            <tr>
+                <td>archiveClassifier</td>
+                <td><literal>null</literal></td>
             </tr>
             <tr>
                 <td>classifier</td>
@@ -54,7 +70,7 @@
             </tr>
             <tr>
                 <td>destinationDirectory</td>
-                <td/>
+                <td><literal>project.distsDir</literal></td>
             </tr>
             <tr>
                 <td>preserveFileTimestamps</td>

--- a/subprojects/docs/src/docs/userguide/base_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/base_plugin.adoc
@@ -75,7 +75,7 @@ Note that the `assemble` task generates all artifacts that are attached to the `
 The Base Plugin only adds conventions related to the creation of archives, such as ZIPs, TARs and JARs. Specifically, it provides the following project properties that you can set:
 
 `archivesBaseName` — default: `$project.name`::
-Provides the default link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:baseName[AbstractArchiveTask.getBaseName()] for archive tasks.
+Provides the default link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveBaseName[AbstractArchiveTask.getArchiveBaseName()] for archive tasks.
 
 `distsDirName` — default: _distributions_::
 Default name of the directory in which distribution archives, i.e. non-JARs, are created.
@@ -85,11 +85,11 @@ Default name of the directory in which library archives, i.e. JARs, are created.
 
 The plugin also provides default values for the following properties on any task that extends link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html[AbstractArchiveTask]:
 
-`destinationDir`::
+`destinationDirectory`::
 Defaults to __``$buildDir``/``$distsDirName``__ for non-JAR archives and __``$buildDir``/``$libsDirName``__ for JARs and derivatives of JAR, such as WARs.
 
-`version`::
+`archiveVersion`::
 Defaults to `$project.version` or 'unspecified' if the project has no version.
 
-`baseName`::
+`archiveBaseName`::
 Defaults to `$archivesBaseName`.

--- a/subprojects/docs/src/docs/userguide/building_java_projects.adoc
+++ b/subprojects/docs/src/docs/userguide/building_java_projects.adoc
@@ -325,7 +325,8 @@ include::sample[dir="userguide/java/basic/groovy",files="build.gradle[tags=defin
 include::sample[dir="userguide/java/basic/kotlin",files="build.gradle.kts[tags=defining-sources-jar-task]"]
 ====
 
-See link:{groovyDslPath}/org.gradle.api.tasks.bundling.Jar.html[Jar] for more details on the configuration options available to you. And note that you need to use `classifier` rather than `appendix` here for correct publication of the JAR.
+See link:{groovyDslPath}/org.gradle.api.tasks.bundling.Jar.html[Jar] for more details on the configuration options available to you.
+And note that you need to use `archiveClassifier` rather than `archiveAppendix` here for correct publication of the JAR.
 
 
 If you instead want to create an 'uber' (AKA 'fat') JAR, then you can use a task definition like this:

--- a/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
@@ -660,7 +660,7 @@ tasks {
 
     register<Zip>("archiveTestReports") {
         val reportType: String by test.get().extra  // <2>
-        appendix = reportType
+        archiveAppendix.set(reportType)
         from(test.get().reports.html.destination)
     }
 }
@@ -678,7 +678,7 @@ tasks.test.doLast { ... }
 val testReportType by tasks.test.get().extra("dev")  // <1>
 
 tasks.create<Zip>("archiveTestReports") {
-    appendix = testReportType  // <2>
+    archiveAppendix.set(testReportType)  // <2>
     from(test.get().reports.html.destination)
 }
 ----

--- a/subprojects/docs/src/docs/userguide/maven_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/maven_plugin.adoc
@@ -191,21 +191,23 @@ When deploying an artifact to a Maven repository, Gradle automatically generates
 | project.group
 
 | artifactId
-| uploadTask.repositories.mavenDeployer.pom.artifactId (if set) or archiveTask.baseName.
+| uploadTask.repositories.mavenDeployer.pom.artifactId (if set) or archiveTask.archiveBaseName.
 
 | version
 | project.version
 
 | packaging
-| archiveTask.extension
+| archiveTask.archiveExtension
 |===
 
-Here, `uploadTask` and `archiveTask` refer to the tasks used for uploading and generating the archive, respectively (for example `uploadArchives` and `jar`). `archiveTask.baseName` defaults to `project.archivesBaseName` which in turn defaults to `project.name`.
+Here, `uploadTask` and `archiveTask` refer to the tasks used for uploading and generating the archive, respectively (for example `uploadArchives` and `jar`).
+`archiveTask.archiveBaseName` defaults to `project.archivesBaseName` which in turn defaults to `project.name`.
 
 [NOTE]
 ====
 
-When you set the “`archiveTask.baseName`” property to a value other than the default, you'll also have to set `uploadTask.repositories.mavenDeployer.pom.artifactId` to the same value. Otherwise, the project at hand may be referenced with the wrong artifact ID from generated POMs for other projects in the same build.
+When you set the “`archiveTask.archiveBaseName`” property to a value other than the default, you'll also have to set `uploadTask.repositories.mavenDeployer.pom.artifactId` to the same value.
+Otherwise, the project at hand may be referenced with the wrong artifact ID from generated POMs for other projects in the same build.
 
 ====
 

--- a/subprojects/docs/src/docs/userguide/publishing_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/publishing_maven.adoc
@@ -219,7 +219,7 @@ subprojects {
         publications {
             mavenJava(MavenPublication) {
                 from components.java
-                artifactId = jar.baseName
+                artifactId = jar.archiveBaseName
             }
         }
     }
@@ -236,7 +236,7 @@ subprojects {
         publications {
             create<MavenPublication>("mavenJava") {
                 from(components["java"])
-                artifactId = tasks.jar.get().baseName
+                artifactId = tasks.jar.get().archiveBaseName.get()
             }
         }
     }
@@ -260,7 +260,7 @@ subprojects {
             mavenJava(MavenPublication) {
                 from components.java
                 afterEvaluate {
-                    artifactId = jar.baseName
+                    artifactId = jar.archiveBaseName
                 }
             }
         }
@@ -279,7 +279,7 @@ subprojects {
             create<MavenPublication>("mavenJava") {
                 from(components["java"])
                 afterEvaluate {
-                    artifactId = tasks.jar.get().baseName
+                    artifactId = tasks.jar.get().archiveBaseName.get()
                 }
             }
         }

--- a/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_4.adoc
@@ -739,7 +739,7 @@ enableFeaturePreview("STABLE_PUBLISHING")
 
 We recommend doing a test run with a local repository to see whether all artifacts still have the expected coordinates. In most cases everything should work as before and you are done. However, your publishing block may rely on the implicit deferred configuration, particularly if it relies on values that may change during the configuration phase of the build.
 
-For example, under the new behavior, the following logic assumes that `jar.baseName` doesn't change after `artifactId` is set:
+For example, under the new behavior, the following logic assumes that `jar.archiveBaseName` doesn't change after `artifactId` is set:
 
 ====
 [.multi-language-sample]
@@ -752,7 +752,7 @@ subprojects {
         publications {
             mavenJava {
                 from components.java
-                artifactId = jar.baseName
+                artifactId = jar.archiveBaseName
             }
         }
     }
@@ -769,7 +769,7 @@ subprojects {
         publications {
             named<MavenPublication>("mavenJava") {
                 from(components["java"])
-                artifactId = tasks.jar.get().baseName
+                artifactId = tasks.jar.get().archiveBaseName.get()
             }
         }
     }
@@ -792,7 +792,7 @@ subprojects {
             mavenJava {
                 from components.java
                 afterEvaluate {
-                    artifactId = jar.baseName
+                    artifactId = jar.archiveBaseName
                 }
             }
         }
@@ -811,7 +811,7 @@ subprojects {
             named<MavenPublication>("mavenJava") {
                 from(components["java"])
                 afterEvaluate {
-                    artifactId = tasks.jar.get().baseName
+                    artifactId = tasks.jar.get().archiveBbaseName.get()
                 }
             }
         }

--- a/subprojects/docs/src/docs/userguide/working_with_files.adoc
+++ b/subprojects/docs/src/docs/userguide/working_with_files.adoc
@@ -292,7 +292,8 @@ include::sample[dir="userguide/files/sampleJavaProject/kotlin",files="build.grad
 
 See how we're using the `compileJava` task as the source of the files to package and we've created a project property `archivesDirPath` to store the location where we put archives, on the basis we're likely to use it elsewhere in the build.
 
-Using a task directly as an argument like this relies on it having <<more_about_tasks.adoc#sec:task_inputs_outputs,defined outputs>>, so it won't always be possible. In addition, this example could be improved further by relying on the Java plugin's convention for `destinationDir` rather than overriding it, but it does demonstrate the use of project properties.
+Using a task directly as an argument like this relies on it having <<more_about_tasks.adoc#sec:task_inputs_outputs,defined outputs>>, so it won't always be possible.
+In addition, this example could be improved further by relying on the Java plugin's convention for `destinationDirectory` rather than overriding it, but it does demonstrate the use of project properties.
 
 [[sec:single_file_paths]]
 === Single files and directories
@@ -758,7 +759,7 @@ Gradle does of course allow you create as many archive tasks as you want, but it
 
 Gradle has several conventions around the naming of archives and where they are created based on the plugins your project uses. The main convention is provided by the <<base_plugin.adoc#base_plugin,Base Plugin>>, which defaults to creating archives in the `$buildDir/distributions` directory and typically uses archive names of the form _[projectName]-[version].[type]_.
 
-The following example comes from a project named 'zipProject', hence the `myZip` task creates an archive named 'zipProject-1.0.zip':
+The following example comes from a project named `zipProject`, hence the `myZip` task creates an archive named `zipProject-1.0.zip`:
 
 .Creation of ZIP archive
 ====
@@ -774,11 +775,15 @@ include::{samplesPath}/userguide/files/archiveNaming/archiveNaming.out[]
 
 Note that the name of the archive does _not_ derive from the name of the task that creates it.
 
-If you want to change the name and location of a generated archive file, you can provide values for the `archiveName` and `destinationDir` properties of the corresponding task. These override any conventions that would otherwise apply.
+If you want to change the name and location of a generated archive file, you can provide values for the `archiveFileName` and `destinationDirectory` properties of the corresponding task.
+These override any conventions that would otherwise apply.
 
-Alternatively, you can make use of the default archive name pattern provided by link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveName[AbstractArchiveTask.getArchiveName()]: _[baseName]-[appendix]-[version]-[classifier].[extension]_. You can set each of these properties on the task separately if you wish. Note that the Base Plugin uses the convention of project name for _baseName_, project version for _version_ and the archive type for _extension_. It does not provide values for the other properties.
+Alternatively, you can make use of the default archive name pattern provided by link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveFileName[AbstractArchiveTask.getArchiveFileName()]: _[archiveBaseName]-[archiveAppendix]-[archiveVersion]-[archiveClassifier].[archiveExtension]_.
+You can set each of these properties on the task separately if you wish.
+Note that the Base Plugin uses the convention of project name for _archiveBaseName_, project version for _archiveVersion_ and the archive type for _archiveExtension_.
+It does not provide values for the other properties.
 
-This example — from the same project as the one above — configures just the `baseName` property, overriding the default value of the project name:
+This example — from the same project as the one above — configures just the `archiveBaseName` property, overriding the default value of the project name:
 
 .Configuration of archive task - custom archive name
 ====
@@ -792,7 +797,7 @@ include::sample[dir="userguide/files/archiveNaming/kotlin",files="build.gradle.k
 include::{samplesPath}/userguide/files/archiveNaming/zipWithCustomName.out[]
 ----
 
-You can also override the default `baseName` value for _all_ the archive tasks in your build by using the _project_ property `archivesBaseName`, as demonstrated by the following example:
+You can also override the default `archiveBaseName` value for _all_ the archive tasks in your build by using the _project_ property `archivesBaseName`, as demonstrated by the following example:
 
 .Configuration of archive task - appendix &amp; classifier
 ====
@@ -808,28 +813,28 @@ include::{samplesPath}/userguide/files/archivesChangedBaseName/zipWithArchivesBa
 
 You can find all the possible archive task properties in the API documentation for link:{groovyDslPath}/org.gradle.api.tasks.bundling.AbstractArchiveTask.html[AbstractArchiveTask], but we have also summarized the main ones here:
 
-`archiveName` — `String`, default: `__baseName__-__appendix__-__version__-__classifier__.__extension__`::
+`archiveFileName` — `Property<String>`, default: `__archiveBaseName__-__archiveAppendix__-__archiveVersion__-__archiveClassifier__.__archiveExtension__`::
 The complete file name of the generated archive. If any of the properties in the default value are empty, their '-' separator is dropped.
 
-`archivePath` — `File`, _read-only_, default: `__destinationDir__/__archiveName__`::
+`archiveFile` — `Provider<RegularFile>`, _read-only_, default: `__destinationDirectory__/__archiveFileName__`::
 The absolute file path of the generated archive.
 
-`destinationDir` — `File`, default: depends on archive type::
+`destinationDirectory` — `DirectoryProperty`, default: depends on archive type::
 The target directory in which to put the generated archive. By default, JARs and WARs go into `$buildDir/libs`. ZIPs and TARs go into `$buildDir/distributions`.
 
-`baseName` — `String`, default: `__project.name__`::
+`archiveBaseName` — `Property<String>`, default: `__project.name__`::
 The base name portion of the archive file name, typically a project name or some other descriptive name for what it contains.
 
-`appendix` — `String`, default: `null`::
+`archiveAppendix` — `Property<String>`, default: `null`::
 The appendix portion of the archive file name that comes immediately after the base name. It is typically used to distinguish between different forms of content, such as code and docs, or a minimal distribution versus a full or complete one.
 
-`version` — `String`, default: `__project.version__`::
+`archiveVersion` — `Property<String>`, default: `__project.version__`::
 The version portion of the archive file name, typically in the form of a normal project or product version.
 
-`classifier` — `String`, default: `null`::
+`archiveClassifier` — `Property<String>`, default: `null`::
 The classifier portion of the archive file name. Often used to distinguish between archives that target different platforms.
 
-`extension` — `String`, default: depends on archive type and compression type::
+`archiveExtension` — `Property<String>`, default: depends on archive type and compression type::
 The filename extension for the archive. By default, this is set based on the archive task type and the compression type (if you're creating a TAR). Will be one of: `zip`, `jar`, `war`, `tar`, `tgz` or `tbz2`. You can of course set this to a custom extension if you wish.
 
 [[sec:sharing_content_between_multiple_archives]]

--- a/subprojects/docs/src/samples/userguide/antMigration/fileDeps/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/antMigration/fileDeps/groovy/build.gradle
@@ -30,11 +30,11 @@ ext {
 
 task javadocJar(type: Jar) {
     from javadoc  // <1>
-    classifier = 'javadoc'
+    archiveClassifier = 'javadoc'
 }
 
 task unpackJavadocs(type: Copy) {
-    from zipTree(javadocJar.archivePath)  // <2>
+    from zipTree(javadocJar.archiveFile)  // <2>
     into tmpDistDir  // <3>
 }
 // end::properties[]

--- a/subprojects/docs/src/samples/userguide/antMigration/fileDeps/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/antMigration/fileDeps/kotlin/build.gradle.kts
@@ -32,11 +32,11 @@ val tmpDistDir by extra { file("$buildDir/dist") }
 tasks {
     register<Jar>("javadocJar") {
         from(javadoc)  // <1>
-        classifier = "javadoc"
+        archiveClassifier.set("javadoc")
     }
 
     register<Copy>("unpackJavadocs") {
-        from(zipTree(named<Jar>("javadocJar").get().archivePath))  // <2>
+        from(zipTree(named<Jar>("javadocJar").get().archiveFile))  // <2>
         into(tmpDistDir)  // <3>
     }
 }

--- a/subprojects/docs/src/samples/userguide/files/archiveNaming/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/archiveNaming/groovy/build.gradle
@@ -9,20 +9,20 @@ task myZip(type: Zip) {
     from 'somedir'
 
     doLast {
-        println archiveName
-        println relativePath(destinationDir)
-        println relativePath(archivePath)
+        println archiveFileName.get()
+        println relativePath(destinationDirectory)
+        println relativePath(archiveFile)
     }
 }
 // end::zip-task[]
 
 // tag::zip-task-with-custom-base-name[]
 task myCustomZip(type: Zip) {
-    baseName = 'customName'
+    archiveBaseName = 'customName'
     from 'somedir'
 
     doLast {
-        println archiveName
+        println archiveFileName.get()
     }
 }
 // end::zip-task-with-custom-base-name[]

--- a/subprojects/docs/src/samples/userguide/files/archiveNaming/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/archiveNaming/kotlin/build.gradle.kts
@@ -9,20 +9,20 @@ tasks.register<Zip>("myZip") {
     from("somedir")
 
     doLast {
-        println(archiveName)
-        println(relativePath(destinationDir))
-        println(relativePath(archivePath))
+        println(archiveFileName.get())
+        println(relativePath(destinationDirectory))
+        println(relativePath(archiveFile))
     }
 }
 // end::zip-task[]
 
 // tag::zip-task-with-custom-base-name[]
 tasks.register<Zip>("myCustomZip") {
-    baseName = "customName"
+    archiveBaseName.set("customName")
     from("somedir")
 
     doLast {
-        println(archiveName)
+        println(archiveFileName.get())
     }
 }
 // end::zip-task-with-custom-base-name[]

--- a/subprojects/docs/src/samples/userguide/files/archivesChangedBaseName/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/archivesChangedBaseName/groovy/build.gradle
@@ -10,15 +10,15 @@ task myZip(type: Zip) {
 }
 
 task myOtherZip(type: Zip) {
-    appendix = 'wrapper'
-    classifier = 'src'
+    archiveAppendix = 'wrapper'
+    archiveClassifier = 'src'
     from 'somedir'
 }
 
 task echoNames {
     doLast {
         println "Project name: ${project.name}"
-        println myZip.archiveName
-        println myOtherZip.archiveName
+        println myZip.archiveFileName.get()
+        println myOtherZip.archiveFileName.get()
     }
 }

--- a/subprojects/docs/src/samples/userguide/files/archivesChangedBaseName/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/archivesChangedBaseName/kotlin/build.gradle.kts
@@ -10,15 +10,15 @@ val myZip by tasks.registering(Zip::class) {
 }
 
 val myOtherZip by tasks.registering(Zip::class) {
-    appendix = "wrapper"
-    classifier = "src"
+    archiveAppendix.set("wrapper")
+    archiveClassifier.set("src")
     from("somedir")
 }
 
 tasks.register("echoNames") {
     doLast {
         println("Project name: ${project.name}")
-        println(myZip.get().archiveName)
-        println(myOtherZip.get().archiveName)
+        println(myZip.get().archiveFileName.get())
+        println(myOtherZip.get().archiveFileName.get())
     }
 }

--- a/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/groovy/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 task uberJar(type: Jar) {
-    archiveAppendix = 'uber'
+    archiveClassifier = 'uber'
 
     from sourceSets.main.output
 

--- a/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/groovy/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 task uberJar(type: Jar) {
-    appendix = 'uber'
+    archiveAppendix = 'uber'
 
     from sourceSets.main.output
 

--- a/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 tasks.register<Jar>("uberJar") {
-    appendix = "uber"
+    archiveAppendix.set("uber")
 
     from(sourceSets.main.get().output)
 

--- a/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/archivesWithJavaPlugin/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 tasks.register<Jar>("uberJar") {
-    archiveAppendix.set("uber")
+    archiveClassifier.set("uber")
 
     from(sourceSets.main.get().output)
 

--- a/subprojects/docs/src/samples/userguide/files/copy/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/copy/groovy/build.gradle
@@ -76,8 +76,8 @@ task copyReportsDirForArchiving2(type: Copy) {
 
 // tag::create-archive-example[]
 task packageDistribution(type: Zip) {
-    archiveName = "my-distribution.zip"
-    destinationDir = file("$buildDir/dist")
+    archiveFileName = "my-distribution.zip"
+    destinationDirectory = file("$buildDir/dist")
 
     from "$buildDir/toArchive"
 }
@@ -242,8 +242,8 @@ task copyAssets (type: Copy) {
 }
 
 task distApp(type: Zip) {
-    archiveName = 'my-app-dist.zip'
-    destinationDir = file("$buildDir/dists")
+    archiveFileName = 'my-app-dist.zip'
+    destinationDirectory = file("$buildDir/dists")
 
     from appClasses
     with webAssetsSpec
@@ -261,8 +261,8 @@ task copyAppAssets(type: Copy) {
 }
 
 task archiveDistAssets(type: Zip) {
-    archiveName = 'distribution-assets.zip'
-    destinationDir = file("$buildDir/dists")
+    archiveFileName = 'distribution-assets.zip'
+    destinationDirectory = file("$buildDir/dists")
 
     from 'distResources', webAssetPatterns
 }

--- a/subprojects/docs/src/samples/userguide/files/copy/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/copy/kotlin/build.gradle.kts
@@ -84,8 +84,8 @@ tasks.register<Copy>("copyReportsDirForArchiving2") {
 
 // tag::create-archive-example[]
 tasks.register<Zip>("packageDistribution") {
-    archiveName = "my-distribution.zip"
-    destinationDir = file("$buildDir/dist")
+    archiveFileName.set("my-distribution.zip")
+    destinationDirectory.set(file("$buildDir/dist"))
 
     from("$buildDir/toArchive")
 }
@@ -243,8 +243,8 @@ tasks.register<Copy>("copyAssets") {
 }
 
 tasks.register<Zip>("distApp") {
-    archiveName = "my-app-dist.zip"
-    destinationDir = file("$buildDir/dists")
+    archiveFileName.set("my-app-dist.zip")
+    destinationDirectory.set(file("$buildDir/dists"))
 
     from(appClasses)
     with(webAssetsSpec)
@@ -262,8 +262,8 @@ tasks.register<Copy>("copyAppAssets") {
 }
 
 tasks.register<Zip>("archiveDistAssets") {
-    archiveName = "distribution-assets.zip"
-    destinationDir = file("$buildDir/dists")
+    archiveFileName.set("distribution-assets.zip")
+    destinationDirectory.set(file("$buildDir/dists"))
 
     from("distResources", webAssetPatterns)
 }

--- a/subprojects/docs/src/samples/userguide/files/sampleJavaProject/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/files/sampleJavaProject/groovy/build.gradle
@@ -18,8 +18,8 @@ ext {
 }
 
 task packageClasses(type: Zip) {
-    appendix = "classes"
-    destinationDir = file(archivesDirPath)
+    archiveAppendix = "classes"
+    destinationDirectory = file(archivesDirPath)
 
     from compileJava
 }

--- a/subprojects/docs/src/samples/userguide/files/sampleJavaProject/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/files/sampleJavaProject/kotlin/build.gradle.kts
@@ -16,8 +16,8 @@ dependencies {
 val archivesDirPath by extra { "$buildDir/archives" }
 
 tasks.register<Zip>("packageClasses") {
-    appendix = "classes"
-    destinationDir = file(archivesDirPath)
+    archiveAppendix.set("classes")
+    destinationDirectory.set(file(archivesDirPath))
 
     from(tasks.compileJava)
 }

--- a/subprojects/docs/src/samples/userguide/java/basic/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/java/basic/groovy/build.gradle
@@ -99,7 +99,7 @@ check.dependsOn integrationTest
 
 // tag::defining-sources-jar-task[]
 task sourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from sourceSets.main.allJava
 }
 // end::defining-sources-jar-task[]

--- a/subprojects/docs/src/samples/userguide/java/basic/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/java/basic/kotlin/build.gradle.kts
@@ -101,7 +101,7 @@ tasks.check { dependsOn(integrationTest) }
 
 // tag::defining-sources-jar-task[]
 tasks.register<Jar>("sourcesJar") {
-    classifier = "sources"
+    archiveClassifier.set("sources")
     from(sourceSets.main.get().allJava)
 }
 // end::defining-sources-jar-task[]

--- a/subprojects/docs/src/samples/userguide/multiproject/dependencies/javaWithCustomConf/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/multiproject/dependencies/javaWithCustomConf/groovy/build.gradle
@@ -12,7 +12,7 @@ project(':api') {
         compile project(':shared')
     }
     task spiJar(type: Jar) {
-        baseName = 'api-spi'
+        archiveBaseName = 'api-spi'
         from sourceSets.main.output
         include('org/gradle/sample/api/**')
     }

--- a/subprojects/docs/src/samples/userguide/multiproject/dependencies/javaWithCustomConf/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/multiproject/dependencies/javaWithCustomConf/kotlin/build.gradle.kts
@@ -12,7 +12,7 @@ project(":api") {
         "implementation"(project(":shared"))
     }
     tasks.register<Jar>("spiJar") {
-        baseName = "api-spi"
+        archiveBaseName.set("api-spi")
         from(project.the<SourceSetContainer>()["main"].output)
         include("org/gradle/sample/api/**")
     }

--- a/subprojects/docs/src/samples/userguide/organizingGradleProjects/customGradleDistribution/build.gradle
+++ b/subprojects/docs/src/samples/userguide/organizingGradleProjects/customGradleDistribution/build.gradle
@@ -11,7 +11,7 @@ task downloadGradle(type: DownloadGradle) {
 task createCustomGradleDistribution(type: Zip) {
     description = 'Builds custom Gradle distribution and bundles initialization scripts.'
     dependsOn downloadGradle
-    archiveName "mycompany-gradle-$downloadGradle.gradleVersion-bin.zip"
+    archiveFileName = "mycompany-gradle-$downloadGradle.gradleVersion-bin.zip"
     from zipTree(downloadGradle.destinationFile)
     from('src/init.d') {
         into "$downloadGradle.distributionNameBase/init.d"

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesArchivesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/files/SamplesArchivesIntegrationTest.groovy
@@ -121,7 +121,7 @@ class SamplesArchivesIntegrationTest extends AbstractSampleIntegrationTest {
 
         then:
         def tmpOutDir = dslDir.file("tmp")
-        def zipFile = dslDir.file("build/libs/archives-example-uber-1.0.0.jar")
+        def zipFile = dslDir.file("build/libs/archives-example-1.0.0-uber.jar")
         zipFile.isFile()
         zipFile.unzipTo(tmpOutDir)
         tmpOutDir.file("META-INF/MANIFEST.MF").isFile()


### PR DESCRIPTION
Contains the userguide and javadoc updates following the deprecations in `AbstractArchiveTask`