### PR TITLE
Add section on controlling dependency versions to Maven migration guide

### DIFF
--- a/subprojects/docs/src/docs/userguide/migrating_from_maven.adoc
+++ b/subprojects/docs/src/docs/userguide/migrating_from_maven.adoc
@@ -288,6 +288,26 @@ If you want to share published artifacts via the filesystem, consider configurin
 
 You might also be interested in learning about Gradle's own <<dependency_cache#dependency_cache,dependency cache>>, which behaves more reliably than Maven's and can be used safely by multiple concurrent Gradle processes.
 
+[[migmvn:controlling_dep_versions]]
+=== Controlling dependency versions
+
+The existence of transitive dependencies means that you can very easily end up with multiple versions of the same dependency in your dependency graph.
+By default, Gradle will pick the newest version of a dependency in the graph, but that's not always the right solution.
+That's why it provides several mechanisms for controlling which version of a given dependency is resolved.
+
+On a per-project basis, you can use:
+
+ * <<managing_transitive_dependencies#sec:dependency_constraints,Dependency constraints>>
+ * <<migmvn:using_boms,Bills of materials>> (Maven BOMs)
+ * <<managing_transitive_dependencies#sec:enforcing_dependency_version,Version forcing>>
+
+There are even more, specialized options listed in the <<customizing_dependency_resolution_behavior#customizing_dependency_resolution_behavior,Customizing Dependency Resolution Behavior>> chapter.
+
+If you want to ensure consistency of versions across all projects in a multi-project build, similar to how the `<dependencyManagement>` block in Maven works, you can use the <<java_platform_plugin#java_platform_plugin,Java Platform Plugin>>.
+This allows you declare a set of dependency constraints that can be applied to multiple projects.
+You can even publish the platform as a Maven BOM or using Gradle's metadata format.
+See the plugin page for more information on how to do that, and in particular the section on <<java_platform_plugin#sec:java_platform_consumption,Consuming platforms>> to see how you can apply a platform to other projects in the same build.
+
 
 [[migmvn:excluding_deps]]
 === Excluding transitive dependencies
@@ -300,8 +320,7 @@ If you want to exclude a dependency for reasons unrelated to versions, then chec
 It shows you how to attach an exclusion either to an entire configuration (often the most appropriate solution) or to a dependency.
 You can even easily apply an exclusion to all configurations.
 
-If you're more interested in controlling which version of a dependency is actually resolved, then Gradle has better options than exclusions.
-Consider <<managing_transitive_dependencies#sec:dependency_constraints,using dependency constraints>> or <<managing_transitive_dependencies#sec:enforcing_dependency_version,forcing a particular version>>.
+If you're more interested in controlling which version of a dependency is actually resolved, see the previous section.
 
 [[migmvn:optional_deps]]
 === Handling optional dependencies
@@ -337,7 +356,7 @@ include::sample[dir="userguide/mavenMigration/importBom/kotlin",files="build.gra
 
 You can learn more about this feature and the difference between `platform()` and `enforcedPlatform()` in the section on <<managing_transitive_dependencies#sec:bom_import,importing version recommendations from a Maven BOM>>.
 
-NOTE: You can use this feature to apply the `<dependencyManagement>` information from any dependency's POM to the Gradle build, even those that don't have a packaging type of `pom`. However, `platform()` and `enforcedPlatform()` will ignore any dependencies declared in the `<dependencies>` block.
+NOTE: You can use this feature to apply the `<dependencyManagement>` information from any dependency's POM to the Gradle build, even those that don't have a packaging type of `pom`. Both `platform()` and `enforcedPlatform()` will ignore any dependencies declared in the `<dependencies>` block.
 
 [[migmvn:multimodule_builds]]
 == Migrating multi-module builds (project aggregation)


### PR DESCRIPTION
This change makes it clearer to Maven users how they should control dependency versions in Gradle builds. It also introduces the Java Platform Plugin as the solution for applying versions across a multi-project build.