### PR TITLE
Allow publishing of optional variants

### DIFF
--- a/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
+++ b/subprojects/composite-builds/src/integTest/groovy/org/gradle/integtests/composite/CompositeBuildDependencyCapabilitiesResolveIntegrationTest.groovy
@@ -65,7 +65,7 @@ class CompositeBuildDependencyCapabilitiesResolveIntegrationTest extends Abstrac
             dependencies {
                 api("com.acme.external:external:1.0") {
                     capabilities {
-                        requireCapability("org:$capability:1.0")
+                        requireCapability("org:$capability")
                     }
                 }
             }

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithOptionalFeatures.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithOptionalFeatures.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.component;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.artifacts.Configuration;
+
+/**
+ * A component which can declare additional variants corresponding to optional
+ * features. When published to Maven POMs, the dependencies of those variants
+ * are exposed as optional dependencies. When published to Gradle metadata, the
+ * variants are published as is.
+ *
+ * @since 5.3
+ */
+@Incubating
+public interface ComponentWithOptionalFeatures extends SoftwareComponent {
+    /**
+     * Declares an additional variant to publish, corresponding to an optional feature.
+     * @param name the name of the variant, used when publishing to Gradle metadata.
+     * @param outgoingConfiguration the configuration corresponding to the variant to use as source of dependencies and artifacts
+     */
+    void addOptionalFeatureVariantFromConfiguration(String name, Configuration outgoingConfiguration);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/UsageContext.java
@@ -28,7 +28,8 @@ import org.gradle.api.capabilities.Capability;
 import java.util.Set;
 
 public interface UsageContext extends HasAttributes, Named {
-    Usage getUsage();
+    @Deprecated
+    Usage getUsage(); // kept for backwards compatibility of plugins using internal APIs
     Set<? extends PublishArtifact> getArtifacts();
     Set<? extends ModuleDependency> getDependencies();
     Set<? extends DependencyConstraint> getDependencyConstraints();

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -65,7 +65,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
                     }
                     capabilities {
-                        requireCapability('org:lib-fixtures:1.0')
+                        requireCapability('org:lib-fixtures')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -66,7 +66,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                         attribute(CUSTOM_ATTRIBUTE, 'c1')
                     }
                     capabilities {
-                        requireCapability('org.test:cap1:1.0')
+                        requireCapability('org.test:cap1')
                     }
                 }
                 conf('org:test:1.0') {
@@ -74,7 +74,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                         attribute(CUSTOM2_ATTRIBUTE, 'c2')
                     }
                     capabilities {
-                        requireCapability('org.test:cap2:1.0')
+                        requireCapability('org.test:cap2')
                     }
                 }
             }
@@ -131,7 +131,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                         attribute(CUSTOM_ATTRIBUTE, 'c1')
                     }
                     capabilities {
-                        requireCapability('org.test:cap1:1.0')
+                        requireCapability('org.test:cap1')
                     }
                 }
                 conf('org:test:1.0') {
@@ -139,7 +139,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                         attribute(CUSTOM_ATTRIBUTE, 'c2')
                     }
                     capabilities {
-                        requireCapability('org.test:cap2:1.0')
+                        requireCapability('org.test:cap2')
                     }
                 }
             }
@@ -222,7 +222,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                         attribute(CUSTOM_ATTRIBUTE, 'c1')
                     }
                     capabilities {
-                        requireCapability('org.test:cap:1.0')
+                        requireCapability('org.test:cap')
                     }
                 }
                 conf('org:test:1.0') {
@@ -230,7 +230,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                         attribute(CUSTOM_ATTRIBUTE, 'c2')
                     }
                     capabilities {
-                        requireCapability('org.test:cap:1.0')
+                        requireCapability('org.test:cap')
                     }
                 }
             }
@@ -610,7 +610,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                 conf('org:foo:1.0')
                 conf('org:foo:1.0') {
                     capabilities {
-                        requireCapability('org:foo-testfixtures:1.0')
+                        requireCapability('org:foo-testfixtures')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/optional/OptionalFeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/optional/OptionalFeaturesResolveIntegrationTest.groovy
@@ -50,7 +50,7 @@ class OptionalFeaturesResolveIntegrationTest extends AbstractModuleDependencyRes
                 conf('org:foo:1.0')
                 conf('org:foo:1.0') {
                     capabilities {
-                        requireCapability('org:feature-1:1.0')
+                        requireCapability('org:feature-1')
                     }
                 }
             }
@@ -104,7 +104,7 @@ class OptionalFeaturesResolveIntegrationTest extends AbstractModuleDependencyRes
                 conf('org:foo:1.0')
                 conf('org:foo:1.0') {
                     capabilities {
-                        requireCapability('org:feature-3:1.0')
+                        requireCapability('org:feature-3')
                     }
                 }
             }
