### PR TITLE
Improve variant disambiguation

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ArtifactSelectionIntegrationTest.groovy
@@ -720,6 +720,7 @@ task show {
             project(':lib') {
                 configurations {
                     compile {
+                        attributes.attribute(buildType, 'n/a')
                         outgoing {
                             variants {
                                 debug {
@@ -763,6 +764,7 @@ task show {
         failure.assertHasCause("""More than one variant of project :lib matches the consumer attributes:
   - Configuration ':lib:compile':
       - Required artifactType 'jar' and found compatible value 'jar'.
+      - Found buildType 'n/a' but wasn't required.
       - Required usage 'api' and found compatible value 'api'.
   - Configuration ':lib:compile' variant debug:
       - Required artifactType 'jar' and found compatible value 'jar'.

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -193,15 +193,28 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
         remaining = new BitSet(candidates.size());
         remaining.or(compatible);
 
-        disambiguateWithRequestedAttributes();
+        disambiguateWithRequestedAttributeValues();
         if (remaining.cardinality() > 1) {
             disambiguateWithExtraAttributes();
         }
-
+        if (remaining.cardinality() > 1) {
+            disambiguateWithRequestedAttributeKeys();
+        }
         return remaining.cardinality() == 0 ? getCandidates(compatible) : getCandidates(remaining);
     }
 
-    private void disambiguateWithRequestedAttributes() {
+    private void disambiguateWithRequestedAttributeKeys() {
+        for (Attribute<?> extraAttribute : extraAttributes) {
+            for (int c = 0; c < candidateAttributeSets.length; c++) {
+                ImmutableAttributes candidateAttributeSet = candidateAttributeSets[c];
+                if (candidateAttributeSet.getAttributes().contains(extraAttribute)) {
+                    remaining.clear(c);
+                }
+            }
+        }
+    }
+
+    private void disambiguateWithRequestedAttributeValues() {
         for (int a = 0; a < requestedAttributes.size(); a++) {
             disambiguateWithAttribute(a);
             if (remaining.cardinality() == 0) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.component.model
+
+import com.google.common.base.Optional
+import com.google.common.collect.ImmutableList
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.capabilities.CapabilitiesMetadata
+import org.gradle.api.capabilities.Capability
+import org.gradle.api.internal.attributes.AttributesSchemaInternal
+import org.gradle.api.internal.attributes.DefaultAttributesSchema
+import org.gradle.api.internal.attributes.ImmutableAttributes
+import org.gradle.internal.component.AmbiguousConfigurationSelectionException
+import org.gradle.internal.component.NoMatchingConfigurationSelectionException
+import org.gradle.util.SnapshotTestUtil
+import org.gradle.util.TestUtil
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static org.gradle.util.AttributeTestUtil.attributes
+
+class AttributeConfigurationSelectorTest extends Specification {
+    private final AttributesSchemaInternal attributesSchema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
+
+    private ComponentResolveMetadata targetComponent
+    private ConfigurationMetadata selected
+    private ImmutableAttributes consumerAttributes = ImmutableAttributes.EMPTY
+    private List<Capability> requestedCapabilities = []
+
+    @Unroll
+    def "selects a variant when there's no ambiguity"() {
+        given:
+        component(
+                variant("api", attributes('org.gradle.usage': 'java-api')),
+                variant("runtime", attributes('org.gradle.usage': 'java-runtime'))
+        )
+
+        and:
+        consumerAttributes('org.gradle.usage': usage)
+
+        when:
+        performSelection()
+
+        then:
+        selected.name == expected
+
+        where:
+        usage          | expected
+        'java-api'     | 'api'
+        'java-runtime' | 'runtime'
+    }
+
+    def "fails to select a variant when there are more than one candidate"() {
+        given:
+        component(
+                variant("api1", attributes('org.gradle.usage': 'java-api')),
+                variant("api2", attributes('org.gradle.usage': 'java-api'))
+        )
+
+        and:
+        consumerAttributes('org.gradle.usage': 'java-api')
+
+        when:
+        performSelection()
+
+        then:
+        AmbiguousConfigurationSelectionException e = thrown()
+        e.message == '''Cannot choose between the following variants of org:lib:1.0:
+  - api1
+  - api2
+All of them match the consumer attributes:
+  - Variant 'api1' capability org:lib:1.0:
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
+  - Variant 'api2' capability org:lib:1.0:
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.'''
+    }
+
+    def "fails to select a variant when there no matching candidates"() {
+        given:
+        component(
+                variant("api", attributes('org.gradle.usage': 'java-api')),
+                variant("runtime", attributes('org.gradle.usage': 'java-runtime'))
+        )
+
+        and:
+        consumerAttributes('org.gradle.usage': 'cplusplus-headers')
+
+        when:
+        performSelection()
+
+        then:
+        NoMatchingConfigurationSelectionException e = thrown()
+        e.message == '''Unable to find a matching variant of org:lib:1.0:
+  - Variant 'api' capability org:lib:1.0:
+      - Required org.gradle.usage 'cplusplus-headers' and found incompatible value 'java-api'.
+  - Variant 'runtime' capability org:lib:1.0:
+      - Required org.gradle.usage 'cplusplus-headers' and found incompatible value 'java-runtime'.'''
+    }
+
+    @Unroll
+    def "can select a variant thanks to the capabilities"() {
+        given:
+        component(
+                variant("api1", attributes('org.gradle.usage': 'java-api'), capability('first')),
+                variant("api2", attributes('org.gradle.usage': 'java-api'), capability('second'))
+        )
+
+        and:
+        consumerAttributes('org.gradle.usage': 'java-api')
+        requestCapability capability(cap)
+
+        when:
+        performSelection()
+
+        then:
+        selected.name == expected
+
+        where:
+        cap      | expected
+        'first'  | 'api1'
+        'second' | 'api2'
+    }
+
+    @Unroll
+    def "can select a variant thanks to the implicit capability"() {
+        given:
+        component(
+                variant("api1", attributes('org.gradle.usage': 'java-api')),
+                variant("api2", attributes('org.gradle.usage': 'java-api'), capability('second'))
+        )
+
+        and:
+        consumerAttributes('org.gradle.usage': 'java-api')
+
+        if (cap) {
+            requestCapability capability(cap)
+        }
+
+        when:
+        performSelection()
+
+        then:
+        selected.name == expected
+
+        where:
+        cap      | expected
+        null     | 'api1'
+        'lib'    | 'api1'
+        'second' | 'api2'
+    }
+
+
+    def "fails if more than one variant provides the implicit capability"() {
+        given:
+        component(
+                variant("api1", attributes('org.gradle.usage': 'java-api')),
+                variant("api2", attributes('org.gradle.usage': 'java-api'), capability('lib'), capability('second'))
+        )
+
+        and:
+        consumerAttributes('org.gradle.usage': 'java-api')
+
+        requestCapability capability('lib')
+
+        when:
+        performSelection()
+
+        then:
+        AmbiguousConfigurationSelectionException e = thrown()
+        e.message == '''Cannot choose between the following variants of org:lib:1.0:
+  - api1
+  - api2
+All of them match the consumer attributes:
+  - Variant 'api1' capability org:lib:1.0:
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
+  - Variant 'api2' capabilities org:lib:1.0 and org:second:1.0:
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.'''
+    }
+
+    private void performSelection() {
+        selected = AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(
+                consumerAttributes,
+                requestedCapabilities,
+                targetComponent,
+                attributesSchema
+        )
+    }
+
+    private consumerAttributes(Map<String, Object> attrs) {
+        this.consumerAttributes = attributes(attrs)
+    }
+
+    private void requestCapability(Capability c) {
+        requestedCapabilities << c
+    }
+
+    private void component(ConfigurationMetadata... variants) {
+        targetComponent = Stub(ComponentResolveMetadata) {
+            getModuleVersionId() >> Stub(ModuleVersionIdentifier) {
+                getGroup() >> 'org'
+                getName() >> 'lib'
+                getVersion() >> '1.0'
+            }
+            getId() >> Stub(ComponentIdentifier) {
+                getDisplayName() >> 'org:lib:1.0'
+            }
+            getVariantsForGraphTraversal() >> Optional.of(
+                    ImmutableList.copyOf(variants)
+            )
+            getAttributesSchema() >> attributesSchema
+        }
+    }
+
+    private ConfigurationMetadata variant(String name, ImmutableAttributes attributes, Capability... capabilities) {
+        Stub(ConfigurationMetadata) {
+            getName() >> name
+            getAttributes() >> attributes
+            getCapabilities() >> Mock(CapabilitiesMetadata) {
+                getCapabilities() >> ImmutableList.copyOf(capabilities)
+            }
+        }
+    }
+
+    private Capability capability(String group, String name, String version = '1.0') {
+        Stub(Capability) {
+            getGroup() >> group
+            getName() >> name
+            getVersion() >> version
+        }
+    }
+
+    private Capability capability(String name) {
+        capability('org', name)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/model/AttributeConfigurationSelectorTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.internal.component.AmbiguousConfigurationSelectionException
 import org.gradle.internal.component.NoMatchingConfigurationSelectionException
 import org.gradle.util.SnapshotTestUtil
 import org.gradle.util.TestUtil
+import org.gradle.util.TextUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -83,14 +84,14 @@ class AttributeConfigurationSelectorTest extends Specification {
 
         then:
         AmbiguousConfigurationSelectionException e = thrown()
-        e.message == '''Cannot choose between the following variants of org:lib:1.0:
+        failsWith(e, '''Cannot choose between the following variants of org:lib:1.0:
   - api1
   - api2
 All of them match the consumer attributes:
   - Variant 'api1' capability org:lib:1.0:
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'api2' capability org:lib:1.0:
-      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.'''
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.''')
     }
 
     def "fails to select a variant when there no matching candidates"() {
@@ -108,11 +109,11 @@ All of them match the consumer attributes:
 
         then:
         NoMatchingConfigurationSelectionException e = thrown()
-        e.message == '''Unable to find a matching variant of org:lib:1.0:
+        failsWith(e, '''Unable to find a matching variant of org:lib:1.0:
   - Variant 'api' capability org:lib:1.0:
       - Required org.gradle.usage 'cplusplus-headers' and found incompatible value 'java-api'.
   - Variant 'runtime' capability org:lib:1.0:
-      - Required org.gradle.usage 'cplusplus-headers' and found incompatible value 'java-runtime'.'''
+      - Required org.gradle.usage 'cplusplus-headers' and found incompatible value 'java-runtime'.''')
     }
 
     @Unroll
@@ -186,7 +187,7 @@ All of them match the consumer attributes:
 
         then:
         AmbiguousConfigurationSelectionException e = thrown()
-        e.message == '''Cannot choose between the following variants of org:lib:1.0:
+        failsWith(e,'''Cannot choose between the following variants of org:lib:1.0:
   - api1
   - api2
   - api3
@@ -196,7 +197,7 @@ All of them match the consumer attributes:
   - Variant 'api2' capability org:lib:1.0:
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'api3' capabilities org:lib:1.0 and org:second:1.0:
-      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.'''
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.''')
     }
 
     def "should select the variant which matches the most attributes"() {
@@ -231,7 +232,7 @@ All of them match the consumer attributes:
 
         then:
         AmbiguousConfigurationSelectionException e = thrown()
-        e.message == '''Cannot choose between the following variants of org:lib:1.0:
+        failsWith(e, '''Cannot choose between the following variants of org:lib:1.0:
   - first
   - second
 All of them match the consumer attributes:
@@ -240,7 +241,7 @@ All of them match the consumer attributes:
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
   - Variant 'second' capability org:lib:1.0:
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
-      - Found other 'true' but wasn't required.'''
+      - Found other 'true' but wasn't required.''')
 
     }
 
@@ -259,7 +260,7 @@ All of them match the consumer attributes:
 
         then:
         AmbiguousConfigurationSelectionException e = thrown()
-        e.message == '''Cannot choose between the following variants of org:lib:1.0:
+        failsWith(e, '''Cannot choose between the following variants of org:lib:1.0:
   - first
   - second
 All of them match the consumer attributes:
@@ -269,7 +270,7 @@ All of them match the consumer attributes:
       - Found other 'true' but wasn't required.
   - Variant 'second' capability org:lib:1.0:
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
-      - Found other 'true' but wasn't required.'''
+      - Found other 'true' but wasn't required.''')
 
     }
 
@@ -347,6 +348,12 @@ All of them match the consumer attributes:
 
     private Capability capability(String name) {
         capability('org', name)
+    }
+
+    private void failsWith(Throwable e, String message) {
+        String actualMessage = TextUtil.normaliseLineSeparators(e.message)
+        String expectedMessage = TextUtil.normaliseLineSeparators(message)
+        assert actualMessage == expectedMessage
     }
 
     private static class UsageCompatibilityRule implements AttributeCompatibilityRule<String> {


### PR DESCRIPTION
### Context

This PR improves variant disambiguation in case after disambiguation, we have multiple candidates, but only one of them has _the same attribute set_ as the requested attributes. For example, given a producer with 2 compatible variants:

- usage: API
- usage: API, extra: foo

and a query "usage: API"
both variants are compatible and we can't disambiguate using extra attributes. However, the 1st one is "closer" to the requested attributes, so we prefer it. This is done in order to reduce the impact of plugins using extra attributes, and producers of "default variants" not being aware of those attributes. For example, if the Java plugin is applied on a producer, we would produce the regular variants (API, runtime, ...) but if another plugin is applied and creates a new outgoing configuration which has an extra attribute, we don't want to update all the existing configurations (and later publications) in order to add a dummy value to the configurations so that we can disambiguate. Said differently, adding a configuration with an extra attribute should not prevent from selecting a configuration just because a new plugin was applied.

