### PR TITLE
Use JaCoCo 0.8.3 by default

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.8.2</literal></td>
+                <td><literal>0.8.3</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -8,6 +8,10 @@ Include only their name, impactful features should be called out separately belo
  [Some person](https://github.com/some-person)
 -->
 
+### Default JaCoCo version upgraded to 0.8.3
+
+[The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.3](http://www.jacoco.org/jacoco/trunk/doc/changes.html) instead of 0.8.2 by default.
+
 ## Improvements for plugin authors
 
 TBD - Abstract service injection getter methods

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/groovy/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.2"
+    toolVersion = "0.8.3"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/kotlin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.2"
+    toolVersion = "0.8.3"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -53,7 +53,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * The jacoco version used if none is explicitly specified.
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.8.2";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.3";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -46,6 +46,7 @@ class JacocoAgentJarTest extends Specification {
         '0.8.0'               | true
         '0.8.1'               | true
         '0.8.2'               | true
+        '0.8.3'               | true
     }
 
     @Unroll
@@ -69,5 +70,6 @@ class JacocoAgentJarTest extends Specification {
         '0.8.0'               | true
         '0.8.1'               | true
         '0.8.2'               | true
+        '0.8.3'               | true
     }
 }


### PR DESCRIPTION
This release includes

* Experimental support for Java 13 class files
* improved filters for Kotlin
* diagnostic messages in HTML report

Full changelog - http://www.jacoco.org/jacoco/trunk/doc/changes.html