### PR TITLE
Spelling

### DIFF
--- a/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
+++ b/subprojects/build-init/src/main/java/org/gradle/buildinit/plugins/internal/BuildScriptBuilder.java
@@ -1246,7 +1246,7 @@ public class BuildScriptBuilder {
         //
         // > Boolean accessor methods (where the name of the getter starts with is and the name of
         // > the setter starts with set) are represented as properties which have the same name as
-        // > the getter method. Boolean properties are visibile with a `is` prefix in Kotlin
+        // > the getter method. Boolean properties are visible with a `is` prefix in Kotlin
         //
         // https://kotlinlang.org/docs/reference/java-interop.html#getters-and-setters
         //

--- a/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
+++ b/subprojects/build-init/src/test/groovy/org/gradle/api/tasks/wrapper/WrapperTest.groovy
@@ -153,7 +153,7 @@ class WrapperTest extends AbstractTaskTest {
             "distributionType", "archiveBase", "archivePath", "gradleVersion")
     }
 
-    def "execute with extant wrapper jar parent directory and extant wraper jar"() {
+    def "execute with extant wrapper jar parent directory and extant wrapper jar"() {
         given:
         def jarDir = new File(getProject().getProjectDir(), "lib")
         jarDir.mkdirs()

--- a/subprojects/core/src/main/java/org/gradle/process/internal/package.html
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/package.html
@@ -27,7 +27,7 @@
       <h3>ExecHandleBuilder</h3>
 
       <p>Creating an instance of {@link org.gradle.util.exec.ExecHandle} is done using the {@link org.gradle.util.exec.ExecHandleBuilder}
-      that provides a bunch of usefull functions to set the arguments/... .</p>
+      that provides a bunch of useful functions to set the arguments/... .</p>
 
       <h3>ExecHandleListener</h3>
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/compression/ArchiversTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/archive/compression/ArchiversTest.groovy
@@ -22,7 +22,7 @@ import spock.lang.Specification
 
 class ArchiversTest extends Specification {
 
-    def "archivers have unqique URIs"() {
+    def "archivers have unique URIs"() {
         when:
         def file = new File("/some/file")
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachingDependencyMetadataInMemoryIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/caching/CachingDependencyMetadataInMemoryIntegrationTest.groovy
@@ -50,7 +50,7 @@ class CachingDependencyMetadataInMemoryIntegrationTest extends AbstractHttpDepen
             task purgeRepo(type: Delete, dependsOn: resolveOne) {
                 delete "${mavenRepo.uri}"
             }
-            //runs last, still works even thoug local repo is empty
+            //runs last, still works even though local repo is empty
             task resolveTwo(dependsOn: purgeRepo) {
                 doLast {
                     println "Resolved " + configurations.two.files*.name

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1041,7 +1041,7 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
                 outputDir2.file("some-unrelated-file.txt") << "added"
                 break
             default:
-                throw new IllegalStateException("Unkown action: ${action}")
+                throw new IllegalStateException("Unknown action: ${action}")
         }
 
         succeeds ":util:resolve", ":app:resolve"

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseProject.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.eclipse.model.EclipseProject.xml
@@ -10,7 +10,7 @@
             </thead>
             <tr>
                 <td>name</td>
-                <td><literal><replaceable>${project.name}</replaceable> (sometimes prefixed with parts of <replaceable>${project.path}</replaceable> to guarantee uniqeness)</literal></td>
+                <td><literal><replaceable>${project.name}</replaceable> (sometimes prefixed with parts of <replaceable>${project.path}</replaceable> to guarantee uniqueness)</literal></td>
             </tr>
             <tr>
                 <td>comment</td>

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.GenerateIdeaModule.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.GenerateIdeaModule.xml
@@ -17,7 +17,7 @@
             <tr>
                 <td>outputFile</td>
                 <td><literal><replaceable>${project.projectDir}</replaceable>/<replaceable>${project.name}</replaceable>.iml</literal>
-                    (sometimes the <replaceable>project.name</replaceable> is prefixed with parts of <replaceable>${project.path}</replaceable> to guarantee uniqeness).
+                    (sometimes the <replaceable>project.name</replaceable> is prefixed with parts of <replaceable>${project.path}</replaceable> to guarantee uniqueness).
                     Bear in mind that usually it is easier to use moduleName property instead of outputFile property.
                 </td>
                 <td/>

--- a/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.plugins.ide.idea.model.IdeaModule.xml
@@ -11,7 +11,7 @@
             </thead>
             <tr>
                 <td>name</td>
-                <td><literal><replaceable>${project.name}</replaceable> (sometimes prefixed with parts of <replaceable>${project.path}</replaceable> to guarantee uniqeness)</literal></td>
+                <td><literal><replaceable>${project.name}</replaceable> (sometimes prefixed with parts of <replaceable>${project.path}</replaceable> to guarantee uniqueness)</literal></td>
                 <td/>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/userguide/repository_types.adoc
+++ b/subprojects/docs/src/docs/userguide/repository_types.adoc
@@ -232,7 +232,7 @@ The following metadata sources are supported:
 
 [NOTE]
 ====
-The defaults for Ivy and Maven repositories change with Gradle 5.0. Before 5.0, `artifact()` was included in the defaults. Leading to some inefficiency when modules are missing completely. To restore this behavior, for example, for Maven central you can use `mavenCentral { mavenPom(); artifact() }`. In a similar way, you can opt into the new behavior in older Gradle verisions using `mavenCentral { mavenPom() }`
+The defaults for Ivy and Maven repositories change with Gradle 5.0. Before 5.0, `artifact()` was included in the defaults. Leading to some inefficiency when modules are missing completely. To restore this behavior, for example, for Maven central you can use `mavenCentral { mavenPom(); artifact() }`. In a similar way, you can opt into the new behavior in older Gradle versions using `mavenCentral { mavenPom() }`
 ====
 
 [[sub:supported_transport_protocols]]

--- a/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
+++ b/subprojects/docs/src/samples/native-binaries/google-test/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
@@ -446,7 +446,7 @@ class TestFactoryBase {
   GTEST_DISALLOW_COPY_AND_ASSIGN_(TestFactoryBase);
 };
 
-// This class provides implementation of TeastFactoryBase interface.
+// This class provides implementation of TestFactoryBase interface.
 // It is used in TEST and TEST_F macros.
 template <class TestClass>
 class TestFactoryImpl : public TestFactoryBase {

--- a/subprojects/docs/src/samples/userguide/tutorial/antLoadfileWithMethod/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/tutorial/antLoadfileWithMethod/groovy/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'ant-load-file-withh-method'
+rootProject.name = 'ant-load-file-with-method'

--- a/subprojects/docs/src/samples/userguide/tutorial/antLoadfileWithMethod/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/tutorial/antLoadfileWithMethod/kotlin/settings.gradle.kts
@@ -1,1 +1,1 @@
-rootProject.name = "ant-load-file-withh-method"
+rootProject.name = "ant-load-file-with-method"

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportDeployWagonTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/wagon/RepositoryTransportDeployWagonTest.groovy
@@ -59,7 +59,7 @@ class RepositoryTransportDeployWagonTest extends Specification {
         'connect' | [Mock(Repository), Mock(AuthenticationInfo), Mock(ProxyInfoProvider)]
     }
 
-    def "waggon disconnect should signal disconnection events"() {
+    def "wagon disconnect should signal disconnection events"() {
         setup:
         SessionListener sessionListener = Mock()
         RepositoryTransportDeployWagon wagon = new RepositoryTransportDeployWagon()

--- a/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/DefaultModelSchemaExtractorTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/model/internal/manage/schema/extract/DefaultModelSchemaExtractorTest.groovy
@@ -1021,13 +1021,13 @@ interface Managed${typeName} {
     }
 
     @Managed
-    interface ManagedTypeWithCovarianceOverriddenMethodExtendingUnamangedTypeWithMethod extends UnmanagedSuperTypeWithMethod {
+    interface ManagedTypeWithCovarianceOverriddenMethodExtendingUnmanagedTypeWithMethod extends UnmanagedSuperTypeWithMethod {
         @Override ByteArrayInputStream doSomething(Object param)
     }
 
     def "accept non-property methods from unmanaged supertype with covariance overridden in managed type"() {
         expect:
-        extract(ManagedTypeWithCovarianceOverriddenMethodExtendingUnamangedTypeWithMethod) instanceof ManagedImplStructSchema
+        extract(ManagedTypeWithCovarianceOverriddenMethodExtendingUnmanagedTypeWithMethod) instanceof ManagedImplStructSchema
     }
 
     interface UnmanagedSuperTypeWithOverloadedMethod {

--- a/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
+++ b/subprojects/performance/src/templates/native-dependents-resources/googleTest/libs/googleTest/1.7.0/include/gtest/internal/gtest-internal.h
@@ -446,7 +446,7 @@ class TestFactoryBase {
   GTEST_DISALLOW_COPY_AND_ASSIGN_(TestFactoryBase);
 };
 
-// This class provides implementation of TeastFactoryBase interface.
+// This class provides implementation of TestFactoryBase interface.
 // It is used in TEST and TEST_F macros.
 template <class TestClass>
 class TestFactoryImpl : public TestFactoryBase {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -262,17 +262,17 @@ test {
     def 'can handle test engine failure'() {
         given:
         createSimpleJupiterTest()
-        file('src/test/java/UninstantiatableExtension.java') << '''
+        file('src/test/java/UninstantiableExtension.java') << '''
 import org.junit.jupiter.api.extension.*;
-public class UninstantiatableExtension implements BeforeEachCallback {
-  private UninstantiatableExtension(){}
+public class UninstantiableExtension implements BeforeEachCallback {
+  private UninstantiableExtension(){}
 
   @Override
   public void beforeEach(final ExtensionContext context) throws Exception {
   }
 }
 '''
-        file('src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension') << 'UninstantiatableExtension'
+        file('src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension') << 'UninstantiableExtension'
         buildFile << '''
             test {
                 systemProperty('junit.jupiter.extensions.autodetection.enabled', 'true')
@@ -285,7 +285,7 @@ public class UninstantiatableExtension implements BeforeEachCallback {
         then:
         new DefaultTestExecutionResult(testDirectory)
             .testClass('UnknownClass')
-            .assertTestFailed('initializationError', containsString('UninstantiatableExtension'))
+            .assertTestFailed('initializationError', containsString('UninstantiableExtension'))
     }
 
     @Issue('https://github.com/gradle/gradle/issues/4427')


### PR DESCRIPTION
### Context
Misspellings make it harder to search for things; they make it harder for people to understand code and descriptions; and sometimes they result in bugs.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes

I'm happy to drop files/directories if they're not yours -- I can't figure out if `subprojects/` is third party content.
I'm happy to split into, e.g. API, docs, code as requested.

--
Generated by https://github.com/jsoref/spelling `f` -- this is the misspelled `a` family

In short, my tool identifies candidates, I manually select and inspect candidates, and corrections are chosen by me manually (although I often let Google suggest the correction instead of typing it myself as it has a lower typo rate).

This is part 7 (part one was #8147)