### PR TITLE
Add support for consuming optional features

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildConfigurationAttributesResolveIntegrationTest.groovy
@@ -597,9 +597,9 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
         then:
         failure.assertHasCause("Could not resolve com.acme.external:external:1.0.")
         failure.assertHasCause("""Unable to find a matching variant of project :external:
-  - Variant 'bar':
+  - Variant 'bar' capability com.acme.external:external:2.0-SNAPSHOT:
       - Required flavor 'free' and found incompatible value 'blue'.
-  - Variant 'foo':
+  - Variant 'foo' capability com.acme.external:external:2.0-SNAPSHOT:
       - Required flavor 'free' and found incompatible value 'red'.""")
 
         when:
@@ -611,9 +611,9 @@ class CompositeBuildConfigurationAttributesResolveIntegrationTest extends Abstra
   - bar
   - foo
 All of them match the consumer attributes:
-  - Variant 'bar':
+  - Variant 'bar' capability com.acme.external:external:2.0-SNAPSHOT:
       - Required flavor 'paid' and found compatible value 'blue'.
-  - Variant 'foo':
+  - Variant 'foo' capability com.acme.external:external:2.0-SNAPSHOT:
       - Required flavor 'paid' and found compatible value 'red'.""")
     }
 

--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.composite
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import spock.lang.Unroll
+
+class CompositeBuildDependencyCapabilitiesResolveIntegrationTest extends AbstractIntegrationSpec {
+
+    @Unroll
+    def "dependency capabilities travel to the included build"() {
+        mavenRepo.module('com.acme.external', 'external', '1.0')
+
+        given:
+        settingsFile << """
+            rootProject.name = 'test'
+            includeBuild "includedBuild"
+        """
+        file('includedBuild/settings.gradle') << '''
+            rootProject.name = 'external'
+        '''
+        file("includedBuild/build.gradle") << """
+            group = 'com.acme.external'
+            version = '2.0-SNAPSHOT'
+            
+            configurations {
+                first {
+                   attributes {
+                       attribute(Attribute.of('org.gradle.usage', Usage), project.objects.named(Usage, 'java-api'))
+                   }
+                   outgoing.capability('org:cap1:1.0')
+                }
+                second {
+                   attributes {
+                       attribute(Attribute.of('org.gradle.usage', Usage), project.objects.named(Usage, 'java-api'))
+                   }
+                   outgoing.capability('org:cap2:1.0')
+                }
+            }
+            
+            artifacts {
+                first file("first-\${version}.jar")
+                second file("second-\${version}.jar")
+            }
+        """
+
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            dependencies {
+                api("com.acme.external:external:1.0") {
+                    capabilities {
+                        requireCapability("org:$capability:1.0")
+                    }
+                }
+            }
+        """
+        def resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.prepare()
+
+        when:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge("com.acme.external:external:1.0", "project :external", "com.acme.external:external:2.0-SNAPSHOT") {
+                    compositeSubstitute()
+                    variant(expectedVariant, ['org.gradle.usage': 'java-api'])
+                    artifact(name: expectedVariant)
+                }
+            }
+        }
+
+        where:
+        capability | expectedVariant
+        'cap1'     | 'first'
+        'cap2'     | 'second'
+    }
+}

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -26,6 +26,7 @@ import org.gradle.internal.resolve.ModuleVersionResolveException;
 import org.gradle.util.Path;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