@@ -119,7 +119,7 @@ class OptionalFeaturesResolveIntegrationTest extends AbstractModuleDependencyRes
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Unable to find a variant of org:foo:1.0 providing the requested capability org:feature-3:1.0:
+        failure.assertHasCause("""Unable to find a variant of org:foo:1.0 providing the requested capability org:feature-3:
    - Variant api provides org:foo:1.0
    - Variant runtime provides org:foo:1.0
    - Variant feature1 provides org:feature-1:1.0
@@ -154,7 +154,7 @@ class OptionalFeaturesResolveIntegrationTest extends AbstractModuleDependencyRes
                 conf('org:foo:1.0')
                 conf('org:foo:1.0') {
                     capabilities {
-                        requireCapabilities('org:feature-1:1.0', 'org:feature-3:1.0')
+                        requireCapabilities('org:feature-1', 'org:feature-3')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/optional/OptionalFeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/optional/OptionalFeaturesResolveIntegrationTest.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.resolve.attributes
+package org.gradle.integtests.resolve.optional
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
@@ -24,7 +24,7 @@ import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 @RequiredFeatures(
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 )
-class OptionalFeaturesIntegrationTest extends AbstractModuleDependencyResolveTest {
+class OptionalFeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "can select a variant providing a different capability"() {
         given:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyFactory.java
@@ -57,11 +57,11 @@ public class DefaultDependencyFactory implements DependencyFactory {
 
     public Dependency createDependency(Object dependencyNotation) {
         Dependency dependency = dependencyNotationParser.parseNotation(dependencyNotation);
-        injectAttributesFactory(dependency);
+        injectServices(dependency);
         return dependency;
     }
 
-    private void injectAttributesFactory(Dependency dependency) {
+    private void injectServices(Dependency dependency) {
         if (dependency instanceof AbstractModuleDependency) {
             AbstractModuleDependency moduleDependency = (AbstractModuleDependency) dependency;
             moduleDependency.setAttributesFactory(attributesFactory);
@@ -72,11 +72,11 @@ public class DefaultDependencyFactory implements DependencyFactory {
     @Override
     public DependencyConstraint createDependencyConstraint(Object dependencyNotation) {
         DependencyConstraint dependencyConstraint = dependencyConstraintNotationParser.parseNotation(dependencyNotation);
-        injectAttributesFactory(dependencyConstraint);
+        injectServices(dependencyConstraint);
         return dependencyConstraint;
     }
 
-    private void injectAttributesFactory(DependencyConstraint dependency) {
+    private void injectServices(DependencyConstraint dependency) {
         if (dependency instanceof DefaultDependencyConstraint) {
             ((DefaultDependencyConstraint) dependency).setAttributesFactory(attributesFactory);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementBuildScopeServices.java
@@ -155,7 +155,7 @@ class DependencyManagementBuildScopeServices {
             DependencyNotationParser.parser(instantiator, factory, classPathRegistry, fileLookup, runtimeShadedJarFactory, currentGradleInstallation, stringInterner),
                 DependencyConstraintNotationParser.parser(instantiator, factory, stringInterner),
                 new ClientModuleNotationParserFactory(instantiator, stringInterner).create(),
-                new CapabilityNotationParserFactory().create(), projectDependencyFactory,
+                new CapabilityNotationParserFactory(false).create(), projectDependencyFactory,
             attributesFactory);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -108,7 +108,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         this.buildOperationExecutor = buildOperationExecutor;
         this.userCodeApplicationContext = userCodeApplicationContext;
         this.artifactNotationParser = new PublishArtifactNotationParserFactory(instantiator, dependencyMetaDataProvider, taskResolver).create();
-        this.capabilityNotationParser = new CapabilityNotationParserFactory().create();
+        this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
         this.attributesFactory = attributesFactory;
         this.projectStateRegistry = projectStateRegistry;
         this.documentationRegistry = documentationRegistry;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
@@ -46,21 +46,22 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
         return SINGLETON_CONVERTER;
     }
 
-    private static class StringNotationParser extends TypedNotationConverter<String, Capability> {
+    private static class StringNotationParser extends TypedNotationConverter<CharSequence, Capability> {
 
         StringNotationParser() {
-            super(String.class);
+            super(CharSequence.class);
         }
 
         @Override
-        protected Capability parseType(String notation) {
-            String[] parts = notation.split(":");
+        protected Capability parseType(CharSequence notation) {
+            String stringNotation = notation.toString();
+            String[] parts = stringNotation.split(":");
             if (parts.length != 3) {
-                reportInvalidNotation(notation);
+                reportInvalidNotation(stringNotation);
             }
             for (String part : parts) {
                 if (StringUtils.isEmpty(part)) {
-                    reportInvalidNotation(notation);
+                    reportInvalidNotation(stringNotation);
                 }
             }
             return new ImmutableCapability(parts[0], parts[1], parts[2]);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.dsl;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.tasks.Optional;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.ImmutableCapability;
 import org.gradle.internal.exceptions.DiagnosticsVisitor;
@@ -30,12 +31,19 @@ import org.gradle.internal.typeconversion.TypedNotationConverter;
 import javax.annotation.Nullable;
 
 public class CapabilityNotationParserFactory implements Factory<NotationParser<Object, Capability>> {
-    private final static NotationParser<Object, Capability> SINGLETON_CONVERTER = createSingletonConverter();
+    private final static NotationParser<Object, Capability> STRICT_CONVERTER = createSingletonConverter(true);
+    private final static NotationParser<Object, Capability> LENIENT_CONVERTER = createSingletonConverter(false);
 
-    private static NotationParser<Object, Capability> createSingletonConverter() {
+    private final boolean strict;
+
+    public CapabilityNotationParserFactory(boolean strict) {
+        this.strict = strict;
+    }
+
+    private static NotationParser<Object, Capability> createSingletonConverter(boolean strict) {
         return NotationParserBuilder.toType(Capability.class)
-            .converter(new StringNotationParser())
-            .converter(new CapabilityMapNotationParser())
+            .converter(new StringNotationParser(strict))
+            .converter(strict ? new StrictCapabilityMapNotationParser() : new LenientCapabilityMapNotationParser())
             .toComposite();
     }
 
@@ -43,13 +51,15 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
     @Override
     public NotationParser<Object, Capability> create() {
         // Currently the converter is stateless, doesn't need any external context, so for performance we return a singleton
-        return SINGLETON_CONVERTER;
+        return strict ? STRICT_CONVERTER : LENIENT_CONVERTER;
     }
 
     private static class StringNotationParser extends TypedNotationConverter<CharSequence, Capability> {
+        private final boolean strict;
 
-        StringNotationParser() {
+        StringNotationParser(boolean strict) {
             super(CharSequence.class);
+            this.strict = strict;
         }
 
         @Override
@@ -57,14 +67,17 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
             String stringNotation = notation.toString();
             String[] parts = stringNotation.split(":");
             if (parts.length != 3) {
-                reportInvalidNotation(stringNotation);
+                if (strict || parts.length != 2) {
+                    reportInvalidNotation(stringNotation);
+                }
             }
             for (String part : parts) {
                 if (StringUtils.isEmpty(part)) {
                     reportInvalidNotation(stringNotation);
                 }
             }
-            return new ImmutableCapability(parts[0], parts[1], parts[2]);
+            String version = parts.length == 3 ? parts[2] : null;
+            return new ImmutableCapability(parts[0], parts[1], version);
         }
 
         private static void reportInvalidNotation(String notation) {
@@ -74,7 +87,7 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
         }
     }
 
-    private static class CapabilityMapNotationParser extends MapNotationConverter<Capability> {
+    private static class StrictCapabilityMapNotationParser extends MapNotationConverter<Capability> {
         @Override
         public void describe(DiagnosticsVisitor visitor) {
             visitor.candidate("Maps").example("[group: 'org.group', name: 'capability', version: '1.0']");
@@ -83,6 +96,19 @@ public class CapabilityNotationParserFactory implements Factory<NotationParser<O
         protected Capability parseMap(@MapKey("group") String group,
                                       @MapKey("name") String name,
                                       @MapKey("version") String version) {
+            return new ImmutableCapability(group, name, version);
+        }
+    }
+
+    private static class LenientCapabilityMapNotationParser extends MapNotationConverter<Capability> {
+        @Override
+        public void describe(DiagnosticsVisitor visitor) {
+            visitor.candidate("Maps").example("[group: 'org.group', name: 'capability', version: '1.0']");
+        }
+
+        protected Capability parseMap(@MapKey("group") String group,
+                                      @MapKey("name") String name,
+                                      @MapKey("version") @Optional String version) {
             return new ImmutableCapability(group, name, version);
         }
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/CapabilityNotationParserFactoryTest.groovy
@@ -19,14 +19,20 @@ package org.gradle.api.internal.artifacts.dsl
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.capabilities.Capability
 import org.gradle.internal.typeconversion.NotationParser
+import spock.lang.Shared
 import spock.lang.Specification
 import spock.lang.Subject
 import spock.lang.Unroll
 
 class CapabilityNotationParserFactoryTest extends Specification {
     @Subject
-    private NotationParser<Object, Capability> parser = new CapabilityNotationParserFactory().create()
+    @Shared
+    private NotationParser<Object, Capability> strictParser = new CapabilityNotationParserFactory(true).create()
+    @Subject
+    @Shared
+    private NotationParser<Object, Capability> lenientParser = new CapabilityNotationParserFactory(false).create()
 
+    @Unroll
     def "can parse string notation"() {
         when:
         def capability = parser.parseNotation("foo:bar:1.0")
@@ -35,12 +41,25 @@ class CapabilityNotationParserFactoryTest extends Specification {
         capability.group == 'foo'
         capability.name == 'bar'
         capability.version == '1.0'
+
+        where:
+        parser << [strictParser, lenientParser]
+    }
+
+    def "can parse string notation without version using lenient parser"() {
+        when:
+        def capability = lenientParser.parseNotation("foo:bar")
+
+        then:
+        capability.group == 'foo'
+        capability.name == 'bar'
+        capability.version == null
     }
 
     @Unroll
-    def "invalid string notation #notation is reported"() {
+    def "invalid string notation #notation is reported for strict parser"() {
         when:
-        parser.parseNotation(notation)
+        strictParser.parseNotation(notation)
 
         then:
         InvalidUserDataException ex = thrown()
@@ -48,13 +67,32 @@ class CapabilityNotationParserFactoryTest extends Specification {
 
         where:
         notation << [
-            "foo:bar",
-            "foo:bar:",
-            "foo::1.0",
-            ":bar:1.0"
+                "foo:bar",
+                "foo:bar:",
+                "foo::1.0",
+                ":bar:1.0"
         ]
     }
 
+    @Unroll
+    def "invalid string notation #notation is reported for lenient parser"() {
+        when:
+        lenientParser.parseNotation(notation)
+
+        then:
+        InvalidUserDataException ex = thrown()
+        ex.message == "Invalid format for capability: '$notation'. The correct notation is a 3-part group:name:version notation, e.g: 'org.group:capability:1.0'"
+
+        where:
+        notation << [
+                "foo:",
+                "foo::",
+                "foo::1.0",
+                ":bar:1.0"
+        ]
+    }
+
+    @Unroll
     def "can parse map notation"() {
         when:
         def capability = parser.parseNotation(group: 'foo', name: "bar", version: "1.0")
@@ -63,12 +101,25 @@ class CapabilityNotationParserFactoryTest extends Specification {
         capability.group == 'foo'
         capability.name == 'bar'
         capability.version == '1.0'
+
+        where:
+        parser << [strictParser, lenientParser]
+    }
+
+    def "can parse map notation without version using lenient parser"() {
+        when:
+        def capability = lenientParser.parseNotation(group: 'foo', name: 'bar')
+
+        then:
+        capability.group == 'foo'
+        capability.name == 'bar'
+        capability.version == null
     }
 
     @Unroll
-    def "invalid map notation #notation is reported"() {
+    def "invalid map notation #notation is reported for strict parser"() {
         when:
-        parser.parseNotation(notation)
+        strictParser.parseNotation(notation)
 
         then:
         InvalidUserDataException ex = thrown()
@@ -80,6 +131,23 @@ class CapabilityNotationParserFactoryTest extends Specification {
         [name: 'foo']                | "Required keys [group, version] are missing from map {name=foo}."
         [name: 'foo', version: 'v1'] | "Required keys [group] are missing from map {name=foo, version=v1}."
         [name: null]                 | "Required keys [group, name, version] are missing from map {name=null}."
+    }
+
+    @Unroll
+    def "invalid map notation #notation is reported for lenient parser"() {
+        when:
+        lenientParser.parseNotation(notation)
+
+        then:
+        InvalidUserDataException ex = thrown()
+        ex.message == error
+
+        where:
+        notation                     | error
+        [group: 'foo']               | "Required keys [name] are missing from map {group=foo}."
+        [name: 'foo']                | "Required keys [group] are missing from map {name=foo}."
+        [name: 'foo', version: 'v1'] | "Required keys [group] are missing from map {name=foo, version=v1}."
+        [name: null]                 | "Required keys [group, name] are missing from map {name=null}."
     }
 
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenDependency.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenDependency.groovy
@@ -22,6 +22,7 @@ class MavenDependency {
     String version
     String classifier
     String type
+    boolean optional
     Collection<MavenDependencyExclusion> exclusions = []
 
     MavenDependency hasType(def type) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenPom.groovy
@@ -31,7 +31,11 @@ class MavenPom {
             pom.dependencies.dependency.each { dep ->
                 def scope = createScope(dep.scope)
                 MavenDependency mavenDependency = createDependency(dep)
-                scope.dependencies[mavenDependency.getKey()] = mavenDependency
+                if (mavenDependency.optional) {
+                    scope.optionalDependencies[mavenDependency.getKey()] = mavenDependency
+                } else {
+                    scope.dependencies[mavenDependency.getKey()] = mavenDependency
+                }
                 scopesByDependency.put(mavenDependency.getKey(), scope.name)
             }
 
@@ -121,6 +125,10 @@ class MavenPom {
 
     private MavenDependency createDependency(def dep) {
         def exclusions = []
+        boolean optional = false
+        if (dep.optional) {
+            optional = "true"==dep.optional.text()
+        }
         if (dep.exclusions) {
             dep.exclusions.exclusion.each { excl ->
                 MavenDependencyExclusion exclusion = new MavenDependencyExclusion(
@@ -138,6 +146,7 @@ class MavenPom {
             classifier: dep.classifier ? dep.classifier.text() : null,
             type: dep.type ? dep.type.text() : null,
             exclusions: exclusions,
+            optional: optional
         )
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenScope.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenScope.groovy
@@ -22,6 +22,7 @@ import org.apache.commons.lang.StringUtils
 
 class MavenScope {
     String name
+    Map<String, MavenDependency> optionalDependencies = [:]
     Map<String, MavenDependency> dependencies = [:]
     Map<String, MavenDependency> dependencyManagement = [:]
 
@@ -34,10 +35,14 @@ class MavenScope {
     }
 
     void assertDependsOn(String... expected) {
+        assertDependencies(dependencies, expected)
+    }
+
+    private void assertDependencies(Map<String, MavenDependency> dependencies, String... expected) {
         assert dependencies.size() == expected.length
         expected.each {
             String key = StringUtils.substringBefore(it, "@")
-            def dependency = expectDependency(key)
+            def dependency = expectDependency(key, dependencies)
 
             String type = null
             if (it != key) {
@@ -45,6 +50,10 @@ class MavenScope {
             }
             assert dependency.hasType(type)
         }
+    }
+
+    void assertOptionalDependencies(String... expected) {
+        assertDependencies(optionalDependencies, expected)
     }
 
     void assertDependencyManagement(String... expected) {
@@ -66,10 +75,10 @@ class MavenScope {
         dep.exclusions.contains(exclusion)
     }
 
-    MavenDependency expectDependency(String key) {
-        final dependency = dependencies[key]
+    MavenDependency expectDependency(String key, Map<String, MavenDependency> lookup = dependencies) {
+        final dependency = lookup[key]
         if (dependency == null) {
-            throw new AssertionError("Could not find expected dependency $key. Actual: ${dependencies.values()}")
+            throw new AssertionError("Could not find expected dependency $key. Actual: ${lookup.values()}")
         }
         return dependency
     }

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -25,7 +25,6 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
-import org.gradle.api.attributes.Usage
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
@@ -411,9 +410,7 @@ class DefaultIvyPublicationTest extends Specification {
 
     def createComponent(def artifacts, def dependencies) {
         def usage = Stub(UsageContext) {
-            getUsage() >> Mock(Usage) {
-                getName() >> Usage.JAVA_RUNTIME
-            }
+            getName() >> 'runtime'
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
         }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/AbstractCppPublishingIntegrationTest.groovy
@@ -39,7 +39,7 @@ abstract class AbstractCppPublishingIntegrationTest extends AbstractInstalledToo
         mainModule.assertArtifactsPublished(getMainModuleArtifacts(module, version))
         assert mainModule.parsedPom.scopes.size() == apiDependencies.isEmpty() ? 0 : 1
         if (!apiDependencies.isEmpty()) {
-            mainModule.parsedPom.scopes.runtime.assertDependsOn(apiDependencies as String[])
+            mainModule.parsedPom.scopes.compile.assertDependsOn(apiDependencies as String[])
         }
 
         def mainMetadata = mainModule.parsedModuleMetadata

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppLibraryPublishingIntegrationTest.groovy
@@ -184,7 +184,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         def deckModule = repo.module('some.group', 'deck', '1.2')
         deckModule.assertPublished()
         deckModule.parsedPom.scopes.size() == 1
-        deckModule.parsedPom.scopes.runtime.assertDependsOn("some.group:card:1.2")
+        deckModule.parsedPom.scopes.compile.assertDependsOn("some.group:card:1.2")
 
         def deckMetadata = deckModule.parsedModuleMetadata
         def deckApi = deckMetadata.variant("api")
@@ -319,7 +319,7 @@ class CppLibraryPublishingIntegrationTest extends AbstractCppPublishingIntegrati
         def deckModule = repo.module('some.group', 'deck', '1.2')
         deckModule.assertPublished()
         deckModule.parsedPom.scopes.size() == 1
-        deckModule.parsedPom.scopes.runtime.assertDependsOn("some.group:card:1.2")
+        deckModule.parsedPom.scopes.compile.assertDependsOn("some.group:card:1.2")
 
         def deckMetadata = deckModule.parsedModuleMetadata
         def deckApi = deckMetadata.variant("api")
@@ -727,7 +727,7 @@ dependencies { implementation 'some.group:greeter:1.2' }
         module.assertPublished()
         with(module.parsedPom) {
             scopes.size() == 1
-            scopes.runtime.hasDependencyExclusion('some.group:card:1.2', new MavenDependencyExclusion('api-group', 'api-module'))
+            scopes.compile.hasDependencyExclusion('some.group:card:1.2', new MavenDependencyExclusion('api-group', 'api-module'))
         }
         with(module.parsedModuleMetadata) {
             variant('api') {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultUsageContext.java
@@ -23,41 +23,37 @@ import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.internal.java.usagecontext.AbstractUsageContext;
+import org.gradle.internal.Cast;
 
 import java.util.Collections;
 import java.util.Set;
 
-public class DefaultUsageContext implements UsageContext, Named {
+public class DefaultUsageContext extends AbstractUsageContext implements Named {
     private final String name;
-    private final Usage usage;
-    private final AttributeContainer attributes;
-
-    private final Set<? extends PublishArtifact> artifacts;
     private final Set<? extends ModuleDependency> dependencies;
     private final Set<? extends DependencyConstraint> dependencyConstraints;
     private final Set<ExcludeRule> globalExcludes;
 
-    DefaultUsageContext(String name, Usage usage, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        this(name, usage, configuration.getAttributes(), artifacts, configuration);
+    DefaultUsageContext(String name, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
+        this(name, configuration.getAttributes(), artifacts, configuration);
     }
 
     public DefaultUsageContext(UsageContext usageContext, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
-        this(usageContext.getName(), usageContext.getUsage(), usageContext.getAttributes(), artifacts, configuration);
+        this(usageContext.getName(), usageContext.getAttributes(), artifacts, configuration);
     }
 
-    public DefaultUsageContext(String name, Usage usage, AttributeContainer attributes) {
-        this(name, usage, attributes, null, null);
+    public DefaultUsageContext(String name, AttributeContainer attributes) {
+        this(name, attributes, null, null);
     }
 
-    private DefaultUsageContext(String name, Usage usage, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
+    private DefaultUsageContext(String name, AttributeContainer attributes, Set<? extends PublishArtifact> artifacts, Configuration configuration) {
+        super(((AttributeContainerInternal)attributes).asImmutable(), Cast.uncheckedCast(artifacts));
         this.name = name;
-        this.usage = usage;
-        this.attributes = attributes;
-        this.artifacts = artifacts;
         if (configuration != null) {
             this.dependencies = configuration.getAllDependencies().withType(ModuleDependency.class);
             this.dependencyConstraints = configuration.getAllDependencyConstraints();
@@ -72,22 +68,6 @@ public class DefaultUsageContext implements UsageContext, Named {
     @Override
     public String getName() {
         return name;
-    }
-
-    @Override
-    public Usage getUsage() {
-        return usage;
-    }
-
-    @Override
-    public AttributeContainer getAttributes() {
-        return attributes;
-    }
-
-    @Override
-    public Set<? extends PublishArtifact> getArtifacts() {
-        assert artifacts != null;
-        return artifacts;
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -52,7 +52,7 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
 
     @Override
     public Set<? extends UsageContext> getUsages() {
-        return ImmutableSet.of(new DefaultUsageContext(name, usage, artifacts, dependencies));
+        return ImmutableSet.of(new DefaultUsageContext(name, artifacts, dependencies));
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/Dimensions.java
@@ -143,13 +143,13 @@ public class Dimensions {
                     addCommonAttributes(buildType, targetMachine, runtimeAttributes);
                     runtimeAttributes.attribute(LINKAGE_ATTRIBUTE, linkage);
 
-                    DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeUsage, runtimeAttributes);
+                    DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeAttributes);
 
                     AttributeContainer linkAttributes = attributesFactory.mutable();
                     linkAttributes.attribute(Usage.USAGE_ATTRIBUTE, linkUsage);
                     addCommonAttributes(buildType, targetMachine, linkAttributes);
                     linkAttributes.attribute(LINKAGE_ATTRIBUTE, linkage);
-                    DefaultUsageContext linkUsageContext = new DefaultUsageContext(variantName + "Link", linkUsage, linkAttributes);
+                    DefaultUsageContext linkUsageContext = new DefaultUsageContext(variantName + "Link", linkAttributes);
 
                     NativeVariantIdentity variantIdentity = new NativeVariantIdentity(variantName, baseName, group, version, buildType.isDebuggable(), buildType.isOptimized(), targetMachine, linkUsageContext, runtimeUsageContext, linkage);
 
@@ -180,7 +180,7 @@ public class Dimensions {
                 runtimeAttributes.attribute(Usage.USAGE_ATTRIBUTE, runtimeUsage);
                 addCommonAttributes(buildType, targetMachine, runtimeAttributes);
 
-                DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeUsage, runtimeAttributes);
+                DefaultUsageContext runtimeUsageContext = new DefaultUsageContext(variantName + "Runtime", runtimeAttributes);
 
                 DefaultUsageContext linkUsageContext = null;
 

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/swift/internal/DefaultSwiftLibraryTest.groovy
@@ -108,8 +108,8 @@ class DefaultSwiftLibraryTest extends Specification {
 
     private NativeVariantIdentity getIdentity() {
         return new NativeVariantIdentity("test", null, null, null, true, false, targetMachine(OperatingSystemFamily.WINDOWS, MachineArchitecture.X86_64),
-            new DefaultUsageContext("test", null, AttributeTestUtil.attributesFactory().mutable()),
-            new DefaultUsageContext("test", null, AttributeTestUtil.attributesFactory().mutable())
+            new DefaultUsageContext("test", AttributeTestUtil.attributesFactory().mutable()),
+            new DefaultUsageContext("test", AttributeTestUtil.attributesFactory().mutable())
         )
     }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishOptionalDependenciesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishOptionalDependenciesJavaIntegTest.groovy
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.test.fixtures.maven.MavenJavaModule
+
+class MavenPublishOptionalDependenciesJavaIntegTest extends AbstractMavenPublishIntegTest {
+    MavenJavaModule javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
+
+    def setup() {
+        createBuildScripts("""
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+""")
+    }
+
+    def "can publish java-library with optional feature"() {
+        mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                    outgoing.capability("org:optional-feature:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addOptionalFeatureVariantFromConfiguration('optionalFeature', configurations.optionalFeatureRuntimeElements)
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("api") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtime") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeature") {
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedPom.scope('compile') {
+            assertOptionalDependencies('org:optionaldep:1.0')
+        }
+        javaLibrary.parsedPom.hasNoScope('runtime')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "org:optional-feature:1.0"
+            withModuleMetadata {
+                expectFiles "publishTest-1.9.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                shouldFail {
+                    // documents the current behavior
+                    assertHasCause("Unable to find a variant of org.gradle.test:publishTest:1.9 providing the requested capability org:optional-feature:1.0")
+                }
+            }
+        }
+    }
+
+    def "doesn't allow publishing an optional feature without capability"() {
+        mavenRepo.module('org', 'optionaldep', '1.0').publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addOptionalFeatureVariantFromConfiguration('optionalFeature', configurations.optionalFeatureRuntimeElements)
+        """
+
+        when:
+        fails "publish"
+
+        then:
+        failure.assertHasCause("Cannot publish optional feature variant optionalFeature because configuration optionalFeatureRuntimeElements doesn't declare any capability")
+    }
+
+    def "reasonable error message when declaring a variant which name already exists"() {
+        given:
+        buildFile << """
+            configurations {
+                optionalFeatureImplementation
+                optionalFeatureRuntimeElements {
+                    extendsFrom optionalFeatureImplementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                    outgoing.capability("org:optional-feature:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeatureImplementation)
+            }
+            
+            dependencies {
+                optionalFeatureImplementation 'org:optionaldep:1.0'
+            }
+            
+            components.java.addOptionalFeatureVariantFromConfiguration('api', configurations.optionalFeatureRuntimeElements)
+        """
+
+        when:
+        fails "publish"
+
+        then:
+        failure.assertHasCause("Cannot add optional feature variant 'api' as a variant with the same name is already registered")
+    }
+
+    def createBuildScripts(def append) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            group = 'org.gradle.test'
+            version = '1.9'
+
+$append
+"""
+
+    }
+
+    def "can group dependencies by optional feature"() {
+        mavenRepo.module('org', 'optionaldep-g1', '1.0').publish()
+        mavenRepo.module('org', 'optionaldep1-g2', '1.0').publish()
+        mavenRepo.module('org', 'optionaldep2-g2', '1.0').publish()
+
+        given:
+        buildFile << """
+            configurations {
+                optionalFeature1Implementation
+                optionalFeature1RuntimeElements {
+                    extendsFrom optionalFeature1Implementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                    outgoing.capability("org:optional-feature1:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeature1Implementation)
+                
+                optionalFeature2Implementation
+                optionalFeature2RuntimeElements {
+                    extendsFrom optionalFeature2Implementation
+                    canBeResolved = false
+                    canBeConsumed = true
+                    attributes {
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, Usage.JAVA_RUNTIME))
+                    }
+                    outgoing.capability("org:optional-feature2:\${version}")
+                }
+                compileClasspath.extendsFrom(optionalFeature2Implementation)
+            }
+            
+            dependencies {
+                optionalFeature1Implementation 'org:optionaldep-g1:1.0'
+                optionalFeature2Implementation 'org:optionaldep1-g2:1.0'
+                optionalFeature2Implementation 'org:optionaldep2-g2:1.0'
+            }
+            
+            components.java.addOptionalFeatureVariantFromConfiguration('optionalFeature1', configurations.optionalFeature1RuntimeElements)
+            components.java.addOptionalFeatureVariantFromConfiguration('optionalFeature2', configurations.optionalFeature2RuntimeElements)
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("api") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtime") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeature1") {
+            dependency('org', 'optionaldep-g1', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("optionalFeature2") {
+            dependency('org', 'optionaldep1-g2', '1.0')
+            dependency('org', 'optionaldep2-g2', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedPom.scope('compile') {
+            assertOptionalDependencies(
+                    'org:optionaldep-g1:1.0',
+                    'org:optionaldep1-g2:1.0',
+                    'org:optionaldep2-g2:1.0')
+        }
+        javaLibrary.parsedPom.hasNoScope('runtime')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+    }
+
+
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
@@ -254,6 +254,11 @@ public class DefaultMavenPom implements MavenPomInternal, MavenPomLicenseSpec, M
         return mavenPublication.getApiDependencies();
     }
 
+    @Override
+    public Set<MavenDependencyInternal> getOptionalDependencies() {
+        return mavenPublication.getOptionalDependencies();
+    }
+
     public Set<MavenDependencyInternal> getRuntimeDependencies() {
         return mavenPublication.getRuntimeDependencies();
     }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -33,7 +33,6 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishException;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
@@ -95,27 +94,28 @@ import java.util.Set;
 import static org.gradle.api.internal.FeaturePreviews.Feature.GRADLE_METADATA;
 
 public class DefaultMavenPublication implements MavenPublicationInternal {
-
     private final static Logger LOG = Logging.getLogger(DefaultMavenPublication.class);
+
+    private static final String API_VARIANT = "api";
+    private static final String RUNTIME_VARIANT = "runtime";
+
     /*
      * Maven supports wildcards in exclusion rules according to:
      * http://www.smartjava.org/content/maven-and-wildcard-exclusions
      * https://issues.apache.org/jira/browse/MNG-3832
      * This should be used for non-transitive dependencies
      */
-    private static final Set<ExcludeRule> EXCLUDE_ALL_RULE = Collections.<ExcludeRule>singleton(new DefaultExcludeRule("*", "*"));
-    private static final Comparator<? super UsageContext> USAGE_ORDERING = new Comparator<UsageContext>() {
-        @Override
-        public int compare(UsageContext left, UsageContext right) {
-            // API first
-            if (left.getUsage().getName().equals(Usage.JAVA_API)) {
-                return -1;
-            }
-            if (right.getUsage().getName().equals(Usage.JAVA_API)) {
-                return 1;
-            }
-            return left.getUsage().getName().compareTo(right.getUsage().getName());
+    private static final Set<ExcludeRule> EXCLUDE_ALL_RULE = Collections.singleton(new DefaultExcludeRule("*", "*"));
+
+    private static final Comparator<String> VARIANT_ORDERING = (left, right) -> {
+        // API first
+        if (API_VARIANT.equals(left)) {
+            return -1;
         }
+        if (API_VARIANT.equals(right)) {
+            return 1;
+        }
+        return left.compareTo(right);
     };
     @VisibleForTesting
     public static final String INCOMPATIBLE_FEATURE = " contains dependencies that will produce a pom file that cannot be consumed by a Maven client.";
@@ -269,7 +269,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
             Set<ExcludeRule> globalExcludes = usageContext.getGlobalExcludes();
 
-            Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext.getUsage());
+            Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext.getName());
             for (ModuleDependency dependency : usageContext.getDependencies()) {
                 if (seenDependencies.add(dependency)) {
                     if (PlatformSupport.isTargettingPlatform(dependency)) {
@@ -296,7 +296,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
                     }
                 }
             }
-            Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(usageContext.getUsage());
+            Set<MavenDependency> dependencyConstraints = dependencyConstraintsFor(usageContext.getName());
             for (DependencyConstraint dependency : usageContext.getDependencyConstraints()) {
                 if (seenConstraints.add(dependency) && dependency.getVersion() != null) {
                     addDependencyConstraint(dependency, dependencyConstraints);
@@ -335,19 +335,19 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
     private List<UsageContext> getSortedUsageContexts() {
         List<UsageContext> usageContexts = Lists.newArrayList(this.component.getUsages());
-        Collections.sort(usageContexts, USAGE_ORDERING);
+        Collections.sort(usageContexts, (u1, u2) -> VARIANT_ORDERING.compare(u1.getName(), u2.getName()));
         return usageContexts;
     }
 
-    private Set<MavenDependencyInternal> dependenciesFor(Usage usage) {
-        if (Usage.JAVA_API.equals(usage.getName())) {
+    private Set<MavenDependencyInternal> dependenciesFor(String name) {
+        if (API_VARIANT.equals(name)) {
             return apiDependencies;
         }
         return runtimeDependencies;
     }
 
-    private Set<MavenDependency> dependencyConstraintsFor(Usage usage) {
-        if (Usage.JAVA_API.equals(usage.getName())) {
+    private Set<MavenDependency> dependencyConstraintsFor(String name) {
+        if (API_VARIANT.equals(name)) {
             return apiDependencyConstraints;
         }
         return runtimeDependencyConstraints;

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -52,6 +52,7 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.java.JavaLibraryPlatform;
+import org.gradle.api.internal.java.usagecontext.OptionalFeatureonfigurationUsageContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -130,6 +131,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     private final PublicationArtifactSet<MavenArtifact> publishableArtifacts;
     private final Set<MavenDependencyInternal> runtimeDependencies = new LinkedHashSet<MavenDependencyInternal>();
     private final Set<MavenDependencyInternal> apiDependencies = new LinkedHashSet<MavenDependencyInternal>();
+    private final Set<MavenDependencyInternal> optionalDependencies = new LinkedHashSet<MavenDependencyInternal>();
     private final Set<MavenDependency> runtimeDependencyConstraints = new LinkedHashSet<MavenDependency>();
     private final Set<MavenDependency> apiDependencyConstraints = new LinkedHashSet<MavenDependency>();
     private final Set<MavenDependency> importDependencyConstraints = new LinkedHashSet<MavenDependency>();
@@ -269,7 +271,7 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
 
             Set<ExcludeRule> globalExcludes = usageContext.getGlobalExcludes();
 
-            Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext.getName());
+            Set<MavenDependencyInternal> dependencies = dependenciesFor(usageContext);
             for (ModuleDependency dependency : usageContext.getDependencies()) {
                 if (seenDependencies.add(dependency)) {
                     if (PlatformSupport.isTargettingPlatform(dependency)) {
@@ -339,7 +341,11 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
         return usageContexts;
     }
 
-    private Set<MavenDependencyInternal> dependenciesFor(String name) {
+    private Set<MavenDependencyInternal> dependenciesFor(UsageContext usage) {
+        if (usage instanceof OptionalFeatureonfigurationUsageContext) {
+            return optionalDependencies;
+        }
+        String name = usage.getName();
         if (API_VARIANT.equals(name)) {
             return apiDependencies;
         }
@@ -489,6 +495,12 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     public Set<MavenDependencyInternal> getApiDependencies() {
         populateFromComponent();
         return apiDependencies;
+    }
+
+    @Override
+    public Set<MavenDependencyInternal> getOptionalDependencies() {
+        populateFromComponent();
+        return optionalDependencies;
     }
 
     public MavenNormalizedPublication asNormalisedPublication() {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
@@ -67,6 +67,8 @@ public interface MavenPomInternal extends MavenPom {
 
     Set<MavenDependencyInternal> getRuntimeDependencies();
 
+    Set<MavenDependencyInternal> getOptionalDependencies();
+
     Action<XmlProvider> getXmlAction();
 
     VersionMappingStrategyInternal getVersionMappingStrategy();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -55,6 +55,8 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
 
     Set<MavenDependencyInternal> getRuntimeDependencies();
 
+    Set<MavenDependencyInternal> getOptionalDependencies();
+
     MavenNormalizedPublication asNormalisedPublication();
 
     // TODO Remove this attempt to guess packaging from artifacts. Packaging should come from component, or be explicitly set.

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -145,6 +145,9 @@ public class GenerateMavenPom extends DefaultTask {
         for (MavenDependencyInternal runtimeDependency : pomInternal.getRuntimeDependencies()) {
             pomGenerator.addRuntimeDependency(runtimeDependency);
         }
+        for (MavenDependencyInternal optionalDependency : pomInternal.getOptionalDependencies()) {
+            pomGenerator.addOptionalDependency(optionalDependency);
+        }
 
         pomGenerator.withXml(pomInternal.getXmlAction());
 

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -214,9 +214,9 @@ class DefaultMavenPublicationTest extends Specification {
         artifact2.file >> artifactFile
         artifact2.classifier >> ""
         artifact2.extension >> "jar"
-        def usage1 = Stub(UsageContext)
+        def usage1 = Stub(UsageContext) { getName() >> 'api' }
         usage1.artifacts >> [artifact1]
-        def usage2 = Stub(UsageContext)
+        def usage2 = Stub(UsageContext) { getName() >> 'runtime' }
         usage2.artifacts >> [artifact2]
         def component = Stub(SoftwareComponentInternal)
         component.usages >> [usage1, usage2]

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -17,19 +17,28 @@
 package org.gradle.api.internal.java;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.ComponentWithOptionalFeatures;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.internal.java.usagecontext.ConfigurationUsageContext;
+import org.gradle.api.internal.java.usagecontext.OptionalFeatureonfigurationUsageContext;
+import org.gradle.api.internal.java.usagecontext.LazyConfigurationUsageContext;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
+import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.gradle.api.plugins.JavaPlugin.API_ELEMENTS_CONFIGURATION_NAME;
@@ -38,7 +47,7 @@ import static org.gradle.api.plugins.JavaPlugin.RUNTIME_ELEMENTS_CONFIGURATION_N
 /**
  * A SoftwareComponent representing a library that runs on a java virtual machine.
  */
-public class JavaLibrary implements SoftwareComponentInternal {
+public class JavaLibrary implements ComponentWithOptionalFeatures, SoftwareComponentInternal {
 
     private final Set<PublishArtifact> artifacts = new LinkedHashSet<PublishArtifact>();
     private final UsageContext runtimeUsage;
@@ -46,6 +55,7 @@ public class JavaLibrary implements SoftwareComponentInternal {
     private final ConfigurationContainer configurations;
     private final ObjectFactory objectFactory;
     private final ImmutableAttributesFactory attributesFactory;
+    private List<OptionalFeatureMapping> optionalFeatures;
 
     @Inject
     public JavaLibrary(ObjectFactory objectFactory, ConfigurationContainer configurations, ImmutableAttributesFactory attributesFactory, PublishArtifact artifact) {
@@ -69,17 +79,73 @@ public class JavaLibrary implements SoftwareComponentInternal {
     }
 
     public Set<UsageContext> getUsages() {
-        return ImmutableSet.of(runtimeUsage, compileUsage);
+        if (optionalFeatures == null) {
+            return ImmutableSet.of(runtimeUsage, compileUsage);
+        }
+        ImmutableSet.Builder<UsageContext> builder = ImmutableSet.builderWithExpectedSize(2 + optionalFeatures.size());
+        builder.add(runtimeUsage);
+        builder.add(compileUsage);
+        for (OptionalFeatureMapping mapping : optionalFeatures) {
+            mapping.validate();
+            builder.add(mapping.toUsageContext());
+        }
+        return builder.build();
     }
 
     private UsageContext createRuntimeUsageContext() {
         ImmutableAttributes attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
-        return new ConfigurationUsageContext("runtime", RUNTIME_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, attributes);
+        return new LazyConfigurationUsageContext("runtime", RUNTIME_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, attributes);
     }
 
     private UsageContext createCompileUsageContext() {
         ImmutableAttributes attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
-        return new ConfigurationUsageContext("api", API_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, attributes);
+        return new LazyConfigurationUsageContext("api", API_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, attributes);
     }
 
+    @Override
+    public void addOptionalFeatureVariantFromConfiguration(String name, Configuration outgoingConfiguration) {
+        if (optionalFeatures == null) {
+            optionalFeatures = Lists.newArrayListWithExpectedSize(2);
+        }
+        assertNoDuplicateVariant(name);
+        optionalFeatures.add(new OptionalFeatureMapping(name, outgoingConfiguration));
+    }
+
+    private void assertNoDuplicateVariant(String name) {
+        if ("runtime".equals(name) || "api".equals(name) ||
+                Lists.transform(optionalFeatures, OptionalFeatureMapping.VARIANT_NAME).contains(name)) {
+            throw new InvalidUserDataException("Cannot add optional feature variant '" + name + "' as a variant with the same name is already registered");
+        }
+    }
+
+    private static class OptionalFeatureMapping {
+        private static final Function<OptionalFeatureMapping, String> VARIANT_NAME = new Function<OptionalFeatureMapping, String>() {
+            @Override
+            public String apply(OptionalFeatureMapping input) {
+                return input.variantName;
+            }
+        };
+
+        private final String variantName;
+        private final Configuration outgoingConfiguration;
+
+        private OptionalFeatureMapping(String variantName, Configuration outgoingConfiguration) {
+            this.variantName = variantName;
+            this.outgoingConfiguration = outgoingConfiguration;
+        }
+
+        UsageContext toUsageContext() {
+            return new OptionalFeatureonfigurationUsageContext(
+                    variantName,
+                    outgoingConfiguration
+            );
+        }
+
+        public void validate() {
+            Collection<? extends Capability> capabilities = outgoingConfiguration.getOutgoing().getCapabilities();
+            if (capabilities.isEmpty()) {
+                throw new InvalidUserDataException("Cannot publish optional feature variant " + variantName + " because configuration " + outgoingConfiguration.getName() + " doesn't declare any capability");
+            }
+        }
+    }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaLibrary.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -72,11 +73,13 @@ public class JavaLibrary implements SoftwareComponentInternal {
     }
 
     private UsageContext createRuntimeUsageContext() {
-        return new ConfigurationUsageContext(Usage.JAVA_RUNTIME, "runtime", RUNTIME_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, objectFactory, attributesFactory);
+        ImmutableAttributes attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+        return new ConfigurationUsageContext("runtime", RUNTIME_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, attributes);
     }
 
     private UsageContext createCompileUsageContext() {
-        return new ConfigurationUsageContext(Usage.JAVA_API, "api", API_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, objectFactory, attributesFactory);
+        ImmutableAttributes attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
+        return new ConfigurationUsageContext("api", API_ELEMENTS_CONFIGURATION_NAME, artifacts, configurations, attributes);
     }
 
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
@@ -26,7 +26,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.internal.java.usagecontext.ConfigurationUsageContext;
+import org.gradle.api.internal.java.usagecontext.LazyConfigurationUsageContext;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlatformPlugin;
 
@@ -77,7 +77,7 @@ public class JavaPlatform implements SoftwareComponentInternal {
         ).asImmutable();
     }
 
-    private final static class JavaPlatformUsageContext extends ConfigurationUsageContext {
+    private final static class JavaPlatformUsageContext extends LazyConfigurationUsageContext {
         private final AttributeContainer attributes;
 
         private JavaPlatformUsageContext(String name,

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/JavaPlatform.java
@@ -22,6 +22,7 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
@@ -60,26 +61,31 @@ public class JavaPlatform implements SoftwareComponentInternal {
     }
 
     private UsageContext createRuntimeUsageContext() {
-        return new JavaPlatformUsageContext(Usage.JAVA_RUNTIME, "runtime", JavaPlatformPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+        ImmutableAttributes attributes = buildAttributes(Usage.JAVA_RUNTIME);
+        return new JavaPlatformUsageContext("runtime", JavaPlatformPlugin.RUNTIME_ELEMENTS_CONFIGURATION_NAME, configurations, attributes);
     }
 
     private UsageContext createApiUsageContext() {
-        return new JavaPlatformUsageContext(Usage.JAVA_API, "api", JavaPlatformPlugin.API_ELEMENTS_CONFIGURATION_NAME, configurations, objectFactory, attributesFactory);
+        ImmutableAttributes attributes = buildAttributes(Usage.JAVA_API);
+        return new JavaPlatformUsageContext("api", JavaPlatformPlugin.API_ELEMENTS_CONFIGURATION_NAME, configurations, attributes);
+    }
+
+    private ImmutableAttributes buildAttributes(String usage) {
+        return ((AttributeContainerInternal) attributesFactory.mutable()
+                .attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage))
+                .attribute(PlatformSupport.COMPONENT_CATEGORY, PlatformSupport.REGULAR_PLATFORM)
+        ).asImmutable();
     }
 
     private final static class JavaPlatformUsageContext extends ConfigurationUsageContext {
         private final AttributeContainer attributes;
 
-        private JavaPlatformUsageContext(String usageName,
-                                         String name,
+        private JavaPlatformUsageContext(String name,
                                          String configurationName,
                                          ConfigurationContainer configurations,
-                                         ObjectFactory objectFactory,
-                                         ImmutableAttributesFactory attributesFactory) {
-            super(usageName, name, configurationName, Collections.<PublishArtifact>emptySet(), configurations, objectFactory, attributesFactory);
-            AttributeContainerInternal attributes = (AttributeContainerInternal) super.getAttributes();
-            // Currently, "enforced" platforms are handled through special casing, so we don't need to publish the enforced version
-            this.attributes = attributesFactory.concat(attributes.asImmutable(), PlatformSupport.COMPONENT_CATEGORY, PlatformSupport.REGULAR_PLATFORM);
+                                         ImmutableAttributes attributes) {
+            super(name, configurationName, Collections.<PublishArtifact>emptySet(), configurations, attributes);
+            this.attributes = attributes;
         }
 
         @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/WebApplication.java
@@ -20,26 +20,26 @@ import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.internal.java.usagecontext.AbstractUsageContext;
 
 import javax.inject.Inject;
 import java.util.Collections;
 import java.util.Set;
 
 public class WebApplication implements SoftwareComponentInternal {
-    private final UsageContext webArchiveUsage = new WebArchiveUsageContext();
+    private final UsageContext webArchiveUsage;
     private final PublishArtifact warArtifact;
-    private final Usage masterUsage;
+    private final String variantName;
 
     @Inject
-    public WebApplication(PublishArtifact warArtifact, Usage masterUsage) {
+    public WebApplication(PublishArtifact warArtifact, String variantName) {
         this.warArtifact = warArtifact;
-        this.masterUsage = masterUsage;
+        this.variantName = variantName;
+        this.webArchiveUsage = new WebArchiveUsageContext();
     }
 
     @Override
@@ -52,25 +52,14 @@ public class WebApplication implements SoftwareComponentInternal {
         return Collections.singleton(webArchiveUsage);
     }
 
-    private class WebArchiveUsageContext implements UsageContext {
-        @Override
-        public Usage getUsage() {
-            return masterUsage;
+    private class WebArchiveUsageContext extends AbstractUsageContext {
+        public WebArchiveUsageContext() {
+            super(ImmutableAttributes.EMPTY, Collections.singleton(warArtifact));
         }
 
         @Override
         public String getName() {
-            return masterUsage.getName();
-        }
-
-        @Override
-        public AttributeContainer getAttributes() {
-            return ImmutableAttributes.EMPTY;
-        }
-
-        @Override
-        public Set<PublishArtifact> getArtifacts() {
-            return Collections.singleton(warArtifact);
+            return variantName;
         }
 
         @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/AbstractConfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/AbstractConfigurationUsageContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.DependencyConstraint;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ModuleDependency;
@@ -31,25 +30,16 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.Set;
 
-public class ConfigurationUsageContext extends AbstractUsageContext {
-    private final String name;
-    private final String configurationName;
-    private final ConfigurationContainer configurations;
+public abstract class AbstractConfigurationUsageContext extends AbstractUsageContext {
+    protected final String name;
     private DomainObjectSet<ModuleDependency> dependencies;
     private DomainObjectSet<DependencyConstraint> dependencyConstraints;
     private Set<? extends Capability> capabilities;
     private Set<ExcludeRule> excludeRules;
 
-
-    public ConfigurationUsageContext(String name,
-                                     String configurationName,
-                                     Set<PublishArtifact> artifacts,
-                                     ConfigurationContainer configurations,
-                                     ImmutableAttributes attributes) {
+    AbstractConfigurationUsageContext(String name, ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
         super(attributes, artifacts);
         this.name = name;
-        this.configurationName = configurationName;
-        this.configurations = configurations;
     }
 
     @Override
@@ -91,7 +81,5 @@ public class ConfigurationUsageContext extends AbstractUsageContext {
         return excludeRules;
     }
 
-    private Configuration getConfiguration() {
-        return configurations.getByName(configurationName);
-    }
+    protected abstract Configuration getConfiguration();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/AbstractUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/AbstractUsageContext.java
@@ -19,31 +19,27 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.UsageContext;
-import org.gradle.api.model.ObjectFactory;
 
 import java.util.Set;
 
 public abstract class AbstractUsageContext implements UsageContext {
-    private final Usage usage;
     private final ImmutableAttributes attributes;
     private final Set<PublishArtifact> artifacts;
 
-    AbstractUsageContext(String usageName, Set<PublishArtifact> artifacts, ObjectFactory objectFactory, ImmutableAttributesFactory attributesFactory) {
-        this.usage = objectFactory.named(Usage.class, usageName);
-        this.attributes = attributesFactory.of(Usage.USAGE_ATTRIBUTE, usage);
+    public AbstractUsageContext(ImmutableAttributes attributes, Set<PublishArtifact> artifacts) {
+        this.attributes = attributes;
         this.artifacts = artifacts;
+    }
+
+    @Override
+    public Usage getUsage() {
+        throw new UnsupportedOperationException("This method has been deprecated, should never be called");
     }
 
     @Override
     public AttributeContainer getAttributes() {
         return attributes;
-    }
-
-    @Override
-    public Usage getUsage() {
-        return usage;
     }
 
     public Set<PublishArtifact> getArtifacts() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationUsageContext.java
@@ -27,8 +27,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.Configurations;
-import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
-import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.Set;
 
@@ -42,14 +41,12 @@ public class ConfigurationUsageContext extends AbstractUsageContext {
     private Set<ExcludeRule> excludeRules;
 
 
-    public ConfigurationUsageContext(String usageName,
-                                     String name,
+    public ConfigurationUsageContext(String name,
                                      String configurationName,
                                      Set<PublishArtifact> artifacts,
                                      ConfigurationContainer configurations,
-                                     ObjectFactory objectFactory,
-                                     ImmutableAttributesFactory attributesFactory) {
-        super(usageName, artifacts, objectFactory, attributesFactory);
+                                     ImmutableAttributes attributes) {
+        super(attributes, artifacts);
         this.name = name;
         this.configurationName = configurationName;
         this.configurations = configurations;

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/LazyConfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/LazyConfigurationUsageContext.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java.usagecontext;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+
+import java.util.Set;
+
+public class LazyConfigurationUsageContext extends AbstractConfigurationUsageContext {
+    private final String configurationName;
+    private final ConfigurationContainer configurations;
+
+    public LazyConfigurationUsageContext(String name,
+                                         String configurationName,
+                                         Set<PublishArtifact> artifacts,
+                                         ConfigurationContainer configurations,
+                                         ImmutableAttributes attributes) {
+        super(name, attributes, artifacts);
+        this.configurationName = configurationName;
+        this.configurations = configurations;
+    }
+
+    @Override
+    protected Configuration getConfiguration() {
+        return configurations.getByName(configurationName);
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/OptionalFeatureonfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/OptionalFeatureonfigurationUsageContext.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.java.usagecontext;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
+
+public class OptionalFeatureonfigurationUsageContext extends AbstractConfigurationUsageContext {
+    private final Configuration configuration;
+
+    public OptionalFeatureonfigurationUsageContext(String name, Configuration configuration) {
+        super(name, ((AttributeContainerInternal)configuration.getAttributes()).asImmutable(), configuration.getArtifacts());
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected Configuration getConfiguration() {
+        return configuration;
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/WarPlugin.java
@@ -22,7 +22,6 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.PublishArtifact;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
 import org.gradle.api.internal.java.WebApplication;
@@ -108,6 +107,6 @@ public class WarPlugin implements Plugin<Project> {
     }
 
     private void configureComponent(Project project, PublishArtifact warArtifact) {
-        project.getComponents().add(objectFactory.newInstance(WebApplication.class, warArtifact, objectFactory.named(Usage.class, "master")));
+        project.getComponents().add(objectFactory.newInstance(WebApplication.class, warArtifact, "master"));
     }
 }


### PR DESCRIPTION
### Context

This is the 2d step in supporting "optional features", at least in the Java ecosystem: this PR adds support for a `ComponentWithOptionalFeatures`, currently only Java libraries, which can register an additional set of variants to publish.

Those variants are assumed to correspond to _optional features_, and as such, they need to:

- be derived from an _outgoing configuration_
- this configuration needs to declare at least one _capability_
- they can attach additional artifacts as long as those artifacts have a different _classifier_

Then, Gradle will publish those additional variants in Gradle metadata as is (because a variant in Gradle metadata has all the required information to do it), or, in the case of a Maven POM file, will map those variants to _optional dependencies_. In both cases, additional variant artifacts are published, if any, with the appropriate classifier.
