### PR TITLE
Fix Javadoc JS and navigation injection

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -328,6 +328,10 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
             // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it
             // Here we generate this file manually
             new File(destinationDir, 'package-list').text = new File(destinationDir, 'element-list').text
+
+            // Commit http://hg.openjdk.java.net/jdk/jdk/rev/89dc31d7572b broke use of JSZip (https://bugs.openjdk.java.net/browse/JDK-8214856) fixed in Java 12 by http://hg.openjdk.java.net/jdk/jdk/rev/b4982a22926b
+            // TODO: Remove this script.js workaround when we distribute Gradle using JDK 12 or higher
+            new File(destinationDir, 'script.js').text = new File(srcDocsDir, 'js/javadoc/script.js').text
         }
     }
 }

--- a/subprojects/docs/src/docs/js/javadoc/script.js
+++ b/subprojects/docs/src/docs/js/javadoc/script.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+var moduleSearchIndex;
+var packageSearchIndex;
+var typeSearchIndex;
+var memberSearchIndex;
+var tagSearchIndex;
+function loadScripts(doc, tag) {
+  createElem(doc, tag, 'jquery/jszip/dist/jszip.js');
+  createElem(doc, tag, 'jquery/jszip-utils/dist/jszip-utils.js');
+  if (window.navigator.userAgent.indexOf('MSIE ') > 0 || window.navigator.userAgent.indexOf('Trident/') > 0 ||
+    window.navigator.userAgent.indexOf('Edge/') > 0) {
+    createElem(doc, tag, 'jquery/jszip-utils/dist/jszip-utils-ie.js');
+  }
+  createElem(doc, tag, 'search.js');
+
+  $.get(pathtoroot + "module-search-index.zip")
+    .done(function() {
+      JSZipUtils.getBinaryContent(pathtoroot + "module-search-index.zip", function(e, data) {
+        JSZip.loadAsync(data).then(function(zip){
+          zip.file("module-search-index.json").async("text").then(function(content){
+            moduleSearchIndex = JSON.parse(content);
+          });
+        });
+      });
+    });
+  $.get(pathtoroot + "package-search-index.zip")
+    .done(function() {
+      JSZipUtils.getBinaryContent(pathtoroot + "package-search-index.zip", function(e, data) {
+        JSZip.loadAsync(data).then(function(zip){
+          zip.file("package-search-index.json").async("text").then(function(content){
+            packageSearchIndex = JSON.parse(content);
+          });
+        });
+      });
+    });
+  $.get(pathtoroot + "type-search-index.zip")
+    .done(function() {
+      JSZipUtils.getBinaryContent(pathtoroot + "type-search-index.zip", function(e, data) {
+        JSZip.loadAsync(data).then(function(zip){
+          zip.file("type-search-index.json").async("text").then(function(content){
+            typeSearchIndex = JSON.parse(content);
+          });
+        });
+      });
+    });
+  $.get(pathtoroot + "member-search-index.zip")
+    .done(function() {
+      JSZipUtils.getBinaryContent(pathtoroot + "member-search-index.zip", function(e, data) {
+        JSZip.loadAsync(data).then(function(zip){
+          zip.file("member-search-index.json").async("text").then(function(content){
+            memberSearchIndex = JSON.parse(content);
+          });
+        });
+      });
+    });
+  $.get(pathtoroot + "tag-search-index.zip")
+    .done(function() {
+      JSZipUtils.getBinaryContent(pathtoroot + "tag-search-index.zip", function(e, data) {
+        JSZip.loadAsync(data).then(function(zip){
+          zip.file("tag-search-index.json").async("text").then(function(content){
+            tagSearchIndex = JSON.parse(content);
+          });
+        });
+      });
+    });
+  if (!moduleSearchIndex) {
+    createElem(doc, tag, 'module-search-index.js');
+  }
+  if (!packageSearchIndex) {
+    createElem(doc, tag, 'package-search-index.js');
+  }
+  if (!typeSearchIndex) {
+    createElem(doc, tag, 'type-search-index.js');
+  }
+  if (!memberSearchIndex) {
+    createElem(doc, tag, 'member-search-index.js');
+  }
+  if (!tagSearchIndex) {
+    createElem(doc, tag, 'tag-search-index.js');
+  }
+  $(window).resize(function() {
+    $('.navPadding').css('padding-top', $('.fixedNav').css("height"));
+  });
+}
+
+function createElem(doc, tag, path) {
+  var script = doc.createElement(tag);
+  var scriptElement = doc.getElementsByTagName(tag)[0];
+  script.src = pathtoroot + path;
+  scriptElement.parentNode.insertBefore(script, scriptElement);
+}
+
+function show(type) {
+  count = 0;
+  for (var key in data) {
+    var row = document.getElementById(key);
+    if ((data[key] &  type) !== 0) {
+      row.style.display = '';
+      row.className = (count++ % 2) ? rowColor : altColor;
+    }
+    else
+      row.style.display = 'none';
+  }
+  updateTabs(type);
+}
+
+function updateTabs(type) {
+  var firstRow = document.getElementById(Object.keys(data)[0]);
+  var table = firstRow.closest('table');
+  for (var value in tabs) {
+    var tab = document.getElementById(tabs[value][0]);
+    if (value == type) {
+      tab.className = activeTableTab;
+      tab.innerHTML = tabs[value][1];
+      tab.setAttribute('aria-selected', true);
+      tab.setAttribute('tabindex',0);
+      table.setAttribute('aria-labelledby', tabs[value][0]);
+    }
+    else {
+      tab.className = tableTab;
+      tab.setAttribute('aria-selected', false);
+      tab.setAttribute('tabindex',-1);
+      tab.setAttribute('onclick', "show("+ value + ")");
+      tab.innerHTML = tabs[value][1];
+    }
+  }
+}
+
+function updateModuleFrame(pFrame, cFrame) {
+  top.packageFrame.location = pFrame;
+  top.classFrame.location = cFrame;
+}
+function switchTab(e) {
+  if (e.keyCode == 37 || e.keyCode == 38) {
+    $("[aria-selected=true]").prev().click().focus();
+    e.preventDefault();
+  }
+  if (e.keyCode == 39 || e.keyCode == 40) {
+    $("[aria-selected=true]").next().click().focus();
+    e.preventDefault();
+  }
+}


### PR DESCRIPTION
This change substitutes our own javadoc script.js in place of the
broken one in JDK 11. See comments for technical details.

Issue: gradle/dotorg-docs#328

NOTE: I could not find a javadoc option to substitute JS like we can CSS. 