### PR TITLE
Set Xms64m when setting to Xmx64m in Wrapper

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/GradleStartScriptGenerator.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/GradleStartScriptGenerator.groovy
@@ -62,7 +62,7 @@ class GradleStartScriptGenerator extends DefaultTask {
         generator.scriptRelPath = 'bin/gradle'
         generator.classpath = ["lib/${launcherJar.singleFile.name}" as String]
         generator.appNameSystemProperty = 'org.gradle.appname'
-        generator.defaultJvmOpts = ["-Xmx64m"]
+        generator.defaultJvmOpts = ["-Xmx64m", "-Xms64m"]
         generator.generateUnixScript(shellScript)
         generator.generateWindowsScript(batchFile)
     }

--- a/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
+++ b/subprojects/build-init/src/main/java/org/gradle/api/tasks/wrapper/Wrapper.java
@@ -131,7 +131,7 @@ public class Wrapper extends DefaultTask {
         generator.setExitEnvironmentVar("GRADLE_EXIT_CONSOLE");
         generator.setAppNameSystemProperty("org.gradle.appname");
         generator.setScriptRelPath(unixScript.getName());
-        generator.setDefaultJvmOpts(ImmutableList.of("-Xmx64m"));
+        generator.setDefaultJvmOpts(ImmutableList.of("-Xmx64m", "-Xms64m"));
         generator.generateUnixScript(unixScript);
         generator.generateWindowsScript(getBatchScript());
     }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/configuration/DaemonParameters.java
@@ -35,8 +35,8 @@ public class DaemonParameters {
     static final int DEFAULT_IDLE_TIMEOUT = 3 * 60 * 60 * 1000;
     public static final int DEFAULT_PERIODIC_CHECK_INTERVAL_MILLIS = 10 * 1000;
 
-    public static final List<String> DEFAULT_JVM_ARGS = ImmutableList.of("-Xmx512m", "-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError");
-    public static final List<String> DEFAULT_JVM_8_ARGS = ImmutableList.of("-Xmx512m", "-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError");
+    public static final List<String> DEFAULT_JVM_ARGS = ImmutableList.of("-Xmx512m", "-Xms256m", "-XX:MaxPermSize=256m", "-XX:+HeapDumpOnOutOfMemoryError");
+    public static final List<String> DEFAULT_JVM_8_ARGS = ImmutableList.of("-Xmx512m", "-Xms256m", "-XX:MaxMetaspaceSize=256m", "-XX:+HeapDumpOnOutOfMemoryError");
     public static final List<String> ALLOW_ENVIRONMENT_VARIABLE_OVERWRITE = ImmutableList.of("--add-opens", "java.base/java.util=ALL-UNNAMED");
 
     private final File gradleUserHomeDir;


### PR DESCRIPTION
### Context

This change prevents the problem described in https://github.com/gradle/gradle/issues/8182, where a value for `Xms` in `JAVA_TOOL_OPTIONS` or `_JAVA_OPTIONS` collides with the `Xmx` default of `64m`. By setting both `Xmx` and `Xms`, the gradle wrapper will default to heap settings that always work.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
