### PR TITLE
Include process command line in daemon startup failure message

### DIFF
--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonFeedbackIntegrationSpec.groovy
@@ -69,7 +69,9 @@ task sleep {
         then:
         def ex = thrown(Exception)
         ex.message.contains(DaemonMessages.UNABLE_TO_START_DAEMON)
-        ex.message.contains("-Xyz")
+        ex.message.contains("Process command line:")
+        ex.message.contains("-Dorg.gradle.jvmargs=-Xyz")
+        ex.message.contains("Unrecognized option: -Xyz")
     }
 
     def "daemon log contains all necessary logging"() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonGreeter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DaemonGreeter.java
@@ -16,11 +16,14 @@
 
 package org.gradle.launcher.daemon.client;
 
+import com.google.common.base.Joiner;
 import org.gradle.api.GradleException;
 import org.gradle.api.internal.DocumentationRegistry;
 import org.gradle.launcher.daemon.bootstrap.DaemonStartupCommunication;
 import org.gradle.launcher.daemon.diagnostics.DaemonStartupInfo;
 import org.gradle.launcher.daemon.logging.DaemonMessages;
+
+import java.util.List;
 
 public class DaemonGreeter {
     private final DocumentationRegistry documentationRegistry;
@@ -29,10 +32,10 @@ public class DaemonGreeter {
         this.documentationRegistry = documentationRegistry;
     }
 
-    public DaemonStartupInfo parseDaemonOutput(String output) {
+    public DaemonStartupInfo parseDaemonOutput(String output, List<String> startupArgs) {
         DaemonStartupCommunication startupCommunication = new DaemonStartupCommunication();
         if (!startupCommunication.containsGreeting(output)) {
-            throw new GradleException(prepareMessage(output));
+            throw new GradleException(prepareMessage(output, startupArgs));
         }
         String[] lines = output.split("\n");
         //Assuming that the diagnostics were printed out to the last line. It's not bullet-proof but seems to be doing fine.
@@ -40,13 +43,14 @@ public class DaemonGreeter {
         return startupCommunication.readDiagnostics(lastLine);
     }
 
-    private String prepareMessage(String output) {
+    private String prepareMessage(String output, List<String> startupArgs) {
         StringBuilder sb = new StringBuilder();
         sb.append(DaemonMessages.UNABLE_TO_START_DAEMON);
         sb.append("\nThis problem might be caused by incorrect configuration of the daemon.");
         sb.append("\nFor example, an unrecognized jvm option is used.");
         sb.append("\nPlease refer to the User Manual chapter on the daemon at ");
         sb.append(documentationRegistry.getDocumentationFor("gradle_daemon"));
+        sb.append("\nProcess command line: ").append(Joiner.on(" ").join(startupArgs));
         sb.append("\nPlease read the following process output to find out more:");
         sb.append("\n-----------------------\n");
         sb.append(output);

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/client/DefaultDaemonStarter.java
@@ -175,7 +175,7 @@ public class DefaultDaemonStarter implements DaemonStarter {
                 execActionFactory.stop();
             }
 
-            return daemonGreeter.parseDaemonOutput(outputConsumer.getProcessOutput());
+            return daemonGreeter.parseDaemonOutput(outputConsumer.getProcessOutput(), args);
         } catch (GradleException e) {
             throw e;
         } catch (Exception e) {

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/bootstrap/DaemonGreeterTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/bootstrap/DaemonGreeterTest.groovy
@@ -27,6 +27,7 @@ import spock.lang.Specification
 class DaemonGreeterTest extends Specification {
 
     def registry = Mock(DocumentationRegistry)
+    def args = ["foo", "bar"]
 
     def "parses the process output"() {
         given:
@@ -42,7 +43,7 @@ another line of output...
         def output = new String(outputStream.toByteArray())
 
         when:
-        def daemonStartupInfo = new DaemonGreeter(registry).parseDaemonOutput(output)
+        def daemonStartupInfo = new DaemonGreeter(registry).parseDaemonOutput(output, args)
 
         then:
         daemonStartupInfo.address == address
@@ -60,17 +61,18 @@ another line of output..."""
         ExecResult result = Mock()
 
         when:
-        new DaemonGreeter(registry).parseDaemonOutput(output);
+        new DaemonGreeter(registry).parseDaemonOutput(output, args);
 
         then:
         def ex = thrown(GradleException)
         ex.message.contains(DaemonMessages.UNABLE_TO_START_DAEMON)
+        ex.message.concat("Process command line: [foo, bar]")
         ex.message.contains("hey joe!")
     }
 
     def "shouts if daemon broke completely..."() {
         when:
-        new DaemonGreeter(registry).parseDaemonOutput("")
+        new DaemonGreeter(registry).parseDaemonOutput("", args)
 
         then:
         def ex = thrown(GradleException)


### PR DESCRIPTION
When daemon startup fails, it can be hard to discover what command-line was invoked. This change adds the command line to the failure message.

I needed this change locally in order to diagnose and fix #8353