### PR TITLE
Do not try to load external dependencies from classpath

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.classpath;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.UncheckedIOException;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.specs.Specs;
 import org.gradle.internal.classpath.CachedJarFileStore;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
@@ -47,6 +46,13 @@ import java.util.zip.ZipFile;
  * Determines the classpath for a module by looking for a '${module}-classpath.properties' resource with 'name' set to the name of the module.
  */
 public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore {
+    private static final Spec<File> SATISFY_ALL = new Spec<File>() {
+        @Override
+        public boolean isSatisfiedBy(File element) {
+            return true;
+        }
+    };
+
     private final GradleInstallation gradleInstallation;
     private final Map<String, Module> modules = new HashMap<String, Module>();
     private final Map<String, Module> externalModules = new HashMap<String, Module>();
@@ -97,7 +103,7 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
     }
 
     private Module loadExternalModule(String name) {
-        File externalJar = findJar(name, Specs.<File>satisfyAll());
+        File externalJar = findJar(name, SATISFY_ALL);
         if (externalJar == null) {
             if (gradleInstallation == null) {
                 throw new UnknownModuleException(String.format("Cannot locate JAR for module '%s' in in classpath: %s.", name, classpath));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classpath/DefaultModuleRegistry.java
@@ -17,6 +17,8 @@ package org.gradle.api.internal.classpath;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.UncheckedIOException;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
 import org.gradle.internal.classpath.CachedJarFileStore;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
@@ -95,7 +97,7 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
     }
 
     private Module loadExternalModule(String name) {
-        File externalJar = findJar(name);
+        File externalJar = findJar(name, Specs.<File>satisfyAll());
         if (externalJar == null) {
             if (gradleInstallation == null) {
                 throw new UnknownModuleException(String.format("Cannot locate JAR for module '%s' in in classpath: %s.", name, classpath));
@@ -138,8 +140,13 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
         throw new UnknownModuleException(String.format("Cannot locate JAR for module '%s' in distribution directory '%s'.", moduleName, gradleInstallation.getGradleHome()));
     }
 
-    private Module loadOptionalModule(String moduleName) {
-        File jarFile = findJar(moduleName);
+    private Module loadOptionalModule(final String moduleName) {
+        File jarFile = findJar(moduleName, new Spec<File>() {
+            @Override
+            public boolean isSatisfiedBy(File jarFile) {
+                return hasModuleProperties(moduleName, jarFile);
+            }
+        });
         if (jarFile != null) {
             Set<File> implementationClasspath = new LinkedHashSet<File>();
             implementationClasspath.add(jarFile);
@@ -147,7 +154,7 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
             return module(moduleName, properties, implementationClasspath);
         }
 
-        String resourceName = moduleName + "-classpath.properties";
+        String resourceName = getClasspathManifestName(moduleName);
         Set<File> implementationClasspath = new LinkedHashSet<File>();
         findImplementationClasspath(moduleName, implementationClasspath);
         for (File file : implementationClasspath) {
@@ -256,7 +263,7 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
         try {
             ZipFile zipFile = new ZipFile(jarFile);
             try {
-                final String entryName = name + "-classpath.properties";
+                String entryName = getClasspathManifestName(name);
                 ZipEntry entry = zipFile.getEntry(entryName);
                 if (entry == null) {
                     throw new IllegalStateException("Did not find " + entryName + " in " + jarFile.getAbsolutePath());
@@ -270,7 +277,26 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
         }
     }
 
-    private File findJar(String name) {
+    private boolean hasModuleProperties(String name, File jarFile) {
+        try {
+            ZipFile zipFile = new ZipFile(jarFile);
+            try {
+                String entryName = getClasspathManifestName(name);
+                ZipEntry entry = zipFile.getEntry(entryName);
+                return entry != null;
+            } finally {
+                zipFile.close();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(String.format("Could not load properties for module '%s' from %s", name, jarFile), e);
+        }
+    }
+
+    private String getClasspathManifestName(String moduleName) {
+        return moduleName + "-classpath.properties";
+    }
+
+    private File findJar(String name, Spec<File> allowedJarFiles) {
         Pattern pattern = Pattern.compile(Pattern.quote(name) + "-\\d.+\\.jar");
         if (gradleInstallation != null) {
             for (File libDir : gradleInstallation.getLibDirs()) {
@@ -282,7 +308,7 @@ public class DefaultModuleRegistry implements ModuleRegistry, CachedJarFileStore
             }
         }
         for (File file : classpath) {
-            if (pattern.matcher(file.getName()).matches()) {
+            if (pattern.matcher(file.getName()).matches() && allowedJarFiles.isSatisfiedBy(file)) {
                 return file;
             }
         }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/classpath/DefaultModuleRegistryTest.groovy
@@ -27,16 +27,21 @@ class DefaultModuleRegistryTest extends Specification {
     @Rule
     final TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
     TestFile runtimeDep
+    TestFile externalRuntimeDep
     TestFile resourcesDir
     TestFile jarFile
     TestFile distDir
+    TestFile externalDependency
 
     def setup() {
         distDir = tmpDir.createDir("dist")
+        def dependencyCache = tmpDir.file("gradle-home/caches/modules-2/files-2.1").createDir()
 
         distDir.createDir("lib")
         distDir.createDir("lib/plugins")
         distDir.createDir("lib/plugins/sonar")
+        externalRuntimeDep = dependencyCache.file("com.something/3.4.5/b4b02fa623c5a618e68478d9a4a67e1e87c023c6/dep-1.2.jar")
+        distDir.zipTo(externalRuntimeDep)
         runtimeDep = distDir.createZip("lib/dep-1.2.jar")
 
         resourcesDir = tmpDir.createDir("some-module/build/resources/main")
@@ -46,6 +51,9 @@ class DefaultModuleRegistryTest extends Specification {
 
         jarFile = distDir.file("lib/gradle-some-module-5.1.jar")
         resourcesDir.zipTo(jarFile)
+
+        externalDependency = dependencyCache.file("com.something/3.0.0/b4b02fa623c5a618e68478d9a4a67e1e87c023c6/gradle-some-module-3.0.0.jar")
+        tmpDir.createDir("externalDependencyContents").zipTo(externalDependency)
     }
 
     def "locates module using jar in distribution image"() {
@@ -67,6 +75,21 @@ class DefaultModuleRegistryTest extends Specification {
         def module = registry.getModule("gradle-some-module")
         module.implementationClasspath.asFiles == [jarFile]
         module.runtimeClasspath.asFiles == [runtimeDep]
+    }
+
+    def "ignores external module jar from runtime ClassLoader"() {
+        def classesDir = tmpDir.createDir("some-module/build/classes/java/main")
+        def staticResourcesDir = tmpDir.createDir("some-module/src/main/resources")
+        def cl = classLoaderFor([externalDependency, classesDir, resourcesDir, staticResourcesDir, externalRuntimeDep])
+        def registry = new DefaultModuleRegistry(cl, ClassPath.EMPTY, null)
+
+        expect:
+        def module = registry.getModule("gradle-some-module")
+        module.implementationClasspath.asFiles == [classesDir, resourcesDir, staticResourcesDir]
+        module.runtimeClasspath.asFiles == [externalRuntimeDep]
+
+        def dep = registry.getExternalModule("dep")
+        dep.implementationClasspath.asFiles == [externalRuntimeDep]
     }
 
     def "locates module using manifest from runtime ClassLoader when run from IDEA with a project imported by IDEA"() {


### PR DESCRIPTION
For some projects `gradle-core-3.0.0.jar` from the AGP is on the
classpath and would be picked up when trying to run from IDEA.
