### PR TITLE
Reduce test permutations run with no-daemon executer

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BehindFlagFeatureRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/BehindFlagFeatureRunner.groovy
@@ -18,6 +18,7 @@ package org.gradle.integtests.fixtures
 
 import groovy.transform.CompileStatic
 import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
+
 /**
  * A base runner for features hidden behind a flag, convenient for executing tests with the flag on or off.
  * If a test only makes sense if the feature is enabled, then it needs to be annotated with {@link RequiredFeatures}.
@@ -26,13 +27,17 @@ import org.gradle.integtests.fixtures.executer.AbstractGradleExecuter
 abstract class BehindFlagFeatureRunner extends AbstractMultiTestRunner {
     final Map<String, Feature> features
 
-    BehindFlagFeatureRunner(Class<?> target, Map<String, Feature> features) {
-        super(target)
+    BehindFlagFeatureRunner(Class<?> target, Map<String, Feature> features, boolean executeAllPermutations) {
+        super(target, executeAllPermutations)
         features.each { systemProperty, description ->
             // Ensure that the system property is propagated to forked Gradle executions
             AbstractGradleExecuter.propagateSystemProperty(systemProperty)
         }
         this.features = features
+    }
+
+    BehindFlagFeatureRunner(Class<?> target, Map<String, Feature> features) {
+        this(target, features, true)
     }
 
     static void extractRequiredFeatures(RequiredFeatures requires, Map<String, String> required) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FluidDependenciesResolveRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/FluidDependenciesResolveRunner.groovy
@@ -17,6 +17,7 @@
 package org.gradle.integtests.fixtures
 
 import groovy.transform.CompileStatic
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
 
 /**
  * Runs tests with fluid dependencies enabled and disabled: when fluid dependencies are enabled, any configuration that
@@ -28,7 +29,11 @@ class FluidDependenciesResolveRunner extends BehindFlagFeatureRunner {
     public final static String ASSUME_FLUID_DEPENDENCIES = "org.gradle.resolution.assumeFluidDependencies"
 
     FluidDependenciesResolveRunner(Class<?> target) {
-        super(target, [ASSUME_FLUID_DEPENDENCIES: booleanFeature("fluid dependencies")])
+        super(target, [ASSUME_FLUID_DEPENDENCIES: booleanFeature("fluid dependencies")], doNotExecuteAllPermutationsForNoDaemonExecuter())
+    }
+
+    private static boolean doNotExecuteAllPermutationsForNoDaemonExecuter() {
+        !GradleContextualExecuter.isNoDaemon()
     }
 
     static isFluid() {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleMetadataResolveRunner.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/GradleMetadataResolveRunner.groovy
@@ -17,6 +17,8 @@
 package org.gradle.integtests.fixtures
 
 import groovy.transform.CompileStatic
+import org.gradle.integtests.fixtures.executer.GradleContextualExecuter
+
 /**
  * Runs tests with and without Gradle metadata support enabled
  */
@@ -28,9 +30,15 @@ class GradleMetadataResolveRunner extends BehindFlagFeatureRunner {
 
     GradleMetadataResolveRunner(Class<?> target) {
         super(target, [
-            (GRADLE_METADATA): booleanFeature("Gradle metadata"),
-            (EXPERIMENTAL_RESOLVE_BEHAVIOR): booleanFeature("Experimental"),
-            (REPOSITORY_TYPE): new Feature(ivy: 'Ivy repository', maven: 'Maven repository')])
+                (GRADLE_METADATA): booleanFeature("Gradle metadata"),
+                (EXPERIMENTAL_RESOLVE_BEHAVIOR): booleanFeature("Experimental"),
+                (REPOSITORY_TYPE): new Feature(ivy: 'Ivy repository', maven: 'Maven repository')
+            ],
+            doNotExecuteAllPermutationsForNoDaemonExecuter())
+    }
+
+    private static boolean doNotExecuteAllPermutationsForNoDaemonExecuter() {
+        !GradleContextualExecuter.isNoDaemon()
     }
 
     def isInvalidCombination(Map<String, String> values) {


### PR DESCRIPTION
Dependency management tests are taking 3-4 hours for no-daemon CI builds. Many of these tests are run in various permutations, and running all permutations specifically with the no-daemon executer does not add much value.

With this change, we only execute a single permutation of each dependency management test when the `noDaemon` executer is used.

More could be done to reduce the number of tests executed in no-daemon scenarios. However, this minor change should help reduce CI times a little.

[CI before change](https://builds.gradle.org/viewLog.html?buildId=19079566&tab=buildResultsDiv&buildTypeId=Gradle_Check_NoDaemon_Java11_Openjdk_Windows_dependencyManagement&branch_Gradle_Check_NoDaemon_Java11_Openjdk_Windows=master)

[CI after change](https://builds.gradle.org/viewLog.html?buildId=19080853&tab=buildResultsDiv&buildTypeId=Gradle_Check_NoDaemon_Java11_Openjdk_Windows_dependencyManagement&branch_Gradle_Check_NoDaemon_Java11_Openjdk_Windows=dd%2Fci%2Freduce-no-daemon-tests)
