### PR TITLE
Add test output only once to cache artifact

### DIFF
--- a/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestTaskReports.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/tasks/testing/TestTaskReports.java
@@ -19,7 +19,7 @@ package org.gradle.api.tasks.testing;
 import org.gradle.api.reporting.DirectoryReport;
 import org.gradle.api.reporting.Report;
 import org.gradle.api.reporting.ReportContainer;
-import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Internal;
 
 /**
  * The reports produced by the {@link Test} task.
@@ -31,7 +31,7 @@ public interface TestTaskReports extends ReportContainer<Report> {
      *
      * @return The HTML report
      */
-    @Nested
+    @Internal
     DirectoryReport getHtml();
 
     /**
@@ -39,7 +39,7 @@ public interface TestTaskReports extends ReportContainer<Report> {
      *
      * @return The test results in “JUnit XML” format
      */
-    @Nested
+    @Internal
     JUnitXmlReport getJunitXml();
 
 }

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/IncrementalTestIntegrationTest.groovy
@@ -126,4 +126,28 @@ public class BarTest {
         then:
         result.assertTaskSkipped(":test")
     }
+
+    def "does not re-run tests when parameter of disabled report changes"() {
+        buildFile << """
+            test {
+                reports.html {
+                    enabled = true
+                }
+                reports.junitXml {
+                    enabled = false
+                    outputPerTestCase = Boolean.parseBoolean(project.property('outputPerTestCase'))
+                }
+            }
+        """
+
+        when:
+        succeeds("test", "-PoutputPerTestCase=true")
+        then:
+        executedAndNotSkipped(":test")
+
+        when:
+        succeeds("test", "-PoutputPerTestCase=false")
+        then:
+        skipped(":test")
+    }
 }


### PR DESCRIPTION
Both reports have been added to the cached artifact by accident, since
the reports are declared as nested parameters via `enabledReports` on
the `ReportContainer` and the getters on `TestTaskReports`.

The annotated getters on `TestTaskReports` also prevented the test task
to be up-to-date when only the configuration for disabled reports
changed.
