### PR TITLE
Make sure constraint attributes are merged with edge attributes

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -55,6 +55,7 @@ class EdgeState implements DependencyGraphEdge {
     private final ModuleExclusion transitiveExclusions;
     private final List<NodeState> targetNodes = Lists.newLinkedList();
     private final boolean isTransitive;
+    private final boolean isConstraint;
 
     private ModuleVersionResolveException targetNodeSelectionFailure;
 
@@ -67,6 +68,7 @@ class EdgeState implements DependencyGraphEdge {
         this.resolveState = resolveState;
         this.selector = resolveState.getSelector(dependencyState);
         this.isTransitive = from.isTransitive() && dependencyMetadata.isTransitive();
+        this.isConstraint = dependencyMetadata.isConstraint();
     }
 
     @Override
@@ -115,7 +117,7 @@ class EdgeState implements DependencyGraphEdge {
             return;
         }
 
-        if (dependencyMetadata.isConstraint()) {
+        if (isConstraint) {
             // Need to double check that the target still has hard edges to it
             ModuleResolveState module = targetComponent.getModule();
             if (module.isPending()) {
@@ -181,7 +183,7 @@ class EdgeState implements DependencyGraphEdge {
         try {
             ImmutableAttributes attributes = resolveState.getRoot().getMetadata().getAttributes();
             attributes = resolveState.getAttributesFactory().concat(attributes, getAttributes());
-            if (isConstraint()) {
+            if (isConstraint) {
                 attributes = selector.getTargetModule().mergeConstraintAttributesWithHardDependencyAttributes(attributes);
             }
             targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema());
@@ -216,7 +218,7 @@ class EdgeState implements DependencyGraphEdge {
 
     @Override
     public boolean contributesArtifacts() {
-        return !dependencyMetadata.isConstraint();
+        return !isConstraint;
     }
 
     @Override
@@ -254,7 +256,7 @@ class EdgeState implements DependencyGraphEdge {
 
     @Override
     public boolean isConstraint() {
-        return dependencyMetadata.isConstraint();
+        return isConstraint;
     }
 
     private ComponentState getSelectedComponent() {
@@ -280,7 +282,7 @@ class EdgeState implements DependencyGraphEdge {
     }
 
     void maybeDecreaseHardEdgeCount() {
-        if (!dependencyMetadata.isConstraint()) {
+        if (!isConstraint) {
             selector.getTargetModule().decreaseHardEdgeCount();
         }
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -181,6 +181,9 @@ class EdgeState implements DependencyGraphEdge {
         try {
             ImmutableAttributes attributes = resolveState.getRoot().getMetadata().getAttributes();
             attributes = resolveState.getAttributesFactory().concat(attributes, getAttributes());
+            if (isConstraint()) {
+                attributes = selector.getTargetModule().mergeConstraintAttributesWithHardDependencyAttributes(attributes);
+            }
             targetConfigurations = dependencyMetadata.selectConfigurations(attributes, targetModuleVersion, resolveState.getAttributesSchema());
         } catch (Exception t) {
             // Failure to select the target variant/configurations from this component, given the dependency attributes/metadata.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -65,6 +65,13 @@ class ModuleResolveState implements CandidateModule {
     private final PendingDependencies pendingDependencies;
     private ComponentState selected;
     private ImmutableAttributes mergedConstraintAttributes = ImmutableAttributes.EMPTY;
+
+    // This field caches an arbitrary edge attributes, used when computing the attributes
+    // of selection of a constraint, in order to make sure we choose a "variant of the constraint"
+    // which is compatible with edges. In theory we shouldn't select a variant for constraints, but
+    // since they are represented as node states, it's required
+    private ImmutableAttributes nonConstraintAttributes = null;
+
     private AttributeMergingException attributeMergingError;
     private VirtualPlatformState platformState;
     private boolean overriddenSelection;
@@ -278,6 +285,7 @@ class ModuleResolveState implements CandidateModule {
     void removeSelector(SelectorState selector) {
         selectors.remove(selector);
         mergedConstraintAttributes = ImmutableAttributes.EMPTY;
+        nonConstraintAttributes = null;
         for (SelectorState selectorState : selectors) {
             mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
         }
@@ -302,13 +310,25 @@ class ModuleResolveState implements CandidateModule {
         return attributesFactory.concat(mergedConstraintAttributes, attributes);
     }
 
+    ImmutableAttributes mergeConstraintAttributesWithHardDependencyAttributes(ImmutableAttributes constraintAttributes) {
+        if (nonConstraintAttributes != null) {
+            return attributesFactory.concat(nonConstraintAttributes, constraintAttributes);
+        }
+        return constraintAttributes;
+    }
+
     private ImmutableAttributes appendAttributes(ImmutableAttributes dependencyAttributes, SelectorState selectorState) {
         try {
             DependencyMetadata dependencyMetadata = selectorState.getDependencyMetadata();
-            if (dependencyMetadata.isConstraint()) {
-                ComponentSelector selector = dependencyMetadata.getSelector();
-                ImmutableAttributes attributes = ((AttributeContainerInternal) selector.getAttributes()).asImmutable();
-                dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
+            boolean constraint = dependencyMetadata.isConstraint();
+            if (nonConstraintAttributes == null && !constraint) {
+                nonConstraintAttributes = ((AttributeContainerInternal) selectorState.getRequested().getAttributes()).asImmutable();
+            } else {
+                if (constraint) {
+                    ComponentSelector selector = dependencyMetadata.getSelector();
+                    ImmutableAttributes attributes = ((AttributeContainerInternal) selector.getAttributes()).asImmutable();
+                    dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
+                }
             }
         } catch (AttributeMergingException e) {
             attributeMergingError = e;


### PR DESCRIPTION
### Context

This commit fixes #8306 by making sure that if we resolve a constraint
edge and need to select a configuration based on attributes, we
consider the attributes of at least one real edge on it before resolving.

This allows the engine to consider attributes on constraints as requirements,
but also not to forget about edge constraints if they were any.
