### PR TITLE
Minor fix around BOM processing

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -151,7 +151,9 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
 
     private void addDependencies(GradlePomModuleDescriptorBuilder mdBuilder, PomReader pomReader) {
         for (PomDependencyMgt dependencyMgt : pomReader.getDependencyMgt().values()) {
-            mdBuilder.addConstraint(dependencyMgt);
+            if (!isDependencyImportScoped(dependencyMgt)) {
+                mdBuilder.addConstraint(dependencyMgt);
+            }
         }
 
         for (PomDependencyData dependency : pomReader.getDependencies().values()) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserProfileTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParserProfileTest.groovy
@@ -495,7 +495,7 @@ class GradlePomModuleDescriptorParserProfileTest extends AbstractGradlePomModule
 
         then:
         def deps = metadata.dependencies
-        deps.size() == 3
+        deps.size() == 2
         def dep = metadata.dependencies[0]
         dep.selector == moduleId('group-two', 'artifact-two', '1.2')
         dep.scope == MavenScope.Compile


### PR DESCRIPTION
* When Gradle transforms an imported BOM into an inlined set of constraints, it no longer declares the BOM coordinates as a constraint as well.
* Added a test showing that, similar to Maven, exclusions on an imported BOM are a no-op.