### PR TITLE
Avoid "undefined" module path breaking Javadoc search

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -323,6 +323,7 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
 
     if (BuildEnvironment.javaVersion.isJava11Compatible()) {
         options.addBooleanOption('html4', true)
+        options.addBooleanOption('-no-module-directories', true)
         doLast {
             // This is a work-around for https://bugs.openjdk.java.net/browse/JDK-8211194. Can be removed once that issue is fixed on JDK's side
             // Since JDK 11, package-list is missing from javadoc output files and superseded by element-list file, but a lot of external tools still need it


### PR DESCRIPTION
Due to https://bugs.openjdk.java.net/browse/JDK-8196202 JDK 11 breaks
the search box in generated javadocs because module directories are
assumed.

This JDK bug is fixed in JDK 12, but until then we need to add
'--no-module-directories' to the javadoc options.

Issue: gradle/dotorg-docs#335
