### PR TITLE
Add test for #8299

### DIFF
--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/StaleOutputIntegrationTest.groovy
@@ -119,6 +119,39 @@ class StaleOutputIntegrationTest extends AbstractIntegrationSpec {
         executedAndNotSkipped(taskWithSources.taskPath)
     }
 
+    @Issue("https://github.com/gradle/gradle/issues/8299")
+    def "two tasks can output in the same directory with --rerun-tasks"() {
+        buildFile << """
+            apply plugin: 'base'
+            
+            task firstCopy {
+                inputs.file('first.file')
+                outputs.dir('build/destination')
+                doLast {
+                    file('build/destination/first.file').text = file('first.file').text
+                }
+            }
+            
+            task secondCopy {
+                inputs.file('second.file')
+                outputs.dir('build/destination')
+                doLast {
+                    file('build/destination/second.file').text = file('second.file').text
+                }
+            }
+            
+            secondCopy.dependsOn firstCopy
+        """
+        file("first.file").createFile()
+        file("second.file").createFile()
+
+        when:
+        succeeds("secondCopy", "--rerun-tasks", "--info")
+        then:
+        file("build/destination/first.file").exists()
+        file("build/destination/second.file").exists()
+    }
+
     def "custom clean targets are removed"() {
         given:
         buildFile << """


### PR DESCRIPTION
Seems like #8299 has been fixed between 5.1.1 and the current release branch. I am adding this test so it won't come back.