### PR TITLE
Small fixes around Java variant-aware dependency management

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.gradle.integtests.resolve.optional
+package org.gradle.integtests.resolve.features
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
 import org.gradle.integtests.fixtures.RequiredFeature
@@ -24,7 +24,7 @@ import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 @RequiredFeatures(
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value = "true")
 )
-class OptionalFeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     def "can select a variant providing a different capability"() {
         given:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -216,7 +216,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
     // as those are synthetic platforms generated at runtime. This test is here to make sure
     // this is the case
     def "can enforce a published platform"() {
-        def platform = mavenHttpRepo.module("org", "platform", "1.0").withModuleMetadata()
+        def platform = mavenHttpRepo.module("org", "platform", "1.0")
+                .withModuleMetadata()
+                .adhocVariants()
                 .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (PlatformSupport.COMPONENT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
                 .dependsOn("org", "foo", "1.0")
                 .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (PlatformSupport.COMPONENT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) { useDefaultArtifacts = false}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -165,7 +165,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
                                                                                                           Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> firstCandidate,
                                                                                                           Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant> secondCandidate) {
 
-        if (matcher.isMatching(firstCandidate.right.attributes, secondCandidate.right.attributes)) {
+        if (matcher.isMatching(firstCandidate.right.attributes, secondCandidate.right.attributes) || matcher.isMatching(secondCandidate.right.attributes, firstCandidate.right.attributes)) {
             if (firstCandidate.right.depth >= secondCandidate.right.depth) {
                 return Optional.of(secondCandidate);
             } else {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -409,7 +409,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
             }
         })
         1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
-        2 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >>> [false, true]
+        3 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >>> [false, false, true]
         1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform1, 3)
         }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -177,6 +177,12 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
         return this
     }
 
+    @Override
+    MavenModule adhocVariants() {
+        variants.clear()
+        this
+    }
+
     private VariantMetadataSpec createVariant(String variant, Map<String, String> attributes) {
         def variantMetadata = new VariantMetadataSpec(variant, attributes)
         variants.removeAll { it.name == variant }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -218,6 +218,12 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public MavenModule adhocVariants() {
+        backingModule.adhocVariants();
+        return t();
+    }
+
+    @Override
     public T parent(String group, String artifactId, String version) {
         backingModule.parent(group, artifactId, version);
         return t();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -82,6 +82,11 @@ interface MavenModule extends Module {
      */
     MavenModule variant(String variant, Map<String, String> attributes, @DelegatesTo(value= VariantMetadataSpec, strategy=Closure.DELEGATE_FIRST) Closure<?> variantConfiguration)
 
+    /**
+     * Clears all predefined variants
+     */
+    MavenModule adhocVariants()
+
     String getPublishArtifactVersion()
 
     String getGroupId()


### PR DESCRIPTION
### Context

This PR fixes a couple of minor issues around Java-centric variant-aware dependency management:

- incomplete usage compatibility rule
- smarter disambiguation strategy in case capabilities are requested
