### PR TITLE
WIP - Add a DSL for registering features on Java libraries

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/TextUtil.java
@@ -16,14 +16,26 @@
 
 package org.gradle.util;
 
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.collect.Iterables;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.gradle.internal.SystemProperties;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.regex.Pattern;
 
 public class TextUtil {
     private static final Pattern WHITESPACE = Pattern.compile("\\s*");
+    private static final Pattern UPPER_CASE = Pattern.compile("(?=\\p{Upper})");
+    private static final Joiner KEBAB_JOINER = Joiner.on("-");
+    private static final Function<String, String> TO_LOWERCASE = new Function<String, String>() {
+        @Override
+        public String apply(String input) {
+            return input.toLowerCase();
+        }
+    };
 
     /**
      * Returns the line separator for Windows.
@@ -146,5 +158,9 @@ public class TextUtil {
 
     public static String normaliseFileAndLineSeparators(String in) {
         return normaliseLineSeparators(normaliseFileSeparators(in));
+    }
+
+    public static String camelToKebabCase(String camelCase) {
+        return KEBAB_JOINER.join(Iterables.transform(Arrays.asList(UPPER_CASE.split(camelCase)), TO_LOWERCASE));
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/util/TextUtilTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/TextUtilTest.groovy
@@ -94,4 +94,23 @@ class TextUtilTest extends Specification {
         TextUtil.shorterOf("", "bb") == ""
         TextUtil.shorterOf("", "") == ""
     }
+
+    @Unroll("#camelCase to kebab = #kebabCase")
+    def kebabCase() {
+        expect:
+        TextUtil.camelToKebabCase(camelCase) == kebabCase
+
+        where:
+        camelCase   | kebabCase
+        ""          | ""
+        "foo"       | "foo"
+        "fooBar"    | "foo-bar"
+        "Foo"       | "foo"
+        "fooBarBaz" | "foo-bar-baz"
+        "ABC"       | "a-b-c"
+        "someT"     | "some-t"
+        "sT"        | "s-t"
+        "aBc"       | "a-bc"
+        "aBec"      | "a-bec"
+    }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishOptionalDependenciesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishOptionalDependenciesJavaIntegTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.test.fixtures.maven.MavenJavaModule
+
+abstract class AbstractMavenPublishOptionalDependenciesJavaIntegTest extends AbstractMavenPublishIntegTest {
+    MavenJavaModule javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
+
+    def setup() {
+        createBuildScripts("""
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+""")
+    }
+
+    def createBuildScripts(def append) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'maven-publish'
+            apply plugin: 'java-library'
+
+            publishing {
+                repositories {
+                    maven { url "${mavenRepo.uri}" }
+                }
+            }
+            group = 'org.gradle.test'
+            version = '1.9'
+
+$append
+"""
+
+    }
+}

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishOptionalDependenciesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishOptionalDependenciesJavaIntegTest.groovy
@@ -16,24 +16,10 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
-import org.gradle.test.fixtures.maven.MavenJavaModule
+
 import spock.lang.Unroll
 
-class MavenPublishOptionalDependenciesJavaIntegTest extends AbstractMavenPublishIntegTest {
-    MavenJavaModule javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
-
-    def setup() {
-        createBuildScripts("""
-            publishing {
-                publications {
-                    maven(MavenPublication) {
-                        from components.java
-                    }
-                }
-            }
-""")
-    }
+class MavenPublishOptionalDependenciesJavaIntegTest extends AbstractMavenPublishOptionalDependenciesJavaIntegTest {
 
     def "can publish java-library with optional feature"() {
         mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
@@ -160,26 +146,6 @@ class MavenPublishOptionalDependenciesJavaIntegTest extends AbstractMavenPublish
 
         then:
         failure.assertHasCause("Cannot add optional feature variant 'api' as a variant with the same name is already registered")
-    }
-
-    def createBuildScripts(def append) {
-        settingsFile << "rootProject.name = 'publishTest' "
-
-        buildFile << """
-            apply plugin: 'maven-publish'
-            apply plugin: 'java-library'
-
-            publishing {
-                repositories {
-                    maven { url "${mavenRepo.uri}" }
-                }
-            }
-            group = 'org.gradle.test'
-            version = '1.9'
-
-$append
-"""
-
     }
 
     def "can group dependencies by optional feature"() {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishOptionalDependenciesJavaPluginIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishOptionalDependenciesJavaPluginIntegTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publish.maven
+
+class MavenPublishOptionalDependenciesJavaPluginIntegTest extends AbstractMavenPublishOptionalDependenciesJavaIntegTest {
+    def "can publish java-library with optional feature using extension"() {
+        mavenRepo.module('org', 'optionaldep', '1.0').withModuleMetadata().publish()
+
+        given:
+        buildFile << """
+            
+            java {
+                registerFeature("feature") {
+                    usingSourceSet(sourceSets.main)
+                }
+            }
+            
+            dependencies {
+                featureImplementation 'org:optionaldep:1.0'
+            }
+        """
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.parsedModuleMetadata.variant("api") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtime") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("featureApi") {
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("featureRuntime") {
+            assert files*.name == ['publishTest-1.9.jar']
+            dependency('org', 'optionaldep', '1.0')
+            noMoreDependencies()
+        }
+        javaLibrary.parsedPom.scope('compile') {
+            assertOptionalDependencies('org:optionaldep:1.0')
+        }
+        javaLibrary.parsedPom.hasNoScope('runtime')
+
+        and:
+        resolveArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveApiArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+        resolveRuntimeArtifacts(javaLibrary) { expectFiles "publishTest-1.9.jar" }
+
+        resolveRuntimeArtifacts(javaLibrary) {
+            optionalFeatureCapabilities << "org.gradle.test:publishTest-feature:1.0"
+            withModuleMetadata {
+                expectFiles "publishTest-1.9.jar", "optionaldep-1.0.jar"
+            }
+            withoutModuleMetadata {
+                shouldFail {
+                    // documents the current behavior
+                    assertHasCause("Unable to find a variant of org.gradle.test:publishTest:1.9 providing the requested capability org.gradle.test:publishTest-feature:1.0")
+                }
+            }
+        }
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOptionalFeatureCompilationIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOptionalFeatureCompilationIntegrationTest.groovy
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java
+
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class JavaLibraryOptionalFeatureCompilationIntegrationTest extends AbstractIntegrationSpec {
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = "test"
+        """
+        buildFile << """
+            allprojects {
+                group = 'org.gradle.test'
+                version = '1.0'
+            }
+        """
+    }
+
+    @Unroll
+    def "project can declare and compile optional feature (configuration=#configuration)"() {
+        settingsFile << """
+            include 'b'
+        """
+        given:
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            java {
+                registerFeature("myFeature") {
+                    usingSourceSet(sourceSets.main)
+                }
+            }
+            
+            dependencies {
+                $configuration project(":b")
+            }
+        """
+        file("b/build.gradle") << """
+            apply plugin: 'java-library'
+        """
+        file("b/src/main/java/com/foo/Foo.java") << """
+            package com.foo;
+            public class Foo {
+                public void foo() {
+                }
+            }
+        """
+        file("src/main/java/com/bar/Bar.java") << """
+            package com.bar;
+            import com.foo.Foo;
+            
+            public class Bar {
+                public void bar() {
+                    Foo foo = new Foo();
+                    foo.foo();
+                }
+            }
+        """
+
+        when:
+        succeeds ':compileJava'
+
+        then:
+        executedAndNotSkipped ':b:compileJava'
+        notExecuted ':b:processResources', ':b:classes', ':b:jar'
+
+        where:
+        configuration << ["myFeatureApi", "myFeatureImplementation"]
+    }
+
+    def "Java Library can depend on optional feature of component"() {
+        settingsFile << """
+            include 'b', 'c', 'd'
+        """
+        given:
+        file("b/build.gradle") << """
+            apply plugin: 'java-library'
+            
+            java {
+                registerFeature("myFeature") {
+                    usingSourceSet(sourceSets.main)
+                }
+            }
+            
+            dependencies {
+                myFeatureApi project(":c")
+                myFeatureImplementation project(":d")
+            }
+            
+        """
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            dependencies {
+                implementation(project(":b")) {
+                    capabilities {
+                        requireCapability("org.gradle.test:b-my-feature")
+                    }
+                }
+            }
+            
+            task verifyClasspath {
+                dependsOn(configurations.compileClasspath)
+                dependsOn(configurations.runtimeClasspath)
+                doLast {
+                    assert configurations.compileClasspath.incoming.resolutionResult.allDependencies.collect {
+                        it.toString()
+                    } as Set == ['project :b', 'project :c'] as Set // only API dependencies
+                    assert configurations.runtimeClasspath.incoming.resolutionResult.allDependencies.collect {
+                        it.toString()
+                    } as Set == ['project :b', 'project :c', 'project :d'] as Set // all dependencies
+                }
+            }
+        """
+        ['c', 'd'].each {
+            file("$it/build.gradle") << """
+            apply plugin: 'java-library'
+        """
+            file("$it/src/main/java/com/baz/Baz${it}.java") << """
+            package com.baz;
+            public class Baz${it} {}
+        """
+        }
+
+        file("b/src/main/java/com/foo/Foo.java") << """
+            package com.foo;
+            public class Foo {
+                public void foo() {
+                }
+            }
+        """
+        file("src/main/java/com/bar/Bar.java") << """
+            package com.bar;
+            import com.foo.Foo;
+            
+            public class Bar {
+                public void bar() {
+                    Foo foo = new Foo();
+                    foo.foo();
+                }
+            }
+        """
+
+        when:
+        succeeds ':compileJava'
+
+        then:
+        executedAndNotSkipped ':b:compileJava', ':c:compileJava', ':d:compileJava'
+        notExecuted ':b:processResources', ':b:classes', ':b:jar', ':c:processResources', ':c:classes', ':c:jar', ':d:processResources', ':d:classes', ':d:jar'
+
+        when:
+        succeeds ':verifyClasspath'
+
+        then:
+        executedAndNotSkipped ':b:jar', ':c:jar', ':d:jar'
+
+    }
+
+    def "main component doesn't expose dependencies from optional feature"() {
+        settingsFile << """
+            include 'b', 'c'
+        """
+        given:
+        file("b/build.gradle") << """
+            apply plugin: 'java-library'
+            
+            java {
+                registerFeature("myFeature") {
+                    usingSourceSet(sourceSets.main)
+                }
+            }
+            
+            dependencies {
+                myFeatureImplementation project(":c")
+            }
+            
+        """
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            dependencies {
+                implementation(project(":b"))
+            }
+            
+            task resolveRuntime {
+                dependsOn(configurations.runtimeClasspath)
+                doLast {
+                    assert configurations.runtimeClasspath.files.name as Set == ['b-1.0.jar'] as Set
+                }
+            }
+        """
+        file("c/build.gradle") << """
+            apply plugin: 'java-library'
+        """
+        file("c/src/main/java/com/baz/Baz.java") << """
+            package com.baz;
+            public class Baz {}
+        """
+        file("b/src/main/java/com/foo/Foo.java") << """
+            package com.foo;
+            public class Foo {
+                public void foo() {
+                }
+            }
+        """
+        file("src/main/java/com/bar/Bar.java") << """
+            package com.bar;
+            import com.foo.Foo;
+            
+            public class Bar {
+                public void bar() {
+                    Foo foo = new Foo();
+                    foo.foo();
+                }
+            }
+        """
+
+        when:
+        succeeds ':compileJava'
+
+        then:
+        executedAndNotSkipped ':b:compileJava', ':c:compileJava'
+        notExecuted ':b:processResources', ':b:classes', ':b:jar', ':c:processResources', ':c:classes', ':c:jar'
+
+        when:
+        succeeds ':resolveRuntime'
+
+        then:
+        executedAndNotSkipped ':b:jar'
+
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/FeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/FeatureSpec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.internal.HasInternalProtocol;
+
+/**
+ * Handler for configuring features, which may contribute additional
+ * configurations, publications, dependencies, ...
+ *
+ * @since 5.3
+ */
+@Incubating
+@HasInternalProtocol
+public interface FeatureSpec {
+    /**
+     * Declares the source set which this feature is built from.
+     * @param sourceSet the source set
+     */
+    void usingSourceSet(SourceSet sourceSet);
+
+    /**
+     * Declares a capability of this feature. By default, a capability
+     * corresponding to the "group", "name" + feature name will be created.
+     * For example, if the group of the component is "org", that the project
+     * name is "lib" and that the feature name is "myFeature", then a
+     * capability named "org:lib-my-feature" is automatically added. Calling
+     * this method override the default and register <i>additional</i> capabilities.
+     *
+     * @param group the group of the capability
+     * @param name the name of the capability
+     * @param version the version of the capability
+     */
+    void capability(String group, String name, String version);
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -116,7 +116,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         JavaPluginConvention javaConvention = new DefaultJavaPluginConvention(project, instantiator, collectionCallbackActionDecorator);
         project.getConvention().getPlugins().put("java", javaConvention);
         project.getExtensions().add(SourceSetContainer.class, "sourceSets", javaConvention.getSourceSets());
-        project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention);
+        project.getExtensions().create(JavaPluginExtension.class, "java", DefaultJavaPluginExtension.class, javaConvention, project);
         return javaConvention;
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.plugins;
 
+import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 
@@ -49,4 +50,13 @@ public interface JavaPluginExtension {
      * @param value The value for the target compatibility
      */
     void setTargetCompatibility(JavaVersion value);
+
+    /**
+     * Registers an optional feature.
+     * @param name the name of the optional feature
+     * @param configureAction the configuration for the optional feature
+     *
+     * @since 5.3
+     */
+    void registerFeature(String name, Action<? super FeatureSpec> configureAction);
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultFeatureSpec.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins.internal;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.Action;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.ComponentWithOptionalFeatures;
+import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.component.SoftwareComponentContainer;
+import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.AppliedPlugin;
+import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.internal.component.external.model.ImmutableCapability;
+
+import java.util.List;
+
+import static org.gradle.api.plugins.JavaLibraryPlugin.registerClassesDirVariant;
+import static org.gradle.api.plugins.JavaPlugin.JAR_TASK_NAME;
+
+public class DefaultFeatureSpec implements FeatureSpecInternal {
+    private final String name;
+    private final JavaPluginConvention javaPluginConvention;
+    private final ConfigurationContainer configurationContainer;
+    private final ObjectFactory objectFactory;
+    private final PluginManager pluginManager;
+    private final SoftwareComponentContainer components;
+    private final TaskContainer tasks;
+    private final List<Capability> capabilities = Lists.newArrayListWithExpectedSize(2);
+
+    private boolean overrideDefaultCapability = true;
+    private SourceSet sourceSet;
+
+    public DefaultFeatureSpec(String name,
+                              Capability defaultCapability,
+                              JavaPluginConvention javaPluginConvention,
+                              ConfigurationContainer configurationContainer,
+                              ObjectFactory objectFactory,
+                              PluginManager pluginManager,
+                              SoftwareComponentContainer components,
+                              TaskContainer tasks) {
+        this.name = name;
+        this.javaPluginConvention = javaPluginConvention;
+        this.configurationContainer = configurationContainer;
+        this.objectFactory = objectFactory;
+        this.pluginManager = pluginManager;
+        this.components = components;
+        this.tasks = tasks;
+        this.capabilities.add(defaultCapability);
+    }
+
+    @Override
+    public void usingSourceSet(SourceSet sourceSet) {
+        this.sourceSet = sourceSet;
+    }
+
+    @Override
+    public void capability(String group, String name, String version) {
+        if (overrideDefaultCapability) {
+            capabilities.clear();
+            overrideDefaultCapability = false;
+        }
+        capabilities.add(new ImmutableCapability(group, name, version));
+    }
+
+    @Override
+    public void create() {
+        if (isMainSourceSet(sourceSet)) {
+            createFromMainSourceSet();
+        } else {
+            throw new UnsupportedOperationException("Registering a feature using a different source set than the main one is not supported.");
+        }
+    }
+
+    private void createFromMainSourceSet() {
+        String apiConfigurationName = name + "Api";
+        String implConfigurationName = name + "Implementation";
+        String apiElementsConfigurationName = apiConfigurationName + "Elements";
+        String runtimeElementsConfigurationName = name + "RuntimeElements";
+        final Configuration api = bucket("API", apiConfigurationName);
+        Configuration impl = bucket("Implementation", implConfigurationName);
+        impl.extendsFrom(api);
+        final Configuration apiElements = export(apiElementsConfigurationName);
+        apiElements.extendsFrom(api);
+        final Configuration runtimeElements = export(runtimeElementsConfigurationName);
+        runtimeElements.extendsFrom(impl);
+        configureUsage(apiElements, Usage.JAVA_API);
+        configureUsage(runtimeElements, Usage.JAVA_RUNTIME);
+        configureCapabilities(apiElements);
+        configureCapabilities(runtimeElements);
+        attachArtifactToConfiguration(apiElements);
+        attachArtifactToConfiguration(runtimeElements);
+        registerClassesDirVariant(tasks, objectFactory, apiElements);
+
+        // since we use the main source set, we need to make sure the compile classpath and runtime classpath are properly configured
+        configurationContainer.getByName(JavaPlugin.COMPILE_CLASSPATH_CONFIGURATION_NAME).extendsFrom(impl);
+        configurationContainer.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME).extendsFrom(impl);
+
+        pluginManager.withPlugin("maven-publish", new Action<AppliedPlugin>() {
+            @Override
+            public void execute(AppliedPlugin plugin) {
+                final ComponentWithOptionalFeatures component = findComponent();
+                if (component != null) {
+                    component.addOptionalFeatureVariantFromConfiguration(name + "Api", apiElements);
+                    component.addOptionalFeatureVariantFromConfiguration(name + "Runtime", runtimeElements);
+                }
+            }
+        });
+    }
+
+    private void attachArtifactToConfiguration(Configuration configuration) {
+        TaskProvider<Task> jar = tasks.named(JAR_TASK_NAME);
+        configuration.getArtifacts().add(new LazyPublishArtifact(jar));
+    }
+
+    private ComponentWithOptionalFeatures findComponent() {
+        SoftwareComponent component = components.findByName("java");
+        if (component instanceof ComponentWithOptionalFeatures) {
+            return (ComponentWithOptionalFeatures) component;
+        }
+        return null;
+    }
+
+    private void configureCapabilities(Configuration apiElements) {
+        for (Capability capability : capabilities) {
+            apiElements.getOutgoing().capability(capability);
+        }
+    }
+
+    private Configuration export(String configName) {
+        Configuration configuration = configurationContainer.maybeCreate(configName);
+        configuration.setCanBeConsumed(true);
+        configuration.setCanBeResolved(false);
+        return configuration;
+    }
+
+    private Configuration bucket(String kind, String configName) {
+        Configuration configuration = configurationContainer.maybeCreate(configName);
+        configuration.setDescription(kind + " dependencies for feature " + name);
+        configuration.setCanBeResolved(false);
+        configuration.setCanBeConsumed(false);
+        return configuration;
+    }
+
+    private void configureUsage(Configuration conf, final String usage) {
+        conf.attributes(new Action<AttributeContainer>() {
+            @Override
+            public void execute(AttributeContainer attrs) {
+                attrs.attribute(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage));
+            }
+        });
+    }
+
+    private boolean isMainSourceSet(SourceSet sourceSet) {
+        SourceSet mainSourceSet = javaPluginConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+        return mainSourceSet.equals(sourceSet);
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -16,15 +16,43 @@
 
 package org.gradle.api.plugins.internal;
 
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.capabilities.Capability;
+import org.gradle.api.component.SoftwareComponentContainer;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.FeatureSpec;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.plugins.PluginManager;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.internal.component.external.model.ImmutableCapability;
+import org.gradle.util.TextUtil;
+
+import java.util.regex.Pattern;
 
 public class DefaultJavaPluginExtension implements JavaPluginExtension {
+    private final static Pattern VALID_FEATURE_NAME = Pattern.compile("[a-zA-Z0-9]+");
     private final JavaPluginConvention convention;
+    private final ConfigurationContainer configurations;
+    private final ObjectFactory objectFactory;
+    private final PluginManager pluginManager;
+    private final SoftwareComponentContainer components;
+    private final TaskContainer tasks;
+    private final Project project;
 
-    public DefaultJavaPluginExtension(JavaPluginConvention convention) {
+    public DefaultJavaPluginExtension(JavaPluginConvention convention,
+                                      Project project) {
         this.convention = convention;
+        this.configurations = project.getConfigurations();
+        this.objectFactory = project.getObjects();
+        this.pluginManager = project.getPluginManager();
+        this.components = project.getComponents();
+        this.tasks = project.getTasks();
+        this.project = project;
     }
 
     @Override
@@ -45,5 +73,39 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
     @Override
     public void setTargetCompatibility(JavaVersion value) {
         convention.setTargetCompatibility(value);
+    }
+
+    @Override
+    public void registerFeature(String name, Action<? super FeatureSpec> configureAction) {
+        // todo: how to deal with group/name/version changes/set too late?
+        Capability defaultCapability = new ImmutableCapability(
+                notNull("group", project.getGroup()),
+                notNull("name", project.getName()) + "-" + TextUtil.camelToKebabCase(name),
+                notNull("version", project.getVersion())
+        );
+        DefaultFeatureSpec spec = new DefaultFeatureSpec(
+                validateFeatureName(name),
+                defaultCapability, convention,
+                configurations,
+                objectFactory,
+                pluginManager,
+                components,
+                tasks);
+        configureAction.execute(spec);
+        spec.create();
+    }
+
+    private static String validateFeatureName(String name) {
+        if (!VALID_FEATURE_NAME.matcher(name).matches()) {
+            throw new InvalidUserDataException("Invalid feature name '" + name + "'. Must match " + VALID_FEATURE_NAME.pattern());
+        }
+        return name;
+    }
+
+    private static String notNull(String id, Object o) {
+        if (o == null) {
+            throw new InvalidUserDataException(id + " must not be null");
+        }
+        return o.toString();
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/FeatureSpecInternal.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/FeatureSpecInternal.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.plugins.internal;
+
+import org.gradle.api.plugins.FeatureSpec;
+
+public interface FeatureSpecInternal extends FeatureSpec {
+    void create();
+}


### PR DESCRIPTION
## Context

This commit makes it easier for a user to register optional features
in the Java ecosystem. Usually, in this world, optional dependencies
are used because for some reason it is not possible to split a project
into subprojects, and there are dependencies which are only required
at runtime if some feature is actually used by the consumer.

We make it easier to support this scenario by automatically setting
up a set of configurations which are used to support optional
features. Features, like Java libraries, may expose both an API
and an implementation. Consumers will select the right variants just
like for libraries.

The API makes it possible to support more scenarios, for example
if the feature is not implemented in the main source set. However,
this is not yet implemented. This means that the only scenario this
commit supports is the case where the main and optional features
are developed in the same, main, source set. Therefore, the artifact
for an optional feature will be the _same_ as the main one.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
