### PR TITLE
Fix handling symbolic links pointing to non-existing files in output directories

### DIFF
--- a/subprojects/files/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
+++ b/subprojects/files/src/testFixtures/groovy/org/gradle/api/internal/file/collections/AbstractDirectoryWalkerTest.groovy
@@ -29,6 +29,7 @@ import org.gradle.util.Requires
 import org.gradle.util.SetSystemProperties
 import org.gradle.util.TestPrecondition
 import org.gradle.util.UsesNativeServices
+import org.junit.Assume
 import org.junit.Rule
 import spock.lang.Issue
 import spock.lang.Specification
@@ -155,6 +156,7 @@ abstract class AbstractDirectoryWalkerTest<T> extends Specification {
     @Requires(TestPrecondition.SYMLINKS)
     @Unroll
     def "missing symbolic link causes an exception - walker: #walkerInstance.class.simpleName"() {
+        Assume.assumeTrue(enableMissingLinkTest())
         given:
         def rootDir = tmpDir.createDir("root")
         def dir = rootDir.createDir("a/b")
@@ -238,4 +240,8 @@ abstract class AbstractDirectoryWalkerTest<T> extends Specification {
     }
 
     protected abstract List<String> walkDirForPaths(T walkerInstance, File rootDir, PatternSet patternSet)
+
+    protected boolean enableMissingLinkTest() {
+        return true
+    }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/BrokenLinkSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/BrokenLinkSnapshot.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.snapshot;
+
+import org.gradle.internal.file.FileType;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.Hashing;
+
+public class BrokenLinkSnapshot extends AbstractFileSystemLocationSnapshot {
+    private static final HashCode SIGNATURE = Hashing.signature(BrokenLinkSnapshot.class);
+
+    public BrokenLinkSnapshot(String absolutePath, String name) {
+        super(absolutePath, name);
+    }
+
+    @Override
+    public FileType getType() {
+        return FileType.Missing;
+    }
+
+    @Override
+    public HashCode getHash() {
+        return SIGNATURE;
+    }
+
+    @Override
+    public boolean isContentAndMetadataUpToDate(FileSystemLocationSnapshot other) {
+        return other instanceof BrokenLinkSnapshot;
+    }
+
+    @Override
+    public void accept(FileSystemSnapshotVisitor visitor) {
+        visitor.visit(this);
+    }
+}


### PR DESCRIPTION
### Context
Fixes #1365 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [-] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [-] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