@@ -71,7 +72,7 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
         for (BuildIdentifier nextTarget : buildDependencies.get(targetBuild)) {
             if (sourceBuild.equals(nextTarget)) {
                 candidateCycle.add(nextTarget);
-                ProjectComponentSelector selector = new DefaultProjectComponentSelector(candidateCycle.get(0), Path.ROOT, Path.ROOT, ":", ImmutableAttributes.EMPTY);
+                ProjectComponentSelector selector = new DefaultProjectComponentSelector(candidateCycle.get(0), Path.ROOT, Path.ROOT, ":", ImmutableAttributes.EMPTY, Collections.emptyList());
                 throw new ModuleVersionResolveException(selector, "Included build dependency cycle: " + reportCycle(candidateCycle));
             }
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -24,6 +24,7 @@ import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.capabilities.Capability;
 
 import javax.annotation.Nullable;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -197,5 +198,5 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * @since 5.2
      */
     @Incubating
-    Set<Capability> getRequestedCapabilities();
+    List<Capability> getRequestedCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.HasConfigurableAttributes;
+import org.gradle.api.capabilities.Capability;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -179,4 +180,22 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      */
     @Incubating
     ModuleDependency attributes(Action<? super AttributeContainer> configureAction);
+
+    /**
+     * Configures the requested capabilities of this dependency.
+     * @param configureAction the configuration action
+     *
+     * @since 5.2
+     */
+    @Incubating
+    ModuleDependency capabilities(Action<? super ModuleDependencyCapabilitiesHandler> configureAction);
+
+    /**
+     * Returns the set of requested capabilities for this dependency.
+     * @return An immutable view of requested capabilities. Updates must be done calling {@link #capabilities(Action)}.
+     *
+     * @since 5.2
+     */
+    @Incubating
+    Set<Capability> getRequestedCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -186,7 +186,7 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * Configures the requested capabilities of this dependency.
      * @param configureAction the configuration action
      *
-     * @since 5.2
+     * @since 5.3
      */
     @Incubating
     ModuleDependency capabilities(Action<? super ModuleDependencyCapabilitiesHandler> configureAction);
@@ -195,7 +195,7 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * Returns the set of requested capabilities for this dependency.
      * @return An immutable view of requested capabilities. Updates must be done calling {@link #capabilities(Action)}.
      *
-     * @since 5.2
+     * @since 5.3
      */
     @Incubating
     List<Capability> getRequestedCapabilities();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.artifacts;
+
+import org.gradle.api.Incubating;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * The capabilities requested for a dependency. This is used in variant-aware dependency
+ * management, to select only variants which provide the requested capabilities. By
+ * default, Gradle will only look for variants which provide the "implicit" capability,
+ * which corresponds to the GAV coordinates of the component. If the user calls methods
+ * on this handler, then the requirements change and explicit capabilities are required.
+ *
+ * @since 5.2
+ */
+@HasInternalProtocol
+@Incubating
+public interface ModuleDependencyCapabilitiesHandler {
+    /**
+     * Requires a single capability.
+     * @param capabilityNotation the capability notation (eg. group:name:version)
+     */
+    void requireCapability(Object capabilityNotation);
+
+    /**
+     * Requires multiple capabilities. The selected variants MUST provide ALL of them
+     * to be selected.
+     * @param capabilityNotations the capability notations (eg. group:name:version)
+     */
+    void requireCapabilities(Object... capabilityNotations);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependencyCapabilitiesHandler.java
@@ -25,7 +25,7 @@ import org.gradle.internal.HasInternalProtocol;
  * which corresponds to the GAV coordinates of the component. If the user calls methods
  * on this handler, then the requirements change and explicit capabilities are required.
  *
- * @since 5.2
+ * @since 5.3
  */
 @HasInternalProtocol
 @Incubating

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
@@ -17,7 +17,10 @@ package org.gradle.api.artifacts.component;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.scan.UsedByScanPlugin;
+
+import java.util.List;
 
 /**
  * Represents some opaque criteria used to select a component instance during dependency resolution. Various sub-interfaces
@@ -54,4 +57,13 @@ public interface ComponentSelector {
      */
     @Incubating
     AttributeContainer getAttributes();
+
+    /**
+     * The requested capabilities.
+     * @return the requested capabilities. If returning an empty list, the implicit capability will be used.
+     *
+     * @since 5.2
+     */
+    @Incubating
+    List<Capability> getRequestedCapabilities();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/component/ComponentSelector.java
@@ -62,7 +62,7 @@ public interface ComponentSelector {
      * The requested capabilities.
      * @return the requested capabilities. If returning an empty list, the implicit capability will be used.
      *
-     * @since 5.2
+     * @since 5.3
      */
     @Incubating
     List<Capability> getRequestedCapabilities();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
@@ -44,7 +44,7 @@ public interface ResolvedVariantResult {
     /**
      * The capabilities provided by this variant
      *
-     * @since 5.2
+     * @since 5.3
      */
     @Incubating
     List<Capability> getCapabilities();

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/result/ResolvedVariantResult.java
@@ -18,6 +18,9 @@ package org.gradle.api.artifacts.result;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
+
+import java.util.List;
 
 /**
  * The result of successfully resolving a component variant.
@@ -37,4 +40,12 @@ public interface ResolvedVariantResult {
      */
     @Incubating
     String getDisplayName();
+
+    /**
+     * The capabilities provided by this variant
+     *
+     * @since 5.2
+     */
+    @Incubating
+    List<Capability> getCapabilities();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -21,7 +21,9 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultExcludeRuleContainer;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -29,8 +31,10 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.internal.ImmutableActionSet;
+import org.gradle.internal.typeconversion.NotationParser;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,10 +45,12 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     private final static Logger LOG = Logging.getLogger(AbstractModuleDependency.class);
 
     private ImmutableAttributesFactory attributesFactory;
+    private NotationParser<Object, Capability> capabilityNotationParser;
     private DefaultExcludeRuleContainer excludeRuleContainer = new DefaultExcludeRuleContainer();
     private Set<DependencyArtifact> artifacts = new HashSet<DependencyArtifact>();
     private ImmutableActionSet<ModuleDependency> onMutate = ImmutableActionSet.empty();
     private AttributeContainerInternal attributes;
+    private ModuleDependencyCapabilitiesInternal moduleDependencyCapabilities;
 
     @Nullable
     private String configuration;
@@ -121,6 +127,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         target.setExcludeRuleContainer(new DefaultExcludeRuleContainer(getExcludeRules()));
         target.setTransitive(isTransitive());
         target.setAttributes(attributes);
+        target.moduleDependencyCapabilities = moduleDependencyCapabilities;
     }
 
     protected boolean isKeyEquals(ModuleDependency dependencyRhs) {
@@ -157,6 +164,9 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         if (!Objects.equal(getAttributes(), dependencyRhs.getAttributes())) {
             return false;
         }
+        if (!Objects.equal(getRequestedCapabilities(), dependencyRhs.getRequestedCapabilities())) {
+            return false;
+        }
         return true;
     }
 
@@ -169,7 +179,7 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     public AbstractModuleDependency attributes(Action<? super AttributeContainer> configureAction) {
         validateMutation();
         if (attributesFactory == null) {
-            warnAboutInternalApiUse();
+            warnAboutInternalApiUse("attributes");
             return this;
         }
         if (attributes == null) {
@@ -179,12 +189,38 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
         return this;
     }
 
-    private void warnAboutInternalApiUse() {
-        LOG.warn("Cannot set attributes for dependency \"" + this.getGroup() + ":" + this.getName() + ":" + this.getVersion() + "\": it was probably created by a plugin using internal APIs");
+    @Override
+    public ModuleDependency capabilities(Action<? super ModuleDependencyCapabilitiesHandler> configureAction) {
+        validateMutation();
+        if (capabilityNotationParser == null) {
+            warnAboutInternalApiUse("capabilities");
+            return this;
+        }
+        if (moduleDependencyCapabilities == null) {
+            moduleDependencyCapabilities = new DefaultMutableModuleDependencyCapabilitiesHandler(capabilityNotationParser);
+        }
+        configureAction.execute(moduleDependencyCapabilities);
+        return this;
+    }
+
+    @Override
+    public Set<Capability> getRequestedCapabilities() {
+        if (moduleDependencyCapabilities == null) {
+            return Collections.emptySet();
+        }
+        return moduleDependencyCapabilities.getRequestedCapabilities();
+    }
+
+    private void warnAboutInternalApiUse(String thing) {
+        LOG.warn("Cannot set " + thing + " for dependency \"" + this.getGroup() + ":" + this.getName() + ":" + this.getVersion() + "\": it was probably created by a plugin using internal APIs");
     }
 
     public void setAttributesFactory(ImmutableAttributesFactory attributesFactory) {
         this.attributesFactory = attributesFactory;
+    }
+
+    public void setCapabilityNotationParser(NotationParser<Object, Capability> capabilityNotationParser) {
+        this.capabilityNotationParser = capabilityNotationParser;
     }
 
     protected ImmutableAttributesFactory getAttributesFactory() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/AbstractModuleDependency.java
@@ -36,6 +36,7 @@ import org.gradle.internal.typeconversion.NotationParser;
 import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -204,9 +205,9 @@ public abstract class AbstractModuleDependency extends AbstractDependency implem
     }
 
     @Override
-    public Set<Capability> getRequestedCapabilities() {
+    public List<Capability> getRequestedCapabilities() {
         if (moduleDependencyCapabilities == null) {
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
         return moduleDependencyCapabilities.getRequestedCapabilities();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableModuleDependencyCapabilitiesHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableModuleDependencyCapabilitiesHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.internal.typeconversion.NotationParser;
+
+import java.util.Set;
+
+public class DefaultMutableModuleDependencyCapabilitiesHandler implements ModuleDependencyCapabilitiesInternal {
+    private final NotationParser<Object, Capability> notationParser;
+    private final Set<Capability> requestedCapabilities = Sets.newHashSet();
+
+    public DefaultMutableModuleDependencyCapabilitiesHandler(NotationParser<Object, Capability> notationParser) {
+        this.notationParser = notationParser;
+    }
+
+
+    @Override
+    public void requireCapability(Object capabilityNotation) {
+        requestedCapabilities.add(notationParser.parseNotation(capabilityNotation));
+    }
+
+    @Override
+    public void requireCapabilities(Object... capabilityNotations) {
+        for (Object notation : capabilityNotations) {
+            requireCapability(notation);
+        }
+    }
+
+    @Override
+    public Set<Capability> getRequestedCapabilities() {
+        return ImmutableSet.copyOf(requestedCapabilities);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableModuleDependencyCapabilitiesHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultMutableModuleDependencyCapabilitiesHandler.java
@@ -15,16 +15,17 @@
  */
 package org.gradle.api.internal.artifacts.dependencies;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.typeconversion.NotationParser;
 
+import java.util.List;
 import java.util.Set;
 
 public class DefaultMutableModuleDependencyCapabilitiesHandler implements ModuleDependencyCapabilitiesInternal {
     private final NotationParser<Object, Capability> notationParser;
-    private final Set<Capability> requestedCapabilities = Sets.newHashSet();
+    private final Set<Capability> requestedCapabilities = Sets.newLinkedHashSet();
 
     public DefaultMutableModuleDependencyCapabilitiesHandler(NotationParser<Object, Capability> notationParser) {
         this.notationParser = notationParser;
@@ -44,7 +45,7 @@ public class DefaultMutableModuleDependencyCapabilitiesHandler implements Module
     }
 
     @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return ImmutableSet.copyOf(requestedCapabilities);
+    public List<Capability> getRequestedCapabilities() {
+        return ImmutableList.copyOf(requestedCapabilities);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependency.java
@@ -159,6 +159,9 @@ public class DefaultProjectDependency extends AbstractModuleDependency implement
         if (!Objects.equal(getAttributes(), that.getAttributes())) {
             return false;
         }
+        if (!Objects.equal(getRequestedCapabilities(), that.getRequestedCapabilities())) {
+            return false;
+        }
         return true;
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/ModuleDependencyCapabilitiesInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/ModuleDependencyCapabilitiesInternal.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.artifacts.dependencies;
 import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
 import org.gradle.api.capabilities.Capability;
 
-import java.util.Set;
+import java.util.List;
 
 public interface ModuleDependencyCapabilitiesInternal extends ModuleDependencyCapabilitiesHandler {
-    Set<Capability> getRequestedCapabilities();
+    List<Capability> getRequestedCapabilities();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/ModuleDependencyCapabilitiesInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/dependencies/ModuleDependencyCapabilitiesInternal.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.dependencies;
+
+import org.gradle.api.artifacts.ModuleDependencyCapabilitiesHandler;
+import org.gradle.api.capabilities.Capability;
+
+import java.util.Set;
+
+public interface ModuleDependencyCapabilitiesInternal extends ModuleDependencyCapabilitiesHandler {
+    Set<Capability> getRequestedCapabilities();
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/api/ResolvedArtifactsApiIntegrationTest.groovy
@@ -694,10 +694,10 @@ ${showFailuresTask(expression)}
         then:
         failure.assertHasCause("Could not resolve all artifacts for configuration ':compile'.")
         failure.assertHasCause("""Unable to find a matching variant of project :a:
-  - Variant 'compile':
+  - Variant 'compile' capability test:a:unspecified:
       - Required volume '11' and found incompatible value '8'.""")
         failure.assertHasCause("""Unable to find a matching variant of project :b:
-  - Variant 'compile':
+  - Variant 'compile' capability test:b:unspecified:
       - Required volume '11' and found incompatible value '9'.""")
 
         where:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/AbstractConfigurationAttributesResolveIntegrationTest.groovy
@@ -35,6 +35,12 @@ abstract class AbstractConfigurationAttributesResolveIntegrationTest extends Abs
         "${free}; ${release}"
     }
 
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+    }
+
     abstract String getDebug()
 
     abstract String getFree()
@@ -391,7 +397,7 @@ include 'a', 'b'
 
         then:
         failure.assertHasCause '''Variant 'bar' in project :b does not match the consumer attributes
-Variant 'bar':
+Variant 'bar' capability test:b:unspecified:
   - Required buildType 'debug' and found incompatible value 'release'.
   - Required flavor 'free' and found compatible value 'free'.'''
 
@@ -527,10 +533,10 @@ Variant 'bar':
         failure.assertHasCause("Could not resolve all task dependencies for configuration ':a:_compileFreeDebug'.")
         failure.assertHasCause("Could not resolve project :b.")
         failure.assertHasCause("""Unable to find a matching variant of project :b:
-  - Variant 'bar':
+  - Variant 'bar' capability test:b:unspecified:
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' but no value provided.
-  - Variant 'foo':
+  - Variant 'foo' capability test:b:unspecified:
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' and found compatible value 'free'.""")
     }
@@ -575,8 +581,9 @@ Variant 'bar':
   - bar
   - foo
 All of them match the consumer attributes:
-  - Variant 'bar': Found buildType 'release' but wasn't required.
-  - Variant 'foo':
+  - Variant 'bar' capability test:b:unspecified:
+      - Found buildType 'release' but wasn't required.
+  - Variant 'foo' capability test:b:unspecified:
       - Found buildType 'release' but wasn't required.
       - Found flavor 'free' but wasn't required.""")
     }
@@ -706,10 +713,10 @@ All of them match the consumer attributes:
 
         then:
         failure.assertHasCause '''Unable to find a matching variant of project :b:
-  - Variant 'bar':
+  - Variant 'bar' capability test:b:unspecified:
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' and found incompatible value 'paid'.
-  - Variant 'foo':
+  - Variant 'foo' capability test:b:unspecified:
       - Required buildType 'debug' and found incompatible value 'release'.
       - Required flavor 'free' and found compatible value 'free'.'''
 
@@ -833,10 +840,10 @@ All of them match the consumer attributes:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Variant 'bar':
+  - Variant 'bar' capability test:b:unspecified:
       - Required buildType 'debug' but no value provided.
       - Required flavor 'free' and found compatible value 'free'.
-  - Variant 'foo':
+  - Variant 'foo' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' but no value provided.""")
     }
@@ -925,9 +932,9 @@ All of them match the consumer attributes:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Variant 'bar':
+  - Variant 'bar' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
-  - Variant 'foo':
+  - Variant 'foo' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'."""
     }
 
@@ -976,11 +983,11 @@ All of them match the consumer attributes:
   - bar
   - foo
 All of them match the consumer attributes:
-  - Variant 'bar':
+  - Variant 'bar' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra 2' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'.
-  - Variant 'foo':
+  - Variant 'foo' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'."""
@@ -1055,10 +1062,10 @@ All of them match the consumer attributes:
   - compile
   - debug
 All of them match the consumer attributes:
-  - Variant 'compile':
+  - Variant 'compile' capability test:b:unspecified:
       - Required buildType 'debug' but no value provided.
       - Required flavor 'free' and found compatible value 'free'.
-  - Variant 'debug':
+  - Variant 'debug' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' but no value provided."""
     }
@@ -1382,11 +1389,11 @@ All of them match the consumer attributes:
   - foo
   - foo2
 All of them match the consumer attributes:
-  - Variant 'foo':
+  - Variant 'foo' capability test:c:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'.
-  - Variant 'foo2':
+  - Variant 'foo2' capability test:c:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Found extra 'extra 2' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'."""
@@ -1399,11 +1406,11 @@ All of them match the consumer attributes:
   - bar
   - bar2
 All of them match the consumer attributes:
-  - Variant 'bar':
+  - Variant 'bar' capability test:c:unspecified:
       - Required buildType 'release' and found compatible value 'release'.
       - Found extra 'extra' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'.
-  - Variant 'bar2':
+  - Variant 'bar2' capability test:c:unspecified:
       - Required buildType 'release' and found compatible value 'release'.
       - Found extra 'extra 2' but wasn't required.
       - Required flavor 'free' and found compatible value 'free'."""

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -64,6 +64,9 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'test-fixtures'))
                     }
+                    capabilities {
+                        requireCapability('org:lib-fixtures:1.0')
+                    }
                 }
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -46,7 +46,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeResolved = false
                     canBeConsumed = true
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'test-fixtures'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
                     }
                     outgoing.capability('org:lib-fixtures:1.0')
                 }
@@ -62,7 +62,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                 implementation project(':lib')
                 implementation (project(':lib')) {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'test-fixtures'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
                     }
                     capabilities {
                         requireCapability('org:lib-fixtures:1.0')
@@ -82,7 +82,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'test-fixtures']
+                    variant "testFixtures", ['org.gradle.usage':'java-api']
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -399,11 +399,11 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
-  - Variant 'api':
+  - Variant 'api' capability org:test:1.0:
       - Required custom 'c2' and found incompatible value 'c1'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
-  - Variant 'runtime':
+  - Variant 'runtime' capability org:test:1.0:
       - Required custom 'c2' and found compatible value 'c2'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'""")
@@ -563,11 +563,11 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         then:
         failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
-  - Variant 'api':
+  - Variant 'api' capability org:test:1.0:
       - Required custom 'c2' and found incompatible value 'c1'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
-  - Variant 'runtime':
+  - Variant 'runtime' capability org:test:1.0:
       - Required custom 'c2' and found compatible value 'c2'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
       - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'""")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -30,11 +30,78 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
     def setup() {
         buildFile << """
             def CUSTOM_ATTRIBUTE = Attribute.of('custom', String)
+            def CUSTOM2_ATTRIBUTE = Attribute.of('custom2', String)
             dependencies.attributesSchema.attribute(CUSTOM_ATTRIBUTE)
+            dependencies.attributesSchema.attribute(CUSTOM2_ATTRIBUTE)
         """
     }
 
     void "can select distinct variants of the same component by using different attributes if they have different capabilities"() {
+        given:
+        repository {
+            'org:test:1.0' {
+                variant('api1') {
+                    attribute('custom', 'c1')
+                    capability('cap1')
+                }
+                variant('api2') {
+                    attribute('custom', 'c2')
+                    capability('cap1')
+                }
+                variant('runtime1') {
+                    attribute('custom2', 'c1')
+                    capability('cap2')
+                }
+                variant('runtime2') {
+                    attribute('custom2', 'c2')
+                    capability('cap2')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c1')
+                    }
+                    capabilities {
+                        requireCapability('org.test:cap1:1.0')
+                    }
+                }
+                conf('org:test:1.0') {
+                    attributes {
+                        attribute(CUSTOM2_ATTRIBUTE, 'c2')
+                    }
+                    capabilities {
+                        requireCapability('org.test:cap2:1.0')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:test:1.0' {
+                expectResolve()
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:test:1.0') {
+                    variant('api1', ['org.gradle.status': defaultStatus(), custom: 'c1'])
+                }
+                module('org:test:1.0') {
+                    variant('runtime2', ['org.gradle.status': defaultStatus(), custom2: 'c2'])
+                }
+            }
+        }
+    }
+
+    void "fails selecting distinct variants of the same component by using attributes if they have different capabilities but incompatible values"() {
         given:
         repository {
             'org:test:1.0' {
@@ -81,22 +148,15 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         when:
         repositoryInteractions {
             'org:test:1.0' {
-                expectResolve()
+                expectGetMetadata()
             }
         }
-        succeeds 'checkDeps'
+        fails 'checkDeps'
 
         then:
-        resolve.expectGraph {
-            root(":", ":test:") {
-                module('org:test:1.0') {
-                    variant('api1', ['org.gradle.status': defaultStatus(), custom: 'c1'])
-                }
-                module('org:test:1.0') {
-                    variant('runtime2', ['org.gradle.status': defaultStatus(), custom: 'c2'])
-                }
-            }
-        }
+        failure.assertHasCause("""Multiple incompatible variants of org:test:1.0 were selected:
+   - Variant org:test:1.0 variant api1 has attributes {custom=c1, org.gradle.status=${defaultStatus()}}
+   - Variant org:test:1.0 variant runtime2 has attributes {custom=c2, org.gradle.status=${defaultStatus()}}""")
     }
 
     void "cannot select distinct variants of the same component by using different attributes if they have the same capabilities"() {
@@ -224,6 +284,101 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     artifact('c2')
                 }
                 variant('altruntime') {
+                    attribute('custom2', 'c3')
+                    capability('cap3')
+                    artifact('c3')
+                }
+            }
+            'org:foo:1.1' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                    artifact('c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                    artifact('c2')
+                }
+                variant('altruntime') {
+                    attribute('custom2', 'c3')
+                    capability('cap3')
+                    artifact('c3')
+                }
+            }
+            'org:bar:1.0' {
+                variant('api') {
+                    dependsOn('org:foo:1.1') {
+                        capability('org.test', 'cap3', '1.0')
+                        attributes.custom2 = 'c3'
+                    }
+                }
+                variant('runtime') {
+                    dependsOn('org:foo:1.1') {
+                        requestedCapability('org.test', 'cap3', '1.0')
+                        attributes.custom2 = 'c3'
+                    }
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0') {
+                    attributes {
+                        attribute(CUSTOM_ATTRIBUTE, 'c2')
+                    }
+                }
+                conf('org:bar:1.0')
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:bar:1.0' {
+                expectResolve()
+            }
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
+            'org:foo:1.1' {
+                expectGetMetadata()
+                expectGetVariantArtifacts('runtime')
+                expectGetVariantArtifacts('altruntime')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                edge('org:foo:1.0', 'org:foo:1.1') {
+                    byConflictResolution('between versions 1.0 and 1.1')
+                    // the following assertion is true but limitations to the test fixtures make it hard to check
+                    //variant('altruntime', [custom: 'c3', 'org.gradle.status': defaultStatus()])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c2'
+                    artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c3'
+                }
+                module('org:bar:1.0') {
+                    module('org:foo:1.1')
+                }
+            }
+        }
+
+    }
+
+    def "prevents selection of 2 variants of the same component with transitive dependency if they have different capabilities but incompatible attributes"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {
+                    attribute('custom', 'c1')
+                    artifact('c1')
+                }
+                variant('runtime') {
+                    attribute('custom', 'c2')
+                    artifact('c2')
+                }
+                variant('altruntime') {
                     attribute('custom', 'c3')
                     capability('cap3')
                     artifact('c3')
@@ -274,35 +429,21 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         when:
         repositoryInteractions {
             'org:bar:1.0' {
-                expectResolve()
+                expectGetMetadata()
             }
             'org:foo:1.0' {
                 expectGetMetadata()
             }
             'org:foo:1.1' {
                 expectGetMetadata()
-                expectGetVariantArtifacts('runtime')
-                expectGetVariantArtifacts('altruntime')
             }
         }
-        succeeds 'checkDeps'
+        fails 'checkDeps'
 
         then:
-        resolve.expectGraph {
-            root(":", ":test:") {
-                edge('org:foo:1.0', 'org:foo:1.1') {
-                    byConflictResolution('between versions 1.0 and 1.1')
-                    // the following assertion is true but limitations to the test fixtures make it hard to check
-                    //variant('altruntime', [custom: 'c3', 'org.gradle.status': defaultStatus()])
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
-                    artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c2'
-                    artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c3'
-                }
-                module('org:bar:1.0') {
-                    module('org:foo:1.1')
-                }
-            }
-        }
+        failure.assertHasCause("""Multiple incompatible variants of org:foo:1.1 were selected:
+   - Variant org:foo:1.1 variant altruntime has attributes {custom=c3, org.gradle.status=${defaultStatus()}}
+   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime}""")
 
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -16,12 +16,10 @@
 
 package org.gradle.integtests.resolve.attributes
 
-
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
 import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 @RequiredFeatures(
@@ -213,7 +211,6 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         conflict << [true, false]
     }
 
-    @Ignore("Requires a way for an external dependency to declare a dependency with a capability")
     def "selects 2 variants of the same component with transitive dependency if they have different capabilities"() {
         given:
         repository {
@@ -250,11 +247,13 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             'org:bar:1.0' {
                 variant('api') {
                     dependsOn('org:foo:1.1') {
+                        capability('org.test', 'cap3', '1.0')
                         attributes.custom = 'c3'
                     }
                 }
                 variant('runtime') {
                     dependsOn('org:foo:1.1') {
+                        requestedCapability('org.test', 'cap3', '1.0')
                         attributes.custom = 'c3'
                     }
                 }
@@ -282,7 +281,6 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             }
             'org:foo:1.1' {
                 expectGetMetadata()
-                expectGetVariantArtifacts('api')
                 expectGetVariantArtifacts('runtime')
                 expectGetVariantArtifacts('altruntime')
             }
@@ -295,10 +293,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                 edge('org:foo:1.0', 'org:foo:1.1') {
                     byConflictResolution('between versions 1.0 and 1.1')
                     // the following assertion is true but limitations to the test fixtures make it hard to check
-                    //variant('api',[custom:'c1', 'org.gradle.status':'integration', 'org.gradle.usage':'java-api'])
+                    //variant('altruntime', [custom: 'c3', 'org.gradle.status': defaultStatus()])
                     variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
-                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c1'
-                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c2'
+                    artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c2'
+                    artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c3'
                 }
                 module('org:bar:1.0') {
                     module('org:foo:1.1')
@@ -492,6 +490,8 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                 module('org:foo:1.0') {
                     variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
                     artifact group: 'org', module: 'foo', version: '1.0'
+                }
+                module('org:foo:1.0') {
                     variant('test-fixtures', ['org.gradle.status': defaultStatus()])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'test-fixtures'
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/OptionalFeaturesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/OptionalFeaturesIntegrationTest.groovy
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures(
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
+)
+class OptionalFeaturesIntegrationTest extends AbstractModuleDependencyResolveTest {
+
+    def "can select a variant providing a different capability"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {}
+                variant('runtime') {}
+                variant('feature1') {
+                    capability('org', 'feature-1', '1.0')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    artifact('feat1')
+                }
+                variant('feature2') {
+                    capability('org', 'feature-2', '1.0')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    artifact('feat2')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0')
+                conf('org:foo:1.0') {
+                    capabilities {
+                        requireCapability('org:feature-1:1.0')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectResolve()
+                expectGetVariantArtifacts('feature1')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:foo:1.0') {
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0'
+
+                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
+                }
+            }
+        }
+    }
+
+    def "reasonable error message when no variant provides required capability"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {}
+                variant('runtime') {}
+                variant('feature1') {
+                    capability('org', 'feature-1', '1.0')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    artifact('feat1')
+                }
+                variant('feature2') {
+                    capability('org', 'feature-2', '1.0')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    artifact('feat2')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0')
+                conf('org:foo:1.0') {
+                    capabilities {
+                        requireCapability('org:feature-3:1.0')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectGetMetadata()
+            }
+        }
+        fails 'checkDeps'
+
+        then:
+        failure.assertHasCause("""Unable to find a variant of org:foo:1.0 providing the requested capability org:feature-3:1.0:
+   - Variant api provides org:foo:1.0
+   - Variant runtime provides org:foo:1.0
+   - Variant feature1 provides org:feature-1:1.0
+   - Variant feature2 provides org:feature-2:1.0""")
+    }
+
+    def "can select a variant providing the required set of capabilities"() {
+        given:
+        repository {
+            'org:foo:1.0' {
+                variant('api') {}
+                variant('runtime') {}
+                variant('v1') {
+                    capability('org', 'feature-1', '1.0')
+                    capability('org', 'feature-2', '1.0')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    artifact('feat1')
+                    artifact('feat2')
+                }
+                variant('v2') {
+                    capability('org', 'feature-1', '1.0')
+                    capability('org', 'feature-3', '1.0')
+                    attribute('org.gradle.usage', 'java-runtime')
+                    artifact('feat1')
+                    artifact('feat3')
+                }
+            }
+        }
+
+        buildFile << """
+            dependencies {
+                conf('org:foo:1.0')
+                conf('org:foo:1.0') {
+                    capabilities {
+                        requireCapabilities('org:feature-1:1.0', 'org:feature-3:1.0')
+                    }
+                }
+            }
+        """
+
+        when:
+        repositoryInteractions {
+            'org:foo:1.0' {
+                expectResolve()
+                expectGetVariantArtifacts('v2')
+            }
+        }
+        succeeds 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:foo:1.0') {
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0'
+
+                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
+                    artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat3'
+                }
+            }
+        }
+    }
+
+
+    static Closure<String> defaultStatus() {
+        { -> GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release' }
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/OptionalFeaturesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/OptionalFeaturesIntegrationTest.groovy
@@ -185,7 +185,6 @@ class OptionalFeaturesIntegrationTest extends AbstractModuleDependencyResolveTes
         }
     }
 
-
     static Closure<String> defaultStatus() {
         { -> GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release' }
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/OptionalFeaturesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/OptionalFeaturesIntegrationTest.groovy
@@ -71,7 +71,8 @@ class OptionalFeaturesIntegrationTest extends AbstractModuleDependencyResolveTes
                 module('org:foo:1.0') {
                     variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
                     artifact group: 'org', module: 'foo', version: '1.0'
-
+                }
+                module('org:foo:1.0') {
                     variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                 }
@@ -174,7 +175,8 @@ class OptionalFeaturesIntegrationTest extends AbstractModuleDependencyResolveTes
                 module('org:foo:1.0') {
                     variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
                     artifact group: 'org', module: 'foo', version: '1.0'
-
+                }
+                module('org:foo:1.0') {
                     variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat3'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ProjectDependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/ProjectDependenciesAttributesIntegrationTest.groovy
@@ -87,9 +87,9 @@ class ProjectDependenciesAttributesIntegrationTest extends AbstractIntegrationSp
 
         then:
         failure.assertHasCause("""Unable to find a matching variant of project :dep:
-  - Variant 'blueVariant':
+  - Variant 'blueVariant' capability test:dep:unspecified:
       - Required color 'green' and found incompatible value 'blue'.
-  - Variant 'redVariant':
+  - Variant 'redVariant' capability test:dep:unspecified:
       - Required color 'green' and found incompatible value 'red'.""")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/StronglyTypedConfigurationAttributesResolveIntegrationTest.groovy
@@ -395,10 +395,10 @@ class StronglyTypedConfigurationAttributesResolveIntegrationTest extends Abstrac
   - foo2
   - foo3
 All of them match the consumer attributes:
-  - Variant 'foo2':
+  - Variant 'foo2' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' and found compatible value 'ONE'.
-  - Variant 'foo3':
+  - Variant 'foo3' capability test:b:unspecified:
       - Required buildType 'debug' and found compatible value 'debug'.
       - Required flavor 'free' and found compatible value 'ONE'."""
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -42,6 +42,7 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
             apply plugin: 'java-library'
             
             configurations.api.outgoing {
+                capability 'test:b:unspecified'
                 capability group:'org', name:'capability', version:'1.0'
             }
         """

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -358,6 +358,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             'asm:asm:3.0'()
             'org.ow2.asm:asm:4.0' {
                 variant('runtime') {
+                    capability('org.ow2.asm', 'asm', '4.0') // explicitly declare capability
                     capability('asm', 'asm', '4.0') // upgrades the asm capability
                 }
             }
@@ -424,11 +425,13 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
         repository {
             'org:testA:1.0' {
                 variant('runtime') {
+                    capability('org', 'testA', '1.0')
                     capability('cap')
                 }
             }
             'org:testB:1.0' {
                 variant('runtime') {
+                    capability('org', 'testB', '1.0')
                     capability('cap')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -32,6 +32,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
             'cglib:cglib:3.2.5'()
             'cglib:cglib-nodep:3.2.5' {
                 variant("runtime") {
+                    capability('cglib', 'cglib-nodep', '3.2.5')
                     capability('cglib', 'cglib', '3.2.5')
                 }
             }
@@ -65,6 +66,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
             'cglib:cglib:3.2.5'()
             'cglib:cglib-nodep:3.2.4' {
                 variant("runtime") {
+                    capability('cglib', 'cglib-nodep', '3.2.4')
                     capability('cglib', 'cglib', '3.2.4')
                 }
             }
@@ -103,6 +105,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         repository {
             'org:test:1.0' {
                 variant("runtime") {
+                    capability('org', 'test', '1.0')
                     capability('org', 'capability', '1.0')
                 }
             }
@@ -145,11 +148,13 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         repository {
             'org:testA:1.0' {
                 variant('runtime') {
+                    capability('org', 'testA', '1.0')
                     capability('cap')
                 }
             }
             'org:testB:1.0' {
                 variant('runtime') {
+                    capability('org', 'testB', '1.0')
                     capability('cap')
                 }
             }
@@ -182,11 +187,13 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         repository {
             'org:testA:1.0' {
                 variant('runtime') {
+                    capability('org', 'testA', '1.0')
                     capability('org', 'cap', '1')
                 }
             }
             'org:testB:1.0' {
                 variant('runtime') {
+                    capability('org', 'testB', '1.0')
                     capability('org', 'cap', '4')
                 }
             }
@@ -198,6 +205,7 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
             }
             'org:testCC:1.0' {
                 variant('runtime') {
+                    capability('org', 'testCC', '1.0')
                     capability('org', 'cap', '2')
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.ClientModule;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.dependencies.AbstractModuleDependency;
 import org.gradle.api.internal.artifacts.dependencies.DefaultDependencyConstraint;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
@@ -36,17 +37,20 @@ public class DefaultDependencyFactory implements DependencyFactory {
     private final NotationParser<Object, Dependency> dependencyNotationParser;
     private final NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser;
     private final NotationParser<Object, ClientModule> clientModuleNotationParser;
+    private final NotationParser<Object, Capability> capabilityNotationParser;
     private final ProjectDependencyFactory projectDependencyFactory;
     private final ImmutableAttributesFactory attributesFactory;
 
     public DefaultDependencyFactory(NotationParser<Object, Dependency> dependencyNotationParser,
                                     NotationParser<Object, DependencyConstraint> dependencyConstraintNotationParser,
                                     NotationParser<Object, ClientModule> clientModuleNotationParser,
+                                    NotationParser<Object, Capability> capabilityNotationParser,
                                     ProjectDependencyFactory projectDependencyFactory,
                                     ImmutableAttributesFactory attributesFactory) {
         this.dependencyNotationParser = dependencyNotationParser;
         this.dependencyConstraintNotationParser = dependencyConstraintNotationParser;
         this.clientModuleNotationParser = clientModuleNotationParser;
+        this.capabilityNotationParser = capabilityNotationParser;
         this.projectDependencyFactory = projectDependencyFactory;
         this.attributesFactory = attributesFactory;
     }
@@ -59,7 +63,9 @@ public class DefaultDependencyFactory implements DependencyFactory {
 
     private void injectAttributesFactory(Dependency dependency) {
         if (dependency instanceof AbstractModuleDependency) {
-            ((AbstractModuleDependency) dependency).setAttributesFactory(attributesFactory);
+            AbstractModuleDependency moduleDependency = (AbstractModuleDependency) dependency;
+            moduleDependency.setAttributesFactory(attributesFactory);
+            moduleDependency.setCapabilityNotationParser(capabilityNotationParser);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -20,9 +20,9 @@ import com.google.common.collect.Sets;
 import org.gradle.StartParameter;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.FeaturePreviews;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.component.DefaultComponentIdentifierFactory;
+import org.gradle.api.internal.artifacts.dsl.CapabilityNotationParserFactory;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheLockingManager;
 import org.gradle.api.internal.artifacts.ivyservice.ArtifactCacheMetadata;
@@ -36,12 +36,12 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultV
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionComparator;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
-import org.gradle.api.internal.artifacts.ivyservice.modulecache.PersistentModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.InMemoryModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleComponentResolveMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCacheProvider;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleRepositoryCaches;
+import org.gradle.api.internal.artifacts.ivyservice.modulecache.PersistentModuleMetadataCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.SuppliedComponentMetadataSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.DefaultModuleArtifactCache;
 import org.gradle.api.internal.artifacts.ivyservice.modulecache.artifacts.DefaultModuleArtifactsCache;
@@ -98,6 +98,7 @@ import org.gradle.internal.build.BuildState;
 import org.gradle.internal.build.BuildStateRegistry;
 import org.gradle.internal.component.external.model.ModuleComponentArtifactMetadata;
 import org.gradle.internal.installation.CurrentGradleInstallation;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
@@ -152,9 +153,9 @@ class DependencyManagementBuildScopeServices {
 
         return new DefaultDependencyFactory(
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileLookup, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
-            DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
-            new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
-            projectDependencyFactory,
+                DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
+                new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
+                new CapabilityNotationParserFactory().create(), projectDependencyFactory,
             attributesFactory);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -53,6 +53,7 @@ public enum CacheLayout {
         .changedTo(63, "4.10-rc-1")
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
+        .changedTo(95410263, "5.2-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencyResolveDetails.java
@@ -109,7 +109,7 @@ public class DefaultDependencyResolveDetails implements DependencyResolveDetails
             if (delegate.getTarget() instanceof ModuleComponentSelector) {
                 ModuleComponentSelector target = (ModuleComponentSelector) delegate.getTarget();
                 if (!useVersion.equals(target.getVersionConstraint())) {
-                    delegate.useTarget(DefaultModuleComponentSelector.newSelector(target.getModuleIdentifier(), useVersion, target.getAttributes()), selectionReason);
+                    delegate.useTarget(DefaultModuleComponentSelector.newSelector(target.getModuleIdentifier(), useVersion, target.getAttributes(), target.getRequestedCapabilities()), selectionReason);
                 } else {
                     // Still 'updated' with reason when version remains the same.
                     delegate.useTarget(delegate.getTarget(), selectionReason);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/UnversionedModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/UnversionedModuleComponentSelector.java
@@ -21,7 +21,11 @@ import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.Collections;
+import java.util.List;
 
 class UnversionedModuleComponentSelector implements ComponentSelector {
     private final ModuleIdentifier moduleIdentifier;
@@ -47,6 +51,11 @@ class UnversionedModuleComponentSelector implements ComponentSelector {
     @Override
     public AttributeContainer getAttributes() {
         return ImmutableAttributes.EMPTY;
+    }
+
+    @Override
+    public List<Capability> getRequestedCapabilities() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializer.java
@@ -62,6 +62,7 @@ import org.gradle.internal.serialize.Encoder;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,7 @@ public class ModuleMetadataSerializer {
         private void writeVariantConstraints(ImmutableList<? extends ComponentVariant.DependencyConstraint> constraints) throws IOException {
             encoder.writeSmallInt(constraints.size());
             for (ComponentVariant.DependencyConstraint constraint : constraints) {
-                componentSelectorSerializer.write(encoder, constraint.getGroup(), constraint.getModule(), constraint.getVersionConstraint(), constraint.getAttributes());
+                componentSelectorSerializer.write(encoder, constraint.getGroup(), constraint.getModule(), constraint.getVersionConstraint(), constraint.getAttributes(), Collections.emptyList());
                 encoder.writeNullableString(constraint.getReason());
             }
         }
@@ -146,7 +147,7 @@ public class ModuleMetadataSerializer {
         private void writeVariantDependencies(List<? extends ComponentVariant.Dependency> dependencies) throws IOException {
             encoder.writeSmallInt(dependencies.size());
             for (ComponentVariant.Dependency dependency : dependencies) {
-                componentSelectorSerializer.write(encoder, dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint(), dependency.getAttributes());
+                componentSelectorSerializer.write(encoder, dependency.getGroup(), dependency.getModule(), dependency.getVersionConstraint(), dependency.getAttributes(), dependency.getRequestedCapabilities());
                 encoder.writeNullableString(dependency.getReason());
                 writeVariantDependencyExcludes(dependency.getExcludes());
             }
@@ -448,7 +449,7 @@ public class ModuleMetadataSerializer {
                 ModuleComponentSelector selector = componentSelectorSerializer.read(decoder);
                 String reason = decoder.readNullableString();
                 ImmutableList<ExcludeMetadata> excludes = readVariantDependencyExcludes();
-                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason, (ImmutableAttributes) selector.getAttributes());
+                variant.addDependency(selector.getGroup(), selector.getModule(), selector.getVersionConstraint(), excludes, reason, (ImmutableAttributes) selector.getAttributes(), selector.getRequestedCapabilities());
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies;
 
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -48,9 +49,9 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
 
     public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
-            DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
-        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null, Collections.emptySet(),
-            Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, dependencyConstraint.getReason());
+            DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of());
+        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
+                Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, dependencyConstraint.getReason());
     }
 
     private IvyDependencyDescriptorFactory findFactoryForDependency(ModuleDependency dependency) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/DefaultDependencyDescriptorFactory.java
@@ -49,7 +49,7 @@ public class DefaultDependencyDescriptorFactory implements DependencyDescriptorF
     public LocalOriginDependencyMetadata createDependencyConstraintDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer attributes, DependencyConstraint dependencyConstraint) {
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
             DefaultModuleIdentifier.newId(nullToEmpty(dependencyConstraint.getGroup()), nullToEmpty(dependencyConstraint.getName())), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes());
-        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null,
+        return new LocalComponentDependencyMetadata(componentId, selector, clientConfiguration, attributes, dependencyConstraint.getAttributes(), null, Collections.emptySet(),
             Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), ((DependencyConstraintInternal)dependencyConstraint).isForce(), false, false, true, dependencyConstraint.getReason());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -48,7 +48,10 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
 
         List<ExcludeMetadata> excludes = convertExcludeRules(clientConfiguration, dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
-                componentId, selector, clientConfiguration, clientAttributes, dependency.getAttributes(), dependency.getTargetConfiguration(),
+                componentId, selector, clientConfiguration, clientAttributes,
+                dependency.getAttributes(),
+                dependency.getTargetConfiguration(),
+                dependency.getRequestedCapabilities(),
                 convertArtifacts(dependency.getArtifacts()),
                 excludes, force, changing, transitive, false, dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ExternalModuleIvyDependencyDescriptorFactory.java
@@ -42,16 +42,16 @@ public class ExternalModuleIvyDependencyDescriptorFactory extends AbstractIvyDep
         boolean transitive = externalModuleDependency.isTransitive();
 
         ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(
-            DefaultModuleIdentifier.newId(nullToEmpty(dependency.getGroup()), nullToEmpty(dependency.getName())),
-            ((VersionConstraintInternal)externalModuleDependency.getVersionConstraint()).asImmutable(),
-            dependency.getAttributes());
+                DefaultModuleIdentifier.newId(nullToEmpty(dependency.getGroup()), nullToEmpty(dependency.getName())),
+                ((VersionConstraintInternal) externalModuleDependency.getVersionConstraint()).asImmutable(),
+                dependency.getAttributes(),
+                dependency.getRequestedCapabilities());
 
         List<ExcludeMetadata> excludes = convertExcludeRules(clientConfiguration, dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
                 componentId, selector, clientConfiguration, clientAttributes,
                 dependency.getAttributes(),
                 dependency.getTargetConfiguration(),
-                dependency.getRequestedCapabilities(),
                 convertArtifacts(dependency.getArtifacts()),
                 excludes, force, changing, transitive, false, dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -49,6 +49,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
             clientAttributes,
             dependency.getAttributes(),
             projectDependency.getTargetConfiguration(),
+            projectDependency.getRequestedCapabilities(),
             convertArtifacts(dependency.getArtifacts()),
             excludes,
             false, false, dependency.isTransitive(), false, dependency.getReason());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -39,7 +39,9 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
     public LocalOriginDependencyMetadata createDependencyDescriptor(ComponentIdentifier componentId, String clientConfiguration, AttributeContainer clientAttributes, ModuleDependency dependency) {
         ProjectDependencyInternal projectDependency = (ProjectDependencyInternal) dependency;
         projectDependency.beforeResolved();
-        ComponentSelector selector = DefaultProjectComponentSelector.newSelector(projectDependency.getDependencyProject(), ((AttributeContainerInternal)projectDependency.getAttributes()).asImmutable());
+        ComponentSelector selector = DefaultProjectComponentSelector.newSelector(projectDependency.getDependencyProject(),
+                ((AttributeContainerInternal)projectDependency.getAttributes()).asImmutable(),
+                projectDependency.getRequestedCapabilities());
 
         List<ExcludeMetadata> excludes = convertExcludeRules(clientConfiguration, dependency.getExcludeRules());
         LocalComponentDependencyMetadata dependencyMetaData = new LocalComponentDependencyMetadata(
@@ -49,8 +51,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
             clientAttributes,
             dependency.getAttributes(),
             projectDependency.getTargetConfiguration(),
-            projectDependency.getRequestedCapabilities(),
-            convertArtifacts(dependency.getArtifacts()),
+                convertArtifacts(dependency.getArtifacts()),
             excludes,
             false, false, dependency.isTransitive(), false, dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectIvyDependencyDescriptorFactory.java
@@ -51,7 +51,7 @@ public class ProjectIvyDependencyDescriptorFactory extends AbstractIvyDependency
             clientAttributes,
             dependency.getAttributes(),
             projectDependency.getTargetConfiguration(),
-                convertArtifacts(dependency.getArtifacts()),
+            convertArtifacts(dependency.getArtifacts()),
             excludes,
             false, false, dependency.isTransitive(), false, dependency.getReason());
         return new DslOriginDependencyMetadataWrapper(dependencyMetaData, dependency);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolutionstrategy/ModuleForcingResolveRule.java
@@ -55,7 +55,7 @@ public class ModuleForcingResolveRule implements Action<DependencySubstitutionIn
             ModuleIdentifier key = selector.getModuleIdentifier();
             if (forcedModules.containsKey(key)) {
                 DefaultImmutableVersionConstraint versionConstraint = new DefaultImmutableVersionConstraint(forcedModules.get(key));
-                details.useTarget(newSelector(key, versionConstraint, selector.getAttributes()), ComponentSelectionReasons.FORCED);
+                details.useTarget(newSelector(key, versionConstraint, selector.getAttributes(), selector.getRequestedCapabilities()), ComponentSelectionReasons.FORCED);
 
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedVariantDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/ResolvedVariantDetails.java
@@ -16,7 +16,10 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph;
 
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.DisplayName;
+
+import java.util.List;
 
 public interface ResolvedVariantDetails {
     /**
@@ -32,4 +35,9 @@ public interface ResolvedVariantDetails {
      * not necessarily the case.
      */
     AttributeContainer getVariantAttributes();
+
+    /**
+     * Returns the capabilities provided by this variant.
+     */
+    List<Capability> getCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/AttributeDesugaring.java
@@ -59,7 +59,7 @@ abstract class AttributeDesugaring {
             AttributeContainer moduleAttributes = module.getAttributes();
             if (!moduleAttributes.isEmpty()) {
                 ImmutableAttributes attributes = ((AttributeContainerInternal) moduleAttributes).asImmutable();
-                return DefaultModuleComponentSelector.newSelector(module.getModuleIdentifier(), module.getVersionConstraint(), desugar(attributes, attributesFactory));
+                return DefaultModuleComponentSelector.newSelector(module.getModuleIdentifier(), module.getVersionConstraint(), desugar(attributes, attributesFactory), module.getRequestedCapabilities());
             }
         }
         if (selector instanceof DefaultProjectComponentSelector) {
@@ -67,7 +67,7 @@ abstract class AttributeDesugaring {
             AttributeContainer projectAttributes = project.getAttributes();
             if (!projectAttributes.isEmpty()) {
                 ImmutableAttributes attributes = ((AttributeContainerInternal) projectAttributes).asImmutable();
-                return new DefaultProjectComponentSelector(project.getBuildIdentifier(), project.getIdentityPath(), project.projectPath(), project.getProjectName(), desugar(attributes, attributesFactory));
+                return new DefaultProjectComponentSelector(project.getBuildIdentifier(), project.getIdentityPath(), project.projectPath(), project.getProjectName(), desugar(attributes, attributesFactory), project.getRequestedCapabilities());
             }
         }
         return selector;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -258,7 +258,8 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
                 DisplayName name = Describables.of(metadata.getName());
                 List<? extends Capability> capabilities = metadata.getCapabilities().getCapabilities();
                 AttributeContainer attributes = AttributeDesugaring.desugar(metadata.getAttributes(), node.getAttributesFactory());
-                ResolvedVariantDetails details = new DefaultVariantDetails(name, attributes, capabilities.isEmpty() ? Collections.singletonList(implicitCapability) : ImmutableList.copyOf(capabilities));
+                List<Capability> resolvedVariantCapabilities = capabilities.isEmpty() ? Collections.singletonList(implicitCapability) : ImmutableList.copyOf(capabilities);
+                ResolvedVariantDetails details = new DefaultVariantDetails(name, attributes, resolvedVariantCapabilities);
                 if (result != null) {
                     result.add(details);
                 } else if (cur != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ComponentState.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
@@ -37,6 +38,7 @@ import org.gradle.internal.DisplayName;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.model.ComponentOverrideMetadata;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DefaultComponentOverrideMetadata;
 import org.gradle.internal.component.model.ModuleSource;
 import org.gradle.internal.resolve.ModuleVersionResolveException;
@@ -252,9 +254,11 @@ public class ComponentState implements ComponentResolutionState, DependencyGraph
         ResolvedVariantDetails cur = null;
         for (NodeState node : nodes) {
             if (node.isSelected()) {
-                DisplayName name = Describables.of(node.getMetadata().getName());
-                AttributeContainer attributes = AttributeDesugaring.desugar(node.getMetadata().getAttributes(), node.getAttributesFactory());
-                ResolvedVariantDetails details = new DefaultVariantDetails(name, attributes);
+                ConfigurationMetadata metadata = node.getMetadata();
+                DisplayName name = Describables.of(metadata.getName());
+                List<? extends Capability> capabilities = metadata.getCapabilities().getCapabilities();
+                AttributeContainer attributes = AttributeDesugaring.desugar(metadata.getAttributes(), node.getAttributesFactory());
+                ResolvedVariantDetails details = new DefaultVariantDetails(name, attributes, capabilities.isEmpty() ? Collections.singletonList(implicitCapability) : ImmutableList.copyOf(capabilities));
                 if (result != null) {
                     result.add(details);
                 } else if (cur != null) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultVariantDetails.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DefaultVariantDetails.java
@@ -16,16 +16,21 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails;
 import org.gradle.internal.DisplayName;
+
+import java.util.List;
 
 public class DefaultVariantDetails implements ResolvedVariantDetails {
     private final DisplayName name;
     private final AttributeContainer attributes;
+    private final List<Capability> capabilities;
 
-    public DefaultVariantDetails(DisplayName name, AttributeContainer attributes) {
+    public DefaultVariantDetails(DisplayName name, AttributeContainer attributes, List<Capability> capabilities) {
         this.name = name;
         this.attributes = attributes;
+        this.capabilities = capabilities;
     }
 
     @Override
@@ -36,5 +41,10 @@ public class DefaultVariantDetails implements ResolvedVariantDetails {
     @Override
     public AttributeContainer getVariantAttributes() {
         return attributes;
+    }
+
+    @Override
+    public List<Capability> getCapabilities() {
+        return capabilities;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -181,7 +181,7 @@ class EdgeState implements DependencyGraphEdge {
         try {
             ImmutableAttributes attributes = resolveState.getRoot().getMetadata().getAttributes();
             attributes = resolveState.getAttributesFactory().concat(attributes, getAttributes());
-            targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema());
+            targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema(), dependencyMetadata.getRequestedCapabilities());
         } catch (Exception t) {
             // Failure to select the target variant/configurations from this component, given the dependency attributes/metadata.
             targetNodeSelectionFailure = new ModuleVersionResolveException(dependencyState.getRequested(), t);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -181,7 +181,7 @@ class EdgeState implements DependencyGraphEdge {
         try {
             ImmutableAttributes attributes = resolveState.getRoot().getMetadata().getAttributes();
             attributes = resolveState.getAttributesFactory().concat(attributes, getAttributes());
-            targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema(), dependencyMetadata.getRequestedCapabilities());
+            targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema(), dependencyState.getRequested().getRequestedCapabilities());
         } catch (Exception t) {
             // Failure to select the target variant/configurations from this component, given the dependency attributes/metadata.
             targetNodeSelectionFailure = new ModuleVersionResolveException(dependencyState.getRequested(), t);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleVariantsSelectionMessageBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/IncompatibleVariantsSelectionMessageBuilder.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+class IncompatibleVariantsSelectionMessageBuilder {
+    static String buildMessage(ComponentState selected, Set<NodeState> incompatibleNodes) {
+        StringBuilder sb = new StringBuilder("Multiple incompatible variants of ")
+                .append(selected.getId())
+                .append(" were selected:\n");
+        ArrayList<NodeState> sorted = Lists.newArrayList(incompatibleNodes);
+        Collections.sort(sorted, Comparator.comparing(NodeState::getNameWithVariant));
+        for (NodeState node : sorted) {
+            sb.append("   - Variant ").append(node.getNameWithVariant()).append(" has attributes ");
+            appendAttributes(sb, node.getMetadata().getAttributes());
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    private static void appendAttributes(StringBuilder sb, ImmutableAttributes attributes) {
+        ImmutableSet<Attribute<?>> keySet = attributes.keySet();
+        List<Attribute<?>> sorted = Lists.newArrayList(keySet);
+        Collections.sort(sorted, Comparator.comparing(Attribute::getName));
+        boolean space = false;
+        sb.append("{");
+        for (Attribute<?> attribute : sorted) {
+            if (space) {
+                sb.append(", ");
+            }
+            sb.append(attribute.getName()).append("=").append(attributes.getAttribute(attribute));
+            space = true;
+        }
+        sb.append("}");
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultConfigurationMetadata;
@@ -78,13 +79,18 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+    public Set<Capability> getRequestedCapabilities() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
         if (targetComponent instanceof LenientPlatformResolveMetadata) {
             LenientPlatformResolveMetadata platformMetadata = (LenientPlatformResolveMetadata) targetComponent;
             return Collections.singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.getPlatformState(), platformId));
         }
         // the target component exists, so we need to fallback to the traditional selection process
-        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.emptySet(), Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformDependencyMetadata.java
@@ -40,6 +40,7 @@ import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalComponentDependencyMetadata;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -79,18 +80,13 @@ class LenientPlatformDependencyMetadata implements ModuleDependencyMetadata, For
     }
 
     @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return Collections.emptySet();
-    }
-
-    @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         if (targetComponent instanceof LenientPlatformResolveMetadata) {
             LenientPlatformResolveMetadata platformMetadata = (LenientPlatformResolveMetadata) targetComponent;
             return Collections.singletonList(new LenientPlatformConfigurationMetadata(platformMetadata.getPlatformState(), platformId));
         }
         // the target component exists, so we need to fallback to the traditional selection process
-        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.emptySet(), Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
+        return new LocalComponentDependencyMetadata(componentId, cs, null, ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, null, Collections.<IvyArtifactName>emptyList(), Collections.<ExcludeMetadata>emptyList(), false, false, true, false, null).selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentSelectorSerializer.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.BuildIdentifier;
@@ -23,11 +24,13 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
+import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.component.local.model.DefaultLibraryComponentSelector;
 import org.gradle.internal.component.local.model.DefaultProjectComponentSelector;
 import org.gradle.internal.serialize.AbstractSerializer;
@@ -36,6 +39,8 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.util.Path;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSelector> {
@@ -53,22 +58,22 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         if (Implementation.ROOT_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             String projectName = decoder.readString();
-            return new DefaultProjectComponentSelector(buildIdentifier, Path.ROOT, Path.ROOT, projectName, readAttributes(decoder));
+            return new DefaultProjectComponentSelector(buildIdentifier, Path.ROOT, Path.ROOT, projectName, readAttributes(decoder), readCapabilities(decoder));
         } else if (Implementation.ROOT_BUILD_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path projectPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, projectPath, projectPath, projectPath.getName(), readAttributes(decoder));
+            return new DefaultProjectComponentSelector(buildIdentifier, projectPath, projectPath, projectPath.getName(), readAttributes(decoder), readCapabilities(decoder));
         } else if (Implementation.OTHER_BUILD_ROOT_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path identityPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, identityPath.getName(), readAttributes(decoder));
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, Path.ROOT, identityPath.getName(), readAttributes(decoder), readCapabilities(decoder));
         } else if (Implementation.OTHER_BUILD_PROJECT.getId() == id) {
             BuildIdentifier buildIdentifier = buildIdentifierSerializer.read(decoder);
             Path identityPath = Path.path(decoder.readString());
             Path projectPath = Path.path(decoder.readString());
-            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, projectPath, projectPath.getName(), readAttributes(decoder));
+            return new DefaultProjectComponentSelector(buildIdentifier, identityPath, projectPath, projectPath.getName(), readAttributes(decoder), readCapabilities(decoder));
         } else if (Implementation.MODULE.getId() == id) {
-            return DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), readVersionConstraint(decoder), readAttributes(decoder));
+            return DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(decoder.readString(), decoder.readString()), readVersionConstraint(decoder), readAttributes(decoder), readCapabilities(decoder));
         } else if (Implementation.LIBRARY.getId() == id) {
             return new DefaultLibraryComponentSelector(decoder.readString(), decoder.readNullableString(), decoder.readNullableString());
         }
@@ -92,6 +97,27 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
         return new DefaultImmutableVersionConstraint(prefers, requires, strictly, rejects);
     }
 
+    private List<Capability> readCapabilities(Decoder decoder) throws IOException {
+        int size = decoder.readSmallInt();
+        if (size == 0) {
+            return Collections.emptyList();
+        }
+        ImmutableList.Builder<Capability> builder = ImmutableList.builderWithExpectedSize(size);
+        for (int i=0; i<size; i++) {
+            builder.add(new ImmutableCapability(decoder.readString(), decoder.readString(), decoder.readNullableString()));
+        }
+        return builder.build();
+    }
+
+    private void writeCapabilities(Encoder encoder, Collection<Capability> capabilities) throws IOException {
+        encoder.writeSmallInt(capabilities.size());
+        for (Capability capability : capabilities) {
+            encoder.writeString(capability.getGroup());
+            encoder.writeString(capability.getName());
+            encoder.writeNullableString(capability.getVersion());
+        }
+    }
+
     public void write(Encoder encoder, ComponentSelector value) throws IOException {
         if (value == null) {
             throw new IllegalArgumentException("Provided component selector may not be null");
@@ -108,27 +134,32 @@ public class ComponentSelectorSerializer extends AbstractSerializer<ComponentSel
             VersionConstraint versionConstraint = moduleComponentSelector.getVersionConstraint();
             writeVersionConstraint(encoder, versionConstraint);
             writeAttributes(encoder, moduleComponentSelector.getAttributes());
+            writeCapabilities(encoder, moduleComponentSelector.getRequestedCapabilities());
         } else if (implementation == Implementation.ROOT_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getProjectName());
             writeAttributes(encoder, projectComponentSelector.getAttributes());
+            writeCapabilities(encoder, projectComponentSelector.getRequestedCapabilities());
         } else if (implementation == Implementation.ROOT_BUILD_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getProjectPath());
             writeAttributes(encoder, projectComponentSelector.getAttributes());
+            writeCapabilities(encoder, projectComponentSelector.getRequestedCapabilities());
         } else if (implementation == Implementation.OTHER_BUILD_ROOT_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
             writeAttributes(encoder, projectComponentSelector.getAttributes());
+            writeCapabilities(encoder, projectComponentSelector.getRequestedCapabilities());
         } else if (implementation == Implementation.OTHER_BUILD_PROJECT) {
             DefaultProjectComponentSelector projectComponentSelector = (DefaultProjectComponentSelector) value;
             buildIdentifierSerializer.write(encoder, projectComponentSelector.getBuildIdentifier());
             encoder.writeString(projectComponentSelector.getIdentityPath().getPath());
             encoder.writeString(projectComponentSelector.getProjectPath());
             writeAttributes(encoder, projectComponentSelector.getAttributes());
+            writeCapabilities(encoder, projectComponentSelector.getRequestedCapabilities());
         } else if (implementation == Implementation.LIBRARY) {
             LibraryComponentSelector libraryComponentSelector = (LibraryComponentSelector) value;
             encoder.writeString(libraryComponentSelector.getProjectPath());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -69,7 +69,7 @@ public class DefaultResolutionResultBuilder {
         List<ResolvedVariantDetails> resolvedVariants = component.getResolvedVariants();
         ImmutableList.Builder<ResolvedVariantResult> builder = ImmutableList.builderWithExpectedSize(resolvedVariants.size());
         for (ResolvedVariantDetails resolvedVariant : resolvedVariants) {
-            builder.add(new DefaultResolvedVariantResult(resolvedVariant.getVariantName(), resolvedVariant.getVariantAttributes()));
+            builder.add(new DefaultResolvedVariantResult(resolvedVariant.getVariantName(), resolvedVariant.getVariantAttributes(), resolvedVariant.getCapabilities()));
         }
         return builder.build();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependenciesMetadataAdapter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.repositories.resolver;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.DependenciesMetadata;
@@ -111,7 +112,8 @@ public abstract class AbstractDependenciesMetadataAdapter<T extends DependencyMe
     }
 
     private org.gradle.internal.component.model.DependencyMetadata toDependencyMetadata(T details) {
-        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes());
+        // TODO: CC make capabilities accessible to rules
+        ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(details.getModule(), DefaultImmutableVersionConstraint.of(details.getVersionConstraint()), details.getAttributes(), ImmutableList.of());
         return new GradleDependencyMetadata(selector, Collections.<ExcludeMetadata>emptyList(), isConstraint(), details.getReason(), false);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/resolver/AbstractDependencyMetadataAdapter.java
@@ -107,7 +107,7 @@ public abstract class AbstractDependencyMetadataAdapter<T extends DependencyMeta
         ModuleComponentSelector selector = getOriginalMetadata().getSelector();
         AttributeContainerInternal attributes = attributesFactory.mutable((AttributeContainerInternal) selector.getAttributes());
         configureAction.execute(attributes);
-        ModuleComponentSelector target = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), selector.getVersionConstraint(), attributes.asImmutable());
+        ModuleComponentSelector target = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), selector.getVersionConstraint(), attributes.asImmutable(), selector.getRequestedCapabilities());
         ModuleDependencyMetadata metadata = (ModuleDependencyMetadata) getOriginalMetadata().withTarget(target);
         updateMetadata(metadata);
         return Cast.uncheckedCast(this);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedArtifactResult.java
@@ -23,6 +23,7 @@ import org.gradle.api.component.Artifact;
 import org.gradle.internal.DisplayName;
 
 import java.io.File;
+import java.util.Collections;
 
 public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
     private final ComponentArtifactIdentifier identifier;
@@ -36,7 +37,7 @@ public class DefaultResolvedArtifactResult implements ResolvedArtifactResult {
 
     public DefaultResolvedArtifactResult(ComponentArtifactIdentifier identifier, DisplayName variantDisplayName, AttributeContainer variantAttributes, Class<? extends Artifact> type, File file) {
         this.identifier = identifier;
-        this.variant = new DefaultResolvedVariantResult(variantDisplayName, variantAttributes);
+        this.variant = new DefaultResolvedVariantResult(variantDisplayName, variantAttributes, Collections.emptyList());
         this.type = type;
         this.file = file;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedComponentResult.java
@@ -100,14 +100,14 @@ public class DefaultResolvedComponentResult implements ResolvedComponentResultIn
     @Override
     public ResolvedVariantResult getVariant() {
         if (variants.isEmpty()) {
-            return new DefaultResolvedVariantResult(Describables.of("<empty>"), ImmutableAttributes.EMPTY);
+            return new DefaultResolvedVariantResult(Describables.of("<empty>"), ImmutableAttributes.EMPTY, Collections.emptyList());
         }
         // Returns an approximation of a composite variant
         List<String> parts = variants.stream()
                 .map(ResolvedVariantResult::getDisplayName)
                 .collect(Collectors.toList());
         DisplayName variantName = new VariantNameBuilder().getVariantName(parts);
-        return new DefaultResolvedVariantResult(variantName, variants.get(0).getAttributes());
+        return new DefaultResolvedVariantResult(variantName, variants.get(0).getAttributes(), variants.get(0).getCapabilities());
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/result/DefaultResolvedVariantResult.java
@@ -18,15 +18,20 @@ package org.gradle.api.internal.artifacts.result;
 
 import org.gradle.api.artifacts.result.ResolvedVariantResult;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.DisplayName;
+
+import java.util.List;
 
 public class DefaultResolvedVariantResult implements ResolvedVariantResult {
     private final DisplayName displayName;
     private final AttributeContainer attributes;
+    private final List<Capability> capabilities;
 
-    public DefaultResolvedVariantResult(DisplayName displayName, AttributeContainer attributes) {
+    public DefaultResolvedVariantResult(DisplayName displayName, AttributeContainer attributes, List<Capability> capabilities) {
         this.displayName = displayName;
         this.attributes = attributes;
+        this.capabilities = capabilities;
     }
 
     @Override
@@ -37,5 +42,10 @@ public class DefaultResolvedVariantResult implements ResolvedVariantResult {
     @Override
     public String getDisplayName() {
         return displayName.getDisplayName();
+    }
+
+    @Override
+    public List<Capability> getCapabilities() {
+        return capabilities;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
@@ -56,13 +56,13 @@ public class AmbiguousConfigurationSelectionException extends RuntimeException {
         // to make sure the output is consistently the same between invocations
         formatter.startChildren();
         for (ConfigurationMetadata ambiguousConf : ambiguousConfigurations.values()) {
-            formatConfiguration(formatter, fromConfigurationAttributes, attributeMatcher, ambiguousConf, variantAware);
+            formatConfiguration(formatter, targetComponent, fromConfigurationAttributes, attributeMatcher, ambiguousConf, variantAware);
         }
         formatter.endChildren();
         return formatter.toString();
     }
 
-    static void formatConfiguration(TreeFormatter formatter, AttributeContainerInternal consumerAttributes, AttributeMatcher attributeMatcher, ConfigurationMetadata configuration, boolean variantAware) {
+    static void formatConfiguration(TreeFormatter formatter, ComponentResolveMetadata targetComponent, AttributeContainerInternal consumerAttributes, AttributeMatcher attributeMatcher, ConfigurationMetadata configuration, boolean variantAware) {
         AttributeContainerInternal producerAttributes = configuration.getAttributes();
         if (variantAware) {
             formatter.node("Variant '");
@@ -71,6 +71,9 @@ public class AmbiguousConfigurationSelectionException extends RuntimeException {
         }
         formatter.append(configuration.getName());
         formatter.append("'");
+        if (variantAware) {
+            formatter.append(" " + CapabilitiesSupport.prettifyCapabilities(targetComponent, configuration.getCapabilities().getCapabilities()));
+        }
         formatAttributeMatches(formatter, consumerAttributes, attributeMatcher, producerAttributes);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/CapabilitiesSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/CapabilitiesSupport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component;
+
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.internal.component.external.model.ImmutableCapability;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+class CapabilitiesSupport {
+    private static String displayName(Capability c) {
+        String version = c.getVersion();
+        if (version != null) {
+            return c.getGroup() + ":" + c.getName() + ":" + c.getVersion();
+        }
+        return c.getGroup() + ":" + c.getName();
+    }
+
+    static String sortedCapabilityList(ComponentResolveMetadata target, Collection<? extends Capability> capabilities) {
+        if (capabilities.isEmpty()) {
+            ModuleVersionIdentifier mvi = target.getModuleVersionId();
+            return displayName(new ImmutableCapability(mvi.getGroup(), mvi.getName(), mvi.getVersion()));
+        }
+        return capabilities.stream()
+                .map(CapabilitiesSupport::displayName)
+                .sorted()
+                .collect(Collectors.joining(" and "));
+    }
+
+    static String prettifyCapabilities(ComponentResolveMetadata targetComponent, Collection<? extends Capability> capabilities) {
+        StringBuilder sb = new StringBuilder("capabilit");
+        if (capabilities.size()>1) {
+            sb.append("ies ");
+            sb.append(sortedCapabilityList(targetComponent, capabilities));
+        } else {
+            sb.append("y ").append(sortedCapabilityList(targetComponent, capabilities));
+        }
+        return sb.toString();
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/IncompatibleConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/IncompatibleConfigurationSelectionException.java
@@ -36,7 +36,7 @@ public class IncompatibleConfigurationSelectionException extends RuntimeExceptio
     private static String generateMessage(AttributeContainerInternal fromConfigurationAttributes, AttributeMatcher attributeMatcher, ComponentResolveMetadata targetComponent, String targetConfiguration, boolean variantAware) {
         TreeFormatter formatter = new TreeFormatter();
         formatter.node((variantAware ? "Variant '" : "Configuration '") + targetConfiguration + "' in " + targetComponent.getId().getDisplayName() + " does not match the consumer attributes");
-        formatConfiguration(formatter, fromConfigurationAttributes, attributeMatcher, targetComponent.getConfiguration(targetConfiguration), variantAware);
+        formatConfiguration(formatter, targetComponent, fromConfigurationAttributes, attributeMatcher, targetComponent.getConfiguration(targetConfiguration), variantAware);
         return formatter.toString();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/IncompatibleVariantsSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/IncompatibleVariantsSelectionException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component;
+
+public class IncompatibleVariantsSelectionException extends VariantSelectionException {
+    public IncompatibleVariantsSelectionException(String message) {
+        super(message);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingCapabilitiesException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingCapabilitiesException.java
@@ -20,14 +20,14 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 
-import java.util.Set;
+import java.util.Collection;
 
 public class NoMatchingCapabilitiesException extends RuntimeException {
-    public NoMatchingCapabilitiesException(ComponentResolveMetadata targetComponent, Set<? extends Capability> requestedCapabilities, ImmutableList<? extends ConfigurationMetadata> candidates) {
+    public NoMatchingCapabilitiesException(ComponentResolveMetadata targetComponent, Collection<? extends Capability> requestedCapabilities, ImmutableList<? extends ConfigurationMetadata> candidates) {
         super(buildMessage(targetComponent, requestedCapabilities, candidates));
     }
 
-    private static String buildMessage(ComponentResolveMetadata targetComponent, Set<? extends Capability> requestedCapabilities, ImmutableList<? extends ConfigurationMetadata> candidates) {
+    private static String buildMessage(ComponentResolveMetadata targetComponent, Collection<? extends Capability> requestedCapabilities, ImmutableList<? extends ConfigurationMetadata> candidates) {
         StringBuilder sb = new StringBuilder("Unable to find a variant of ");
         sb.append(targetComponent.getId()).append(" providing the requested ");
         sb.append(CapabilitiesSupport.prettifyCapabilities(targetComponent, requestedCapabilities));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingCapabilitiesException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingCapabilitiesException.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component;
+
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.internal.component.model.ComponentResolveMetadata;
+import org.gradle.internal.component.model.ConfigurationMetadata;
+
+import java.util.Set;
+
+public class NoMatchingCapabilitiesException extends RuntimeException {
+    public NoMatchingCapabilitiesException(ComponentResolveMetadata targetComponent, Set<? extends Capability> requestedCapabilities, ImmutableList<? extends ConfigurationMetadata> candidates) {
+        super(buildMessage(targetComponent, requestedCapabilities, candidates));
+    }
+
+    private static String buildMessage(ComponentResolveMetadata targetComponent, Set<? extends Capability> requestedCapabilities, ImmutableList<? extends ConfigurationMetadata> candidates) {
+        StringBuilder sb = new StringBuilder("Unable to find a variant of ");
+        sb.append(targetComponent.getId()).append(" providing the requested ");
+        sb.append(CapabilitiesSupport.prettifyCapabilities(targetComponent, requestedCapabilities));
+        sb.append(":\n");
+        for (ConfigurationMetadata candidate : candidates) {
+            sb.append("   - Variant ").append(candidate.getName()).append(" provides ");
+            sb.append(CapabilitiesSupport.sortedCapabilityList(targetComponent, candidate.getCapabilities().getCapabilities())).append("\n");
+        }
+        return sb.toString();
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingConfigurationSelectionException.java
@@ -54,7 +54,7 @@ public class NoMatchingConfigurationSelectionException extends RuntimeException 
             // We're sorting the names of the configurations and later attributes
             // to make sure the output is consistently the same between invocations
             for (ConfigurationMetadata configuration : configurations.values()) {
-                formatConfiguration(formatter, fromConfigurationAttributes, attributeMatcher, configuration, variantAware);
+                formatConfiguration(formatter, targetComponent, fromConfigurationAttributes, attributeMatcher, configuration, variantAware);
             }
         }
         formatter.endChildren();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/ivypublish/DefaultIvyModulePublishMetadata.java
@@ -104,7 +104,7 @@ public class DefaultIvyModulePublishMetadata implements IvyModulePublishMetadata
                     VERSION_TRANSFORMER.transform(versionConstraint.getRequiredVersion()),
                     VERSION_TRANSFORMER.transform(versionConstraint.getStrictVersion()),
                     CollectionUtils.collect(versionConstraint.getRejectedVersions(), VERSION_TRANSFORMER));
-            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), transformedConstraint, selector.getAttributes());
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), transformedConstraint, selector.getAttributes(), selector.getRequestedCapabilities());
             return dependency.withTarget(newSelector);
         }
         return dependency;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -77,7 +77,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.componentId = componentIdentifier;
         this.moduleVersionId = moduleVersionId;
         this.componentLevelAttributes = defaultAttributes(attributesFactory);
-        this.variantMetadataRules = new VariantMetadataRules(attributesFactory);
+        this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
     }
 
     protected AbstractMutableModuleComponentResolveMetadata(ModuleComponentResolveMetadata metadata) {
@@ -91,7 +91,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.variants = metadata.getVariants();
         this.attributesFactory = metadata.getAttributesFactory();
         this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
-        this.variantMetadataRules = new VariantMetadataRules(attributesFactory);
+        this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
         this.variantMetadataRules.setVariantDerivationStrategy(metadata.getVariantMetadataRules().getVariantDerivationStrategy());
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -21,12 +21,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
-import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -48,6 +49,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.gradle.internal.component.model.ComponentResolveMetadata.DEFAULT_STATUS_SCHEME;
 
@@ -291,8 +293,8 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
-        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes) {
-            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes));
+        public void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities) {
+            dependencies.add(new DependencyImpl(group, module, versionConstraint, excludes, reason, attributes, requestedCapabilities));
         }
 
         @Override
@@ -361,14 +363,20 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         private final ImmutableList<ExcludeMetadata> excludes;
         private final String reason;
         private final ImmutableAttributes attributes;
+        private final ImmutableList<Capability> requestedCapabilities;
 
-        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes) {
+        DependencyImpl(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities) {
             this.group = group;
             this.module = module;
             this.versionConstraint = versionConstraint;
             this.excludes = ImmutableList.copyOf(excludes);
             this.reason = reason;
             this.attributes = attributes;
+            this.requestedCapabilities = ImmutableList.copyOf(
+                    requestedCapabilities.stream()
+                    .map(c -> new ImmutableCapability(c.getGroup(), c.getName(), c.getVersion()))
+                    .collect(Collectors.toList())
+            );
         }
 
         @Override
@@ -402,6 +410,11 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         }
 
         @Override
+        public List<Capability> getRequestedCapabilities() {
+            return requestedCapabilities;
+        }
+
+        @Override
         public boolean equals(Object o) {
             if (this == o) {
                 return true;
@@ -416,7 +429,8 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
                 && Objects.equal(versionConstraint, that.versionConstraint)
                 && Objects.equal(excludes, that.excludes)
                 && Objects.equal(reason, that.reason)
-                && Objects.equal(attributes, that.attributes);
+                && Objects.equal(attributes, that.attributes)
+                && Objects.equal(requestedCapabilities, that.requestedCapabilities);
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -54,13 +54,13 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
         // metadata as well.
         boolean forcedDependencies = PlatformSupport.hasForcedDependencies(variant);
         for (ComponentVariant.Dependency dependency : variant.getDependencies()) {
-            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes());
+            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes(), dependency.getRequestedCapabilities());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
             dependencies.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), forcedDependencies));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : variant.getDependencyConstraints()) {
             dependencies.add(new GradleDependencyMetadata(
-                DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes()),
+                DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
                 dependencyConstraint.getReason(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ComponentVariant.java
@@ -18,9 +18,12 @@ package org.gradle.internal.component.external.model;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.VariantResolveMetadata;
+
+import java.util.List;
 
 /**
  * An _immutable_ view of the variant of a component.
@@ -48,6 +51,8 @@ public interface ComponentVariant extends VariantResolveMetadata {
         String getReason();
 
         ImmutableAttributes getAttributes();
+
+        List<Capability> getRequestedCapabilities();
     }
 
     interface DependencyConstraint {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DefaultProjectDependencyMetadata;
@@ -32,7 +33,9 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A `ModuleDependencyMetadata` implementation that is backed by an `ExternalDependencyDescriptor` bound to a particular
@@ -78,11 +81,11 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
      * otherwise revert to legacy selection of target configurations.
      */
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
         // This is a slight different condition than that used for a dependency declared in a Gradle project,
         // which is (targetHasVariants || consumerHasAttributes), relying on the fallback to 'default' for consumer attributes without any variants.
         if (alwaysUseAttributeMatching || hasVariants(targetComponent)) {
-            return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, targetComponent, consumerSchema));
+            return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema));
         }
         return dependencyDescriptor.selectLegacyConfigurations(componentId, configuration, targetComponent);
     }
@@ -133,6 +136,11 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
             return this;
         }
         return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason);
+    }
+
+    @Override
+    public Set<Capability> getRequestedCapabilities() {
+        return Collections.emptySet();
     }
 
     public ConfigurationBoundExternalDependencyMetadata withDescriptor(ExternalDependencyDescriptor descriptor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -33,9 +33,8 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A `ModuleDependencyMetadata` implementation that is backed by an `ExternalDependencyDescriptor` bound to a particular
@@ -81,7 +80,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
      * otherwise revert to legacy selection of target configurations.
      */
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         // This is a slight different condition than that used for a dependency declared in a Gradle project,
         // which is (targetHasVariants || consumerHasAttributes), relying on the fallback to 'default' for consumer attributes without any variants.
         if (alwaysUseAttributeMatching || hasVariants(targetComponent)) {
@@ -107,7 +106,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             ModuleComponentSelector moduleTarget = (ModuleComponentSelector) target;
-            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(moduleTarget.getModuleIdentifier(), moduleTarget.getVersionConstraint(), moduleTarget.getAttributes());
+            ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(moduleTarget.getModuleIdentifier(), moduleTarget.getVersionConstraint(), moduleTarget.getAttributes(), moduleTarget.getRequestedCapabilities());
             if (newSelector.equals(getSelector())) {
                 return this;
             }
@@ -126,7 +125,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes());
+        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes(), selector.getRequestedCapabilities());
         return withRequested(newSelector);
     }
 
@@ -136,11 +135,6 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
             return this;
         }
         return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason);
-    }
-
-    @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return Collections.emptySet();
     }
 
     public ConfigurationBoundExternalDependencyMetadata withDescriptor(ExternalDependencyDescriptor descriptor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultModuleComponentSelector.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.component.external.model;
 
 import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.ModuleVersionSelector;
 import org.gradle.api.artifacts.VersionConstraint;
@@ -23,27 +24,34 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
+import java.util.Collection;
+import java.util.List;
+
 public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     private final ModuleIdentifier moduleIdentifier;
     private final ImmutableVersionConstraint versionConstraint;
     private final ImmutableAttributes attributes;
+    private final ImmutableList<Capability> requestedCapabilities;
     private final int hashCode;
 
-    private DefaultModuleComponentSelector(ModuleIdentifier module, ImmutableVersionConstraint version, ImmutableAttributes attributes) {
+    private DefaultModuleComponentSelector(ModuleIdentifier module, ImmutableVersionConstraint version, ImmutableAttributes attributes, ImmutableList<Capability> requestedCapabilities) {
         assert module != null : "module cannot be null";
         assert version != null : "version cannot be null";
         assert attributes != null : "attributes cannot be null";
+        assert requestedCapabilities != null : "capabilities cannot be null";
         this.moduleIdentifier = module;
         this.versionConstraint = version;
         this.attributes = attributes;
+        this.requestedCapabilities = requestedCapabilities;
         // Do NOT change the order of members used in hash code here, it's been empirically
         // tested to reduce the number of collisions on a large dependency graph (performance test)
-        this.hashCode = Objects.hashCode(version, module, attributes);
+        this.hashCode = Objects.hashCode(version, module, attributes, requestedCapabilities);
     }
 
     public String getDisplayName() {
@@ -84,6 +92,11 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     }
 
     @Override
+    public List<Capability> getRequestedCapabilities() {
+        return requestedCapabilities;
+    }
+
+    @Override
     public AttributeContainer getAttributes() {
         return attributes;
     }
@@ -121,6 +134,9 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         if (!attributes.equals(that.attributes)) {
             return false;
         }
+        if (!requestedCapabilities.equals(that.requestedCapabilities)) {
+            return false;
+        }
 
         return true;
     }
@@ -135,11 +151,12 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
         return getDisplayName();
     }
 
-    public static ModuleComponentSelector newSelector(ModuleIdentifier id, VersionConstraint version, AttributeContainer attributes) {
+    public static ModuleComponentSelector newSelector(ModuleIdentifier id, VersionConstraint version, AttributeContainer attributes, Collection<Capability> requestedCapabilities) {
         assert attributes != null : "attributes cannot be null";
         assert version != null : "version cannot be null";
+        assert requestedCapabilities != null : "capabilities cannot be null";
         assertModuleIdentifier(id);
-        return new DefaultModuleComponentSelector(id, DefaultImmutableVersionConstraint.of(version), ((AttributeContainerInternal)attributes).asImmutable());
+        return new DefaultModuleComponentSelector(id, DefaultImmutableVersionConstraint.of(version), ((AttributeContainerInternal)attributes).asImmutable(), ImmutableList.copyOf(requestedCapabilities));
     }
 
     private static void assertModuleIdentifier(ModuleIdentifier id) {
@@ -150,15 +167,15 @@ public class DefaultModuleComponentSelector implements ModuleComponentSelector {
     public static ModuleComponentSelector newSelector(ModuleIdentifier id, VersionConstraint version) {
         assert version != null : "version cannot be null";
         assertModuleIdentifier(id);
-        return new DefaultModuleComponentSelector(id, DefaultImmutableVersionConstraint.of(version), ImmutableAttributes.EMPTY);
+        return new DefaultModuleComponentSelector(id, DefaultImmutableVersionConstraint.of(version), ImmutableAttributes.EMPTY, ImmutableList.of());
     }
 
     public static ModuleComponentSelector newSelector(ModuleIdentifier id, String version) {
         assertModuleIdentifier(id);
-        return new DefaultModuleComponentSelector(id, DefaultImmutableVersionConstraint.of(version), ImmutableAttributes.EMPTY);
+        return new DefaultModuleComponentSelector(id, DefaultImmutableVersionConstraint.of(version), ImmutableAttributes.EMPTY, ImmutableList.of());
     }
 
     public static ModuleComponentSelector newSelector(ModuleVersionSelector selector) {
-        return new DefaultModuleComponentSelector(selector.getModule(), DefaultImmutableVersionConstraint.of(selector.getVersion()), ImmutableAttributes.EMPTY);
+        return new DefaultModuleComponentSelector(selector.getModule(), DefaultImmutableVersionConstraint.of(selector.getVersion()), ImmutableAttributes.EMPTY, ImmutableList.of());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -28,8 +28,8 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {
     private final ModuleDependencyMetadata delegate;
@@ -54,12 +54,7 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
     }
 
     @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return delegate.getRequestedCapabilities();
-    }
-
-    @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ForcedDependencyMetadataWrapper.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -28,6 +29,7 @@ import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.List;
+import java.util.Set;
 
 public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadata, ModuleDependencyMetadata {
     private final ModuleDependencyMetadata delegate;
@@ -52,8 +54,13 @@ public class ForcedDependencyMetadataWrapper implements ForcingDependencyMetadat
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+    public Set<Capability> getRequestedCapabilities() {
+        return delegate.getRequestedCapabilities();
+    }
+
+    @Override
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -34,9 +34,8 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class GradleDependencyMetadata implements ModuleDependencyMetadata, ForcingDependencyMetadata {
     private final ModuleComponentSelector selector;
@@ -63,7 +62,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
         if (requestedVersion.equals(selector.getVersionConstraint())) {
             return this;
         }
-        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes()), excludes, constraint, reason, force);
+        return new GradleDependencyMetadata(DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes(), selector.getRequestedCapabilities()), excludes, constraint, reason, force);
     }
 
     @Override
@@ -72,11 +71,6 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
             return this;
         }
         return new GradleDependencyMetadata(selector, excludes, constraint, reason, force);
-    }
-
-    @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return Collections.emptySet();
     }
 
     @Override
@@ -101,7 +95,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
      * Always use attribute matching to choose a target variant.
      */
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.local.model.DefaultProjectDependencyMetadata;
@@ -33,7 +34,9 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.ForcingDependencyMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class GradleDependencyMetadata implements ModuleDependencyMetadata, ForcingDependencyMetadata {
     private final ModuleComponentSelector selector;
@@ -72,6 +75,11 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
     }
 
     @Override
+    public Set<Capability> getRequestedCapabilities() {
+        return Collections.emptySet();
+    }
+
+    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         if (target instanceof ModuleComponentSelector) {
             return new GradleDependencyMetadata((ModuleComponentSelector) target, excludes, constraint, reason, force);
@@ -93,8 +101,8 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
      * Always use attribute matching to choose a target variant.
      */
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-        return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, targetComponent, consumerSchema));
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+        return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/LazyToRealisedModuleComponentResolveMetadataHelper.java
@@ -64,13 +64,13 @@ public class LazyToRealisedModuleComponentResolveMetadataHelper {
     private static List<GradleDependencyMetadata> convertDependencies(List<? extends ComponentVariant.Dependency> dependencies, List<? extends ComponentVariant.DependencyConstraint> dependencyConstraints, boolean force) {
         List<GradleDependencyMetadata> result = new ArrayList<GradleDependencyMetadata>(dependencies.size());
         for (ComponentVariant.Dependency dependency : dependencies) {
-            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes());
+            ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependency.getGroup(), dependency.getModule()), dependency.getVersionConstraint(), dependency.getAttributes(), dependency.getRequestedCapabilities());
             List<ExcludeMetadata> excludes = dependency.getExcludes();
             result.add(new GradleDependencyMetadata(selector, excludes, false, dependency.getReason(), force));
         }
         for (ComponentVariant.DependencyConstraint dependencyConstraint : dependencyConstraints) {
             result.add(new GradleDependencyMetadata(
-                DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes()),
+                DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(dependencyConstraint.getGroup(), dependencyConstraint.getModule()), dependencyConstraint.getVersionConstraint(), dependencyConstraint.getAttributes(), ImmutableList.of()),
                 Collections.<ExcludeMetadata>emptyList(),
                 true,
                 dependencyConstraint.getReason(),

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.external.model;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -27,6 +28,7 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.List;
+import java.util.Set;
 
 public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata {
     private final DependencyMetadata delegate;
@@ -55,6 +57,11 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
+    public Set<Capability> getRequestedCapabilities() {
+        return delegate.getRequestedCapabilities();
+    }
+
+    @Override
     public DependencyMetadata withTarget(ComponentSelector target) {
         return delegate.withTarget(target);
     }
@@ -70,8 +77,8 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ModuleDependencyMetadataWrapper.java
@@ -27,8 +27,8 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata {
     private final DependencyMetadata delegate;
@@ -47,18 +47,13 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     @Override
     public ModuleDependencyMetadata withRequestedVersion(VersionConstraint requestedVersion) {
         ModuleComponentSelector selector = getSelector();
-        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes());
+        ModuleComponentSelector newSelector = DefaultModuleComponentSelector.newSelector(selector.getModuleIdentifier(), requestedVersion, selector.getAttributes(), selector.getRequestedCapabilities());
         return new ModuleDependencyMetadataWrapper(delegate.withTarget(newSelector));
     }
 
     @Override
     public ModuleDependencyMetadata withReason(String reason) {
         return new ModuleDependencyMetadataWrapper(delegate.withReason(reason));
-    }
-
-    @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return delegate.getRequestedCapabilities();
     }
 
     @Override
@@ -77,7 +72,7 @@ public class ModuleDependencyMetadataWrapper implements ModuleDependencyMetadata
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableComponentVariant.java
@@ -17,6 +17,7 @@
 package org.gradle.internal.component.external.model;
 
 import org.gradle.api.artifacts.VersionConstraint;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ExcludeMetadata;
 
@@ -25,7 +26,7 @@ import java.util.List;
 public interface MutableComponentVariant {
     void addFile(String name, String uri);
 
-    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes);
+    void addDependency(String group, String module, VersionConstraint versionConstraint, List<ExcludeMetadata> excludes, String reason, ImmutableAttributes attributes, List<? extends Capability> requestedCapabilities);
 
     void addDependencyConstraint(String group, String module, VersionConstraint versionConstraint, String reason, ImmutableAttributes attributes);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLibraryComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLibraryComponentSelector.java
@@ -22,9 +22,12 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.LibraryComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
 
 public class DefaultLibraryComponentSelector implements LibraryComponentSelector {
     private final String projectPath;
@@ -87,6 +90,11 @@ public class DefaultLibraryComponentSelector implements LibraryComponentSelector
     @Override
     public AttributeContainer getAttributes() {
         return ImmutableAttributes.EMPTY;
+    }
+
+    @Override
+    public List<Capability> getRequestedCapabilities() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectComponentSelector.java
@@ -21,11 +21,15 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.internal.build.BuildState;
 import org.gradle.util.Path;
+
+import java.util.Collections;
+import java.util.List;
 
 public class DefaultProjectComponentSelector implements ProjectComponentSelector {
     private final BuildIdentifier buildIdentifier;
@@ -33,19 +37,22 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
     private final Path identityPath;
     private final String projectName;
     private final ImmutableAttributes attributes;
+    private final List<Capability> requestedCapabilities;
     private String displayName;
 
-    public DefaultProjectComponentSelector(BuildIdentifier buildIdentifier, Path identityPath, Path projectPath, String projectName, ImmutableAttributes attributes) {
+    public DefaultProjectComponentSelector(BuildIdentifier buildIdentifier, Path identityPath, Path projectPath, String projectName, ImmutableAttributes attributes, List<Capability> requestedCapabilities) {
         assert buildIdentifier != null : "build cannot be null";
         assert identityPath != null : "identity path cannot be null";
         assert projectPath != null : "project path cannot be null";
         assert projectName != null : "project name cannot be null";
         assert attributes != null : "attributes cannot be null";
+        assert requestedCapabilities != null : "capabilities cannot be null";
         this.buildIdentifier = buildIdentifier;
         this.identityPath = identityPath;
         this.projectPath = projectPath;
         this.projectName = projectName;
         this.attributes = attributes;
+        this.requestedCapabilities = requestedCapabilities;
     }
 
     public String getDisplayName() {
@@ -97,6 +104,11 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
     }
 
     @Override
+    public List<Capability> getRequestedCapabilities() {
+        return requestedCapabilities;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -109,6 +121,9 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
             return false;
         }
         if (!attributes.equals(that.attributes)) {
+            return false;
+        }
+        if (!requestedCapabilities.equals(that.requestedCapabilities)) {
             return false;
         }
         return true;
@@ -125,18 +140,18 @@ public class DefaultProjectComponentSelector implements ProjectComponentSelector
     }
 
     public static ProjectComponentSelector newSelector(Project project) {
-        return newSelector(project, ImmutableAttributes.EMPTY);
+        return newSelector(project, ImmutableAttributes.EMPTY, Collections.emptyList());
     }
 
-    public static ProjectComponentSelector newSelector(Project project, ImmutableAttributes attributes) {
+    public static ProjectComponentSelector newSelector(Project project, ImmutableAttributes attributes, List<Capability> requestedCapabilities) {
         ProjectInternal projectInternal = (ProjectInternal) project;
         BuildIdentifier currentBuild = projectInternal.getServices().get(BuildState.class).getBuildIdentifier();
-        return new DefaultProjectComponentSelector(currentBuild, projectInternal.getIdentityPath(), projectInternal.getProjectPath(), project.getName(), attributes);
+        return new DefaultProjectComponentSelector(currentBuild, projectInternal.getIdentityPath(), projectInternal.getProjectPath(), project.getName(), attributes, requestedCapabilities);
     }
 
     public static ProjectComponentSelector newSelector(ProjectComponentIdentifier identifier) {
         DefaultProjectComponentIdentifier projectComponentIdentifier = (DefaultProjectComponentIdentifier) identifier;
-        return new DefaultProjectComponentSelector(projectComponentIdentifier.getBuild(), projectComponentIdentifier.getIdentityPath(), projectComponentIdentifier.projectPath(), projectComponentIdentifier.getProjectName(), ImmutableAttributes.EMPTY);
+        return new DefaultProjectComponentSelector(projectComponentIdentifier.getBuild(), projectComponentIdentifier.getIdentityPath(), projectComponentIdentifier.projectPath(), projectComponentIdentifier.getProjectName(), ImmutableAttributes.EMPTY, Collections.emptyList());
     }
 
     public ProjectComponentIdentifier toIdentifier() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ProjectComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -28,6 +29,7 @@ import org.gradle.internal.component.model.IvyArtifactName;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     private final ProjectComponentSelector selector;
@@ -79,8 +81,8 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override
@@ -91,6 +93,11 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     @Override
     public DependencyMetadata withReason(String reason) {
         return delegate.withReason(reason);
+    }
+
+    @Override
+    public Set<Capability> getRequestedCapabilities() {
+        return delegate.getRequestedCapabilities();
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultProjectDependencyMetadata.java
@@ -27,9 +27,9 @@ import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     private final ProjectComponentSelector selector;
@@ -81,7 +81,7 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
@@ -93,11 +93,6 @@ public class DefaultProjectDependencyMetadata implements DependencyMetadata {
     @Override
     public DependencyMetadata withReason(String reason) {
         return delegate.withReason(reason);
-    }
-
-    @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return delegate.getRequestedCapabilities();
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -18,6 +18,7 @@ package org.gradle.internal.component.local.model;
 
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.model.ComponentResolveMetadata;
@@ -28,6 +29,7 @@ import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
 import java.util.List;
+import java.util.Set;
 
 public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMetadata, LocalOriginDependencyMetadata {
     private final LocalOriginDependencyMetadata delegate;
@@ -56,8 +58,8 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
-        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema);
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+        return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
     @Override
@@ -113,6 +115,11 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     @Override
     public DependencyMetadata withReason(String reason) {
         return delegate.withReason(reason);
+    }
+
+    @Override
+    public Set<Capability> getRequestedCapabilities() {
+        return delegate.getRequestedCapabilities();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DslOriginDependencyMetadataWrapper.java
@@ -28,8 +28,8 @@ import org.gradle.internal.component.model.ExcludeMetadata;
 import org.gradle.internal.component.model.IvyArtifactName;
 import org.gradle.internal.component.model.LocalOriginDependencyMetadata;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMetadata, LocalOriginDependencyMetadata {
     private final LocalOriginDependencyMetadata delegate;
@@ -58,7 +58,7 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     }
 
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         return delegate.selectConfigurations(consumerAttributes, targetComponent, consumerSchema, explicitRequestedCapabilities);
     }
 
@@ -115,11 +115,6 @@ public class DslOriginDependencyMetadataWrapper implements DslOriginDependencyMe
     @Override
     public DependencyMetadata withReason(String reason) {
         return delegate.withReason(reason);
-    }
-
-    @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return delegate.getRequestedCapabilities();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -87,8 +87,8 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                         ? DefaultMutableVersionConstraint.withStrictVersion(lockedVersion)
                         : DefaultMutableVersionConstraint.withVersion(lockedVersion);
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(lockedDependency.getGroup(), lockedDependency.getModule()), versionConstraint);
-                    result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null, Collections.emptySet(),
-                        Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, true, getLockReason(strict, lockedVersion)));
+                    result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
+                            Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, true, getLockReason(strict, lockedVersion)));
                 }
             }
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/RootLocalComponentMetadata.java
@@ -87,7 +87,7 @@ public class RootLocalComponentMetadata extends DefaultLocalComponentMetadata {
                         ? DefaultMutableVersionConstraint.withStrictVersion(lockedVersion)
                         : DefaultMutableVersionConstraint.withVersion(lockedVersion);
                     ModuleComponentSelector selector = DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(lockedDependency.getGroup(), lockedDependency.getModule()), versionConstraint);
-                    result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null,
+                    result.add(new LocalComponentDependencyMetadata(getComponentId(), selector, getName(), getAttributes(),  ImmutableAttributes.EMPTY, null, Collections.emptySet(),
                         Collections.<IvyArtifactName>emptyList(),  Collections.<ExcludeMetadata>emptyList(), false, false, false, true, true, getLockReason(strict, lockedVersion)));
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -19,16 +19,21 @@ package org.gradle.internal.component.model;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.AmbiguousConfigurationSelectionException;
+import org.gradle.internal.component.NoMatchingCapabilitiesException;
 import org.gradle.internal.component.NoMatchingConfigurationSelectionException;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 public abstract class AttributeConfigurationSelector {
 
-    public static ConfigurationMetadata selectConfigurationUsingAttributeMatching(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+    public static ConfigurationMetadata selectConfigurationUsingAttributeMatching(ImmutableAttributes consumerAttributes, Set<? extends Capability> explicitRequestedCapabilities, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         Optional<ImmutableList<? extends ConfigurationMetadata>> variantsForGraphTraversal = targetComponent.getVariantsForGraphTraversal();
         ImmutableList<? extends ConfigurationMetadata> consumableConfigurations = variantsForGraphTraversal.or(ImmutableList.<ConfigurationMetadata>of());
         AttributesSchemaInternal producerAttributeSchema = targetComponent.getAttributesSchema();
@@ -37,6 +42,8 @@ public abstract class AttributeConfigurationSelector {
         if (fallbackConfiguration != null && !fallbackConfiguration.isCanBeConsumed()) {
             fallbackConfiguration = null;
         }
+        ModuleVersionIdentifier versionId = targetComponent.getModuleVersionId();
+        consumableConfigurations = filterVariantsByRequestedCapabilities(targetComponent, explicitRequestedCapabilities, consumableConfigurations, versionId.getGroup(), versionId.getName());
         List<ConfigurationMetadata> matches = attributeMatcher.matches(consumableConfigurations, consumerAttributes, fallbackConfiguration);
         if (matches.size() == 1) {
             ConfigurationMetadata match = matches.get(0);
@@ -49,5 +56,78 @@ public abstract class AttributeConfigurationSelector {
         } else {
             throw new NoMatchingConfigurationSelectionException(consumerAttributes, attributeMatcher, targetComponent, variantsForGraphTraversal.isPresent());
         }
+    }
+
+    private static ImmutableList<? extends ConfigurationMetadata> filterVariantsByRequestedCapabilities(ComponentResolveMetadata targetComponent, Set<? extends Capability> explicitRequestedCapabilities, ImmutableList<? extends ConfigurationMetadata> consumableConfigurations, String group, String name) {
+        if (consumableConfigurations.isEmpty()) {
+            return consumableConfigurations;
+        }
+        ImmutableList.Builder<ConfigurationMetadata> builder = new ImmutableList.Builder<>();
+        boolean explicitlyRequested = !explicitRequestedCapabilities.isEmpty();
+        for (ConfigurationMetadata configuration : consumableConfigurations) {
+            List<? extends Capability> capabilities = configuration.getCapabilities().getCapabilities();
+            if (explicitlyRequested) {
+                // some capabilities are explicitly required (in other words, we're not _necessarily_ looking for the default capability
+                // so we need to filter the configurations
+                if (providesAllCapabilities(targetComponent, explicitRequestedCapabilities, capabilities)) {
+                    builder.add(configuration);
+                }
+            } else {
+                // we need to make sure the variants we consider provide the implicit capability
+                if (containsImplicitCapability(capabilities, group, name)) {
+                    builder.add(configuration);
+                }
+            }
+        }
+        ImmutableList<ConfigurationMetadata> filtered = builder.build();
+        if (filtered.isEmpty()) {
+            throw new NoMatchingCapabilitiesException(targetComponent, explicitRequestedCapabilities, consumableConfigurations);
+        }
+        return filtered;
+    }
+
+    /**
+     * Determines if a producer variant provides all the requested capabilities. When doing so it does
+     * NOT consider capability versions, as they will be used later in the engine during conflict resolution.
+     */
+    private static boolean providesAllCapabilities(ComponentResolveMetadata targetComponent, Set<? extends Capability> explicitRequestedCapabilities, List<? extends Capability> providerCapabilities) {
+        if (providerCapabilities.isEmpty()) {
+            // producer doesn't declare anything, so we assume that it only provides the implicit capability
+            if (explicitRequestedCapabilities.size() == 1) {
+                Capability requested = explicitRequestedCapabilities.iterator().next();
+                ModuleVersionIdentifier mvi = targetComponent.getModuleVersionId();
+                if (requested.getGroup().equals(mvi.getGroup()) && requested.getName().equals(mvi.getName())) {
+                    return true;
+                }
+            }
+        }
+        for (Capability requested : explicitRequestedCapabilities) {
+            String requestedGroup = requested.getGroup();
+            String requestedName = requested.getName();
+            boolean found = false;
+            for (Capability provided : providerCapabilities) {
+                if (provided.getGroup().equals(requestedGroup) && provided.getName().equals(requestedName)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean containsImplicitCapability(Collection<? extends Capability> capabilities, String group, String name) {
+        if (capabilities.isEmpty()) {
+            // An empty capability list means that it's an implicit capability only
+            return true;
+        }
+        for (Capability capability : capabilities) {
+            if (group.equals(capability.getGroup()) && name.equals(capability.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -29,11 +29,10 @@ import org.gradle.internal.component.NoMatchingConfigurationSelectionException;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public abstract class AttributeConfigurationSelector {
 
-    public static ConfigurationMetadata selectConfigurationUsingAttributeMatching(ImmutableAttributes consumerAttributes, Set<? extends Capability> explicitRequestedCapabilities, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
+    public static ConfigurationMetadata selectConfigurationUsingAttributeMatching(ImmutableAttributes consumerAttributes, Collection<? extends Capability> explicitRequestedCapabilities, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema) {
         Optional<ImmutableList<? extends ConfigurationMetadata>> variantsForGraphTraversal = targetComponent.getVariantsForGraphTraversal();
         ImmutableList<? extends ConfigurationMetadata> consumableConfigurations = variantsForGraphTraversal.or(ImmutableList.<ConfigurationMetadata>of());
         AttributesSchemaInternal producerAttributeSchema = targetComponent.getAttributesSchema();
@@ -58,7 +57,7 @@ public abstract class AttributeConfigurationSelector {
         }
     }
 
-    private static ImmutableList<? extends ConfigurationMetadata> filterVariantsByRequestedCapabilities(ComponentResolveMetadata targetComponent, Set<? extends Capability> explicitRequestedCapabilities, ImmutableList<? extends ConfigurationMetadata> consumableConfigurations, String group, String name) {
+    private static ImmutableList<? extends ConfigurationMetadata> filterVariantsByRequestedCapabilities(ComponentResolveMetadata targetComponent, Collection<? extends Capability> explicitRequestedCapabilities, ImmutableList<? extends ConfigurationMetadata> consumableConfigurations, String group, String name) {
         if (consumableConfigurations.isEmpty()) {
             return consumableConfigurations;
         }
@@ -90,7 +89,7 @@ public abstract class AttributeConfigurationSelector {
      * Determines if a producer variant provides all the requested capabilities. When doing so it does
      * NOT consider capability versions, as they will be used later in the engine during conflict resolution.
      */
-    private static boolean providesAllCapabilities(ComponentResolveMetadata targetComponent, Set<? extends Capability> explicitRequestedCapabilities, List<? extends Capability> providerCapabilities) {
+    private static boolean providesAllCapabilities(ComponentResolveMetadata targetComponent, Collection<? extends Capability> explicitRequestedCapabilities, List<? extends Capability> providerCapabilities) {
         if (providerCapabilities.isEmpty()) {
             // producer doesn't declare anything, so we assume that it only provides the implicit capability
             if (explicitRequestedCapabilities.size() == 1) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -21,8 +21,8 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 /**
  * A dependency that can participate in dependency resolution.
@@ -39,7 +39,7 @@ public interface DependencyMetadata {
     /**
      * Select the target configurations for this dependency from the given target component.
      */
-    List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities);
+    List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities);
 
     /**
      * Returns a view of the excludes filtered for this dependency in this configuration.
@@ -85,6 +85,4 @@ public interface DependencyMetadata {
      * Returns a copy of this dependency with the given selection reason.
      */
     DependencyMetadata withReason(String reason);
-
-    Set<Capability> getRequestedCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DependencyMetadata.java
@@ -17,10 +17,12 @@
 package org.gradle.internal.component.model;
 
 import org.gradle.api.artifacts.component.ComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * A dependency that can participate in dependency resolution.
@@ -37,7 +39,7 @@ public interface DependencyMetadata {
     /**
      * Select the target configurations for this dependency from the given target component.
      */
-    List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema);
+    List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities);
 
     /**
      * Returns a view of the excludes filtered for this dependency in this configuration.
@@ -84,4 +86,5 @@ public interface DependencyMetadata {
      */
     DependencyMetadata withReason(String reason);
 
+    Set<Capability> getRequestedCapabilities();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -31,8 +31,8 @@ import org.gradle.internal.component.IncompatibleConfigurationSelectionException
 import org.gradle.internal.exceptions.ConfigurationNotConsumableException;
 import org.gradle.util.GUtil;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class LocalComponentDependencyMetadata implements LocalOriginDependencyMetadata {
     private final ComponentIdentifier componentId;
@@ -50,7 +50,6 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
 
     private final AttributeContainer moduleAttributes;
     private final ImmutableAttributes dependencyAttributes;
-    private final Set<Capability> requestedCapabilities;
 
     public LocalComponentDependencyMetadata(ComponentIdentifier componentId,
                                             ComponentSelector selector,
@@ -58,12 +57,11 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             AttributeContainer moduleAttributes,
                                             AttributeContainer dependencyAttributes,
                                             String dependencyConfiguration,
-                                            Set<Capability> requestedCapabilities,
                                             List<IvyArtifactName> artifactNames,
                                             List<ExcludeMetadata> excludes,
                                             boolean force, boolean changing, boolean transitive, boolean constraint,
                                             String reason) {
-        this(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, requestedCapabilities, artifactNames, excludes, force, changing, transitive, constraint, false, reason);
+        this(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, false, reason);
     }
 
     public LocalComponentDependencyMetadata(ComponentIdentifier componentId,
@@ -72,7 +70,6 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
                                             AttributeContainer moduleAttributes,
                                             AttributeContainer dependencyAttributes,
                                             String dependencyConfiguration,
-                                            Set<Capability> requestedCapabilities,
                                             List<IvyArtifactName> artifactNames,
                                             List<ExcludeMetadata> excludes,
                                             boolean force, boolean changing, boolean transitive,
@@ -84,7 +81,6 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         this.moduleAttributes = moduleAttributes;
         this.dependencyAttributes = ((AttributeContainerInternal)dependencyAttributes).asImmutable();
         this.dependencyConfiguration = dependencyConfiguration;
-        this.requestedCapabilities = requestedCapabilities;
         this.artifactNames = ImmutableList.copyOf(artifactNames);
         this.excludes = excludes;
         this.force = force;
@@ -131,7 +127,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
      * @return A List containing a single `ConfigurationMetadata` representing the target variant.
      */
     @Override
-    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Set<? extends Capability> explicitRequestedCapabilities) {
+    public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
         boolean consumerHasAttributes = !consumerAttributes.isEmpty();
         Optional<ImmutableList<? extends ConfigurationMetadata>> targetVariants = targetComponent.getVariantsForGraphTraversal();
         boolean useConfigurationAttributes = dependencyConfiguration == null && (consumerHasAttributes || targetVariants.isPresent());
@@ -222,21 +218,16 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         return copyWithReason(reason);
     }
 
-    @Override
-    public Set<Capability> getRequestedCapabilities() {
-        return requestedCapabilities;
-    }
-
     private LocalOriginDependencyMetadata copyWithTarget(ComponentSelector selector) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, requestedCapabilities, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
     }
 
     private LocalOriginDependencyMetadata copyWithReason(String reason) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, requestedCapabilities, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
     }
 
     private LocalOriginDependencyMetadata copyWithForce(boolean force) {
-        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, requestedCapabilities, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
+        return new LocalComponentDependencyMetadata(componentId, selector, moduleConfiguration, moduleAttributes, dependencyAttributes, dependencyConfiguration, artifactNames, excludes, force, changing, transitive, constraint, fromLock, reason);
     }
 
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ModuleComponentSelectorSerializerTest.groovy
@@ -18,9 +18,11 @@ package org.gradle.api.internal.artifacts
 
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.MutableVersionConstraint
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.DesugaredAttributeContainerSerializer
 import org.gradle.api.internal.model.NamedObjectInstantiator
+import org.gradle.internal.component.external.model.ImmutableCapability
 import org.gradle.internal.serialize.SerializerSpec
 import spock.lang.Unroll
 
@@ -36,10 +38,10 @@ class ModuleComponentSelectorSerializerTest extends SerializerSpec {
     @Unroll
     def "serializes"() {
         when:
-        def result = serialize(newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar')), serializer)
+        def result = serialize(newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar'), [capability("foo")]), serializer)
 
         then:
-        result == newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar'))
+        result == newSelector(UTIL, constraint(version, strict, rejects), attributes(foo: 'bar'), [capability("foo")])
 
         where:
         version | strict   | rejects
@@ -58,5 +60,9 @@ class ModuleComponentSelectorSerializerTest extends SerializerSpec {
             constraint.reject(reject)
         }
         return constraint
+    }
+
+    private static Capability capability(String name) {
+        return new ImmutableCapability("test", name, "1.16")
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/component/DefaultComponentIdentifierFactoryTest.groovy
@@ -65,7 +65,7 @@ class DefaultComponentIdentifierFactoryTest extends Specification {
     def "can create component identifier for project dependency in same build"() {
         given:
         def buildId = new DefaultBuildIdentifier("build")
-        def selector = new DefaultProjectComponentSelector(buildId, Path.path(":id:path"), Path.path(":project:path"), "name", ImmutableAttributes.EMPTY)
+        def selector = new DefaultProjectComponentSelector(buildId, Path.path(":id:path"), Path.path(":project:path"), "name", ImmutableAttributes.EMPTY, [])
 
         when:
         def componentIdentifier = componentIdentifierFactory.createProjectComponentIdentifier(selector)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -54,12 +54,15 @@ class CacheLayoutTest extends Specification {
 
         then:
         cacheLayout.name == 'metadata'
-        cacheLayout.key == 'metadata-2.69'
-        cacheLayout.version == CacheVersion.parse("2.69")
-        cacheLayout.version.toString() == '2.69'
-        cacheLayout.getPath(new File('some/dir')) == new File('some/dir/metadata-2.69')
+        cacheLayout.key == "metadata-2.${expectedVersion}"
+        cacheLayout.version == CacheVersion.parse("2.${expectedVersion}")
+        cacheLayout.version.toString() == "2.${expectedVersion}"
+        cacheLayout.getPath(new File('some/dir')) == new File("some/dir/metadata-2.${expectedVersion}")
         !cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-1")).present
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
+
+        where:
+        expectedVersion = 95410263
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -144,7 +144,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant
         1 * variant.addFile("a.zip", "a.zop")
-        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant.addDependency("g1", "m1", prefers("v1"), [], null, ImmutableAttributes.EMPTY, [])
         1 * metadata.setContentHash(_)
         0 * _
     }
@@ -250,7 +250,7 @@ class ModuleMetadataParserTest extends Specification {
             {
                 "attributes": { "usage": "runtime", "packaging": "zip" },
                 "dependencies": [ 
-                    { "module": "m3", "group": "g3", "version": { "prefers": "v3" }},
+                    { "module": "m3", "group": "g3", "version": { "prefers": "v3" }, "requestedCapabilities":[{"group":"org", "name":"foo", "version":"1.0"}]},
                     { "module": "m4", "version": { "strictly": "v5" }, "group": "g4"},
                     { "module": "m5", "version": { "prefers": "v5", "requires": "v5", "rejects": ["v6", "v7"] }, "group": "g5"},
                     { "module": "m6", "group": "g6", "version": { "strictly": "v6" }, "reason": "v5 is buggy"}
@@ -263,15 +263,15 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY)
-        1 * variant1.addDependency("g3", "m3", requires("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g0", "m0", emptyConstraint(), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant1.addDependency("g3", "m3", requires("v3"), excludes("gx:mx", "*:*"), null, ImmutableAttributes.EMPTY, [])
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY)
-        1 * variant2.addDependency("g4", "m4", strictly("v5"), [], null, ImmutableAttributes.EMPTY)
-        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY)
-        1 * variant2.addDependency("g6", "m6", strictly("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g3", "m3", prefers("v3"), [], null, ImmutableAttributes.EMPTY, { it[0].group == 'org' && it[0].name=='foo' && it[0].version=='1.0'})
+        1 * variant2.addDependency("g4", "m4", strictly("v5"), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant2.addDependency("g5", "m5", prefersAndRejects("v5", ["v6", "v7"]), [], null, ImmutableAttributes.EMPTY, [])
+        1 * variant2.addDependency("g6", "m6", strictly("v6"), [], "v5 is buggy", ImmutableAttributes.EMPTY, [])
         1 * metadata.setContentHash(_)
         0 * _
     }
@@ -359,8 +359,8 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, attributes(custom: 'foo'))
-        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, attributes(custom: 'foo', other:'bar'))
+        1 * variant1.addDependency("g1", "m1", requires("v1"), [], null, attributes(custom: 'foo'), [])
+        1 * variant1.addDependency("g2", "m2", prefers("v2"), [], null, attributes(custom: 'foo', other: 'bar'), [])
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
         1 * variant2.addDependencyConstraint("g1", "m1", prefers("v1"), null, attributes(custom: 'foo'))
         1 * variant2.addDependencyConstraint("g2", "m2", requires("v2"), null, attributes(custom: 'foo', other: 'bar'))
@@ -499,9 +499,9 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes(usage: "compile")) >> variant1
-        1 * variant1.addDependency("g1", "m1", version("v1"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant1.addDependency("g1", "m1", version("v1"), [], null, ImmutableAttributes.EMPTY, [])
         1 * metadata.addVariant("runtime", attributes(usage: "runtime", packaging: "zip")) >> variant2
-        1 * variant2.addDependency("g2", "m2", version("v2"), [], null, ImmutableAttributes.EMPTY)
+        1 * variant2.addDependency("g2", "m2", version("v2"), [], null, ImmutableAttributes.EMPTY, [])
         1 * metadata.setContentHash(_)
         0 * _
     }
@@ -627,7 +627,7 @@ class ModuleMetadataParserTest extends Specification {
 
         then:
         1 * metadata.addVariant("api", attributes([:])) >> variant
-        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY)
+        1 * variant.addDependency("g", "m", prefers("v"), excludes("g:*"), null, ImmutableAttributes.EMPTY, [])
         1 * metadata.setContentHash(_)
         0 * metadata._
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/ProjectDependencyDescriptorFactoryTest.groovy
@@ -55,7 +55,7 @@ class ProjectDependencyDescriptorFactoryTest extends AbstractDependencyDescripto
         assertDependencyDescriptorHasCommonFixtureValues(dependencyMetaData)
         !dependencyMetaData.changing
         !dependencyMetaData.force
-        dependencyMetaData.selector == new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root", ImmutableAttributes.EMPTY)
+        dependencyMetaData.selector == new DefaultProjectComponentSelector(DefaultBuildIdentifier.ROOT, Path.ROOT, Path.ROOT, "root", ImmutableAttributes.EMPTY, [])
         projectDependency == dependencyMetaData.source
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
@@ -1100,7 +1101,7 @@ class DependencyGraphBuilderTest extends Specification {
             excludeRules << new DefaultExclude(moduleIdentifierFactory.module(excluded.moduleVersionId.group, excluded.moduleVersionId.name))
         }
         def dependencyMetaData = new LocalComponentDependencyMetadata(from.id, componentSelector,
-            "default", null, ImmutableAttributes.EMPTY, "default", [] as List<IvyArtifactName>,
+            "default", null, ImmutableAttributes.EMPTY, "default", [] as Set<Capability>, [] as List<IvyArtifactName>,
             excludeRules, force, false, transitive, false, null)
         dependencyMetaData = new DslOriginDependencyMetadataWrapper(dependencyMetaData, Stub(ModuleDependency) {
             getAttributes() >> ImmutableAttributes.EMPTY

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ResolveException
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ComponentSelector
-import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
@@ -1101,8 +1100,8 @@ class DependencyGraphBuilderTest extends Specification {
             excludeRules << new DefaultExclude(moduleIdentifierFactory.module(excluded.moduleVersionId.group, excluded.moduleVersionId.name))
         }
         def dependencyMetaData = new LocalComponentDependencyMetadata(from.id, componentSelector,
-            "default", null, ImmutableAttributes.EMPTY, "default", [] as Set<Capability>, [] as List<IvyArtifactName>,
-            excludeRules, force, false, transitive, false, null)
+                "default", null, ImmutableAttributes.EMPTY, "default", [] as List<IvyArtifactName>,
+                excludeRules, force, false, transitive, false, null)
         dependencyMetaData = new DslOriginDependencyMetadataWrapper(dependencyMetaData, Stub(ModuleDependency) {
             getAttributes() >> ImmutableAttributes.EMPTY
         })

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/ComponentResultSerializerTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.result
 
 import org.gradle.api.attributes.Attribute
+import org.gradle.api.capabilities.Capability
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.ResolvedVariantDetails
@@ -41,10 +42,12 @@ class ComponentResultSerializerTest extends SerializerSpec {
         def v1 = Mock(ResolvedVariantDetails) {
             getVariantName() >> Describables.of("v1")
             getVariantAttributes() >> ImmutableAttributes.EMPTY
+            getCapabilities() >> [capability('foo')]
         }
         def v2 = Mock(ResolvedVariantDetails) {
             getVariantName() >> Describables.of("v2")
             getVariantAttributes() >> attributes
+            getCapabilities() >> [capability('bar'), capability('baz')]
         }
         def selection = new DetachedComponentResult(12L,
             newId('org', 'foo', '2.0'),
@@ -63,8 +66,27 @@ class ComponentResultSerializerTest extends SerializerSpec {
         result.resolvedVariants.size() == 2
         result.resolvedVariants[0].variantName.displayName == 'v1'
         result.resolvedVariants[0].variantAttributes == ImmutableAttributes.EMPTY
+        result.resolvedVariants[0].capabilities.size() == 1
+        result.resolvedVariants[0].capabilities[0].group== 'org'
+        result.resolvedVariants[0].capabilities[0].name == 'foo'
+        result.resolvedVariants[0].capabilities[0].version == '1.0'
         result.resolvedVariants[1].variantName.displayName == 'v2'
         result.resolvedVariants[1].variantAttributes == attributes.asImmutable()
+        result.resolvedVariants[1].capabilities.size() == 2
+        result.resolvedVariants[1].capabilities[0].group== 'org'
+        result.resolvedVariants[1].capabilities[0].name == 'bar'
+        result.resolvedVariants[1].capabilities[0].version == '1.0'
+        result.resolvedVariants[1].capabilities[1].group== 'org'
+        result.resolvedVariants[1].capabilities[1].name == 'baz'
+        result.resolvedVariants[1].capabilities[1].version == '1.0'
         result.repositoryName == 'repoName'
+    }
+
+    private Capability capability(String name) {
+        Mock(Capability) {
+            getGroup() >> 'org'
+            getName() >> name
+            getVersion() >> '1.0'
+        }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -158,7 +158,7 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
 
         def configuration = consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
         configuration.dependencies

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/resolver/ComponentMetadataDetailsAdapterTest.groovy
@@ -158,9 +158,9 @@ class ComponentMetadataDetailsAdapterTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(DefaultModuleIdentifier.newId(consumerIdentifier.group, consumerIdentifier.name), new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
 
-        def configuration = consumer.selectConfigurations(attributes, immutable, schema)[0]
+        def configuration = consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
         configuration.dependencies
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
@@ -76,7 +76,7 @@ class DefaultIvyModuleDescriptorWriterTest extends Specification {
     def addDependencyDescriptor(BuildableLocalConfigurationMetadata metadata, String organisation = "org.test", String moduleName, String revision = "1.0") {
         def dep = new LocalComponentDependencyMetadata(metadata.getComponentId(),
             DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(organisation, moduleName), new DefaultMutableVersionConstraint(revision)),
-            "runtime", null, ImmutableAttributes.EMPTY, "default", [] as List, [], false, false, true, false, null)
+            "runtime", null, ImmutableAttributes.EMPTY, "default", [] as Set, [] as List, [], false, false, true, false, null)
         metadata.addDependency(dep)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/ivypublish/DefaultIvyModuleDescriptorWriterTest.groovy
@@ -75,8 +75,8 @@ class DefaultIvyModuleDescriptorWriterTest extends Specification {
 
     def addDependencyDescriptor(BuildableLocalConfigurationMetadata metadata, String organisation = "org.test", String moduleName, String revision = "1.0") {
         def dep = new LocalComponentDependencyMetadata(metadata.getComponentId(),
-            DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(organisation, moduleName), new DefaultMutableVersionConstraint(revision)),
-            "runtime", null, ImmutableAttributes.EMPTY, "default", [] as Set, [] as List, [], false, false, true, false, null)
+                DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(organisation, moduleName), new DefaultMutableVersionConstraint(revision)),
+                "runtime", null, ImmutableAttributes.EMPTY, "default", [] as List, [], false, false, true, false, null)
         metadata.addDependency(dep)
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -109,7 +109,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
             if (addAllDependenciesAsConstraints()) {
                 defaultVariant.addDependencyConstraint("org.test", name, new DefaultMutableVersionConstraint("1.0"), null, ImmutableAttributes.EMPTY)
             } else {
-                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY)
+                defaultVariant.addDependency("org.test", name, new DefaultMutableVersionConstraint("1.0"), [], null, ImmutableAttributes.EMPTY, [])
             }
         }
         metadata
@@ -287,7 +287,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
 
         consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -287,8 +287,8 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
         def componentIdentifier = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("org.test", "consumer"), "1.0")
         def consumerIdentifier = DefaultModuleVersionIdentifier.newId(componentIdentifier)
         def componentSelector = newSelector(consumerIdentifier.module, new DefaultMutableVersionConstraint(consumerIdentifier.version))
-        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def consumer = new LocalComponentDependencyMetadata(componentIdentifier, componentSelector, "default", attributes, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
 
-        consumer.selectConfigurations(attributes, immutable, schema)[0]
+        consumer.selectConfigurations(attributes, immutable, schema, [] as Set)[0]
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadataTest.groovy
@@ -233,11 +233,11 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         def metadata = createMetadata(id)
 
         given:
-        def v1 = metadata.addVariant("api", attributes(usage: "compile"),)
-        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY)
-        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested", ImmutableAttributes.EMPTY)
-        def v2 = metadata.addVariant("runtime", attributes(usage: "runtime"),)
-        v2.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY)
+        def v1 = metadata.addVariant("api", attributes(usage: "compile"))
+        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [])
+        v1.addDependency("g2", "m2", v("v2"), [], "v2 is tested", ImmutableAttributes.EMPTY, [])
+        def v2 = metadata.addVariant("runtime", attributes(usage: "runtime"))
+        v2.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [])
 
         expect:
         metadata.variants.size() == 2
@@ -285,11 +285,11 @@ abstract class AbstractMutableModuleComponentResolveMetadataTest extends Specifi
         def v1 = metadata.addVariant("api", attributes1,)
         v1.addFile("f1.jar", "f1.jar")
         v1.addFile("f2.jar", "f2-1.2.jar")
-        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY)
+        v1.addDependency("g1", "m1", v("v1"), [], null, ImmutableAttributes.EMPTY, [])
         def v2 = metadata.addVariant("runtime", attributes2,)
         v2.addFile("f2", "f2-version.zip")
-        v2.addDependency("g2", "m2", v("v2"), [], null, ImmutableAttributes.EMPTY)
-        v2.addDependency("g3", "m3", v("v3"), [], null, ImmutableAttributes.EMPTY)
+        v2.addDependency("g2", "m2", v("v2"), [], null, ImmutableAttributes.EMPTY, [])
+        v2.addDependency("g3", "m3", v("v3"), [], null, ImmutableAttributes.EMPTY, [])
 
         expect:
         def immutable = metadata.asImmutable()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/local/model/DefaultProjectComponentSelectorTest.groovy
@@ -32,7 +32,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "is instantiated with non-null constructor parameter values"() {
         when:
-        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName", ImmutableAttributes.EMPTY)
+        ProjectComponentSelector defaultBuildComponentSelector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName", ImmutableAttributes.EMPTY, [])
 
         then:
         defaultBuildComponentSelector.projectPath == ":project:path"
@@ -77,7 +77,7 @@ class DefaultProjectComponentSelectorTest extends Specification {
 
     def "matches id (#buildName #projectPath)"() {
         expect:
-        def selector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName", ImmutableAttributes.EMPTY)
+        def selector = new DefaultProjectComponentSelector(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName", ImmutableAttributes.EMPTY, [])
         def sameIdPath = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path"), Path.path(":project:path"), "projectName")
         def differentIdPath = new DefaultProjectComponentIdentifier(Stub(BuildIdentifier), Path.path(":id:path2"), Path.path(":project:path"), "projectName")
         selector.matchesStrictly(sameIdPath)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -66,14 +66,14 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     def "returns this when same target requested"() {
         def selector = Stub(ProjectComponentSelector)
-        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
 
         expect:
         dep.withTarget(selector).is(dep)
     }
 
     def "selects the target configuration from target component"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         def toConfig = Stub(LocalConfigurationMetadata) {
             isCanBeConsumed() >> true
@@ -84,12 +84,12 @@ class LocalComponentDependencyMetadataTest extends Specification {
         toComponent.getConfiguration("to") >> toConfig
 
         expect:
-        dep.selectConfigurations(attributes([:]), toComponent, attributesSchema) == [toConfig]
+        dep.selectConfigurations(attributes([:]), toComponent, attributesSchema, [] as Set) == [toConfig]
     }
 
     @Unroll("selects configuration '#expected' from target component (#scenario)")
     def "selects the target configuration from target component which matches the attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -114,7 +114,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
         toComponent.getConfiguration("bar") >> toBarConfig
 
         expect:
-        dep.selectConfigurations(attributes(queryAttributes), toComponent, attributesSchema)*.name as Set == [expected] as Set
+        dep.selectConfigurations(attributes(queryAttributes), toComponent, attributesSchema, [] as Set)*.name as Set == [expected] as Set
 
         where:
         scenario                                         | queryAttributes                 | expected
@@ -124,7 +124,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     def "revalidates default configuration if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, Dependency.DEFAULT_CONFIGURATION, [] as Set, [] as List, [], false, false, true, false, null)
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
             isCanBeResolved() >> true
@@ -144,7 +144,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
         toComponent.getConfiguration("default") >> defaultConfig
 
         when:
-        dep.selectConfigurations(attributes(key: 'other'), toComponent, attributesSchema)*.name as Set
+        dep.selectConfigurations(attributes(key: 'other'), toComponent, attributesSchema, [] as Set)*.name as Set
 
         then:
         def e = thrown(IncompatibleConfigurationSelectionException)
@@ -154,7 +154,7 @@ Configuration 'default':
     }
 
     def "revalidates explicit configuration selection if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, 'bar', [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, 'bar', [] as Set, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -182,7 +182,7 @@ Configuration 'default':
         toComponent.getConfiguration("bar") >> toBarConfig
 
         when:
-        dep.selectConfigurations(attributes(key: 'something'), toComponent, attributesSchema)*.name as Set
+        dep.selectConfigurations(attributes(key: 'something'), toComponent, attributesSchema, [] as Set)*.name as Set
 
         then:
         def e = thrown(IncompatibleConfigurationSelectionException)
@@ -193,7 +193,7 @@ Configuration 'bar':
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -228,7 +228,7 @@ Configuration 'bar':
 
         expect:
         try {
-            def result = dep.selectConfigurations(attributes(queryAttributes), toComponent, attributesSchema)*.name as Set
+            def result = dep.selectConfigurations(attributes(queryAttributes), toComponent, attributesSchema, [] as Set)*.name as Set
             if (expected == null && result) {
                 throw new AssertionError("Expected an ambiguous result, but got $result")
             }
@@ -263,7 +263,7 @@ Configuration 'bar':
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy using short-hand notation (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy using short-hand notation"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -298,7 +298,7 @@ Configuration 'bar':
 
         expect:
         try {
-            def result = dep.selectConfigurations(attributes(queryAttributes), toComponent, attributesSchema)*.name as Set
+            def result = dep.selectConfigurations(attributes(queryAttributes), toComponent, attributesSchema, [] as Set)*.name as Set
             if (expected == null && result) {
                 throw new AssertionError("Expected an ambiguous result, but got $result")
             }
@@ -333,7 +333,7 @@ Configuration 'bar':
 
     def "fails to select target configuration when not present in the target component"() {
         def fromId = Stub(ComponentIdentifier) { getDisplayName() >> "thing a" }
-        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         toComponent.id >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
 
@@ -341,7 +341,7 @@ Configuration 'bar':
         toComponent.getConfiguration("to") >> null
 
         when:
-        dep.selectConfigurations(attributes([:]), toComponent, attributesSchema)
+        dep.selectConfigurations(attributes([:]), toComponent, attributesSchema,[] as Set)
 
         then:
         def e = thrown(ConfigurationNotFoundException)
@@ -350,7 +350,7 @@ Configuration 'bar':
 
     def "excludes nothing when no exclude rules provided"() {
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -362,7 +362,7 @@ Configuration 'bar':
         def exclude1 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "*"))
         def exclude2 = new DefaultExclude(DefaultModuleIdentifier.newId("group2", "*"))
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [exclude1, exclude2], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [exclude1, exclude2], false, false, true, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -393,7 +393,7 @@ Configuration 'bar':
 
     @Unroll("can select a compatible attribute value (#scenario)")
     def "can select a compatible attribute value"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -422,7 +422,7 @@ Configuration 'bar':
         toComponent.getConfiguration("bar") >> toBarConfig
 
         expect:
-        dep.selectConfigurations(attributes(queryAttributes), toComponent, attributeSchemaWithCompatibility)*.name as Set == [expected] as Set
+        dep.selectConfigurations(attributes(queryAttributes), toComponent, attributeSchemaWithCompatibility, [] as Set)*.name as Set == [expected] as Set
 
         where:
         scenario                     | queryAttributes                 | expected

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/LocalComponentDependencyMetadataTest.groovy
@@ -66,14 +66,14 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     def "returns this when same target requested"() {
         def selector = Stub(ProjectComponentSelector)
-        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, selector, "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
 
         expect:
         dep.withTarget(selector).is(dep)
     }
 
     def "selects the target configuration from target component"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         def toConfig = Stub(LocalConfigurationMetadata) {
             isCanBeConsumed() >> true
@@ -89,7 +89,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
 
     @Unroll("selects configuration '#expected' from target component (#scenario)")
     def "selects the target configuration from target component which matches the attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -124,7 +124,7 @@ class LocalComponentDependencyMetadataTest extends Specification {
     }
 
     def "revalidates default configuration if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, Dependency.DEFAULT_CONFIGURATION, [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, Dependency.DEFAULT_CONFIGURATION, [] as List, [], false, false, true, false, null)
         def defaultConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'default'
             isCanBeResolved() >> true
@@ -154,7 +154,7 @@ Configuration 'default':
     }
 
     def "revalidates explicit configuration selection if it has attributes"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, 'bar', [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, 'bar', [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -193,7 +193,7 @@ Configuration 'bar':
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -263,7 +263,7 @@ Configuration 'bar':
 
     @Unroll("selects configuration '#expected' from target component with Java proximity matching strategy using short-hand notation (#scenario)")
     def "selects the target configuration from target component with Java proximity matching strategy using short-hand notation"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'
@@ -333,7 +333,7 @@ Configuration 'bar':
 
     def "fails to select target configuration when not present in the target component"() {
         def fromId = Stub(ComponentIdentifier) { getDisplayName() >> "thing a" }
-        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(fromId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
         def toComponent = Stub(ComponentResolveMetadata)
         toComponent.id >> Stub(ComponentIdentifier) { getDisplayName() >> "thing b" }
 
@@ -350,7 +350,7 @@ Configuration 'bar':
 
     def "excludes nothing when no exclude rules provided"() {
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [], false, false, true, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -362,7 +362,7 @@ Configuration 'bar':
         def exclude1 = new DefaultExclude(DefaultModuleIdentifier.newId("group1", "*"))
         def exclude2 = new DefaultExclude(DefaultModuleIdentifier.newId("group2", "*"))
         def moduleExclusions = new ModuleExclusions(new DefaultImmutableModuleIdentifierFactory())
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as Set, [] as List, [exclude1, exclude2], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, "to", [] as List, [exclude1, exclude2], false, false, true, false, null)
 
         expect:
         def exclusions = moduleExclusions.excludeAny(copyOf(dep.excludes))
@@ -393,7 +393,7 @@ Configuration 'bar':
 
     @Unroll("can select a compatible attribute value (#scenario)")
     def "can select a compatible attribute value"() {
-        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as Set, [] as List, [], false, false, true, false, null)
+        def dep = new LocalComponentDependencyMetadata(componentId, Stub(ComponentSelector), "from", null, ImmutableAttributes.EMPTY, null, [] as List, [], false, false, true, false, null)
         def defaultConfig = defaultConfiguration()
         def toFooConfig = Stub(LocalConfigurationMetadata) {
             getName() >> 'foo'

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -56,7 +56,7 @@ class ResolutionResultDataBuilder {
         attributes.each {
             mutableAttributes.attribute(Attribute.of(it.key, String), it.value)
         }
-        return new DefaultResolvedVariantResult(Describables.of(name), mutableAttributes)
+        return new DefaultResolvedVariantResult(Describables.of(name), mutableAttributes, [])
     }
 
     static ModuleComponentSelector newSelector(String group, String module, String version) {

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/internal/component/local/model/TestComponentIdentifiers.java
@@ -22,6 +22,8 @@ import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.util.Path;
 
+import java.util.Collections;
+
 public class TestComponentIdentifiers {
     public static ProjectComponentIdentifier newProjectId(String projectPath) {
         return newProjectId(":", projectPath);
@@ -46,6 +48,6 @@ public class TestComponentIdentifiers {
         if (name == null) {
             name = "root";
         }
-        return new DefaultProjectComponentSelector(new DefaultBuildIdentifier(buildName), path, path, name, ImmutableAttributes.EMPTY);
+        return new DefaultProjectComponentSelector(new DefaultBuildIdentifier(buildName), path, path, name, ImmutableAttributes.EMPTY, Collections.emptyList());
     }
 }

--- a/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
+++ b/subprojects/diagnostics/src/test/groovy/org/gradle/api/tasks/diagnostics/internal/insight/DependencyInsightReporterSpec.groovy
@@ -198,7 +198,7 @@ class DependencyInsightReporterSpec extends Specification {
     }
 
     private static DefaultResolvedVariantResult defaultVariant() {
-        new DefaultResolvedVariantResult(Describables.of("default"), ImmutableAttributes.EMPTY)
+        new DefaultResolvedVariantResult(Describables.of("default"), ImmutableAttributes.EMPTY, [])
     }
 
     private static DefaultResolvedDependencyResult path(String path) {

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md
@@ -98,6 +98,7 @@ This value must contain an array with zero or more elements. Each element must b
 - `excludes`: optional. Defines the exclusions that apply to this dependency. 
 - `reason`: optional. A explanation why the dependency is used. Can typically be used to explain why a specific version is requested.
 - `attributes`: optional. If set, attributes will override the consumer attributes during dependency resolution for this specific dependency.
+- `requestedCapabilities`: optional. If set, declares the capabilities that the dependency must provide in order to be selected. See `capabilities` above for the format.
 
 #### `version` value
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/DependencySpec.groovy
@@ -31,6 +31,7 @@ class DependencySpec {
     List<ExcludeSpec> exclusions = []
     String reason
     Map<String, ?> attributes
+    List<CapabilitySpec> requestedCapabilities = []
 
     DependencySpec(String g, String m, String v, String preferredVersion, String strictVersion, List<String> rejects, Collection<Map> excludes, String reason, Map<String, ?> attributes) {
         group = g
@@ -52,6 +53,11 @@ class DependencySpec {
 
     DependencySpec attribute(String name, Object value) {
         attributes[name] = value
+        this
+    }
+
+    DependencySpec requestedCapability(String group, String name, String version) {
+        requestedCapabilities << new CapabilitySpec(group:group, name:name, version:version)
         this
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -100,6 +100,15 @@ class GradleFileModuleAdapter {
                                     }
                                 }
                             }
+                            if (d.requestedCapabilities) {
+                                requestedCapabilities(d.requestedCapabilities.collect { c ->
+                                    { ->
+                                        group c.group
+                                        name c.name
+                                        version c.version
+                                    }
+                                })
+                            }
                         }
                     })
                     dependencyConstraints(v.dependencyConstraints.collect { dc ->

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -541,7 +541,10 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
     }
 
     def "fails compile and link against a library with different operating system family support"() {
-        settingsFile << "include 'app', 'hello'"
+        settingsFile << """
+            rootProject.name = 'test'
+            include 'app', 'hello'
+        """
         def app = new CppAppWithLibrary()
 
         given:
@@ -569,7 +572,7 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         fails ":app:assemble"
 
         failure.assertHasCause """Unable to find a matching variant of project :hello:
-  - Variant 'cppApiElements':
+  - Variant 'cppApiElements' capability test:hello:unspecified:
       - Required org.gradle.native.architecture '${currentArchitecture}' but no value provided.
       - Required org.gradle.native.debuggable 'true' but no value provided.
       - Required org.gradle.native.operatingSystem '${currentOsFamilyName}' but no value provided.

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -23,6 +23,7 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
@@ -163,7 +164,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
         return new LocalComponentDependencyMetadata(
             new OpaqueComponentIdentifier("TODO"),
             selector, usageConfigurationName, null, ImmutableAttributes.EMPTY, mappedUsageConfiguration,
-            ImmutableList.<IvyArtifactName>of(),
+            ImmutableSet.<Capability>of(), ImmutableList.<IvyArtifactName>of(),
             EXCLUDE_RULES,
             false, false, true, false, null);
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/model/DefaultLibraryLocalComponentMetadata.java
@@ -23,7 +23,6 @@ import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyLockingState;
@@ -164,7 +163,7 @@ public class DefaultLibraryLocalComponentMetadata extends DefaultLocalComponentM
         return new LocalComponentDependencyMetadata(
             new OpaqueComponentIdentifier("TODO"),
             selector, usageConfigurationName, null, ImmutableAttributes.EMPTY, mappedUsageConfiguration,
-            ImmutableSet.<Capability>of(), ImmutableList.<IvyArtifactName>of(),
+                ImmutableList.<IvyArtifactName>of(),
             EXCLUDE_RULES,
             false, false, true, false, null);
     }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -307,7 +307,7 @@ public class ModuleMetadataFileGenerator {
         writeDependencies(variant, versionMappingStrategy, jsonWriter);
         writeDependencyConstraints(variant, jsonWriter, versionMappingStrategy);
         writeArtifacts(publication, variant, jsonWriter);
-        writeCapabilities(variant, jsonWriter);
+        writeCapabilities("capabilities", variant.getCapabilities(), jsonWriter);
 
         jsonWriter.endObject();
     }
@@ -430,8 +430,10 @@ public class ModuleMetadataFileGenerator {
             writeVersionConstraint(vc, resolvedVersion, jsonWriter);
         }
         if (dependency instanceof ModuleDependency) {
-            writeExcludes((ModuleDependency) dependency, additionalExcludes, jsonWriter);
-            writeAttributes(((ModuleDependency) dependency).getAttributes(), jsonWriter);
+            ModuleDependency moduleDependency = (ModuleDependency) dependency;
+            writeExcludes(moduleDependency, additionalExcludes, jsonWriter);
+            writeAttributes(moduleDependency.getAttributes(), jsonWriter);
+            writeCapabilities("requestedCapabilities", moduleDependency.getRequestedCapabilities(), jsonWriter);
         }
         String reason = dependency.getReason();
         if (StringUtils.isNotEmpty(reason)) {
@@ -500,10 +502,9 @@ public class ModuleMetadataFileGenerator {
         jsonWriter.endArray();
     }
 
-    private void writeCapabilities(UsageContext variant, JsonWriter jsonWriter) throws IOException {
-        Set<? extends Capability> capabilities = variant.getCapabilities();
+    private void writeCapabilities(String key, Collection<? extends Capability> capabilities, JsonWriter jsonWriter) throws IOException {
         if (!capabilities.isEmpty()) {
-            jsonWriter.name("capabilities");
+            jsonWriter.name(key);
             jsonWriter.beginArray();
             for (Capability capability : capabilities) {
                 jsonWriter.beginObject();

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -33,6 +33,7 @@ import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDepende
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
+import org.gradle.internal.component.external.model.ImmutableCapability
 import org.gradle.internal.id.UniqueId
 import org.gradle.internal.scopeids.id.BuildInvocationScopeId
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
@@ -266,10 +267,18 @@ class ModuleMetadataFileGeneratorTest extends Specification {
         d7.transitive >> true
         d7.attributes >> attributes(foo: 'foo', bar: 'baz')
 
+        def d8 = Stub(ModuleDependency)
+        d8.group >> "g1"
+        d8.name >> "m1"
+        d8.version >> "v1"
+        d8.transitive >> true
+        d8.attributes >> ImmutableAttributes.EMPTY
+        d8.requestedCapabilities >> [new ImmutableCapability("org", "test", "1.0")]
+
         def v1 = Stub(UsageContext)
         v1.name >> "v1"
         v1.attributes >> attributes(usage: "compile")
-        v1.dependencies >> [d1]
+        v1.dependencies >> [d1, d8]
 
         def v2 = Stub(UsageContext)
         v2.name >> "v2"
@@ -309,6 +318,20 @@ class ModuleMetadataFileGeneratorTest extends Specification {
           "version": {
             "requires": "v1"
           }
+        },
+        {
+          "group": "g1",
+          "module": "m1",
+          "version": {
+            "requires": "v1"
+          },
+          "requestedCapabilities": [
+            {
+              "group": "org",
+              "name": "test",
+              "version": "1.0"
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
## Context

This pull request adds support for the long awaited "optional dependencies" support. However, Gradle will _not_ implement it like Maven (aka `<optional>true</optional>`), but will leverage variant-aware dependency management to provide a richer model.

Basically, the idea for a consumer is to say "I need this component C, with support for optional features F1 and F2". Gradle will then automatically find the main artifacts for C, but will _also_ include dependencies required for F1 and F2. This means that "optional dependencies" are not a bucket of dependencies that are magically removed when publishing or resolving, but are real things grouped under logical features.

The main advantage of this technique is that we know _why_ some dependencies are here: to provide some capability. We can also leverage _capability conflict resolution_ to make sure that incompatible capabilities are never found in the graph. It is therefore possible for a component to say that it provides optional features F1 and F2, but that you must choose between one of the 2. This is often the case when choosing a database binding, for example.

For example, a dependency declaration can now ask for a specific _capability_ for a component:

```
dependencies {
    api("org:mylib:1.0") {
        capabilities {
            requireCapability("org:my-capability:1.0")
        }
    }
}
```

By default, without capabilities declaration, a dependency would search for variants providing the _implicit_ capability, which corresponds to the GAV coordinates of the component. If, on the other hand, we explicitly require a capability like in the above, the engine will first search for the variants which provide the requested capabilities.

This can be used, for example, to depend both on the main and test fixtures artifacts of a dependency, in the same dependency graph:

```
dependencies {
    api("org:mylib:1.0")
    testCompile("org:mylib:1.0") {
        capabilities {
            requireCapability("org:mylib-testfixtures:1.0")
        }
    }
}
```

This does **not** bypass attribute based matching in any case: if the provider has more than one "test fixtures" variant, then we would select the appropriate one using attributes.


This pull request is WIP.