### PR TITLE
Prevent concurrent access to SystemProperties

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/SystemProperties.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/SystemProperties.java
@@ -73,35 +73,35 @@ public class SystemProperties {
     }
 
     @SuppressWarnings("unchecked")
-    public Map<String, String> asMap() {
+    public synchronized Map<String, String> asMap() {
         return (Map) System.getProperties();
     }
 
-    public String getLineSeparator() {
+    public synchronized String getLineSeparator() {
         return System.getProperty("line.separator");
     }
 
-    public String getJavaIoTmpDir() {
+    public synchronized String getJavaIoTmpDir() {
         return System.getProperty("java.io.tmpdir");
     }
 
-    public String getUserHome() {
+    public synchronized String getUserHome() {
         return System.getProperty("user.home");
     }
 
-    public String getUserName() {
+    public synchronized String getUserName() {
         return System.getProperty("user.name");
     }
 
-    public String getJavaVersion() {
+    public synchronized String getJavaVersion() {
         return System.getProperty("java.version");
     }
 
-    public File getCurrentDir() {
+    public synchronized File getCurrentDir() {
         return new File(System.getProperty("user.dir"));
     }
 
-    public File getJavaHomeDir() {
+    public synchronized File getJavaHomeDir() {
         return new File(System.getProperty("java.home"));
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/SystemPropertiesTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/SystemPropertiesTest.groovy
@@ -20,7 +20,6 @@ import spock.lang.Specification
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.atomic.AtomicReference
 
 class SystemPropertiesTest extends Specification {
     def "can be queried for standard system properties"() {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/SystemPropertiesTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/SystemPropertiesTest.groovy
@@ -18,10 +18,61 @@ package org.gradle.internal
 
 import spock.lang.Specification
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.atomic.AtomicReference
+
 class SystemPropertiesTest extends Specification {
     def "can be queried for standard system properties"() {
         expect:
         SystemProperties.instance.standardProperties.contains("os.name")
         !SystemProperties.instance.standardProperties.contains("foo.bar")
+    }
+
+    def "prohibits concurrent reads of Java Home while factory is busy"() {
+        def repeat = 100
+        def initialJavaHomePath = SystemProperties.instance.javaHomeDir.path
+        def temporaryJavaHomePath = initialJavaHomePath + "-2"
+
+        def valuesSeenByFactory = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>())
+
+        def factory = new Factory<Object>() {
+            @Override
+            Object create() {
+                valuesSeenByFactory.add(SystemProperties.instance.javaHomeDir.path)
+                return new Object()
+            }
+        }
+
+        def latch = new CountDownLatch(2)
+
+        new Thread(new Runnable() {
+            @Override
+            void run() {
+                for (int i = 0; i < repeat; i++) {
+                    SystemProperties.instance.withJavaHome(new File(temporaryJavaHomePath), factory)
+                }
+                latch.countDown()
+            }
+        }).start()
+
+        def valuesSeenByAnotherThread = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>())
+
+        new Thread(new Runnable() {
+            @Override
+            void run() {
+                for (int i = 0; i < repeat; i++) {
+                    valuesSeenByAnotherThread.add(SystemProperties.instance.javaHomeDir.path)
+                }
+
+                latch.countDown()
+            }
+        }).start()
+
+        latch.await()
+
+        expect:
+        valuesSeenByFactory == Collections.singleton(temporaryJavaHomePath)
+        valuesSeenByAnotherThread == Collections.singleton(initialJavaHomePath)
     }
 }


### PR DESCRIPTION
Fixes #7842 and expected to transitively fix #1782.

This change prohibits reads of system properties while `withSystemProperty(factory)` is busy, preventing observing mutated state with temporary value.

I have another version with `ReentrantReadWriteLock` that allows concurrent reads if there is no writing going on, but decided to go with simplicity of `synchronized`.