### PR TITLE
Polish feature variant API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithFeatures.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithFeatures.java
@@ -17,6 +17,8 @@ package org.gradle.api.component;
 
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationVariant;
+import org.gradle.api.specs.Spec;
 
 /**
  * A component which can declare additional variants corresponding to
@@ -30,8 +32,8 @@ import org.gradle.api.artifacts.Configuration;
 public interface ComponentWithFeatures extends SoftwareComponent {
     /**
      * Declares an additional variant to publish, corresponding to an additional feature.
-     * @param name the name of the variant, used when publishing to Gradle metadata.
      * @param outgoingConfiguration the configuration corresponding to the variant to use as source of dependencies and artifacts
+     * @param spec tell if this outgoing variant of this configuration should be published
      */
-    void addFeatureVariantFromConfiguration(String name, Configuration outgoingConfiguration);
+    void addFeatureVariantsFromConfiguration(Configuration outgoingConfiguration, Spec<? super ConfigurationVariant> spec);
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -68,7 +68,7 @@ class GradleModuleMetadata {
 
     Variant variant(String name) {
         def matches = variants.findAll { it.name == name }
-        assert matches.size() == 1 : "Variant '$name' not found"
+        assert matches.size() == 1 : "Variant '$name' not found in ${variants.name}"
         return matches.first()
     }
 

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
@@ -46,10 +46,10 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
         javaLibrary.parsedModuleMetadata.variant("runtime") {
             noMoreDependencies()
         }
-        javaLibrary.parsedModuleMetadata.variant("featureApi") {
+        javaLibrary.parsedModuleMetadata.variant("featureApiElements") {
             noMoreDependencies()
         }
-        javaLibrary.parsedModuleMetadata.variant("featureRuntime") {
+        javaLibrary.parsedModuleMetadata.variant("featureRuntimeElements") {
             assert files*.name == ['publishTest-1.9.jar']
             dependency('org', 'optionaldep', '1.0')
             noMoreDependencies()
@@ -109,10 +109,10 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
         javaLibrary.parsedModuleMetadata.variant("runtime") {
             noMoreDependencies()
         }
-        javaLibrary.parsedModuleMetadata.variant("featureApi") {
+        javaLibrary.parsedModuleMetadata.variant("featureApiElements") {
             noMoreDependencies()
         }
-        javaLibrary.parsedModuleMetadata.variant("featureRuntime") {
+        javaLibrary.parsedModuleMetadata.variant("featureRuntimeElements") {
             assert files*.name == ["${name}-${version}.jar"]
             dependency('org', 'optionaldep', '1.0')
             noMoreDependencies()

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationUsageContext.java
@@ -16,13 +16,14 @@
 package org.gradle.api.internal.java.usagecontext;
 
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 
 public class FeatureConfigurationUsageContext extends AbstractConfigurationUsageContext {
     private final Configuration configuration;
 
-    public FeatureConfigurationUsageContext(String name, Configuration configuration) {
-        super(name, ((AttributeContainerInternal)configuration.getAttributes()).asImmutable(), configuration.getArtifacts());
+    public FeatureConfigurationUsageContext(String name, Configuration configuration, ConfigurationVariant variant) {
+        super(name, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts());
         this.configuration = configuration;
     }
 
@@ -30,4 +31,5 @@ public class FeatureConfigurationUsageContext extends AbstractConfigurationUsage
     protected Configuration getConfiguration() {
         return configuration;
     }
+
 }


### PR DESCRIPTION
### Context

This commit updates the feature variant API so that we now don't provide
a variant name, but instead just the outgoing configuration. Then all
potential outgoing variants of this configuration are considered and
it is possible to filter out variants for publishing.

