### PR TITLE
Allow artifact transform parameter object to have property of type `ConfigurableFileCollection`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.model;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
@@ -88,6 +89,13 @@ public interface ObjectFactory {
      * @since 5.0
      */
     SourceDirectorySet sourceDirectorySet(String name, String displayName);
+
+    /**
+     * Creates a new {@link ConfigurableFileCollection}. The collection is initially empty.
+     *
+     * @since 5.3
+     */
+    ConfigurableFileCollection fileCollection();
 
     /**
      * Creates a {@link Property} implementation to hold values of the given type. The property has no initial value.

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskDefinitionIntegrationTest.groovy
@@ -565,4 +565,29 @@ class TaskDefinitionIntegrationTest extends AbstractIntegrationSpec {
         then:
         failure.assertHasCause("Adding a task provider directly to the task container is not supported.")
     }
+
+    def "can define task using abstract FileCollection getter"() {
+        given:
+        buildFile << """
+            abstract class MyTask extends DefaultTask {
+                @InputFiles
+                abstract ConfigurableFileCollection getSource()
+                
+                @TaskAction
+                void go() {
+                    println("files = \${source.files.name}")
+                }
+            }
+            
+            tasks.create("thing", MyTask) {
+                source.from("a", "b", "c")
+            }
+        """
+
+        when:
+        succeeds("thing")
+
+        then:
+        outputContains("files = [a, b, c]")
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -37,6 +37,13 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
     @Nullable
     private final TaskResolver taskResolver;
 
+    // Used by the Kotlin-dsl base plugin
+    // TODO - remove this
+    @Deprecated
+    public DefaultFileCollectionFactory() {
+        this(new IdentityFileResolver(), null);
+    }
+
     public DefaultFileCollectionFactory(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
         this.fileResolver = fileResolver;
         this.taskResolver = taskResolver;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -17,17 +17,36 @@
 package org.gradle.api.internal.file;
 
 import org.gradle.api.Buildable;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.FileCollectionAdapter;
 import org.gradle.api.internal.file.collections.ListBackedFileSet;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
+import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.tasks.TaskDependency;
+import org.gradle.internal.file.PathToFileResolver;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.Collections;
 
 public class DefaultFileCollectionFactory implements FileCollectionFactory {
+    private final PathToFileResolver fileResolver;
+    @Nullable
+    private final TaskResolver taskResolver;
+
+    public DefaultFileCollectionFactory(PathToFileResolver fileResolver, @Nullable TaskResolver taskResolver) {
+        this.fileResolver = fileResolver;
+        this.taskResolver = taskResolver;
+    }
+
+    @Override
+    public ConfigurableFileCollection configurableFiles() {
+        return new DefaultConfigurableFileCollection(fileResolver, taskResolver);
+    }
+
     @Override
     public FileCollection create(final TaskDependency builtBy, MinimalFileSet contents) {
         if (contents instanceof Buildable) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file;
 
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
 import org.gradle.api.tasks.TaskDependency;
@@ -54,4 +55,9 @@ public interface FileCollectionFactory {
      * The collection is not live. The provided {@link Iterable} is queried on construction and discarded.
      */
     FileCollection fixed(String displayName, Collection<File> files);
+
+    /**
+     * Creates an empty {@link ConfigurableFileCollection} instance.
+     */
+    ConfigurableFileCollection configurableFiles();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -17,12 +17,14 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.Named;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.file.DefaultSourceDirectorySet;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FilePropertyFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
@@ -53,13 +55,15 @@ public class DefaultObjectFactory implements ObjectFactory {
     private final FileResolver fileResolver;
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
     private final FilePropertyFactory filePropertyFactory;
+    private final FileCollectionFactory fileCollectionFactory;
 
-    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory) {
+    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory) {
         this.instantiator = instantiator;
         this.namedObjectInstantiator = namedObjectInstantiator;
         this.fileResolver = fileResolver;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         this.filePropertyFactory = filePropertyFactory;
+        this.fileCollectionFactory = fileCollectionFactory;
     }
 
     @Override
@@ -70,6 +74,11 @@ public class DefaultObjectFactory implements ObjectFactory {
     @Override
     public <T> T newInstance(Class<? extends T> type, Object... parameters) throws ObjectInstantiationException {
         return instantiator.newInstance(type, parameters);
+    }
+
+    @Override
+    public ConfigurableFileCollection fileCollection() {
+        return fileCollectionFactory.configurableFiles();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.model;
 
 import org.gradle.api.Named;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
@@ -43,6 +44,11 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     @Override
     public SourceDirectorySet sourceDirectorySet(String name, String displayName) {
         throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing source directory sets");
+    }
+
+    @Override
+    public ConfigurableFileCollection fileCollection() {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing file collections");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -48,12 +48,9 @@ import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.DynamicPropertyNamer;
-import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.MutationGuards;
-import org.gradle.internal.extensibility.NoConventionMapping;
 import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.ReflectiveNamedDomainObjectFactory;
 import org.gradle.api.internal.artifacts.Module;
@@ -86,6 +83,9 @@ import org.gradle.internal.Actions;
 import org.gradle.internal.Factories;
 import org.gradle.internal.Factory;
 import org.gradle.internal.event.ListenerBroadcast;
+import org.gradle.internal.extensibility.ExtensibleDynamicObject;
+import org.gradle.internal.extensibility.NoConventionMapping;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.logging.StandardOutputCapture;
 import org.gradle.internal.metaobject.BeanDynamicObject;
@@ -241,7 +241,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
         }
 
         services = serviceRegistryFactory.createFor(this);
-        taskContainer = services.newInstance(TaskContainerInternal.class);
+        taskContainer = services.get(TaskContainerInternal.class);
 
         extensibleDynamicObject = new ExtensibleDynamicObject(this, Project.class, services.get(InstantiatorFactory.class).injectAndDecorateLenient(services));
         if (parent != null) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -76,6 +76,7 @@ import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.concurrent.ParallelismConfigurationManager;
 import org.gradle.internal.environment.GradleBuildEnvironment;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.filewatch.DefaultFileWatcherFactory;
 import org.gradle.internal.filewatch.FileWatcherFactory;
 import org.gradle.internal.hash.DefaultStreamHasher;
@@ -251,10 +252,9 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultDirectoryFileTreeFactory(patternSetFactory, fileSystem);
     }
 
-    FileCollectionFactory createFileCollectionFactory() {
-        return new DefaultFileCollectionFactory();
+    FileCollectionFactory createFileCollectionFactory(PathToFileResolver fileResolver) {
+        return new DefaultFileCollectionFactory(fileResolver, null);
     }
-
 
     ModelRuleExtractor createModelRuleInspector(List<MethodModelRuleExtractor> extractors, ModelSchemaStore modelSchemaStore, StructBindingsStore structBindingsStore, ManagedProxyFactory managedProxyFactory) {
         List<MethodModelRuleExtractor> coreExtractors = MethodModelRuleExtractors.coreExtractors(modelSchemaStore);
@@ -317,13 +317,14 @@ public class GlobalScopeServices extends BasicGlobalScopeServices {
         return new DefaultMemoryManager(osMemoryInfo, jvmMemoryInfo, listenerManager, executorFactory);
     }
 
-    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory) {
+    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory) {
         return new DefaultObjectFactory(
             instantiatorFactory.injectAndDecorate(services),
             NamedObjectInstantiator.INSTANCE,
             fileResolver,
             directoryFileTreeFactory,
-            new DefaultFilePropertyFactory(fileResolver));
+            new DefaultFilePropertyFactory(fileResolver),
+            fileCollectionFactory);
     }
 
     ProviderFactory createProviderFactory() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/DefaultFileCollectionFactoryTest.groovy
@@ -18,11 +18,13 @@ package org.gradle.api.internal.file
 
 import org.gradle.api.Task
 import org.gradle.api.internal.file.collections.MinimalFileSet
+import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.api.tasks.TaskDependency
+import org.gradle.internal.file.PathToFileResolver
 import spock.lang.Specification
 
 class DefaultFileCollectionFactoryTest extends Specification {
-    def factory = new DefaultFileCollectionFactory()
+    def factory = new DefaultFileCollectionFactory(Stub(PathToFileResolver), Stub(TaskResolver))
 
     def "lazily queries contents of collection created from MinimalFileSet"() {
         def contents = Mock(MinimalFileSet)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.model
 
+import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
@@ -25,7 +26,7 @@ import spock.lang.Unroll
 
 
 class DefaultObjectFactoryTest extends Specification {
-    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory))
+    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory), Stub(FileCollectionFactory))
 
     def "property has no value"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectSpec.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.ConfigurableFileTree
 import org.gradle.api.internal.GradleInternal
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.api.internal.file.DefaultFileOperations
 import org.gradle.api.internal.file.DefaultProjectLayout
 import org.gradle.api.internal.file.FileLookup
@@ -37,6 +36,7 @@ import org.gradle.api.internal.tasks.TaskResolver
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.resource.TextResourceLoader
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.ServiceRegistryFactory
@@ -154,7 +154,7 @@ class DefaultProjectSpec extends Specification {
         def serviceRegistry = Stub(ServiceRegistry)
 
         _ * serviceRegistryFactory.createFor(_) >> serviceRegistry
-        _ * serviceRegistry.newInstance(TaskContainerInternal) >> Stub(TaskContainerInternal)
+        _ * serviceRegistry.get(TaskContainerInternal) >> Stub(TaskContainerInternal)
         _ * serviceRegistry.get(InstantiatorFactory) >> Stub(InstantiatorFactory)
         _ * serviceRegistry.get(AttributesSchema) >> Stub(AttributesSchema)
         _ * serviceRegistry.get(ModelRegistry) >> Stub(ModelRegistry)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -39,7 +39,6 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer
 import org.gradle.api.internal.GradleInternal
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.api.internal.ProcessOperations
 import org.gradle.api.internal.artifacts.Module
 import org.gradle.api.internal.artifacts.ProjectBackedModule
@@ -70,6 +69,7 @@ import org.gradle.groovy.scripts.EmptyScript
 import org.gradle.groovy.scripts.ScriptSource
 import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.Factory
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.metaobject.BeanDynamicObject
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -174,7 +174,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock = Stub(ServiceRegistry)
 
         projectServiceRegistryFactoryMock.createFor({ it != null }) >> serviceRegistryMock
-        serviceRegistryMock.newInstance(TaskContainerInternal) >> taskContainerMock
+        serviceRegistryMock.get(TaskContainerInternal) >> taskContainerMock
         taskContainerMock.getTasksAsDynamicObject() >> new BeanDynamicObject(new TaskContainerDynamicObject(someTask: testTask))
         serviceRegistryMock.get((Type) RepositoryHandler) >> repositoryHandlerMock
         serviceRegistryMock.get(ConfigurationContainer) >> configurationContainerMock

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -23,7 +23,6 @@ import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.DomainObjectContext
 import org.gradle.api.internal.GradleInternal
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.api.internal.artifacts.DependencyManagementServices
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory
@@ -45,7 +44,7 @@ import org.gradle.api.internal.project.DefaultAntBuilderFactory
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.internal.project.taskfactory.ITaskFactory
-import org.gradle.api.internal.tasks.DefaultTaskContainerFactory
+import org.gradle.api.internal.tasks.DefaultTaskContainer
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.internal.tasks.TaskStatistics
 import org.gradle.api.logging.LoggingManager
@@ -56,6 +55,7 @@ import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.Factory
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
 import org.gradle.internal.operations.BuildOperationExecutor
@@ -143,13 +143,13 @@ class ProjectScopeServicesTest extends Specification {
         1 * plugin2.registerProjectServices(_)
     }
 
-    def "provides a TaskContainerFactory"() {
+    def "provides a TaskContainer"() {
         def instantiator = Stub(Instantiator)
         1 * instantiatorFactory.injectAndDecorate(registry) >> instantiator
         1 * taskFactory.createChild({ it.is project }, instantiator) >> Stub(ITaskFactory)
 
         expect:
-        registry.getFactory(TaskContainerInternal) instanceof DefaultTaskContainerFactory
+        registry.get(TaskContainerInternal) instanceof DefaultTaskContainer
     }
 
     def "provides a ToolingModelBuilderRegistry"() {

--- a/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/invocation/DefaultGradleSpec.groovy
@@ -21,7 +21,6 @@ import org.gradle.api.Action
 import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.GradleInternal
-import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.initialization.ClassLoaderScope
@@ -42,6 +41,7 @@ import org.gradle.internal.event.DefaultListenerManager
 import org.gradle.internal.event.ListenerManager
 import org.gradle.internal.installation.CurrentGradleInstallation
 import org.gradle.internal.installation.GradleInstallation
+import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.scan.config.BuildScanConfigInit
@@ -73,7 +73,7 @@ class DefaultGradleSpec extends Specification {
         _ * serviceRegistry.get(FileResolver) >> Mock(FileResolver)
         _ * serviceRegistry.get(ScriptHandler) >> Mock(ScriptHandler)
         _ * serviceRegistry.get(TaskExecutionGraphInternal) >> Mock(TaskExecutionGraphInternal)
-        _ * serviceRegistry.newInstance(TaskContainerInternal) >> Mock(TaskContainerInternal)
+        _ * serviceRegistry.get(TaskContainerInternal) >> Mock(TaskContainerInternal)
         _ * serviceRegistry.get(ModelRegistry) >> Stub(ModelRegistry)
         _ * serviceRegistry.get(InstantiatorFactory) >> Mock(InstantiatorFactory)
         _ * serviceRegistry.get(ListenerManager) >> listenerManager

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/api/internal/file/TestFiles.java
@@ -108,7 +108,7 @@ public class TestFiles {
     }
 
     public static FileCollectionFactory fileCollectionFactory() {
-        return new DefaultFileCollectionFactory();
+        return new DefaultFileCollectionFactory(pathToFileResolver(), null);
     }
 
     public static ExecFactory execFactory() {

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -72,7 +72,7 @@ class TestUtil {
     private static ObjectFactory objFactory(FileResolver fileResolver) {
         DefaultServiceRegistry services = new DefaultServiceRegistry()
         services.add(ProviderFactory, new DefaultProviderFactory())
-        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver))
+        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver), TestFiles.fileCollectionFactory())
     }
 
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -75,6 +75,59 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    def "transform can receive file collection via parameter object"() {
+        settingsFile << """
+            include 'a', 'b', 'c'
+        """
+        setupBuildWithColorAttributes()
+        buildFile << """
+            allprojects {
+                dependencies {
+                    registerTransform(MakeGreen) {
+                        from.attribute(color, 'blue')
+                        to.attribute(color, 'green')
+                        parameters {
+                            someFiles.from('a.txt')
+                            someFiles.from('b.txt')
+                        }
+                    }
+                }
+            }
+            
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+            
+            @TransformAction(MakeGreenAction)
+            interface MakeGreen {
+                ConfigurableFileCollection getSomeFiles()
+            }
+            
+            abstract class MakeGreenAction extends ArtifactTransform {
+                @TransformParameters
+                abstract MakeGreen getConf()
+                
+                List<File> transform(File input) {
+                    println "processing \${input.name} using \${conf.someFiles*.name}"
+                    def output = new File(outputDirectory, input.name + ".green")
+                    output.text = "ok"
+                    return [output]
+                }
+            }
+"""
+
+        when:
+        run(":a:resolve")
+
+        then:
+        outputContains("processing b.jar using [a.txt, b.txt]")
+        outputContains("processing c.jar using [a.txt, b.txt]")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
     @Unroll
     def "transform can receive dependencies via abstract getter of type #targetType"() {
         settingsFile << """

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -26,12 +26,11 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.AttributesSchema;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.file.ProjectLayout;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.FeaturePreviews;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.component.ComponentIdentifierFactory;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationContainerInternal;
 import org.gradle.api.internal.artifacts.configurations.DefaultConfigurationContainer;
@@ -124,6 +123,7 @@ import org.gradle.internal.execution.timeout.TimeoutHandler;
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter;
 import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter;
 import org.gradle.internal.id.UniqueId;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.locking.DefaultDependencyLockingHandler;
 import org.gradle.internal.locking.DefaultDependencyLockingProvider;
@@ -272,8 +272,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             );
         }
 
-        VariantTransformRegistry createVariantTransforms(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, TransformerInvoker transformerInvoker) {
-            return new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, isolatableFactory, classLoaderHierarchyHasher, transformerInvoker);
+        VariantTransformRegistry createVariantTransforms(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, ServiceRegistry services, TransformerInvoker transformerInvoker) {
+            return new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, isolatableFactory, classLoaderHierarchyHasher, services, transformerInvoker);
         }
 
         BaseRepositoryFactory createBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
@@ -45,12 +45,13 @@ public class DefaultTransformationRegistration implements VariantTransformRegist
 
         // TODO - should snapshot later
         Isolatable<Object[]> paramsSnapshot;
+        Isolatable<?> configSnapshot;
         try {
             paramsSnapshot = isolatableFactory.isolate(params);
+            configSnapshot = isolatableFactory.isolate(config);
         } catch (Exception e) {
             throw new VariantTransformConfigurationException(String.format("Could not snapshot parameters values for transform %s: %s", ModelType.of(implementation).getDisplayName(), Arrays.asList(params)), e);
         }
-        Isolatable<?> configSnapshot = isolatableFactory.isolate(config);
 
         paramsSnapshot.appendToHasher(hasher);
         configSnapshot.appendToHasher(hasher);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -33,6 +33,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
+import org.gradle.internal.service.ServiceRegistry;
 
 import javax.annotation.Nullable;
 import java.util.List;
@@ -43,14 +44,16 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final IsolatableFactory isolatableFactory;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
+    private final ServiceRegistry services;
     private final InstantiatorFactory instantiatorFactory;
     private final TransformerInvoker transformerInvoker;
 
-    public DefaultVariantTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory immutableAttributesFactory, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, TransformerInvoker transformerInvoker) {
+    public DefaultVariantTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory immutableAttributesFactory, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, ServiceRegistry services, TransformerInvoker transformerInvoker) {
         this.instantiatorFactory = instantiatorFactory;
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.isolatableFactory = isolatableFactory;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
+        this.services = services;
         this.transformerInvoker = transformerInvoker;
     }
 
@@ -62,9 +65,8 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
 
     @Override
     public <T> void registerTransform(Class<T> configurationType, Action<? super ArtifactTransformSpec<T>> registrationAction) {
-        // TODO - should inject services into parameters
-        // TODO - should decorate, need to stop using serialization of the config object
-        T configuration = instantiatorFactory.inject().newInstance(configurationType);
+        // TODO - should decorate
+        T configuration = instantiatorFactory.inject(services).newInstance(configurationType);
         TypedRegistration<T> registration = instantiatorFactory.decorateLenient().newInstance(TypedRegistration.class, configuration, immutableAttributesFactory);
         register(registration, registrationAction);
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.isolation.TestIsolatableFactory
+import org.gradle.internal.service.ServiceRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.AttributeTestUtil
 import org.gradle.util.TestUtil
@@ -44,7 +45,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
     def isolatableFactory = new TestIsolatableFactory()
     def classLoaderHierarchyHasher = Mock(ClassLoaderHierarchyHasher)
     def attributesFactory = AttributeTestUtil.attributesFactory()
-    def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, isolatableFactory, classLoaderHierarchyHasher, transformerInvoker)
+    def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, isolatableFactory, classLoaderHierarchyHasher, Stub(ServiceRegistry), transformerInvoker)
 
     def "setup"() {
         _ * classLoaderHierarchyHasher.getClassLoaderHash(_) >> HashCode.fromInt(123)

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -12,6 +12,7 @@ Include only their name, impactful features should be called out separately belo
 
 TBD - Abstract service injection getter methods
 TBD - Abstract mutable property
+TBD - Abstract `ConfigurableFileCollection` property
 TBD - Use an interface for Gradle instantiated types
 
 ## Upgrade Instructions

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
@@ -479,11 +479,11 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             return mainGetter != null;
         }
 
-        public Iterable<Method> getOverridableGetters() {
+        public List<Method> getOverridableGetters() {
             return overridableGetters;
         }
 
-        public Iterable<Method> getOverridableSetters() {
+        public List<Method> getOverridableSetters() {
             return overridableSetters;
         }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
@@ -784,7 +784,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
     private static class ManagedTypeHandler extends ClassGenerationHandler {
         private final List<PropertyMetaData> mutableProperties = new ArrayList<>();
-        private final List<PropertyMetaData> fileCollectionProperties = new ArrayList<>();
+        private final List<PropertyMetaData> readOnlyProperties = new ArrayList<>();
         private boolean hasFields;
 
         @Override
@@ -811,7 +811,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             if (property.setters.isEmpty()) {
                 if (property.getType().equals(ConfigurableFileCollection.class)) {
                     // Read-only file collection property
-                    fileCollectionProperties.add(property);
+                    readOnlyProperties.add(property);
                     return true;
                 }
                 return false;
@@ -827,7 +827,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             if (!hasFields) {
                 visitor.mixInManaged();
             }
-            if (!fileCollectionProperties.isEmpty()) {
+            if (!readOnlyProperties.isEmpty()) {
                 visitor.mixInServiceInjection();
             }
         }
@@ -843,14 +843,14 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     visitor.applyManagedStateToSetter(property, setter);
                 }
             }
-            for (PropertyMetaData property : fileCollectionProperties) {
+            for (PropertyMetaData property : readOnlyProperties) {
                 visitor.applyManagedStateToProperty(property);
                 for (Method getter : property.getters) {
                     visitor.applyReadOnlyManagedStateToGetter(property, getter);
                 }
             }
             if (!hasFields) {
-                visitor.addManagedMethods(mutableProperties);
+                visitor.addManagedMethods(mutableProperties, readOnlyProperties);
             }
         }
     }
@@ -1140,7 +1140,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
         void applyReadOnlyManagedStateToGetter(PropertyMetaData property, Method getter);
 
-        void addManagedMethods(List<PropertyMetaData> properties);
+        void addManagedMethods(List<PropertyMetaData> properties, List<PropertyMetaData> readOnlyProperties);
 
         void applyConventionMappingToProperty(PropertyMetaData property);
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
@@ -24,6 +24,7 @@ import groovy.lang.Closure;
 import groovy.lang.GroovyObject;
 import org.gradle.api.Action;
 import org.gradle.api.NonExtensible;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.ExtensionAware;
@@ -782,7 +783,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
     }
 
     private static class ManagedTypeHandler extends ClassGenerationHandler {
-        private final List<PropertyMetaData> properties = new ArrayList<>();
+        private final List<PropertyMetaData> mutableProperties = new ArrayList<>();
+        private final List<PropertyMetaData> fileCollectionProperties = new ArrayList<>();
         private boolean hasFields;
 
         @Override
@@ -792,6 +794,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
 
         @Override
         boolean claimProperty(PropertyMetaData property) {
+            // Skip properties with non-abstract getter or setter implementations
             for (Method getter : property.getters) {
                 if (!Modifier.isAbstract(getter.getModifiers())) {
                     return false;
@@ -802,11 +805,21 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     return false;
                 }
             }
-            if (property.setters.isEmpty()) {
+            if (property.getters.isEmpty()) {
                 return false;
             }
-            properties.add(property);
-            return true;
+            if (property.setters.isEmpty()) {
+                if (property.getType().equals(ConfigurableFileCollection.class)) {
+                    // Read-only file collection property
+                    fileCollectionProperties.add(property);
+                    return true;
+                }
+                return false;
+            } else {
+                // Mutable property
+                mutableProperties.add(property);
+                return true;
+            }
         }
 
         @Override
@@ -814,11 +827,14 @@ abstract class AbstractClassGenerator implements ClassGenerator {
             if (!hasFields) {
                 visitor.mixInManaged();
             }
+            if (!fileCollectionProperties.isEmpty()) {
+                visitor.mixInServiceInjection();
+            }
         }
 
         @Override
         void applyTo(ClassGenerationVisitor visitor) {
-            for (PropertyMetaData property : properties) {
+            for (PropertyMetaData property : mutableProperties) {
                 visitor.applyManagedStateToProperty(property);
                 for (Method getter : property.getters) {
                     visitor.applyManagedStateToGetter(property, getter);
@@ -827,8 +843,14 @@ abstract class AbstractClassGenerator implements ClassGenerator {
                     visitor.applyManagedStateToSetter(property, setter);
                 }
             }
+            for (PropertyMetaData property : fileCollectionProperties) {
+                visitor.applyManagedStateToProperty(property);
+                for (Method getter : property.getters) {
+                    visitor.applyReadOnlyManagedStateToGetter(property, getter);
+                }
+            }
             if (!hasFields) {
-                visitor.addManagedMethods(properties);
+                visitor.addManagedMethods(mutableProperties);
             }
         }
     }
@@ -1115,6 +1137,8 @@ abstract class AbstractClassGenerator implements ClassGenerator {
         void applyManagedStateToGetter(PropertyMetaData property, Method getter);
 
         void applyManagedStateToSetter(PropertyMetaData property, Method setter);
+
+        void applyReadOnlyManagedStateToGetter(PropertyMetaData property, Method getter);
 
         void addManagedMethods(List<PropertyMetaData> properties);
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiatorFactory.java
@@ -45,7 +45,7 @@ public interface InstantiatorFactory {
     Instantiator inject();
 
     /**
-     * Create a new {@link InstantiationScheme} that can inject services and user provided values into the instances it creates, but does not decorate the instances. Supports using the {@link javax.inject.Inject} annotation plus additional custom annotations.
+     * Create an {@link InstantiationScheme} that can inject services and user provided values into the instances it creates, but does not decorate the instances. Supports using the {@link javax.inject.Inject} annotation plus the given custom inject annotations.
      *
      * @param injectAnnotations Zero or more annotations that mark properties whose value will be injected on creation. Each annotation must be known to this factory via a {@link InjectAnnotationHandler}.
      */

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
@@ -549,8 +549,12 @@ public class AsmBackedClassGeneratorTest {
         assertEquals(InterfaceFileCollectionBean.class, managed.publicType());
         assertFalse(managed.immutable());
         Object[] state = (Object[]) managed.unpackState();
+        assertEquals(1, state.length);
+        assertTrue(state[0] instanceof ConfigurableFileCollection);
+        assertSame(state[0], bean.getFiles());
 
-        // TODO - implement the rest of this
+        InterfaceFileCollectionBean copy = managed.managedFactory().fromState(InterfaceFileCollectionBean.class, state);
+        assertTrue(copy.getFiles().isEmpty());
     }
 
     @Test

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
@@ -540,6 +540,20 @@ public class AsmBackedClassGeneratorTest {
     }
 
     @Test
+    public void canUnpackAndRecreateInterfaceWithFileCollectionGetter() throws Exception {
+        TestFile projectDir = tmpDir.getTestDirectory();
+        InterfaceFileCollectionBean bean = newInstance(InterfaceFileCollectionBean.class, TestUtil.createRootProject(projectDir).getServices());
+        assertThat(bean, instanceOf(Managed.class));
+
+        Managed managed = (Managed) bean;
+        assertEquals(InterfaceFileCollectionBean.class, managed.publicType());
+        assertFalse(managed.immutable());
+        Object[] state = (Object[]) managed.unpackState();
+
+        // TODO - implement the rest of this
+    }
+
+    @Test
     public void canConstructInstanceOfInterfaceWithDefaultMethodsOnly() throws Exception {
         InterfaceWithDefaultMethods bean = newInstance(InterfaceWithDefaultMethods.class);
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/IsolatedFileCollection.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/IsolatedFileCollection.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot.impl;
+
+import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.internal.file.IdentityFileResolver;
+import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
+import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.isolation.Isolatable;
+import org.gradle.internal.snapshot.ValueSnapshot;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.util.Set;
+
+public class IsolatedFileCollection implements Isolatable<ConfigurableFileCollection> {
+    private final Set<File> files;
+
+    public IsolatedFileCollection(ConfigurableFileCollection files) {
+        this.files = files.getFiles();
+    }
+
+    @Override
+    public ValueSnapshot asSnapshot() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
+
+    @Override
+    public void appendToHasher(Hasher hasher) {
+        hasher.putString("files");
+        for (File file : files) {
+            hasher.putString(file.getAbsolutePath());
+        }
+    }
+
+    @Nullable
+    @Override
+    public ConfigurableFileCollection isolate() {
+        return new DefaultConfigurableFileCollection(new IdentityFileResolver(), null, files);
+    }
+
+    @Nullable
+    @Override
+    public <S> S coerce(Class<S> type) {
+        if (type.isAssignableFrom(ConfigurableFileCollection.class)) {
+            return type.cast(isolate());
+        }
+        return null;
+    }
+}

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/snapshot/impl/DefaultValueSnapshotterTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.internal.snapshot.impl
 
 import org.gradle.api.Named
+import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.model.NamedObjectInstantiator
 import org.gradle.api.provider.Provider
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
@@ -626,6 +627,25 @@ class DefaultValueSnapshotterTest extends Specification {
         def copy = isolated.isolate()
         !copy.is(value)
         copy.prop1 == "a"
+    }
+
+    def "creates isolated ConfigurableFileCollection"() {
+        def empty = TestFiles.fileCollectionFactory().configurableFiles()
+        def files1 = TestFiles.fileCollectionFactory().configurableFiles()
+        files1.from(new File("a").absoluteFile)
+
+        expect:
+        def isolatedEmpty = snapshotter.isolate(empty)
+        isolatedEmpty instanceof IsolatedFileCollection
+        def copyEmpty = isolatedEmpty.isolate()
+        !copyEmpty.is(empty)
+        copyEmpty.files as List == []
+
+        def isolated = snapshotter.isolate(files1)
+        isolated instanceof IsolatedFileCollection
+        def copy = isolated.isolate()
+        !copy.is(files1)
+        copy.files == files1.files
     }
 
     def "creates snapshot for serializable type"() {


### PR DESCRIPTION
### Context

This PR allows an artifact transform parameter object to use properties of type `ConfigurableFileCollection` to inject additional input files into transforms.

- Allow abstract read-only properties of type `ConfigurableFileCollection` on generated types.
- Handle unpacking and recreating "managed" instances of these types.
- Allow instances of `ConfigurableFileCollection` to be isolated.

Currently only handles pre-built file collection, and does not handle resolvable or buildable files.

This PR also adds a new public API method on `ObjectFactory` to create `ConfigurableFileCollection` instances, replacing `ProjectLayout.configurableFiles()`. A later PR will finish up adding this to the API (eg updating docs and samples).

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
