### PR TITLE
Fix inefficient ClassPageRenderer

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/report/ClassPageRenderer.java
@@ -51,14 +51,16 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
         SimpleMarkupWriter writer = htmlWriter.startElement("table");
         renderTableHead(writer, determineTableHeaders());
 
+        boolean methodNameColumnExists = methodNameColumnExists();
+
         for (TestResult test : getResults().getTestResults()) {
-            renderTableRow(writer, test);
+            renderTableRow(writer, test, determineTableRow(test, methodNameColumnExists));
         }
         htmlWriter.endElement();
     }
 
-    private List<String> determineTableRow(TestResult test) {
-        return methodNameColumnExists()
+    private List<String> determineTableRow(TestResult test, boolean methodNameColumnExists) {
+        return methodNameColumnExists
             ? Arrays.asList(test.getDisplayName(), test.getName(), test.getFormattedDuration(), test.getFormattedResultType())
             : Arrays.asList(test.getDisplayName(), test.getFormattedDuration(), test.getFormattedResultType());
     }
@@ -75,9 +77,9 @@ class ClassPageRenderer extends PageRenderer<ClassTestResults> {
         writer.endElement().endElement();
     }
 
-    private void renderTableRow(SimpleMarkupWriter writer, TestResult test) throws IOException {
+    private void renderTableRow(SimpleMarkupWriter writer, TestResult test, List<String> rowCells) throws IOException {
         writer.startElement("tr");
-        for (String cell : determineTableRow(test)) {
+        for (String cell : rowCells) {
             writer.startElement("td").attribute("class", test.getStatusClass()).characters(cell).endElement();
         }
         writer.endElement();


### PR DESCRIPTION
See https://github.com/gradle/gradle/issues/8294

Previously we used an inefficient O(n^2) algorithm when rendering HTML test report class page.
This PR fixes it by normal O(n) code.

Thanks @ymwang1984 for reporting and suggesting.