### PR TITLE
add preamble to 5.2 release notes

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -1,6 +1,9 @@
 The Gradle team is excited to announce Gradle 5.2.
 
-This release features [1](), [2](), ... [n](), and more.
+This release features the [Java Platform plugin](userguide/java_platform_plugin.html) which allows users to define sets of dependencies that work together, [new C++ plugins](userguide/cpp_plugins.html) with dependency management built-in, [new C++ project types for the Build Init Plugin](userguide/build_init_plugin.html#sec:cppapplication_), and more.
+
+Read the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn about breaking changes and considerations for upgrading from Gradle 5.0. If upgrading from Gradle 4.x, please read 
+[upgrading from Gradle 4.x to 5.0](userguide/upgrading_version_4.html) first. Users upgrading from 5.1, should not have to worry about breaking changes.
 
 We would like to thank the following community contributors to this release of Gradle:
 
@@ -21,8 +24,10 @@ Standalone downloads are available at [gradle.org/release-candidate](https://gra
 
 ## The Java Platform plugin
 
-A new plugin, the [Java Platform plugin](userguide/java_platform_plugin.html) allows the declaration and publication of platforms for the Java ecosystem.
-A platform is typically published as a bill-of-material (BOM) file, and can be used as a source of recommendations for versions, between projects or externally.
+A new plugin, the [Java Platform plugin](userguide/java_platform_plugin.html) allows you to declare and publish a platform for the Java ecosystem. A platform is typically published as a 
+bill-of-material (BOM) file and can be used to define a set of versions for dependencies that are known to work together. These versions can be published and consumed elsewhere as dependency 
+recommendations.
+
 Read the [Java Platform plugin section of the userguide](userguide/java_platform_plugin.html) for more details.
 
 ## Maven publication: expose resolved versions
@@ -36,13 +41,13 @@ See more information about the [Gradle native project](https://github.com/gradle
 
 ### Recommend C++ projects use new C++ plugins
 
-We introduced new C++ plugins [last year](https://blog.gradle.org/introducing-the-new-cpp-plugins) that we thought were more feature rich and familiar to Gradle users. At the time, we thought they weren't mature enough for serious adoption.
+We introduced [new C++ plugins](https://blog.gradle.org/introducing-the-new-cpp-plugins) last year that we thought were more feature rich and familiar to Gradle users.
 
-In this release, we are recommending new C++ projects to use these plugins over [the existing software model plugins](userguide/native_software.html). The new plugins do not currently support C, Objective-C or Objective-C++ out of the box, but they have [a lot of other things to offer](userguide/cpp_plugins.html#cpp:features).
+In this release, we are recommending new C++ projects use these plugins over [the existing software model plugins](userguide/native_software.html). The new plugins do not currently support C, Objective-C or Objective-C++ out of the box, but they have [a lot of other things to offer](userguide/cpp_plugins.html#cpp:features).
 
 ### Build Init can now generate C++ sample projects
 
-If you want to get started quickly with a C++ project, try running `gradle init` and following the instructions to generate a sample C++ application or library.
+If you want to get started quickly with a C++ project, try running `gradle init` and following the instructions to generate a sample C++ application or library. You'll notice that the projects will be generated with the `cpp-application` or `cpp-library` plugins instead of the `cpp` plugin. This is now the recommended approach when starting new projects.
 
 ### Support for additional Windows native toolchains
 
@@ -61,9 +66,18 @@ This release includes some improvements to Gradle's console integration on Windo
 
 The implementation of the rich console has been improved to remove some distracting visual artifacts on Windows. 
 
+## Improvements for plugin authors 
+
+### Service injection into project extensions
+
+Previously, Gradle supported [service injection into tasks](userguide/custom_tasks.html#service_injection) and [service injection into plugins](userguide/custom_plugins.html#service_injection). In 
+this Gradle release, these services are also available for injection directly into project extensions. Using this can help simplify your plugin implementation.
+
+See the [user manual](userguide/custom_plugins.html#service_injection) for details.
+
 ## Support for setting environment variables when using Gradle TestKit
   
-Gradle [TestKit](userguide/test_kit.html) based tests can now specify environment variables via [`GradleRunner`](javadoc/org/gradle/testkit/runner/GradleRunner.html). These environemnt variables will be visible to the build under test.
+Gradle [TestKit](userguide/test_kit.html) based tests can now specify environment variables via [`GradleRunner`](javadoc/org/gradle/testkit/runner/GradleRunner.html). These environment variables will be visible to the build under test.
 
 Contributed by [Szczepan Faber](https://github.com/mockitoguy).
 

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -1,9 +1,10 @@
 The Gradle team is excited to announce Gradle 5.2.
 
-This release features the [Java Platform plugin](userguide/java_platform_plugin.html) which allows users to define sets of dependencies that work together, [new C++ plugins](userguide/cpp_plugins.html) with dependency management built-in, [new C++ project types for the Build Init Plugin](userguide/build_init_plugin.html#sec:cppapplication_), and more.
+This release features a new [Java Platform plugin](#the-java-platform-plugin), [improved C++ plugins](userguide/cpp_plugins.html), [new C++ project types for `gradle init`](userguide/build_init_plugin.html#sec:cppapplication_), [service injection into plugins and project extensions](#service-injection-into-plugins-and-project-extensions) and more.
 
-Read the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn about breaking changes and considerations for upgrading from Gradle 5.0. If upgrading from Gradle 4.x, please read 
-[upgrading from Gradle 4.x to 5.0](userguide/upgrading_version_4.html) first. Users upgrading from 5.1, should not have to worry about breaking changes.
+Read the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn about breaking changes and considerations for upgrading from Gradle 5.0.
+If upgrading from Gradle 4.x, please read [upgrading from Gradle 4.x to 5.0](userguide/upgrading_version_4.html) first.
+Users upgrading from 5.1 should not have to worry about breaking changes.
 
 We would like to thank the following community contributors to this release of Gradle:
 
@@ -16,24 +17,19 @@ and [Richard Newton](https://github.com/ricnewton).
 
 ## Upgrade Instructions
 
-Switch your build to use Gradle 5.2 by updating your wrapper properties:
+Switch your build to use Gradle 5.2 RC1 by updating your wrapper properties:
 
-`./gradlew wrapper --gradle-version=5.2`
+`./gradlew wrapper --gradle-version=5.2-rc-1`
 
 Standalone downloads are available at [gradle.org/release-candidate](https://gradle.org/release-candidate). 
 
 ## The Java Platform plugin
 
-A new plugin, the [Java Platform plugin](userguide/java_platform_plugin.html) allows you to declare and publish a platform for the Java ecosystem. A platform is typically published as a 
-bill-of-material (BOM) file and can be used to define a set of versions for dependencies that are known to work together. These versions can be published and consumed elsewhere as dependency 
-recommendations.
+This release features the [Java Platform plugin](userguide/java_platform_plugin.html), which allows you to declare a platform.
+Like Maven BOMs, platforms can be used to define a set of versions for dependencies that are known to work together.
+These versions can be published and consumed elsewhere as dependency recommendations.
 
 Read the [Java Platform plugin section of the userguide](userguide/java_platform_plugin.html) for more details.
-
-## Maven publication: expose resolved versions
-
-When using the [`maven-publish` plugin](userguide/publishing_maven.html), you can now opt-in to publish the _resolved_ dependency versions instead of the _declared_ ones.
-For details, have a look at the [dedicated section](userguide/publishing_maven.html#publishing_maven:resolved_dependencies) in the plugin documentation.
 
 ## Building native software with Gradle 
 
@@ -41,7 +37,7 @@ See more information about the [Gradle native project](https://github.com/gradle
 
 ### Recommend C++ projects use new C++ plugins
 
-We introduced [new C++ plugins](https://blog.gradle.org/introducing-the-new-cpp-plugins) last year that we thought were more feature rich and familiar to Gradle users.
+We introduced [new C++ plugins](https://blog.gradle.org/introducing-the-new-cpp-plugins) last year that are more feature rich and familiar to Gradle users.
 
 In this release, we are recommending new C++ projects use these plugins over [the existing software model plugins](userguide/native_software.html). The new plugins do not currently support C, Objective-C or Objective-C++ out of the box, but they have [a lot of other things to offer](userguide/cpp_plugins.html#cpp:features).
 
@@ -58,28 +54,40 @@ These toolchains are now officially supported by Gradle. See [the userguide](use
 
 Gradle now automatically hides the `main` symbol when building native applications, so applications can be tested on Windows like they already were on macOS and Linux.
 
-Contributed by [Richard Newton](https://github.com/ricnewton).
+Contributed by [Richard Newton](https://github.com/ricnewton). 
+
+## Improvements for custom task authors 
+
+### Service injection into plugins and project extensions
+
+There are several [useful services](userguide/custom_tasks.html#service_injection) that Gradle makes available for task and plugin implementations to use.
+Previously, these were available for injection into task and plugin instances.
+In this Gradle release these services are also available for injection directly into project extensions.
+Services are also now available for injection into the elements of a container created using the `project.container(Class)` method.
+Using this feature can help simplify your plugin implementation.
+
+Services can be injected into an instance either as constructor parameters or using a property getter method.
+In this release both options are available for all types for which service injection is available.
+In previous Gradle versions, using a property getter method was not supported for plugin types.
+
+See the user manual sections on [service injection for plugins](userguide/custom_plugins.html#service_injection) and [service injection into tasks](userguide/custom_tasks.html#service_injection) for details.
+
+### Support for setting environment variables when using Gradle TestKit
+  
+Gradle [TestKit](userguide/test_kit.html) based tests can now specify environment variables via [`GradleRunner`](javadoc/org/gradle/testkit/runner/GradleRunner.html). These environment variables will be visible to the build under test.
+
+Contributed by [Szczepan Faber](https://github.com/mockitoguy).
+
+## Maven publication can expose resolved versions
+
+When using the [`maven-publish` plugin](userguide/publishing_maven.html), you can now opt-in to publish the _resolved_ dependency versions instead of the _declared_ ones.
+For details, have a look at the [dedicated section](userguide/publishing_maven.html#publishing_maven:resolved_dependencies) in the plugin documentation.
 
 ## Rich console improvements on Windows
 
 This release includes some improvements to Gradle's console integration on Windows. Gradle now detects when it is running from Mintty on Windows and enables the rich console. Mintty is a popular terminal emulator used by projects such as Cygwin and Git for Windows. 
 
-The implementation of the rich console has been improved to remove some distracting visual artifacts on Windows. 
-
-## Improvements for plugin authors 
-
-### Service injection into project extensions
-
-Previously, Gradle supported [service injection into tasks](userguide/custom_tasks.html#service_injection) and [service injection into plugins](userguide/custom_plugins.html#service_injection). In 
-this Gradle release, these services are also available for injection directly into project extensions. Using this can help simplify your plugin implementation.
-
-See the [user manual](userguide/custom_plugins.html#service_injection) for details.
-
-## Support for setting environment variables when using Gradle TestKit
-  
-Gradle [TestKit](userguide/test_kit.html) based tests can now specify environment variables via [`GradleRunner`](javadoc/org/gradle/testkit/runner/GradleRunner.html). These environment variables will be visible to the build under test.
-
-Contributed by [Szczepan Faber](https://github.com/mockitoguy).
+The implementation of the rich console has been improved to remove some distracting visual artifacts on Windows.
 
 ## Annotation processor improvements
 
@@ -94,16 +102,6 @@ Contributed by [Thomas Broyer](https://github.com/tbroyer).
 Tasks that use `JavaExec` now track the version of Java used instead of the absolute path to the `java` executable.
 
 Contributed by [Theodore Ni](https://github.com/tjni).
-
-## Improvements for plugin authors 
-
-### Service injection into plugins and project extensions
-
-There are several [useful services](userguide/custom_tasks.html#service_injection) that Gradle makes available for task and plugin implementations to use. Previously, these were available for injection into task and plugin instances. In this Gradle release these services are also available for injection directly into project extensions. Services are also now available for injection into the elements of a container created using the `project.container(Class)` method. Using this feature can help simplify your plugin implementation.
-
-Services can be injected into an instance either as constructor parameters or using a property getter method. In this release both options are available for all types for which service injection is available. In previous Gradle versions, using a property getter method was not supported for plugin types.
-
-See the [User Manual](userguide/custom_plugins.html#service_injection) for details.
 
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/docs/release/release-features.txt
+++ b/subprojects/docs/src/docs/release/release-features.txt
@@ -1,0 +1,3 @@
+- Define sets of dependencies that work together with Java Platform plugin
+- New C++ plugins with dependency management built-in
+- New project types for init task

--- a/subprojects/docs/src/docs/release/release-features.txt
+++ b/subprojects/docs/src/docs/release/release-features.txt
@@ -1,3 +1,4 @@
 - Define sets of dependencies that work together with Java Platform plugin
 - New C++ plugins with dependency management built-in
-- New project types for init task
+- New C++ project types for gradle init
+- Service injection into plugins and project extensions

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -33,6 +33,13 @@ Some plugins will break with this new version of Gradle, for example because the
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[changes_5.2]]
+== Upgrading from 5.1 and earlier
+
+=== Potential breaking changes
+
+none
+
 [[changes_5.1]]
 == Upgrading from 5.0 and earlier
 


### PR DESCRIPTION

<img width="689" alt="screenshot 2019-01-23 at 14 22 24" src="https://user-images.githubusercontent.com/4601577/51609464-7d1a5800-1f1a-11e9-9587-46fa1bb88430.png">

 .
 .
 .

<img width="699" alt="screenshot 2019-01-23 at 14 23 12" src="https://user-images.githubusercontent.com/4601577/51609471-81df0c00-1f1a-11e9-88f7-1c5b1fb520ad.png">


from: https://builds.gradle.org/repository/download/Gradle_Check_BuildDistributions/19377045:id/distributions/gradle-5.2-all.zip!/gradle-5.2-20190123130553%2B0000/docs/release-notes.html