### PR TITLE
Re-enable daemon on CI

### DIFF
--- a/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
+++ b/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
@@ -10,7 +10,7 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildTyp
     name = "Build Distributions"
     description = "Creation and verification of the distribution and documentation"
 
-    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=${distributionTestJavaHome}", daemon = false)
+    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=${distributionTestJavaHome}")
 
     artifactRules = """$artifactRules
         build/distributions/*.zip => distributions

--- a/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
+++ b/.teamcity/Gradle_Check/configurations/FunctionalTest.kt
@@ -7,7 +7,7 @@ import model.Stage
 import model.TestCoverage
 import model.TestType
 
-class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", useDaemon: Boolean = true, stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
+class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject: String = "", stage: Stage) : BaseGradleBuildType(model, stage = stage, init = {
     uuid = testCoverage.asConfigurationId(model, subProject)
     id = AbsoluteId(uuid)
     name = testCoverage.asName() + if (!subProject.isEmpty()) " ($subProject)" else ""
@@ -29,8 +29,7 @@ class FunctionalTest(model: CIBuildModel, testCoverage: TestCoverage, subProject
                             + buildScanTags.map { buildScanTag(it) }
                             + buildScanValues.map { buildScanCustomValue(it.key, it.value) }
                     ).joinToString(separator = " "),
-            timeout = testCoverage.testType.timeout,
-            daemon = useDaemon)
+            timeout = testCoverage.testType.timeout)
 
     params {
         param("env.JAVA_HOME", "%${testCoverage.os}.${testCoverage.buildJvmVersion}.openjdk.64bit%")

--- a/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
+++ b/.teamcity/Gradle_Check/configurations/IndividualPerformanceScenarioWorkers.kt
@@ -41,7 +41,7 @@ class IndividualPerformanceScenarioWorkers(model: CIBuildModel) : BaseGradleBuil
             name = "GRADLE_RUNNER"
             tasks = ""
             gradleParams = (
-                    gradleParameters(daemon = false, isContinue = false)
+                    gradleParameters(isContinue = false)
                     + listOf("""clean %templates% fullPerformanceTests --scenarios "%scenario%" --baselines %baselines% --warmups %warmups% --runs %runs% --checks %checks% --channel %channel% -x prepareSamples -Porg.gradle.performance.branchName=%teamcity.build.branch% -Porg.gradle.performance.db.url=%performance.db.url% -Porg.gradle.performance.db.username=%performance.db.username% -Porg.gradle.performance.db.password=%performance.db.password.tcagent% -PtimestampedVersion""",
                             buildScanTag("IndividualPerformanceScenarioWorkers"), "-PtestJavaHome=${individualPerformanceTestJavaHome}")
                             + model.parentBuildCache.gradleParameters(OS.linux)

--- a/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTest.kt
@@ -40,7 +40,7 @@ class PerformanceTest(model: CIBuildModel, type: PerformanceTestType, stage: Sta
             name = "GRADLE_RUNNER"
             tasks = ""
             gradleParams = (
-                    gradleParameters(daemon = false)
+                    gradleParameters()
                     + listOf("clean distributed${type.taskId}s -x prepareSamples --baselines %performance.baselines% ${type.extraParameters} -PtimestampedVersion -Porg.gradle.performance.branchName=%teamcity.build.branch% -Porg.gradle.performance.db.url=%performance.db.url% -Porg.gradle.performance.db.username=%performance.db.username% -PteamCityUsername=%TC_USERNAME% -PteamCityPassword=%teamcity.password.restbot% -Porg.gradle.performance.buildTypeId=${IndividualPerformanceScenarioWorkers(model).id} -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id% -Porg.gradle.performance.db.password=%performance.db.password.tcagent%",
                             buildScanTag("PerformanceTest"), "-PtestJavaHome=${coordinatorPerformanceTestJavaHome}")
                             + model.parentBuildCache.gradleParameters(OS.linux)

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -153,12 +153,12 @@ data class CIBuildModel (
             GradleSubproject("testingJvm"),
             GradleSubproject("testingJunitPlatform"),
             GradleSubproject("testingNative"),
-            GradleSubproject("toolingApi", crossVersionTests = true, useDaemon = false),
+            GradleSubproject("toolingApi", crossVersionTests = true),
             GradleSubproject("toolingApiBuilders", functionalTests = false),
             GradleSubproject("toolingNative", unitTests = false, functionalTests = false, crossVersionTests = true),
             GradleSubproject("versionControl"),
             GradleSubproject("workers"),
-            GradleSubproject("wrapper", crossVersionTests = true, useDaemon = false),
+            GradleSubproject("wrapper", crossVersionTests = true),
 
             GradleSubproject("soak", unitTests = false, functionalTests = false),
 
@@ -183,14 +183,12 @@ data class CIBuildModel (
             GradleSubproject("smokeTest", unitTests = false, functionalTests = false))
         )
 
-data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false, val useDaemon: Boolean = true) {
+data class GradleSubproject(val name: String, val unitTests: Boolean = true, val functionalTests: Boolean = true, val crossVersionTests: Boolean = false, val containsSlowTests: Boolean = false) {
     fun asDirectoryName(): String {
         return name.replace(Regex("([A-Z])"), { "-" + it.groups[1]!!.value.toLowerCase() })
     }
 
     fun hasTestsOf(type: TestType) = (unitTests && type.unitTests) || (functionalTests && type.functionalTests) || (crossVersionTests && type.crossVersionTests)
-
-    fun useDaemonFor(type: TestType) = useDaemon && type != TestType.noDaemon
 }
 
 interface BuildCache {

--- a/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
+++ b/.teamcity/Gradle_Check/projects/FunctionalTestProject.kt
@@ -23,7 +23,7 @@ class FunctionalTestProject(model: CIBuildModel, testConfig: TestCoverage, stage
         }
 
         if (subProject.hasTestsOf(testConfig.testType)) {
-            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemonFor(testConfig.testType), stage))
+            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
         }
     }
 }){

--- a/.teamcity/Gradle_Check/projects/StageProject.kt
+++ b/.teamcity/Gradle_Check/projects/StageProject.kt
@@ -70,7 +70,7 @@ class StageProject(model: CIBuildModel, stage: Stage, containsDeferredTests: Boo
                             subProject.hasTestsOf(testConfig.testType)
                         }
                         .forEach { testConfig ->
-                            buildType(FunctionalTest(model, testConfig, subProject.name, subProject.useDaemonFor(testConfig.testType), stage))
+                            buildType(FunctionalTest(model, testConfig, subProject.name, stage))
                         }
                 }
         }


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/1767

Previously we disabled daemon in some CI builds as a workaround of https://github.com/gradle/gradle-private/issues/1352 . Now that issue has been fixed, so we re-enable disabled daemons.

Also, there seems no reason to enable daemon in performance tests, so we enable them as well.