### PR TITLE
Limitations on multiple composite builds with shared builds

### DIFF
--- a/subprojects/docs/src/docs/userguide/composite_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/composite_builds.adoc
@@ -206,6 +206,7 @@ Limitations of the current implementation include:
 
 * No support for included builds that have publications that don't mirror the project default configuration. See <<#included_build_substitution_limitations,Cases where composite builds won't work>>.
 * Software model based native builds are not supported. (Binary dependencies are not yet supported for native builds).
+* Multiple composite builds may conflict when run in parallel, if more than one includes the same build. Gradle does no locking to verify that the same included build is not executed in parallel. Even multiple composite builds executed serially may cause issues if any of the subsequent builds cause any changes in the underlying included build.
 
 Improvements we have planned for upcoming releases include:
 


### PR DESCRIPTION
Add additional limitations on the Gradle composite builds related to multiple composite builds referring
to the same shared builds.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
