### PR TITLE
Use `_Decorated` as class name for generated task classes

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -626,7 +626,7 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
         when:
         withBuildCache().run "customTask", "--info"
         then:
-        output.contains "Caching disabled for task ':customTask': Task class was loaded with an unknown classloader (class 'CustomTask\$Dsl')."
+        output.contains "Caching disabled for task ':customTask': Task class was loaded with an unknown classloader (class 'CustomTask_Decorated')."
     }
 
     def "task with custom action loaded with custom classloader is not cached"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalBuildIntegrationTest.groovy
@@ -1097,7 +1097,7 @@ task generate(type: TransformerTask) {
         succeeds "customTask", "--info"
         then:
         skippedTasks.empty
-        output.contains "The type of task ':customTask' was loaded with an unknown classloader (class 'CustomTask\$Dsl')."
+        output.contains "The type of task ':customTask' was loaded with an unknown classloader (class 'CustomTask_Decorated')."
     }
 
     def "task with custom action loaded with custom classloader is never up-to-date"() {

--- a/subprojects/docs/src/samples/userguide/tutorial/projectReports/propertyListReport.out
+++ b/subprojects/docs/src/samples/userguide/tutorial/projectReports/propertyListReport.out
@@ -6,6 +6,6 @@ Project :api - The shared API for the application
 allprojects: [project ':api']
 ant: org.gradle.api.internal.project.DefaultAntBuilder@12345
 antBuilderFactory: org.gradle.api.internal.project.DefaultAntBuilderFactory@12345
-artifacts: org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler$Dsl@12345
+artifacts: org.gradle.api.internal.artifacts.dsl.DefaultArtifactHandler_Decorated@12345
 asDynamicObject: DynamicObject for project ':api'
 baseClassLoaderScope: org.gradle.api.internal.initialization.DefaultClassLoaderScope@12345

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AsmBackedClassGenerator.java
@@ -118,7 +118,9 @@ public class AsmBackedClassGenerator extends AbstractClassGenerator {
      * Returns a generator that applies DSL mix-in, extensibility and service injection for generated classes.
      */
     static ClassGenerator decorateAndInject(Collection<? extends InjectAnnotationHandler> allKnownAnnotations, Collection<Class<? extends Annotation>> enabledAnnotations) {
-        return new AsmBackedClassGenerator(true, "$Dsl", allKnownAnnotations, enabledAnnotations);
+        // TODO wolfs: We use `_Decorated` here, since IDEA import currently relies on this
+        // See https://github.com/gradle/gradle/issues/8244
+        return new AsmBackedClassGenerator(true, "_Decorated", allKnownAnnotations, enabledAnnotations);
     }
 
     /**


### PR DESCRIPTION
If we don't, there seems to be some problems when syncing with IDEA.
See #8244