### PR TITLE
Fix example headline in java_platform_plugin

### DIFF
--- a/subprojects/docs/src/docs/userguide/java_platform_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_platform_plugin.adoc
@@ -81,7 +81,8 @@ include::sample[dir="java-platform/quickstart/kotlin",files="build.gradle.kts[ta
 == Local project constraints
 
 If you have a multi-project build and want to publish a platform that links to subprojects, you can do it by declaring constraints on the subprojects which belong to the platform, as in the example below:
-.Allowing declaration of dependencies
+
+.Declaring constraints on subprojects
 ====
 include::sample[dir="java-platform/multiproject/groovy/platform",files="build.gradle[tags=project-constraints]"]
 include::sample[dir="java-platform/multiproject/kotlin/platform",files="build.gradle.kts[tags=project-constraints]"]


### PR DESCRIPTION
This will fix the example headline in the [docs](https://docs.gradle.org/5.2-rc-1/userguide/java_platform_plugin.html#sec:java_platform_consumption).

Currently:
![bildschirmfoto 2019-01-30 um 09 37 25](https://user-images.githubusercontent.com/10229883/51968658-d0d4f600-2472-11e9-847d-b9b0ccd0cd4f.png)
This PR will fix it and move into something like this:
![bildschirmfoto 2019-01-30 um 09 37 35](https://user-images.githubusercontent.com/10229883/51968660-d0d4f600-2472-11e9-8208-ef71a2ec4b9f.png)

