### PR TITLE
Remove not yet finished transform register method

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -20,7 +20,6 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
@@ -442,15 +441,6 @@ public interface DependencyHandler {
      * @since 3.5
      */
     void registerTransform(Action<? super VariantTransform> registrationAction);
-
-    /**
-     * Registers an artifact transform.
-     *
-     * @see org.gradle.api.artifacts.transform.ArtifactTransform
-     * @since 5.2
-     */
-    @Incubating
-    <T> void registerTransform(Class<T> configurationType, Action<? super ArtifactTransformSpec<T>> registrationAction);
 
     /**
      * Declares a dependency on a platform. If the target coordinates represent multiple

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -18,10 +18,12 @@ package org.gradle.integtests.resolve.transform
 
 import org.gradle.api.artifacts.transform.ArtifactTransformDependencies
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 
 class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
+    @Ignore("The API has been removed for 5.2")
     def "transform can receive configuration via constructor parameter"() {
         settingsFile << """
             include 'a', 'b', 'c'
@@ -79,6 +81,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @Ignore("The API has been removed for 5.2")
     def "transform can receive configuration via abstract getter"() {
         settingsFile << """
             include 'a', 'b', 'c'
@@ -132,6 +135,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    @Ignore("Ignored for 5.2")
     def "transform can receive configuration and construction parameters"() {
         settingsFile << """
             include 'a', 'b', 'c'

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -27,7 +27,6 @@ import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
@@ -210,11 +209,6 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     @Override
     public void registerTransform(Action<? super VariantTransform> registrationAction) {
         transforms.registerTransform(registrationAction);
-    }
-
-    @Override
-    public <T> void registerTransform(Class<T> configurationType, Action<? super ArtifactTransformSpec<T>> registrationAction) {
-        transforms.registerTransform(configurationType, registrationAction);
     }
 
     @Override


### PR DESCRIPTION
We don't want to expose this new API in Gradle 5.2.