### PR TITLE
Fix overcounting of unpacked directories

### DIFF
--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -290,7 +290,6 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
         TarArchiveEntry entry;
 
         while ((entry = input.getNextTarEntry()) != null) {
-            entries.increment(1);
             boolean isDir = entry.isDirectory();
             int directoriesLeft = parser.nextPath(entry.getName(), isDir);
             for (int i = 0; i < directoriesLeft; i++) {
@@ -299,6 +298,7 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
             if (parser.getDepth() == 0) {
                 break;
             }
+            entries.increment(1);
 
             File file = new File(treeRoot, parser.getRelativePath());
             if (isDir) {

--- a/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/BuildCacheBuildOperationsIntegrationTest.groovy
+++ b/subprojects/build-cache/src/integTest/groovy/org/gradle/caching/internal/BuildCacheBuildOperationsIntegrationTest.groovy
@@ -113,6 +113,9 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
                  
                 @OutputDirectory
                 File dir = project.file("build/dir")
+                
+                @OutputDirectory
+                File otherDir = project.file("build/otherDir")
 
                 @TaskAction
                 void generate() {
@@ -145,7 +148,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
 
         packOp.details.cacheKey != null
         packOp.result.archiveSize == localCache.cacheArtifact(packOp.details.cacheKey.toString()).length()
-        packOp.result.archiveEntryCount == 4
+        packOp.result.archiveEntryCount == 5
 
         when:
         succeeds("clean", "t")
@@ -162,7 +165,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         def sizeDiff = cacheArtifact.length() - unpackOp.details.archiveSize.toLong()
         sizeDiff > -100 && sizeDiff < 100
 
-        unpackOp.result.archiveEntryCount == 4
+        unpackOp.result.archiveEntryCount == 5
     }
 
     @Unroll
@@ -278,7 +281,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
             assert !localCacheArtifact.exists()
         }
 
-        packOp.result.archiveEntryCount == 4
+        packOp.result.archiveEntryCount == 5
         remoteStoreOp.details.archiveSize == packOp.result.archiveSize
 
         operations.orderedSerialSiblings(remoteMissLoadOp, packOp, remoteStoreOp)
@@ -336,7 +339,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
             assert !localCacheArtifact.exists()
         }
 
-        unpackOp.result.archiveEntryCount == 4
+        unpackOp.result.archiveEntryCount == 5
         unpackOp.details.archiveSize == remoteHitLoadOp.result.archiveSize
 
         operations.orderedSerialSiblings(remoteHitLoadOp, unpackOp)
@@ -382,7 +385,7 @@ class BuildCacheBuildOperationsIntegrationTest extends AbstractIntegrationSpec {
         def localCacheArtifact = localCache.cacheArtifact(packOp.details.cacheKey.toString())
         !localCacheArtifact.exists()
 
-        packOp.result.archiveEntryCount == 4
+        packOp.result.archiveEntryCount == 5
 
         operations.orderedSerialSiblings(remoteMissLoadOp, packOp)
     }


### PR DESCRIPTION
The tar unpacker was counting every root directory except the
first one twice, because it was incrementing its counter before
checking whether it has left the current root.

The increment is now done after this check and a test case for this
condition was added.
