### PR TITLE
 OSX: don't try to infer Finder invocation 

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -164,9 +164,4 @@ APP_ARGS=\$(save "\$@")
 # Collect all arguments for the java command, following the shell quoting and substitution rules
 eval set -- \$DEFAULT_JVM_OPTS \$JAVA_OPTS \$${optsEnvironmentVar} <% if ( appNameSystemProperty ) { %>"\"-D${appNameSystemProperty}=\$APP_BASE_NAME\"" <% } %>-classpath "\"\$CLASSPATH\"" ${mainClassName} "\$APP_ARGS"
 
-# by default we should be in the correct project dir, but when run from Finder on Mac, the cwd is wrong
-if [ "\$(uname)" = "Darwin" ] && [ "\$HOME" = "\$PWD" ]; then
-  cd "\$(dirname "\$0")"
-fi
-
 exec "\$JAVACMD" "\$@"

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class UnixStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.unixLineSeparator).length == 172
+        destination.toString().split(TextUtil.windowsLineSeparator).length == 1 && destination.toString().split(TextUtil.unixLineSeparator).length > 1
     }
 
     def "defaultJvmOpts is expanded properly in unix script"() {


### PR DESCRIPTION
== DETAILS

When an application packaged by Gradle is executed from a user's
home directory, the working directory is unexpectedly changed to the
script directory.

One consequence of this is that relative paths given on the command line
will fail to resolve. Other consequences would vary from one app to the next.

To the best of my knowledge, there's no way to reliably distinguish between
a terminal invocation and a Finder invocation:

- simply assuming "pwd==$HOME -> Finder" is too broad and caused #5978
- "pwd==$HOME and $0 is absolute path" has the same risk of false-positive,
  except now the root cause is even harder to spot
- environment variables are exactly the same, terminal vs Finder

If there's actually a compelling use-case for being able to execute
scripts via Finder, my recommendation is to build a proper Mac OSX
Application bundle (`project_name.app`).

NOTE: I don't know if "double-click from the finder" is explicitly mentioned anywhere in the docs, and I don't know where to look.

Signed-off-by: Nathan Strong <nstrong@tripwire.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
