### PR TITLE
Let AbstractGradleExecuter ignore kotlinc deprecation warnings

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1193,6 +1193,9 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
                     if (line.matches(".*use(s)? or override(s)? a deprecated API\\.")) {
                         // A javac warning, ignore
                         i++;
+                    } else if (line.matches("w: .* is deprecated\\..*")) {
+                        // A kotlinc warning, ignore
+                        i++;
                     } else if (isDeprecationMessageInHelpDescription(line)) {
                         i++;
                     } else if (line.matches(".*\\s+deprecated.*")) {


### PR DESCRIPTION
so they don't interfere with Gradle deprecation warning assertions