### PR TITLE
Spelling

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTask.groovy
@@ -65,7 +65,7 @@ class ExtractDslMetaDataTask extends SourceTask {
         }
 
         //updating/modifying the metadata and making sure every type reference across the metadata is fully qualified
-        //so, the superClassName, interafaces and types needed by declared properties and declared methods will have fully qualified name
+        //so, the superClassName, interfaces and types needed by declared properties and declared methods will have fully qualified name
         TypeNameResolver resolver = new TypeNameResolver(repository)
         repository.each { name, metaData ->
             fullyQualifyAllTypeNames(metaData, resolver)

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/GrammarDelegate.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/GrammarDelegate.java
@@ -30,9 +30,9 @@ import java.util.List;
 public class GrammarDelegate {
     public static List<GrammarDelegate> extractGrammarDelegates(GrammarFile antlrGrammarFile) {
         List<GrammarDelegate> grammarDelegates = new ArrayList<GrammarDelegate>();
-        Enumeration grammarFileGramars = antlrGrammarFile.getGrammars().elements();
-        while (grammarFileGramars.hasMoreElements()) {
-            grammarDelegates.add(new GrammarDelegate(grammarFileGramars.nextElement()));
+        Enumeration grammarFileGrammars = antlrGrammarFile.getGrammars().elements();
+        while (grammarFileGrammars.hasMoreElements()) {
+            grammarDelegates.add(new GrammarDelegate(grammarFileGrammars.nextElement()));
         }
         return grammarDelegates;
     }
@@ -82,7 +82,7 @@ public class GrammarDelegate {
     /**
      * Retrieves the name of this vocabulary imported by this grammar.
      *
-     * @return The gammar's imported vocabulary name.
+     * @return The grammar's imported vocabulary name.
      */
     public String getImportVocab() {
         return importVocab;
@@ -91,7 +91,7 @@ public class GrammarDelegate {
     /**
      * Retrieves the name of this vocabulary exported by this grammar.
      *
-     * @return The gammar's exported vocabulary name.
+     * @return The grammar's exported vocabulary name.
      */
     public String getExportVocab() {
         return exportVocab;

--- a/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/GrammarFileMetadata.java
+++ b/subprojects/antlr/src/main/java/org/gradle/api/plugins/antlr/internal/antlr2/GrammarFileMetadata.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Models information about an Antlr grammar file, including the inidividual {@link #getGrammars grammars} (lexers,
+ * Models information about an Antlr grammar file, including the individual {@link #getGrammars grammars} (lexers,
  * parsers, etc) contained within it.
  */
 public class GrammarFileMetadata {

--- a/subprojects/base-services-groovy/base-services-groovy.gradle.kts
+++ b/subprojects/base-services-groovy/base-services-groovy.gradle.kts
@@ -17,7 +17,7 @@ import org.gradle.gradlebuild.unittestandcompile.ModuleType
  */
 plugins {
     `java-library`
-    // DynamicObjectAware and DynamicObjectUtil should move to org.gralde.internal.metaobject (but it breaks third-party plugins)
+    // DynamicObjectAware and DynamicObjectUtil should move to org.gradle.internal.metaobject (but it breaks third-party plugins)
     // gradlebuild.classycle
 }
 

--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/packaging/impl/TarBuildCacheEntryPacker.java
@@ -305,8 +305,8 @@ public class TarBuildCacheEntryPacker implements BuildCacheEntryPacker {
                 FileUtils.forceMkdir(file);
                 chmodUnpackedFile(entry, file);
                 String internedAbsolutePath = stringInterner.intern(file.getAbsolutePath());
-                String indernedDirName = stringInterner.intern(parser.getName());
-                builder.preVisitDirectory(internedAbsolutePath, indernedDirName);
+                String internedDirName = stringInterner.intern(parser.getName());
+                builder.preVisitDirectory(internedAbsolutePath, internedDirName);
             } else {
                 RegularFileSnapshot fileSnapshot = unpackFile(input, entry, file, parser.getName());
                 builder.visit(fileSnapshot);

--- a/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/compare/internal/BuildOutcomeComparisonResult.java
+++ b/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/compare/internal/BuildOutcomeComparisonResult.java
@@ -22,7 +22,7 @@ import org.gradle.api.plugins.buildcomparison.outcome.internal.BuildOutcomeAssoc
 /**
  * The result of a comparison between to associated build outcomes.
  *
- * Implementors exposes information about how the outcomes were different.
+ * Implementers exposes information about how the outcomes were different.
  *
  * @param <T> The type of outcome that was compared.
  */

--- a/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/outcome/internal/BuildOutcomeAssociation.java
+++ b/subprojects/build-comparison/src/main/java/org/gradle/api/plugins/buildcomparison/outcome/internal/BuildOutcomeAssociation.java
@@ -40,7 +40,7 @@ public interface BuildOutcomeAssociation<T extends BuildOutcome> {
     /**
      * The common type of the from and to outcomes.
      *
-     * The from and to outcomes may be subtypes or implementors of this type. This type
+     * The from and to outcomes may be subtypes or implementers of this type. This type
      * will be used to determine how they should be compared.
      *
      * @return The common type of the from and to outcomes. Never null.

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultSourceDirectorySet.java
@@ -73,7 +73,7 @@ public class DefaultSourceDirectorySet extends CompositeFileTree implements Sour
         this.outputDir = objectFactory.property(File.class);
     }
 
-    // Used by the Javascript plugins
+    // Used by the JavaScript plugins
     @Deprecated
     public DefaultSourceDirectorySet(String name, String displayName, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
         this(name, displayName, fileResolver, directoryFileTreeFactory, new InstantiatorBackedObjectFactory(DirectInstantiator.INSTANCE));

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskOutputCachingDisabledReasonCategory.java
@@ -64,7 +64,7 @@ public enum TaskOutputCachingDisabledReasonCategory {
     OVERLAPPING_OUTPUTS,
 
     /**
-     * The task implementation is not cacheable. Reasons for non-cacheable task implemenations:
+     * The task implementation is not cacheable. Reasons for non-cacheable task implementations:
      * <ul>
      *     <li>the task type is loaded via a custom classloader Gradle wasn't able to track,</li>
      *     <li>a Java lambda was used to implement the task (see https://github.com/gradle/gradle/issues/5510).</li>

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -528,8 +528,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         this.filter = filter;
     }
 
-    public void setContinueOnFailure(boolean continueOnFailre) {
-        this.continueOnFailure = continueOnFailre;
+    public void setContinueOnFailure(boolean continueOnFailure) {
+        this.continueOnFailure = continueOnFailure;
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -1475,14 +1475,14 @@ public class GradleResolveVisitor extends ResolveVisitor {
             resolveOrFail(anInterface, node, true);
         }
 
-        checkCyclicInheritence(node, node.getUnresolvedSuperClass(), node.getInterfaces());
+        checkCyclicInheritance(node, node.getUnresolvedSuperClass(), node.getInterfaces());
 
         super.visitClass(node);
 
         currentClass = oldNode;
     }
 
-    private void checkCyclicInheritence(ClassNode originalNode, ClassNode parentToCompare, ClassNode[] interfacesToCompare) {
+    private void checkCyclicInheritance(ClassNode originalNode, ClassNode parentToCompare, ClassNode[] interfacesToCompare) {
         if (!originalNode.isInterface()) {
             if (parentToCompare == null) {
                 return;
@@ -1502,7 +1502,7 @@ public class GradleResolveVisitor extends ResolveVisitor {
             if (parentToCompare == ClassHelper.OBJECT_TYPE) {
                 return;
             }
-            checkCyclicInheritence(originalNode, parentToCompare.getUnresolvedSuperClass(), null);
+            checkCyclicInheritance(originalNode, parentToCompare.getUnresolvedSuperClass(), null);
         } else {
             if (interfacesToCompare != null && interfacesToCompare.length > 0) {
                 // check interfaces at this level first
@@ -1514,7 +1514,7 @@ public class GradleResolveVisitor extends ResolveVisitor {
                 }
                 // check next level of interfaces
                 for (ClassNode intf : interfacesToCompare) {
-                    checkCyclicInheritence(originalNode, null, intf.getInterfaces());
+                    checkCyclicInheritance(originalNode, null, intf.getInterfaces());
                 }
             } else {
                 return;

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -74,7 +74,7 @@ import java.util.Set;
 
 /**
  * A Gradle version of the Groovy {@link ResolveVisitor} that takes some shortcuts to make resolving faster. It tries to be as close as the original implementation, while having a significant impact
- * on performance, by taking advantage of knowlegdge of Gradle default imports, including a mapping from simple name to fully qualified class name. It also avoids unnecessary lookups of classnodes.
+ * on performance, by taking advantage of knowledge of Gradle default imports, including a mapping from simple name to fully qualified class name. It also avoids unnecessary lookups of classnodes.
  *
  * @since 2.12
  */

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/internal/GradleResolveVisitor.java
@@ -404,7 +404,7 @@ public class GradleResolveVisitor extends ResolveVisitor {
         // to access that class directly, so A becomes a valid
         // name in X.
         // GROOVY-4043: Do this check up the hierarchy, if needed
-        Map<String, ClassNode> hierClasses = new LinkedHashMap<String, ClassNode>();
+        Map<String, ClassNode> classHierarchy = new LinkedHashMap<String, ClassNode>();
         ClassNode val;
         for (ClassNode classToCheck = currentClass;
             /*
@@ -413,13 +413,13 @@ public class GradleResolveVisitor extends ResolveVisitor {
              */
              classToCheck != null && classToCheck != ClassHelper.OBJECT_TYPE && !SCRIPTS_PACKAGE.equals(classToCheck.getPackageName());
              classToCheck = classToCheck.getSuperClass()) {
-            if (hierClasses.containsKey(classToCheck.getName())) {
+            if (classHierarchy.containsKey(classToCheck.getName())) {
                 break;
             }
-            hierClasses.put(classToCheck.getName(), classToCheck);
+            classHierarchy.put(classToCheck.getName(), classToCheck);
         }
 
-        for (ClassNode classToCheck : hierClasses.values()) {
+        for (ClassNode classToCheck : classHierarchy.values()) {
             val = new ConstructedNestedClass(classToCheck, type.getName());
             if (resolveFromCompileUnit(val)) {
                 type.setRedirect(val);

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleApiSpecProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleApiSpecProvider.java
@@ -55,7 +55,7 @@ public interface GradleApiSpecProvider {
     }
 
     /**
-     * Empty {@link Spec} implementation to be extended by SPI implementors to isolate them
+     * Empty {@link Spec} implementation to be extended by SPI implementers to isolate them
      * from changes to the interface.
      */
     class SpecAdapter implements Spec {

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/internal/DefaultListenerBuildOperationDecoratorTest.groovy
@@ -49,7 +49,7 @@ class DefaultListenerBuildOperationDecoratorTest extends Specification {
     def context = new TestUserCodeApplicationContext()
     def decorator = new DefaultListenerBuildOperationDecorator(buildOperationExecutor, context)
 
-    def 'ignores implementors of InternalListener'() {
+    def 'ignores implementers of InternalListener'() {
         given:
         def action = Mock(InternalAction)
         def buildListener = new InternalBuildAdapter()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/AlignmentIntegrationTest.groovy
@@ -713,7 +713,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 byPublishedPlatform('org.springframework', 'spring-platform', '1.0')
             }
 
-            // Spring core intentionnaly doesn't belong to the Spring platform.
+            // Spring core intentionally doesn't belong to the Spring platform.
             module('core') group('org.springframework') tries('1.0') alignsTo('1.1')
         }
         run ':checkDeps'
@@ -795,7 +795,7 @@ class AlignmentIntegrationTest extends AbstractAlignmentSpec {
                 byPublishedPlatform('org.springframework', 'spring-platform', '1.0')
             }
 
-            // Spring core intentionnaly doesn't belong to the Spring platform.
+            // Spring core intentionally doesn't belong to the Spring platform.
             module('core') group('org.springframework') tries('1.0') alignsTo('1.1')
         }
         run ':checkDeps'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesDependencyResolveIntegTest.groovy
@@ -51,7 +51,7 @@ class  ComponentSelectionRulesDependencyResolveIntegTest extends AbstractCompone
 """
 
         when:
-        def chosenModule = setupInterations(selector, chosenVersion, downloadedMetadata)
+        def chosenModule = setupInteractions(selector, chosenVersion, downloadedMetadata)
 
         then:
         checkDependencies {
@@ -85,7 +85,7 @@ class  ComponentSelectionRulesDependencyResolveIntegTest extends AbstractCompone
         "1.1"                | "select branch" | "1.1"         | '["1.1"]'        | ['1.1']            | false           | false            | []
     }
 
-    private String setupInterations(String selector, String chosenVersion, List<String> downloadedMetadata, Closure<Void> more = {}) {
+    private String setupInteractions(String selector, String chosenVersion, List<String> downloadedMetadata, Closure<Void> more = {}) {
         def chosenModule = chosenVersion ? (chosenVersion.contains('-lib') ? 'lib' : 'api') : null
         repositoryInteractions {
             'org.utils:api' {
@@ -143,7 +143,7 @@ class  ComponentSelectionRulesDependencyResolveIntegTest extends AbstractCompone
 """
 
         when:
-        setupInterations(selector, null, downloadedMetadata)
+        setupInteractions(selector, null, downloadedMetadata)
 
         then:
         checkDependencies(':checkLenient')
@@ -204,7 +204,7 @@ class  ComponentSelectionRulesDependencyResolveIntegTest extends AbstractCompone
 """
 
         when:
-        setupInterations('1.+', null, ['1.2', '1.1', '1.0'])
+        setupInteractions('1.+', null, ['1.2', '1.1', '1.0'])
 
         then:
         fails ':checkDeps'
@@ -281,7 +281,7 @@ Required by:
 """
 
         when:
-        setupInterations(selector, null, downloadedMetadata)
+        setupInteractions(selector, null, downloadedMetadata)
 
         then:
         checkDependencies(':checkLenient')
@@ -406,7 +406,7 @@ Required by:
         """
 
         when:
-        setupInterations(selector, chosen, downloadedMetadata) {
+        setupInteractions(selector, chosen, downloadedMetadata) {
             'org.utils:lib' {
                 expectVersionListing()
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyResolveRulesPreferProjectModulesIntegrationTest.groovy
@@ -120,7 +120,7 @@ class DependencyResolveRulesPreferProjectModulesIntegrationTest extends Abstract
                 }
 
                 ${AbstractProjectDependencyConflictResolutionIntegrationSpec.check('ModuleC', 'projectId("ModuleC")', 'baseConf', 'projectId("ModuleC")')}
-                // 'preferProjectModules()' is not inehrited from 'baseConf'
+                // 'preferProjectModules()' is not inherited from 'baseConf'
                 // and hence the higher version is picked from repo
                 ${AbstractProjectDependencyConflictResolutionIntegrationSpec.check('ModuleC', 'projectId("ModuleC")', 'conf', 'moduleId("myorg", "ModuleC", "2.0")')}
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/suppliers/CustomVersionListerIntegrationTest.groovy
@@ -98,7 +98,7 @@ class CustomVersionListerIntegrationTest extends AbstractModuleDependencyResolve
         failure.assertHasCause("Could not find any matches for org:testA:+ as no versions of org:testA are available.")
     }
 
-    void "can version listing can use module identifer to return the version list"() {
+    void "can version listing can use module identifier to return the version list"() {
         withLister([testA: [1, 2, 3], testB: [1, 2]])
         given:
         repository {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/CachingDependencySubstitutionApplicator.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/CachingDependencySubstitutionApplicator.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.util.Map;
 
 /**
- * This caching substitutor is not indended to be called from places where it can be executed concurrently.
+ * This caching substitutor is not intended to be called from places where it can be executed concurrently.
  */
 @NotThreadSafe
 public class CachingDependencySubstitutionApplicator implements DependencySubstitutionApplicator {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousConfigurationSelectionException.java
@@ -85,13 +85,13 @@ public class AmbiguousConfigurationSelectionException extends RuntimeException {
         for (Attribute<?> attribute : consumerAttributes.keySet()) {
             allAttributes.put(attribute.getName(), attribute);
         }
-        ImmutableAttributes immmutableConsumer = consumerAttributes.asImmutable();
+        ImmutableAttributes immutableConsumer = consumerAttributes.asImmutable();
         ImmutableAttributes immutableProducer = producerAttributes.asImmutable();
         formatter.startChildren();
         for (Attribute<?> attribute : allAttributes.values()) {
             Attribute<Object> untyped = Cast.uncheckedCast(attribute);
             String attributeName = attribute.getName();
-            AttributeValue<Object> consumerValue = immmutableConsumer.findEntry(untyped);
+            AttributeValue<Object> consumerValue = immutableConsumer.findEntry(untyped);
             AttributeValue<?> producerValue = immutableProducer.findEntry(attribute.getName());
             if (consumerValue.isPresent() && producerValue.isPresent()) {
                 if (attributeMatcher.isMatching(untyped, producerValue.coerce(attribute), consumerValue.coerce(attribute))) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -100,7 +100,7 @@ public interface MutableModuleComponentResolveMetadata {
 
     /**
      * Declares that this component belongs to a platform.
-     * @param platform the identifer of the platform
+     * @param platform the identifier of the platform
      */
     void belongsTo(ComponentIdentifier platform);
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ModuleIdentifierNotationConverterTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/notations/ModuleIdentifierNotationConverterTest.groovy
@@ -36,7 +36,7 @@ class ModuleIdentifierNotationConverterTest extends Specification {
     }
     @Subject parser = NotationParserBuilder.toType(ModuleIdentifier).fromCharSequence(new ModuleIdentifierNotationConverter(moduleIdentifierFactory)).toComposite()
 
-    def "parses module identifer notation"() {
+    def "parses module identifier notation"() {
         expect:
         parser.parseNotation("org.gradle:gradle-core") == newId("org.gradle", "gradle-core")
         parser.parseNotation(" foo:bar ") == newId("foo", "bar")

--- a/subprojects/docs/src/docs/userguide/comparing_builds.adoc
+++ b/subprojects/docs/src/docs/userguide/comparing_builds.adoc
@@ -38,7 +38,7 @@ By comparing builds in these scenarios you can make an informed decision about t
 The following are the terms used for build comparison and their definitions.
 
 “Build”::
-In the context of build comparison, a build is not necessarily a Gradle build. It can be any invokable “process” that produces observable “outcomes”. At least one of the builds in a comparison will be a Gradle build.
+In the context of build comparison, a build is not necessarily a Gradle build. It can be any invocable “process” that produces observable “outcomes”. At least one of the builds in a comparison will be a Gradle build.
 “Build Outcome”::
 Something that happens in an observable manner during a build, such as the creation of a zip file or test execution. These are the things that are compared.
 “Source Build”::

--- a/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
+++ b/subprojects/docs/src/docs/userguide/kotlin_dsl.adoc
@@ -41,7 +41,7 @@ If you are interested in migrating an existing Gradle build to the Kotlin DSL, p
 [[sec:ide_support]]
 == IDE support
 
-The Kotlin DSL is fully supported by Intellij IDEA and Android Studio. Other IDEs do not yet provide helpful tools for editing Kotlin DSL files, but you can still import Kotlin-DSL-based builds and work with them as usual.
+The Kotlin DSL is fully supported by IntelliJ IDEA and Android Studio. Other IDEs do not yet provide helpful tools for editing Kotlin DSL files, but you can still import Kotlin-DSL-based builds and work with them as usual.
 
 .IDE support matrix
 [cols=">.^,^.^,^.^,^.^",frame=none,grid=rows,options="header"]

--- a/subprojects/docs/src/samples/customModel/languageType/src/docs/userguide/chapter1.md
+++ b/subprojects/docs/src/samples/customModel/languageType/src/docs/userguide/chapter1.md
@@ -1,4 +1,4 @@
-# Chapter 1 - Intoduction
+# Chapter 1 - Introduction
 
 ## Hello World
 

--- a/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/TestDB.h
+++ b/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/TestDB.h
@@ -166,7 +166,7 @@ typedef CU_Suite* CU_pSuite;          /**< Pointer to a CUnit suite. */
  *  holds a pointer to the head of the linked list of CU_Suite objects.
  *  <br /><br />
  *
- *  With this structure, the user will normally add suites implictly to 
+ *  With this structure, the user will normally add suites implicitly to 
  *  the internal test registry using CU_add_suite(), and then add tests 
  *  to each suite using CU_add_test().  Test runs are then initiated 
  *  using one of the appropriate functions in TestRun.c via one of the 

--- a/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/TestRun.h
+++ b/subprojects/docs/src/samples/native-binaries/cunit/libs/cunit/2.1-2/include/CUnit/TestRun.h
@@ -56,7 +56,7 @@
  *  The callback mechanism works as follows.  The CUnit runtime system
  *  supports the registering and calling of functions at the start and end
  *  of each test, when all tests are complete, and when a suite
- *  initialialization function returns an error.  This allows clients to
+ *  initialization function returns an error.  This allows clients to
  *  perform actions associated with these events such as output formatting
  *  and reporting.
  */
@@ -263,7 +263,7 @@ CU_EXPORT CU_ErrorCode CU_run_test(CU_pSuite pSuite, CU_pTest pTest);
  *  if it is not successful.  Both the suite and test specified
  *  must be active for the test to be run.  The suite is not
  *  considered to be run, although it may be counted as a failed
- *  suite if the intialization or cleanup functions fail.
+ *  suite if the initialization or cleanup functions fail.
  *
  *  @param pSuite The suite containing the test (non-NULL)
  *  @param pTest  The test to run (non-NULL)

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/gtest.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/gtest.h
@@ -1255,7 +1255,7 @@ class GTEST_API_ UnitTest {
   internal::UnitTestImpl* impl() { return impl_; }
   const internal::UnitTestImpl* impl() const { return impl_; }
 
-  // These classes and funcions are friends as they need to access private
+  // These classes and functions are friends as they need to access private
   // members of UnitTest.
   friend class Test;
   friend class internal::AssertHelper;

--- a/subprojects/docs/src/samples/native-binaries/prebuilt/3rd-party-lib/boost_1_55_0/boost/version.hpp
+++ b/subprojects/docs/src/samples/native-binaries/prebuilt/3rd-party-lib/boost_1_55_0/boost/version.hpp
@@ -10,7 +10,7 @@
 #define BOOST_VERSION_HPP
 
 //
-//  Caution, this is the only boost header that is guarenteed
+//  Caution, this is the only boost header that is guaranteed
 //  to change with every boost release, including this header
 //  will cause a recompile every time a new boost version is
 //  released.

--- a/subprojects/docs/src/samples/play/play-2.6/conf/application.conf
+++ b/subprojects/docs/src/samples/play/play-2.6/conf/application.conf
@@ -71,7 +71,7 @@ play.modules {
 # use of the IntelliJ IDEA REST interface:
 #play.editor="http://localhost:63342/api/file/?file=%s&line=%s"
 
-## Internationalisation
+## Internationalization
 # https://www.playframework.com/documentation/latest/JavaI18N
 # https://www.playframework.com/documentation/latest/ScalaI18N
 # ~~~~~

--- a/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioCppApplicationProjectIntegrationTest.groovy
+++ b/subprojects/ide-native/src/integTest/groovy/org/gradle/ide/visualstudio/VisualStudioCppApplicationProjectIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.language.VariantContext
 import org.gradle.nativeplatform.fixtures.app.CppApp
 import org.gradle.nativeplatform.fixtures.app.CppSourceElement
 
-class VisualStudioCppApplicationProjectIntegationTest extends AbstractVisualStudioProjectIntegrationTest {
+class VisualStudioCppApplicationProjectIntegrationTest extends AbstractVisualStudioProjectIntegrationTest {
     @Override
     void makeSingleProject() {
         buildFile << """

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest.groovy
@@ -496,7 +496,7 @@ dependencies {
         } catch (AssertionFailedError error) {
             println "EXPECTED:\n${expectedXml}"
             println "ACTUAL:\n${actualXml}"
-            throw new ComparisonFailure("Comparison filure: expected: $expectedFile, actual: $actualFile"
+            throw new ComparisonFailure("Comparison failure: expected: $expectedFile, actual: $actualFile"
                 + "\nUnexpected content for generated actualFile: ${error.message}", expectedXml, actualXml).initCause(error)
         }
     }

--- a/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
+++ b/subprojects/ide/src/integTest/groovy/org/gradle/plugins/ide/idea/IdeaIntegrationTest.groovy
@@ -431,7 +431,7 @@ apply plugin: 'org.gradle.scala-lang'
         } catch (AssertionFailedError error) {
             println "EXPECTED:\n${expectedXml}"
             println "ACTUAL:\n${actualXml}"
-            throw new ComparisonFailure("Comparison filure: expected: $expectedFile, actual: $actualFile"
+            throw new ComparisonFailure("Comparison failure: expected: $expectedFile, actual: $actualFile"
                 + "\nUnexpected content for generated actualFile: ${error.message}", expectedXml, actualXml).initCause(error)
         }
     }

--- a/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompile.java
+++ b/subprojects/javascript/src/main/java/org/gradle/plugins/javascript/coffeescript/CoffeeScriptCompile.java
@@ -66,7 +66,7 @@ public class CoffeeScriptCompile extends SourceTask {
     }
 
     /**
-     * Sets Coffee Script Javascript file.
+     * Sets Coffee Script JavaScript file.
      *
      * @since 4.0
      */

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileFilesFactory.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileFilesFactory.java
@@ -56,11 +56,11 @@ public class IncrementalCompileFilesFactory {
         this.ignoreUnresolvedHeadersInDependencies = Boolean.getBoolean(IGNORE_UNRESOLVED_HEADERS_IN_DEPENDENCIES_PROPERTY_NAME);
     }
 
-    public IncementalCompileSourceProcessor files(CompilationState previousCompileState) {
-        return new DefaultIncementalCompileSourceProcessor(previousCompileState);
+    public IncrementalCompileSourceProcessor files(CompilationState previousCompileState) {
+        return new DefaultIncrementalCompileSourceProcessor(previousCompileState);
     }
 
-    private class DefaultIncementalCompileSourceProcessor implements IncementalCompileSourceProcessor {
+    private class DefaultIncrementalCompileSourceProcessor implements IncrementalCompileSourceProcessor {
         private final CompilationState previous;
         private final BuildableCompilationState current = new BuildableCompilationState();
         private final List<File> toRecompile = new ArrayList<File>();
@@ -68,7 +68,7 @@ public class IncrementalCompileFilesFactory {
         private final Map<File, FileDetails> visitedFiles = new HashMap<File, FileDetails>();
         private boolean hasUnresolvedHeaders;
 
-        DefaultIncementalCompileSourceProcessor(CompilationState previousCompileState) {
+        DefaultIncrementalCompileSourceProcessor(CompilationState previousCompileState) {
             this.previous = previousCompileState == null ? new CompilationState() : previousCompileState;
         }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessor.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileProcessor.java
@@ -40,7 +40,7 @@ public class IncrementalCompileProcessor {
             @Override
             public IncrementalCompilation call(BuildOperationContext context) {
                 CompilationState previousCompileState = previousCompileStateCache.get();
-                IncementalCompileSourceProcessor processor = incrementalCompileFilesFactory.files(previousCompileState);
+                IncrementalCompileSourceProcessor processor = incrementalCompileFilesFactory.files(previousCompileState);
                 for (File sourceFile : sourceFiles) {
                     processor.processSource(sourceFile);
                 }

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileSourceProcessor.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalCompileSourceProcessor.java
@@ -18,7 +18,7 @@ package org.gradle.language.nativeplatform.internal.incremental;
 
 import java.io.File;
 
-public interface IncementalCompileSourceProcessor {
+public interface IncrementalCompileSourceProcessor {
     void processSource(File sourceFile);
 
     IncrementalCompilation getResult();

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/DaemonCommandLineConverterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/cli/converter/DaemonCommandLineConverterTest.groovy
@@ -49,10 +49,10 @@ class DaemonCommandLineConverterTest extends Specification {
         def converted = convert(options)
 
         then:
-        converted.foreground == foregound
+        converted.foreground == foreground
 
         where:
-        options                         | foregound
+        options                         | foreground
         []                              | false
         ['--foreground']                | true
         ['--foreground', '--no-daemon'] | true

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultColorMapTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultColorMapTest.groovy
@@ -57,7 +57,7 @@ class DefaultColorMapTest extends Specification {
         this.map = new DefaultColorMap()
         Ansi ansi = Mock()
 
-        when: 'A color is requested for SuccessHeder which is overridden'
+        when: 'A color is requested for SuccessHeader which is overridden'
         def color = map.getColourFor(Style.SuccessHeader)
         color.on(ansi)
 

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/AbstractDelegationBinding.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/AbstractDelegationBinding.java
@@ -20,20 +20,20 @@ import org.gradle.internal.reflect.PropertyAccessorType;
 import org.gradle.model.internal.method.WeaklyTypeReferencingMethod;
 
 public abstract class AbstractDelegationBinding extends AbstractStructMethodBinding implements StructMethodImplementationBinding {
-    private final WeaklyTypeReferencingMethod<?, ?> implementorMethod;
+    private final WeaklyTypeReferencingMethod<?, ?> implementerMethod;
 
-    public AbstractDelegationBinding(WeaklyTypeReferencingMethod<?, ?> source, WeaklyTypeReferencingMethod<?, ?> implementorMethod, PropertyAccessorType accessorType) {
+    public AbstractDelegationBinding(WeaklyTypeReferencingMethod<?, ?> source, WeaklyTypeReferencingMethod<?, ?> implementerMethod, PropertyAccessorType accessorType) {
         super(source, accessorType);
-        this.implementorMethod = implementorMethod;
+        this.implementerMethod = implementerMethod;
     }
 
     @Override
-    public WeaklyTypeReferencingMethod<?, ?> getImplementorMethod() {
-        return implementorMethod;
+    public WeaklyTypeReferencingMethod<?, ?> getImplementerMethod() {
+        return implementerMethod;
     }
 
     @Override
     public String toString() {
-        return getViewMethod() + " -> " + implementorMethod;
+        return getViewMethod() + " -> " + implementerMethod;
     }
 }

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/DefaultStructBindingsStore.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/DefaultStructBindingsStore.java
@@ -263,7 +263,7 @@ public class DefaultStructBindingsStore implements StructBindingsStore {
         Set<WeaklyTypeReferencingMethod<?, ?>> implMethods = Sets.newLinkedHashSet();
         for (StructMethodBinding binding : bindings) {
             if (binding instanceof StructMethodImplementationBinding) {
-                implMethods.add(((StructMethodImplementationBinding) binding).getImplementorMethod());
+                implMethods.add(((StructMethodImplementationBinding) binding).getImplementerMethod());
             }
         }
         switch (implMethods.size()) {

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/DirectMethodBinding.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/DirectMethodBinding.java
@@ -28,7 +28,7 @@ public class DirectMethodBinding extends AbstractStructMethodBinding implements 
     }
 
     @Override
-    public WeaklyTypeReferencingMethod<?, ?> getImplementorMethod() {
+    public WeaklyTypeReferencingMethod<?, ?> getImplementerMethod() {
         return getViewMethod();
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/StructMethodImplementationBinding.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/manage/binding/StructMethodImplementationBinding.java
@@ -19,5 +19,5 @@ package org.gradle.model.internal.manage.binding;
 import org.gradle.model.internal.method.WeaklyTypeReferencingMethod;
 
 public interface StructMethodImplementationBinding extends StructMethodBinding {
-    WeaklyTypeReferencingMethod<?, ?> getImplementorMethod();
+    WeaklyTypeReferencingMethod<?, ?> getImplementerMethod();
 }

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/binding/DefaultStructBindingsStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/binding/DefaultStructBindingsStoreTest.groovy
@@ -267,8 +267,8 @@ class DefaultStructBindingsStoreTest extends Specification {
         bindings.methodBindings*.getClass() == [DelegateMethodBinding, DelegateMethodBinding]
         bindings.methodBindings*.viewMethod*.name == ["getValue", "getValue"]
         bindings.methodBindings*.viewMethod*.method*.returnType == [Number, Integer]
-        bindings.methodBindings*.implementorMethod*.name == ["getValue", "getValue"]
-        bindings.methodBindings*.implementorMethod*.method*.returnType == [Integer, Integer]
+        bindings.methodBindings*.implementerMethod*.name == ["getValue", "getValue"]
+        bindings.methodBindings*.implementerMethod*.method*.returnType == [Integer, Integer]
     }
 
     static enum MyEnum {

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/gtest.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/gtest.h
@@ -1255,7 +1255,7 @@ class GTEST_API_ UnitTest {
   internal::UnitTestImpl* impl() { return impl_; }
   const internal::UnitTestImpl* impl() const { return impl_; }
 
-  // These classes and funcions are friends as they need to access private
+  // These classes and functions are friends as they need to access private
   // members of UnitTest.
   friend class Test;
   friend class internal::AssertHelper;

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayJavaScriptPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayJavaScriptPlugin.java
@@ -54,12 +54,12 @@ public class PlayJavaScriptPlugin implements Plugin<Project> {
 
     static class Rules extends RuleSource {
         @ComponentType
-        void registerJavaScript(TypeBuilder<JavaScriptSourceSet> builder) {
+        void registerJavascript(TypeBuilder<JavaScriptSourceSet> builder) {
             builder.defaultImplementation(DefaultJavaScriptSourceSet.class);
         }
 
         @Finalize
-        void createJavaScriptSourceSets(@Each PlayApplicationSpec playComponent) {
+        void createJavascriptSourceSets(@Each PlayApplicationSpec playComponent) {
             playComponent.getSources().create("javaScript", JavaScriptSourceSet.class, new Action<JavaScriptSourceSet>() {
                 @Override
                 public void execute(JavaScriptSourceSet javaScriptSourceSet) {

--- a/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayJavaScriptPlugin.java
+++ b/subprojects/platform-play/src/main/java/org/gradle/play/plugins/PlayJavaScriptPlugin.java
@@ -54,12 +54,12 @@ public class PlayJavaScriptPlugin implements Plugin<Project> {
 
     static class Rules extends RuleSource {
         @ComponentType
-        void registerJavascript(TypeBuilder<JavaScriptSourceSet> builder) {
+        void registerJavaScript(TypeBuilder<JavaScriptSourceSet> builder) {
             builder.defaultImplementation(DefaultJavaScriptSourceSet.class);
         }
 
         @Finalize
-        void createJavascriptSourceSets(@Each PlayApplicationSpec playComponent) {
+        void createJavaScriptSourceSets(@Each PlayApplicationSpec playComponent) {
             playComponent.getSources().create("javaScript", JavaScriptSourceSet.class, new Action<JavaScriptSourceSet>() {
                 @Override
                 public void execute(JavaScriptSourceSet javaScriptSourceSet) {

--- a/subprojects/reporting/src/main/java/org/gradle/api/reporting/Reporting.java
+++ b/subprojects/reporting/src/main/java/org/gradle/api/reporting/Reporting.java
@@ -61,7 +61,7 @@ public interface Reporting<T extends ReportContainer> {
     /**
      * A {@link ReportContainer} instance.
      * <p>
-     * Implementors specify a specific implementation of {@link ReportContainer} that describes the types of reports that
+     * Implementers specify a specific implementation of {@link ReportContainer} that describes the types of reports that
      * are available.
      *
      * @return The report container

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/SignatoryProvider.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/signatory/SignatoryProvider.java
@@ -36,7 +36,7 @@ public interface SignatoryProvider<T extends Signatory> {
     /**
      * <p>Attempts to create a signatory for the project that will be used everywhere something is to be signed and an explicit signatory has not been set (for the task/operation).</p>
      *
-     * <p>This may be called multiple times and the implementor is free to return a different instance if the project state has changed in someway that influences the default signatory.</p>
+     * <p>This may be called multiple times and the implementer is free to return a different instance if the project state has changed in someway that influences the default signatory.</p>
      *
      * @param project The project which the signatory is for
      * @return The signatory, or {@code null} if there is insufficient information available to create one.

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JavaScriptPluginsSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/JavaScriptPluginsSmokeTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.smoketests
 
 import org.gradle.testkit.runner.TaskOutcome
 
-class JavascriptPluginsSmokeTest extends AbstractSmokeTest {
+class JavaScriptPluginsSmokeTest extends AbstractSmokeTest {
 
     def 'js plugin'() {
         given:
@@ -60,7 +60,7 @@ class JavascriptPluginsSmokeTest extends AbstractSmokeTest {
             """.stripIndent()
 
         file("jsSrcDir/app.js") << """
-            console.log("Hello from Javascript");
+            console.log("Hello from JavaScript");
         """
 
         when:


### PR DESCRIPTION
### Context
Misspellings make it harder to search for things; they make it harder for people to understand code and descriptions; and sometimes they result in bugs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

I'm happy to drop files/directories if they're not yours -- I can't figure out if `subprojects/` is third party content.
I'm happy to split into, e.g. API, docs, code as requested.

--
Generated by https://github.com/jsoref/spelling `f` -- this is the misspelled `a` family

In short, my tool identifies candidates, I manually select and inspect candidates, and corrections are chosen by me manually (although I often let Google suggest the correction instead of typing it myself as it has a lower typo rate).

This is part 4 (part one was #8147)