### PR TITLE
Make DSL metadata extraction deterministic

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTask.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTask.groovy
@@ -19,6 +19,7 @@ import com.github.javaparser.JavaParser
 import groovy.time.TimeCategory
 import groovy.time.TimeDuration
 import org.gradle.api.Action
+import org.gradle.api.Transformer
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.OutputFile
@@ -26,12 +27,11 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
+import org.gradle.build.docs.DocGenerationException
 import org.gradle.build.docs.dsl.source.model.ClassMetaData
 import org.gradle.build.docs.dsl.source.model.TypeMetaData
 import org.gradle.build.docs.model.ClassMetaDataRepository
 import org.gradle.build.docs.model.SimpleClassMetaDataRepository
-import org.gradle.build.docs.DocGenerationException
-import org.gradle.api.Transformer
 
 /**
  * Extracts meta-data from the Groovy and Java source files which make up the Gradle API. Persists the meta-data to a file

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/AbstractLanguageElement.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/AbstractLanguageElement.java
@@ -21,6 +21,7 @@ import org.gradle.api.Transformer;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public abstract class AbstractLanguageElement implements LanguageElement, Serializable {
     private String rawCommentText;
@@ -61,5 +62,23 @@ public abstract class AbstractLanguageElement implements LanguageElement, Serial
         for (int i = 0; i < annotationNames.size(); i++) {
             annotationNames.set(i, transformer.transform(annotationNames.get(i)));
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractLanguageElement that = (AbstractLanguageElement) o;
+        return Objects.equals(rawCommentText, that.rawCommentText) &&
+            Objects.equals(annotationNames, that.annotationNames);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rawCommentText, annotationNames);
     }
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/ClassMetaData.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/ClassMetaData.java
@@ -23,7 +23,13 @@ import org.gradle.build.docs.model.ClassMetaDataRepository;
 import org.gradle.util.GUtil;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Static meta-data about a class extracted from the source for the class.

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/MethodMetaData.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/MethodMetaData.java
@@ -21,6 +21,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Static meta-data about a method extracted from the source for the class.
@@ -45,6 +46,29 @@ public class MethodMetaData extends AbstractLanguageElement implements Serializa
         return String.format("%s.%s()", ownerClass, name);
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MethodMetaData that = (MethodMetaData) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(ownerClass.getClassName(), that.ownerClass.getClassName()) &&
+            Objects.equals(parameters, that.parameters) &&
+            Objects.equals(returnType, that.returnType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), name, ownerClass, parameters, returnType);
+    }
+
     public ClassMetaData getOwnerClass() {
         return ownerClass;
     }
@@ -61,7 +85,7 @@ public class MethodMetaData extends AbstractLanguageElement implements Serializa
         LinkedList<ClassMetaData> queue = new LinkedList<ClassMetaData>();
         queue.add(ownerClass.getSuperClass());
         queue.addAll(ownerClass.getInterfaces());
-        
+
         String overrideSignature = getOverrideSignature();
 
         while (!queue.isEmpty()) {
@@ -98,7 +122,7 @@ public class MethodMetaData extends AbstractLanguageElement implements Serializa
         builder.append(name);
         builder.append('(');
         for (int i = 0; i < parameters.size(); i++) {
-            ParameterMetaData param =  parameters.get(i);
+            ParameterMetaData param = parameters.get(i);
             if (i > 0) {
                 builder.append(", ");
             }
@@ -116,7 +140,7 @@ public class MethodMetaData extends AbstractLanguageElement implements Serializa
         builder.append(name);
         builder.append('(');
         for (int i = 0; i < parameters.size(); i++) {
-            ParameterMetaData param =  parameters.get(i);
+            ParameterMetaData param = parameters.get(i);
             if (i > 0) {
                 builder.append(", ");
             }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/ParameterMetaData.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/ParameterMetaData.java
@@ -18,6 +18,7 @@ package org.gradle.build.docs.dsl.source.model;
 import org.gradle.api.Action;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * Static meta-data about a method parameter extracted from the source for the method.
@@ -52,5 +53,23 @@ public class ParameterMetaData implements Serializable, TypeContainer {
 
     public void visitTypes(Action<TypeMetaData> action) {
         action.execute(type);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ParameterMetaData that = (ParameterMetaData) o;
+        return Objects.equals(name, that.name) &&
+            Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type);
     }
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/TypeMetaData.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/TypeMetaData.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Static meta-data about a type reference extracted from source.
@@ -191,5 +192,28 @@ public class TypeMetaData implements Serializable, TypeContainer {
         void visitText(String text);
 
         void visitType(String name);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TypeMetaData that = (TypeMetaData) o;
+        return arrayDimensions == that.arrayDimensions &&
+            varargs == that.varargs &&
+            wildcard == that.wildcard &&
+            Objects.equals(name, that.name) &&
+            Objects.equals(typeArgs, that.typeArgs) &&
+            Objects.equals(upperBounds, that.upperBounds) &&
+            Objects.equals(lowerBounds, that.lowerBounds);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, arrayDimensions, varargs, typeArgs, wildcard, upperBounds, lowerBounds);
     }
 }

--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTaskTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/dsl/source/ExtractDslMetaDataTaskTest.groovy
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package org.gradle.build.docs.dsl.source
+
 import org.gradle.api.Project
 import org.gradle.build.docs.dsl.source.model.ClassMetaData
 import org.gradle.build.docs.model.SimpleClassMetaDataRepository
@@ -33,13 +34,32 @@ class ExtractDslMetaDataTaskTest extends Specification {
         task.destFile?.delete()
     }
 
-    def extractsClassMetaData() {
+    def extractionIsDeterministic() {
+        given:
+        writeSources()
+
+        when:
+        task.extract()
+        String firstMd5 = task.destFile.bytes.md5()
+        task.extract()
+        String secondMd5 = task.destFile.bytes.md5()
+
+        then:
+        firstMd5 == secondMd5
+    }
+
+    void writeSources() {
         task.source testFile('org/gradle/test/JavaClass.java')
         task.source testFile('org/gradle/test/JavaInterface.java')
         task.source testFile('org/gradle/test/A.java')
         task.source testFile('org/gradle/test/CombinedInterface.java')
         task.source testFile('org/gradle/test/Interface1.java')
         task.source testFile('org/gradle/test/Interface2.java')
+    }
+
+    def extractsClassMetaData() {
+        given:
+        writeSources()
 
         when:
         task.extract()
@@ -62,6 +82,10 @@ class ExtractDslMetaDataTaskTest extends Specification {
         javaInterface.superClassName == null
         javaInterface.interfaceNames == ['org.gradle.test.Interface1', 'org.gradle.test.Interface2']
         javaInterface.annotationTypeNames == []
+    }
+
+    String md5(File file) {
+        return file.bytes.md5()
     }
 
     def extractsPropertyMetaData() {


### PR DESCRIPTION
### Context

Previously MethodMetaData class doesn't override hashCode(), which results in indeterministic
when serializing `HashSet<MethodMetaData>`. This PR fixes that by providing proper hashCode() implementation.

This seems to be the cause of https://github.com/gradle/gradle-private/issues/1792

Without this change:

```
# zhb @ bs-MacBook-Pro in ~/Projects/community-gradle on git:master x [10:27:35]
$ ./gradlew clean :docs:dslMetaData -s && md5 subprojects/docs/build/src/dsl-meta-data.bin && ./gradlew clean :docs:dslMetaData && md5 subprojects/docs/build/src/dsl-meta-data.bin

> Task :docs:dslMetaData
Parsed 1540 classes in 3.140 seconds

BUILD SUCCESSFUL in 1m 6s
89 actionable tasks: 14 executed, 75 up-to-date

MD5 (subprojects/docs/build/src/dsl-meta-data.bin) = 484a40f3a81ca3768435d3f8e761a6d6

> Task :docs:dslMetaData
Parsed 1540 classes in 1.946 seconds

BUILD SUCCESSFUL in 4s
89 actionable tasks: 14 executed, 75 up-to-date

MD5 (subprojects/docs/build/src/dsl-meta-data.bin) = 6b62d953321d0fc52aff1f799bdbe87b
```

With this change:

```
# zhb @ bs-MacBook-Pro in ~/Projects/gradle on git:blindpirate/fix-nondeterministic o [10:25:51] 
$ ./gradlew clean :docs:dslMetaData -s && md5 subprojects/docs/build/src/dsl-meta-data.bin && ./gradlew clean :docs:dslMetaData && md5 subprojects/docs/build/src/dsl-meta-data.bin 

> Task :docs:dslMetaData
Parsed 1540 classes in 4.030 seconds

BUILD SUCCESSFUL in 9s
89 actionable tasks: 14 executed, 75 up-to-date

MD5 (subprojects/docs/build/src/dsl-meta-data.bin) = 7be06d3fd9e75f7c30854745221e9e4f

> Task :docs:dslMetaData
Parsed 1540 classes in 2.032 seconds

BUILD SUCCESSFUL in 5s
89 actionable tasks: 14 executed, 75 up-to-date

MD5 (subprojects/docs/build/src/dsl-meta-data.bin) = 7be06d3fd9e75f7c30854745221e9e4f

```