### PR TITLE
Some FileCollection cleanup

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/file/ProjectLayoutIntegrationTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.file
 
-import org.gradle.api.internal.file.collections.ImmutableFileCollection
+
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
@@ -219,7 +219,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         'FileCollection'             | 'Closure'        | 'project.layout.files({ "src/resource/file.txt" })'
         'FileCollection'             | 'List'           | 'project.layout.files([ "src/resource/file.txt" ])'
         'FileCollection'             | 'array'          | 'project.layout.files([ "src/resource/file.txt" ] as Object[])'
-        'FileCollection'             | 'FileCollection' | "project.layout.files(${ImmutableFileCollection.name}.of(new File('src/resource/file.txt')))"
+        'FileCollection'             | 'FileCollection' | "project.layout.files(project.layout.files('src/resource/file.txt'))"
         'FileCollection'             | 'Callable'       | "project.layout.files($STRING_CALLABLE)"
         'FileCollection'             | 'Provider'       | "project.layout.files(provider($STRING_CALLABLE))"
         'FileCollection'             | 'nested objects' | "project.layout.files({[{$STRING_CALLABLE}]})"
@@ -234,7 +234,7 @@ class ProjectLayoutIntegrationTest extends AbstractIntegrationSpec {
         'ConfigurableFileCollection' | 'Closure'        | 'project.layout.configurableFiles({ "src/resource/file.txt" })'
         'ConfigurableFileCollection' | 'List'           | 'project.layout.configurableFiles([ "src/resource/file.txt" ])'
         'ConfigurableFileCollection' | 'array'          | 'project.layout.configurableFiles([ "src/resource/file.txt" ] as Object[])'
-        'ConfigurableFileCollection' | 'FileCollection' | "project.layout.configurableFiles(${ImmutableFileCollection.name}.of(new File('src/resource/file.txt')))"
+        'ConfigurableFileCollection' | 'FileCollection' | "project.layout.configurableFiles(project.layout.files('src/resource/file.txt'))"
         'ConfigurableFileCollection' | 'Callable'       | "project.layout.configurableFiles($STRING_CALLABLE)"
         'ConfigurableFileCollection' | 'Provider'       | "project.layout.configurableFiles(provider($STRING_CALLABLE))"
         'ConfigurableFileCollection' | 'nested objects' | "project.layout.configurableFiles({[{$STRING_CALLABLE}]})"

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -30,7 +30,6 @@ import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.taskfactory.TaskIdentity;
@@ -161,12 +160,11 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
         this.shouldRunAfter = new DefaultTaskDependency(tasks);
         this.services = project.getServices();
 
-        FileResolver fileResolver = project.getFileResolver();
         PropertyWalker propertyWalker = services.get(PropertyWalker.class);
         FileCollectionFactory fileCollectionFactory = services.get(FileCollectionFactory.class);
         taskMutator = new TaskMutator(this);
         taskInputs = new DefaultTaskInputs(this, taskMutator, propertyWalker, fileCollectionFactory);
-        taskOutputs = new DefaultTaskOutputs(this, taskMutator, propertyWalker, fileResolver, fileCollectionFactory);
+        taskOutputs = new DefaultTaskOutputs(this, taskMutator, propertyWalker, fileCollectionFactory);
         taskDestroyables = new DefaultTaskDestroyables(taskMutator);
         taskLocalState = new DefaultTaskLocalState(taskMutator);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Set;
 
 public class DefaultFileCollectionFactory implements FileCollectionFactory {
+    public static final String DEFAULT_DISPLAY_NAME = "file collection";
     private final PathToFileResolver fileResolver;
     @Nullable
     private final TaskResolver taskResolver;
@@ -90,7 +91,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal resolving(Object... files) {
-        return resolving("file collection", files);
+        return resolving(DEFAULT_DISPLAY_NAME, files);
     }
 
     @Override
@@ -104,11 +105,26 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
     }
 
     @Override
+    public FileCollectionInternal empty() {
+        return empty(DEFAULT_DISPLAY_NAME);
+    }
+
+    @Override
+    public FileCollectionInternal fixed(File... files) {
+        return fixed(DEFAULT_DISPLAY_NAME, files);
+    }
+
+    @Override
     public FileCollectionInternal fixed(final String displayName, File... files) {
         if (files.length == 0) {
             return new EmptyFileCollection(displayName);
         }
         return new FixedFileCollection(displayName, ImmutableSet.copyOf(files));
+    }
+
+    @Override
+    public FileCollectionInternal fixed(Collection<File> files) {
+        return fixed(DEFAULT_DISPLAY_NAME, files);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileCollectionFactory.java
@@ -46,6 +46,21 @@ public interface FileCollectionFactory {
     FileCollectionInternal empty(String displayName);
 
     /**
+     * Creates an empty {@link FileCollection}
+     */
+    FileCollectionInternal empty();
+
+    /**
+     * Creates a {@link FileCollection} with the given files as content.
+     */
+    FileCollectionInternal fixed(File... files);
+
+    /**
+     * Creates a {@link FileCollection} with the given files as content.
+     */
+    FileCollectionInternal fixed(Collection<File> files);
+
+    /**
      * Creates a {@link FileCollection} with the given files as content.
      */
     FileCollectionInternal fixed(String displayName, File... files);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/FileOperations.java
@@ -50,10 +50,8 @@ public interface FileOperations {
      * Creates an immutable file collection with the given paths. The paths are resolved
      * with the file resolver.
      *
-     * If no resolution is required, use {@link org.gradle.api.internal.file.collections.ImmutableFileCollection#of(File...)} instead.
-     *
      * @see #getFileResolver()
-.     */
+     */
     FileCollection immutableFiles(Object... paths);
 
     ConfigurableFileTree fileTree(Object baseDir);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClasspathHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClasspathHasher.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.initialization.loadercache;
 
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.classloader.ClasspathHasher;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
@@ -26,14 +26,16 @@ import org.gradle.internal.hash.HashCode;
 public class DefaultClasspathHasher implements ClasspathHasher {
 
     private final ClasspathFingerprinter fingerprinter;
+    private final FileCollectionFactory fileCollectionFactory;
 
-    public DefaultClasspathHasher(ClasspathFingerprinter fingerprinter) {
+    public DefaultClasspathHasher(ClasspathFingerprinter fingerprinter, FileCollectionFactory fileCollectionFactory) {
         this.fingerprinter = fingerprinter;
+        this.fileCollectionFactory = fileCollectionFactory;
     }
 
     @Override
     public HashCode hash(ClassPath classpath) {
-        CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(ImmutableFileCollection.of(classpath.getAsFiles()));
+        CurrentFileCollectionFingerprint fingerprint = fingerprinter.fingerprint(fileCollectionFactory.fixed(classpath.getAsFiles()));
         return fingerprint.getHash();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskOutputs.java
@@ -38,7 +38,6 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.specs.AndSpec;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskOutputFilePropertyBuilder;
-import org.gradle.internal.file.PathToFileResolver;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -51,7 +50,6 @@ import java.util.concurrent.Callable;
 public class DefaultTaskOutputs implements TaskOutputsInternal {
     private final FileCollection allOutputFiles;
     private final PropertyWalker propertyWalker;
-    private final PathToFileResolver fileResolver;
     private final FileCollectionFactory fileCollectionFactory;
     private AndSpec<TaskInternal> upToDateSpec = AndSpec.empty();
     private List<SelfDescribingSpec<TaskInternal>> cacheIfSpecs = new LinkedList<SelfDescribingSpec<TaskInternal>>();
@@ -61,12 +59,11 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     private final TaskInternal task;
     private final TaskMutator taskMutator;
 
-    public DefaultTaskOutputs(final TaskInternal task, TaskMutator taskMutator, PropertyWalker propertyWalker, PathToFileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
+    public DefaultTaskOutputs(final TaskInternal task, TaskMutator taskMutator, PropertyWalker propertyWalker, FileCollectionFactory fileCollectionFactory) {
         this.task = task;
         this.taskMutator = taskMutator;
         this.allOutputFiles = new TaskOutputUnionFileCollection(task);
         this.propertyWalker = propertyWalker;
-        this.fileResolver = fileResolver;
         this.fileCollectionFactory = fileCollectionFactory;
     }
 
@@ -149,7 +146,7 @@ public class DefaultTaskOutputs implements TaskOutputsInternal {
     }
 
     public ImmutableSortedSet<OutputFilePropertySpec> getFileProperties() {
-        GetOutputFilesVisitor visitor = new GetOutputFilesVisitor(task.toString(), fileResolver, fileCollectionFactory);
+        GetOutputFilesVisitor visitor = new GetOutputFilesVisitor(task.toString(), fileCollectionFactory);
         TaskPropertyUtils.visitProperties(propertyWalker, task, visitor);
         return visitor.getFileProperties();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuter.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.changedetection.TaskExecutionMode;
 import org.gradle.api.internal.changedetection.TaskExecutionModeResolver;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.collections.LazilyInitializedFileCollection;
 import org.gradle.api.internal.tasks.TaskExecuter;
 import org.gradle.api.internal.tasks.TaskExecuterResult;
@@ -34,7 +33,6 @@ import org.gradle.api.internal.tasks.properties.DefaultTaskProperties;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
 import org.gradle.internal.execution.history.AfterPreviousExecutionState;
-import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
@@ -50,23 +48,21 @@ public class ResolveTaskExecutionModeExecuter implements TaskExecuter {
     private static final Logger LOGGER = LoggerFactory.getLogger(ResolveTaskExecutionModeExecuter.class);
 
     private final PropertyWalker propertyWalker;
-    private final PathToFileResolver fileResolver;
     private final TaskExecuter executer;
     private final TaskExecutionModeResolver executionModeResolver;
     private final FileCollectionFactory fileCollectionFactory;
 
-    public ResolveTaskExecutionModeExecuter(TaskExecutionModeResolver executionModeResolver, PathToFileResolver fileResolver, FileCollectionFactory fileCollectionFactory, PropertyWalker propertyWalker, TaskExecuter executer) {
+    public ResolveTaskExecutionModeExecuter(TaskExecutionModeResolver executionModeResolver, FileCollectionFactory fileCollectionFactory, PropertyWalker propertyWalker, TaskExecuter executer) {
         this.fileCollectionFactory = fileCollectionFactory;
         this.propertyWalker = propertyWalker;
-        this.fileResolver = fileResolver;
         this.executer = executer;
         this.executionModeResolver = executionModeResolver;
     }
 
     @Override
-    public TaskExecuterResult execute(TaskInternal task, TaskStateInternal state, final TaskExecutionContext context) {
+    public TaskExecuterResult execute(final TaskInternal task, TaskStateInternal state, final TaskExecutionContext context) {
         Timer clock = Time.startTimer();
-        TaskProperties properties = DefaultTaskProperties.resolve(propertyWalker, fileResolver, fileCollectionFactory, task);
+        TaskProperties properties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task);
         context.setTaskProperties(properties);
         TaskExecutionMode taskExecutionMode = executionModeResolver.getExecutionMode(task, properties);
         TaskOutputsInternal outputs = task.getOutputs();
@@ -77,7 +73,7 @@ public class ResolveTaskExecutionModeExecuter implements TaskExecuter {
             public FileCollection createDelegate() {
                 AfterPreviousExecutionState previousExecution = context.getAfterPreviousExecution();
                 if (previousExecution == null) {
-                    return ImmutableFileCollection.of();
+                    return fileCollectionFactory.empty();
                 }
                 ImmutableCollection<FileCollectionFingerprint> outputFingerprints = previousExecution.getOutputFileProperties().values();
                 Set<File> outputs = new HashSet<File>();
@@ -86,12 +82,12 @@ public class ResolveTaskExecutionModeExecuter implements TaskExecuter {
                         outputs.add(new File(absolutePath));
                     }
                 }
-                return ImmutableFileCollection.of(outputs);
+                return fileCollectionFactory.fixed(outputs);
             }
 
             @Override
             public String getDisplayName() {
-                return "previous output files";
+                return "previous output files of " + task.toString();
             }
         });
         LOGGER.debug("Putting task artifact state for {} into context took {}.", task, clock.getElapsed());

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultCacheableOutputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultCacheableOutputFilePropertySpec.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.properties;
 
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
+import org.gradle.api.file.FileCollection;
 import org.gradle.internal.file.TreeType;
 import org.gradle.internal.fingerprint.OutputNormalizer;
 
@@ -25,13 +25,11 @@ import java.io.File;
 
 public class DefaultCacheableOutputFilePropertySpec extends AbstractFilePropertySpec implements CacheableOutputFilePropertySpec {
     private final String propertySuffix;
-    private final File outputFile;
     private final TreeType outputType;
 
-    public DefaultCacheableOutputFilePropertySpec(String propertyName, @Nullable String propertySuffix, File outputFile, TreeType outputType) {
-        super(propertyName, OutputNormalizer.class, ImmutableFileCollection.of(outputFile));
+    public DefaultCacheableOutputFilePropertySpec(String propertyName, @Nullable String propertySuffix, FileCollection outputFiles, TreeType outputType) {
+        super(propertyName, OutputNormalizer.class, outputFiles);
         this.propertySuffix = propertySuffix;
-        this.outputFile = outputFile;
         this.outputType = outputType;
     }
 
@@ -43,7 +41,7 @@ public class DefaultCacheableOutputFilePropertySpec extends AbstractFileProperty
     @Override
     @Nullable
     public File getOutputFile() {
-        return outputFile;
+        return getPropertyFiles().getSingleFile();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -30,7 +30,6 @@ import org.gradle.api.internal.tasks.TaskValidationContext;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.Factory;
-import org.gradle.internal.file.PathToFileResolver;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -51,10 +50,10 @@ public class DefaultTaskProperties implements TaskProperties {
     private FileCollection destroyableFiles;
     private List<ValidatingProperty> validatingProperties;
 
-    public static TaskProperties resolve(PropertyWalker propertyWalker, PathToFileResolver resolver, FileCollectionFactory fileCollectionFactory, TaskInternal task) {
+    public static TaskProperties resolve(PropertyWalker propertyWalker, FileCollectionFactory fileCollectionFactory, TaskInternal task) {
         String beanName = task.toString();
         GetInputFilesVisitor inputFilesVisitor = new GetInputFilesVisitor(beanName, fileCollectionFactory);
-        GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor(beanName, resolver, fileCollectionFactory);
+        GetOutputFilesVisitor outputFilesVisitor = new GetOutputFilesVisitor(beanName, fileCollectionFactory);
         GetInputPropertiesVisitor inputPropertiesVisitor = new GetInputPropertiesVisitor(beanName);
         GetLocalStateVisitor localStateVisitor = new GetLocalStateVisitor(beanName, fileCollectionFactory);
         GetDestroyablesVisitor destroyablesVisitor = new GetDestroyablesVisitor(beanName, fileCollectionFactory);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetOutputFilesVisitor.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.file.FileCollectionFactory;
-import org.gradle.internal.file.PathToFileResolver;
 
 import java.util.List;
 import java.util.function.Consumer;
@@ -29,21 +28,19 @@ import java.util.function.Consumer;
 public class GetOutputFilesVisitor extends PropertyVisitor.Adapter {
     private final List<OutputFilePropertySpec> specs = Lists.newArrayList();
     private final String ownerDisplayName;
-    private final PathToFileResolver fileResolver;
     private final FileCollectionFactory fileCollectionFactory;
     private ImmutableSortedSet<OutputFilePropertySpec> fileProperties;
     private boolean hasDeclaredOutputs;
 
-    public GetOutputFilesVisitor(String ownerDisplayName, PathToFileResolver fileResolver, FileCollectionFactory fileCollectionFactory) {
+    public GetOutputFilesVisitor(String ownerDisplayName, FileCollectionFactory fileCollectionFactory) {
         this.ownerDisplayName = ownerDisplayName;
-        this.fileResolver = fileResolver;
         this.fileCollectionFactory = fileCollectionFactory;
     }
 
     @Override
     public void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
         hasDeclaredOutputs = true;
-        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileResolver, fileCollectionFactory, new Consumer<OutputFilePropertySpec>() {
+        FileParameterUtils.resolveOutputFilePropertySpecs(ownerDisplayName, propertyName, value, filePropertyType, fileCollectionFactory, new Consumer<OutputFilePropertySpec>() {
             @Override
             public void accept(OutputFilePropertySpec outputFilePropertySpec) {
                 specs.add(outputFilePropertySpec);

--- a/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/ProjectExecutionServices.java
@@ -154,7 +154,7 @@ public class ProjectExecutionServices extends DefaultServiceRegistry {
         executer = new ResolveAfterPreviousExecutionStateTaskExecuter(executionHistoryStore, executer);
         executer = new CleanupStaleOutputsExecuter(cleanupRegistry, outputFilesRepository, buildOperationExecutor, outputChangeListener, executer);
         executer = new FinalizePropertiesTaskExecuter(executer);
-        executer = new ResolveTaskExecutionModeExecuter(repository, resolver, fileCollectionFactory, propertyWalker, executer);
+        executer = new ResolveTaskExecutionModeExecuter(repository, fileCollectionFactory, propertyWalker, executer);
         executer = new SkipTaskWithNoActionsExecuter(taskExecutionGraph, executer);
         executer = new SkipOnlyIfTaskExecuter(executer);
         executer = new CatchExceptionTaskExecuter(executer);

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -614,13 +614,12 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                             new Runnable() {
                                 @Override
                                 public void run() {
-                                    FileParameterUtils.resolveOutputFilePropertySpecs(task.toString(), propertyName, value, filePropertyType, resolver, fileCollectionFactory, new Consumer<OutputFilePropertySpec>() {
+                                    FileParameterUtils.resolveOutputFilePropertySpecs(task.toString(), propertyName, value, filePropertyType, fileCollectionFactory, new Consumer<OutputFilePropertySpec>() {
                                         @Override
                                         public void accept(OutputFilePropertySpec outputFilePropertySpec) {
                                             mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, outputFilePropertySpec.getPropertyFiles()));
                                         }
                                     });
-
                                 }
                             }
                         );

--- a/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
+++ b/subprojects/core/src/main/java/org/gradle/groovy/scripts/DefaultScript.java
@@ -165,7 +165,7 @@ public abstract class DefaultScript extends BasicScript {
 
     @Override
     public ConfigurableFileCollection files(Object paths, Closure configureClosure) {
-        return ConfigureUtil.configure(configureClosure, fileOperations.configurableFiles(paths));
+        return ConfigureUtil.configure(configureClosure, files(paths));
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleUserHomeScopeServices.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.changedetection.state.GlobalScopeFileTimeStampIns
 import org.gradle.api.internal.changedetection.state.ResourceFilter;
 import org.gradle.api.internal.changedetection.state.ResourceSnapshotterCacheService;
 import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.TemporaryFileProvider;
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache;
 import org.gradle.api.internal.initialization.loadercache.DefaultClassLoaderCache;
@@ -201,8 +202,8 @@ public class GradleUserHomeScopeServices {
         return new DefaultClasspathFingerprinter(resourceSnapshotterCacheService, fileSystemSnapshotter, ResourceFilter.FILTER_NOTHING, stringInterner);
     }
 
-    ClasspathHasher createClasspathHasher(ClasspathFingerprinter fingerprinter) {
-        return new DefaultClasspathHasher(fingerprinter);
+    ClasspathHasher createClasspathHasher(ClasspathFingerprinter fingerprinter, FileCollectionFactory fileCollectionFactory) {
+        return new DefaultClasspathHasher(fingerprinter, fileCollectionFactory);
     }
 
     HashingClassLoaderFactory createClassLoaderFactory(ClasspathHasher classpathHasher) {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -640,7 +640,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         def task = (value == null) ? expectTaskCreated(type) : expectTaskCreated(type, value as Object[])
 
         when:
-        def taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileResolver, fileCollectionFactory, task)
+        def taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task)
 
         then:
         taskProperties.inputPropertyValues.create().keySet() == inputs as Set
@@ -686,7 +686,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         def task = expectTaskCreated(TaskWithLocalState, localState)
 
         when:
-        def taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileResolver, fileCollectionFactory, task)
+        def taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task)
 
         then:
         taskProperties.localStateFiles.files as List == [localState]
@@ -702,7 +702,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         def task = expectTaskCreated(TaskWithDestroyable, destroyable)
 
         when:
-        def taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileResolver, fileCollectionFactory, task)
+        def taskProperties = DefaultTaskProperties.resolve(propertyWalker, fileCollectionFactory, task)
 
         then:
         taskProperties.destroyableFiles.files as List == [destroyable]

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -18,7 +18,6 @@ package org.gradle.api.internal.tasks
 import org.gradle.api.internal.TaskInputsInternal
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.properties.DefaultPropertyWalker
 import org.gradle.api.internal.tasks.properties.DefaultTypeMetadataStore
 import org.gradle.api.internal.tasks.properties.OutputFilePropertyType
@@ -53,24 +52,18 @@ class DefaultTaskOutputsTest extends Specification {
             }
         }
     }
-    private final resolver = TestFiles.resolver(temporaryFolder.testDirectory)
     private final fileCollectionFactory = TestFiles.fileCollectionFactory(temporaryFolder.testDirectory)
 
-    def project = Stub(ProjectInternal) {
-        getFileFileResolver() >> resolver
-    }
     def task = Mock(TaskInternal) {
         getName() >> "task"
         toString() >> "task 'task'"
-        getProject() >> project
-        getProject() >> project
         getOutputs() >> { outputs }
         getInputs() >> Stub(TaskInputsInternal)
         getDestroyables() >> Stub(TaskDestroyablesInternal)
         getLocalState() >> Stub(TaskLocalStateInternal)
     }
 
-    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs(task, taskStatusNagger, new DefaultPropertyWalker(new DefaultTypeMetadataStore([], new TestCrossBuildInMemoryCacheFactory())), resolver, fileCollectionFactory)
+    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs(task, taskStatusNagger, new DefaultPropertyWalker(new DefaultTypeMetadataStore([], new TestCrossBuildInMemoryCacheFactory())), fileCollectionFactory)
 
     void hasNoOutputsByDefault() {
         setup:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ResolveTaskExecutionModeExecuterTest.groovy
@@ -33,7 +33,6 @@ import org.gradle.api.internal.tasks.TaskExecutionContext
 import org.gradle.api.internal.tasks.TaskLocalStateInternal
 import org.gradle.api.internal.tasks.TaskStateInternal
 import org.gradle.api.internal.tasks.properties.PropertyWalker
-import org.gradle.internal.file.PathToFileResolver
 import spock.lang.Specification
 import spock.lang.Subject
 
@@ -49,13 +48,12 @@ class ResolveTaskExecutionModeExecuterTest extends Specification {
     final taskContext = Mock(TaskExecutionContext)
     final repository = Mock(TaskExecutionModeResolver)
     final executionMode = TaskExecutionMode.INCREMENTAL
-    final resolver = Mock(PathToFileResolver)
     final fileCollectionFactory = Mock(FileCollectionFactory)
     final propertyWalker = Mock(PropertyWalker)
     final project = Mock(ProjectInternal)
     final Action<Task> action = Mock(Action)
 
-    final executer = new ResolveTaskExecutionModeExecuter(repository, resolver, fileCollectionFactory, propertyWalker, delegate)
+    final executer = new ResolveTaskExecutionModeExecuter(repository, fileCollectionFactory, propertyWalker, delegate)
 
     def 'taskContext is initialized and cleaned as expected'() {
         when:

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/GradleUserHomeScopeServicesTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.internal.cache.StringInterner
 import org.gradle.api.internal.changedetection.state.CrossBuildFileHashCache
 import org.gradle.api.internal.changedetection.state.GlobalScopeFileTimeStampInspector
 import org.gradle.api.internal.classpath.ModuleRegistry
+import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TemporaryFileProvider
 import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory
 import org.gradle.api.internal.initialization.loadercache.ClassLoaderCache
@@ -125,6 +126,7 @@ class GradleUserHomeScopeServicesTest extends WorkspaceTest {
         expectParentServiceLocated(ClassLoaderRegistry)
         expectParentServiceLocated(DirectoryFileTreeFactory)
         expectParentServiceLocated(StreamHasher)
+        expectParentServiceLocated(FileCollectionFactory)
 
         expect:
         findsAndCachesService(serviceType)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -68,9 +68,9 @@ class Producer extends DefaultTask {
 
     /**
      * Each project produces 'blue' variants, and has a task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
-     * Caller will need to provide an implementation of 'MakeGreen' transform
+     * Caller will need to provide an implementation of 'MakeGreen' transform action
      */
-    void setupBuildWithColorTransform() {
+    void setupBuildWithColorTransformAction() {
         setupBuildWithColorAttributes()
         buildFile << """
 allprojects {
@@ -78,6 +78,27 @@ allprojects {
         registerTransformAction(MakeGreen) {
             from.attribute(color, 'blue')
             to.attribute(color, 'green')
+        }
+    }
+}
+"""
+    }
+
+    /**
+     * Each project produces 'blue' variants, and has a task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Caller will need to provide an implementation of 'MakeGreen' transform configuration and a `makeGreenParameters()` method to apply to the configuration object
+     */
+    void setupBuildWithColorTransform() {
+        setupBuildWithColorAttributes()
+        buildFile << """
+allprojects { p ->
+    dependencies {
+        registerTransform(MakeGreen) {
+            from.attribute(color, 'blue')
+            to.attribute(color, 'green')
+            parameters {
+                makeGreenParameters(p, it)
+            }
         }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+
+
+class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
+    /**
+     * Caller should add elements to the 'inputFiles' property to make them inputs to the transform
+     */
+    def setupBuildWithTransformFileInputs() {
+        buildFile << """
+            def makeGreenParameters(project, params) { 
+                params.someFiles.from(project.inputFiles)
+            }
+        """
+        setupBuildWithColorTransform()
+        buildFile << """
+            @TransformAction(MakeGreenAction)
+            interface MakeGreen {
+                @Input
+                ConfigurableFileCollection getSomeFiles()
+            }
+            
+            abstract class MakeGreenAction implements ArtifactTransformAction {
+                @TransformParameters
+                abstract MakeGreen getParameters()
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    println "processing \${input.name} using \${parameters.someFiles*.name}"
+                    def output = outputs.registerOutput(input.name + ".green")
+                    output.text = "ok"
+                }
+            }
+        """
+    }
+
+    def "transform can receive pre-built file collection via parameter object"() {
+        settingsFile << """
+                include 'a', 'b', 'c'
+            """
+        // TODO - should be able to do this after registering the transform
+        buildFile << """
+            allprojects {
+                ext.inputFiles = files('a.txt', 'b.txt')
+            }
+        """
+        setupBuildWithTransformFileInputs()
+        buildFile << """
+            
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+"""
+
+        when:
+        run(":a:resolve")
+
+        then:
+        outputContains("processing b.jar using [a.txt, b.txt]")
+        outputContains("processing c.jar using [a.txt, b.txt]")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
+    def "transform can receive a file collection containing external dependencies as parameter"() {
+        mavenRepo.module("test", "tool-a", "1.2").publish()
+        mavenRepo.module("test", "tool-b", "1.2").publish()
+
+        settingsFile << """
+                include 'a', 'b', 'c'
+            """
+        // TODO - should be able to add the dependencies after registering the transform
+        buildFile << """
+            allprojects {
+                configurations.create("tools") { }
+                repositories.maven { url = '${mavenRepo.uri}' }
+                ext.inputFiles = configurations.tools
+            }
+            
+            project(':a') {
+                dependencies {
+                    tools 'test:tool-a:1.2'
+                    tools 'test:tool-b:1.2'
+                }
+            }
+"""
+        setupBuildWithTransformFileInputs()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+"""
+
+        when:
+        run(":a:resolve")
+
+        then:
+        outputContains("processing b.jar using [tool-a-1.2.jar, tool-b-1.2.jar]")
+        outputContains("processing c.jar using [tool-a-1.2.jar, tool-b-1.2.jar]")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
+    def "transform can receive a file collection containing task outputs as parameter"() {
+        settingsFile << """
+                include 'a', 'b', 'c'
+            """
+        // TODO - should be able to add task outputs after registering transform
+        buildFile << """
+            allprojects {
+                task tool(type: Producer) {
+                    outputFile = file("build/tool-\${project.name}.jar")
+                }
+                ext.inputFiles = files(tool.outputFile)                
+            }
+        """
+        setupBuildWithTransformFileInputs()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+"""
+
+        when:
+        run(":a:resolve")
+
+        then:
+        // TODO - should run the producer task
+//        result.assertTasksExecuted("a:tool", "b:producer", "c:producer", "a:resolve")
+        outputContains("processing b.jar using [tool-a.jar]")
+        outputContains("processing c.jar using [tool-a.jar]")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
+    def "transform can receive a file collection containing transform outputs as parameter"() {
+        settingsFile << """
+                include 'a', 'b', 'c', 'd', 'e'
+            """
+        // TODO - should be able to add the dependencies after registering the transform
+        buildFile << """
+            allprojects {
+                def attr = Attribute.of('color', String)
+                configurations.create("tools") {
+                    canBeConsumed = false
+                    attributes.attribute(attr, 'blue')
+                }
+                ext.inputFiles = configurations.tools.incoming.artifactView {
+                    attributes.attribute(attr, 'green')
+                }.files
+            }
+            
+            project(':a') {
+                dependencies {
+                    tools project(':d')
+                    tools project(':e')
+                }
+            }
+"""
+        setupBuildWithTransformFileInputs()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+"""
+
+        when:
+        run(":a:resolve")
+
+        then:
+        // the eager resolve of `configuration.tools` happens before the transform is registered and some caching means the transform is ignored
+        // (see https://github.com/gradle/gradle/issues/8418)
+        // this means nothing ends up in the result. Removing the eager resolve will fix this
+//        result.assertTasksExecuted(":b:producer", ":c:producer", ":d:producer", ":e:producer", "a:resolve")
+//        outputContains("processing b.jar using [d.jar.green, e.jar.green]")
+//        outputContains("processing c.jar using [d.jar.green, e.jar.green]")
+//        outputContains("result = [b.jar.green, c.jar.green]")
+        outputContains("result = []")
+    }
+
+    def "transform can receive a file collection containing substituted external dependencies as parameter"() {
+        file("tools/settings.gradle") << """
+            include 'tool-a', 'tool-b'
+        """
+        file("tools/build.gradle") << """
+            allprojects { 
+                group = 'test'
+                configurations.create("default")
+                task producer(type: Producer) {
+                    outputFile = file("build/\${project.name}.jar")
+                }
+                artifacts."default" producer.outputFile
+            }
+            
+            class Producer extends DefaultTask {
+                @OutputFile
+                RegularFileProperty outputFile = project.objects.fileProperty()
+            
+                @TaskAction
+                def go() {
+                    outputFile.get().asFile.text = "output"
+                }
+            }
+        """
+        settingsFile << """
+                include 'a', 'b', 'c'
+                includeBuild 'tools'
+            """
+        // TODO - should be able to add the dependencies after registering the transform
+        buildFile << """
+            allprojects {
+                configurations.create("tools") { }
+                ext.inputFiles = configurations.tools
+            }
+            
+            project(':a') {
+                dependencies {
+                    tools 'test:tool-a:1.2'
+                    tools 'test:tool-b:1.2'
+                }
+            }
+"""
+        setupBuildWithTransformFileInputs()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+"""
+
+        when:
+        run(":a:resolve")
+
+        then:
+        // TODO - should run the producer tasks
+//        result.assertTasksExecuted(":tools:tool-a:producer", ":tools:tool-b:producer", ":b:producer", "c:producer", ":a:resolve")
+        outputContains("processing b.jar using [tool-a.jar, tool-b.jar]")
+        outputContains("processing c.jar using [tool-a.jar, tool-b.jar]")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -257,6 +257,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                     ArtifactTransformListener artifactTransformListener,
                                                     // For now we assume absolute paths when dealing with dependencies
                                                     AbsolutePathFileCollectionFingerprinter dependencyFingerprinter,
+                                                    FileCollectionFactory fileCollectionFactory,
                                                     OutputFileCollectionFingerprinter outputFileCollectionFingerprinter,
                                                     ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
                                                     ProjectFinder projectFinder,
@@ -267,6 +268,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 artifactTransformListener,
                 transformationWorkspaceProvider,
                 dependencyFingerprinter,
+                fileCollectionFactory,
                 outputFileCollectionFingerprinter,
                 classLoaderHierarchyHasher,
                 projectFinder,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -672,7 +672,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
             public void run() {
                 resolveExclusively(GRAPH_RESOLVED);
             }
-        });
+        }, fileCollectionFactory);
     }
 
     private ResolverResults getResultsForBuildDependencies() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultExtraExecutionGraphDependenciesResolverFactory.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.internal.artifacts.ResolverResults;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.WorkNodeAction;
 import org.gradle.internal.Factory;
 
@@ -25,15 +26,17 @@ public class DefaultExtraExecutionGraphDependenciesResolverFactory implements Ex
     private final Factory<ResolverResults> graphResults;
     private final Factory<ResolverResults> artifactResults;
     private final WorkNodeAction graphResolveAction;
+    private final FileCollectionFactory fileCollectionFactory;
 
-    public DefaultExtraExecutionGraphDependenciesResolverFactory(Factory<ResolverResults> graphResults, Factory<ResolverResults> artifactResults, WorkNodeAction graphResolveAction) {
+    public DefaultExtraExecutionGraphDependenciesResolverFactory(Factory<ResolverResults> graphResults, Factory<ResolverResults> artifactResults, WorkNodeAction graphResolveAction, FileCollectionFactory fileCollectionFactory) {
         this.graphResults = graphResults;
         this.artifactResults = artifactResults;
         this.graphResolveAction = graphResolveAction;
+        this.fileCollectionFactory = fileCollectionFactory;
     }
 
     @Override
     public ExecutionGraphDependenciesResolver create(ComponentIdentifier componentIdentifier) {
-        return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, graphResolveAction);
+        return new DefaultExecutionGraphDependenciesResolver(componentIdentifier, graphResults, artifactResults, graphResolveAction, fileCollectionFactory);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.file.RelativePath;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
 import org.gradle.api.internal.artifacts.transform.TransformationWorkspaceProvider.TransformationWorkspace;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
+import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.origin.OriginMetadata;
@@ -80,6 +80,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
     private final ArtifactTransformListener artifactTransformListener;
     private final CachingTransformationWorkspaceProvider immutableTransformationWorkspaceProvider;
     private final FileCollectionFingerprinter dependencyFingerprinter;
+    private final FileCollectionFactory fileCollectionFactory;
     private final OutputFileCollectionFingerprinter outputFingerprinter;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final ProjectFinder projectFinder;
@@ -90,6 +91,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
                                      ArtifactTransformListener artifactTransformListener,
                                      CachingTransformationWorkspaceProvider immutableTransformationWorkspaceProvider,
                                      FileCollectionFingerprinter dependencyFingerprinter,
+                                     FileCollectionFactory fileCollectionFactory,
                                      OutputFileCollectionFingerprinter outputFileCollectionFingerprinter,
                                      ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
                                      ProjectFinder projectFinder,
@@ -99,6 +101,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         this.artifactTransformListener = artifactTransformListener;
         this.immutableTransformationWorkspaceProvider = immutableTransformationWorkspaceProvider;
         this.dependencyFingerprinter = dependencyFingerprinter;
+        this.fileCollectionFactory = fileCollectionFactory;
         this.outputFingerprinter = outputFileCollectionFingerprinter;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.projectFinder = projectFinder;
@@ -122,6 +125,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
                     workspace,
                     identityString,
                     workspaceProvider.getExecutionHistoryStore(),
+                    fileCollectionFactory,
                     primaryInput,
                     primaryInputFingerprint,
                     dependencies,
@@ -197,6 +201,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         private final File primaryInput;
         private final String identityString;
         private final ExecutionHistoryStore executionHistoryStore;
+        private final FileCollectionFactory fileCollectionFactory;
         private final ArtifactTransformDependencies dependencies;
         private final ImmutableSortedMap<String, ValueSnapshot> inputSnapshots;
         private final ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints;
@@ -208,6 +213,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
             TransformationWorkspace workspace,
             String identityString,
             ExecutionHistoryStore executionHistoryStore,
+            FileCollectionFactory fileCollectionFactory,
             File primaryInput,
             CurrentFileCollectionFingerprint primaryInputFingerprint,
             ArtifactTransformDependencies dependencies,
@@ -215,6 +221,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
             OutputFileCollectionFingerprinter outputFingerprinter
         ) {
             this.implementationSnapshot = implementationSnapshot;
+            this.fileCollectionFactory = fileCollectionFactory;
             this.primaryInput = primaryInput;
             this.transformer = transformer;
             this.workspace = workspace;
@@ -304,8 +311,8 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
 
         @Override
         public void visitOutputProperties(OutputPropertyVisitor visitor) {
-            visitor.visitOutputProperty(OUTPUT_DIRECTORY_PROPERTY_NAME, TreeType.DIRECTORY, ImmutableFileCollection.of(workspace.getOutputDirectory()));
-            visitor.visitOutputProperty(RESULTS_FILE_PROPERTY_NAME, TreeType.FILE, ImmutableFileCollection.of(workspace.getResultsFile()));
+            visitor.visitOutputProperty(OUTPUT_DIRECTORY_PROPERTY_NAME, TreeType.DIRECTORY, fileCollectionFactory.fixed(workspace.getOutputDirectory()));
+            visitor.visitOutputProperty(RESULTS_FILE_PROPERTY_NAME, TreeType.FILE, fileCollectionFactory.fixed(workspace.getResultsFile()));
         }
 
         @Override
@@ -374,8 +381,8 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         }
 
         private ImmutableSortedMap<String, CurrentFileCollectionFingerprint> snapshotOutputs() {
-            CurrentFileCollectionFingerprint outputFingerprint = outputFingerprinter.fingerprint(ImmutableFileCollection.of(workspace.getOutputDirectory()));
-            CurrentFileCollectionFingerprint resultsFileFingerprint = outputFingerprinter.fingerprint(ImmutableFileCollection.of(workspace.getResultsFile()));
+            CurrentFileCollectionFingerprint outputFingerprint = outputFingerprinter.fingerprint(fileCollectionFactory.fixed(workspace.getOutputDirectory()));
+            CurrentFileCollectionFingerprint resultsFileFingerprint = outputFingerprinter.fingerprint(fileCollectionFactory.fixed(workspace.getResultsFile()));
             return ImmutableSortedMap.of(
                 OUTPUT_DIRECTORY_PROPERTY_NAME, outputFingerprint,
                 RESULTS_FILE_PROPERTY_NAME, resultsFileFingerprint);

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -55,6 +55,7 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
     def executionHistoryStore = new TestExecutionHistoryStore()
     def transformationWorkspaceProvider = new TestTransformationWorkspaceProvider(immutableTransformsStoreDirectory, executionHistoryStore)
 
+    def fileCollectionFactory = TestFiles.fileCollectionFactory()
     def artifactTransformListener = Mock(ArtifactTransformListener)
     def stringInterner = new StringInterner()
     def dependencyFingerprinter = new AbsolutePathFileCollectionFingerprinter(stringInterner, fileSystemSnapshotter)
@@ -87,6 +88,7 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         artifactTransformListener,
         transformationWorkspaceProvider,
         dependencyFingerprinter,
+        fileCollectionFactory,
         outputFilesFingerprinter,
         classloaderHasher,
         projectFinder,

--- a/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
+++ b/subprojects/ide-native/src/main/groovy/org/gradle/ide/visualstudio/plugins/VisualStudioPlugin.java
@@ -116,7 +116,7 @@ public class VisualStudioPlugin extends IdePlugin {
             vsProject.getSourceFiles().from(cppApplication.getCppSource());
             vsProject.getHeaderFiles().from(cppApplication.getHeaderFiles());
             cppApplication.getBinaries().whenElementFinalized(CppExecutable.class, executable -> {
-                extension.getProjectRegistry().addProjectConfiguration(new CppApplicationVisualStudioTargetBinary(project.getName(), project.getPath(), cppApplication, executable));
+                extension.getProjectRegistry().addProjectConfiguration(new CppApplicationVisualStudioTargetBinary(project.getName(), project.getPath(), cppApplication, executable, project.getLayout()));
             });
         });
         project.afterEvaluate(proj -> {
@@ -131,10 +131,10 @@ public class VisualStudioPlugin extends IdePlugin {
                     vsProject.getHeaderFiles().from(cppLibrary.getHeaderFiles());
                 }
                 cppLibrary.getBinaries().whenElementFinalized(CppSharedLibrary.class, library -> {
-                    extension.getProjectRegistry().addProjectConfiguration(new CppSharedLibraryVisualStudioTargetBinary(project.getName(), project.getPath(), cppLibrary, library));
+                    extension.getProjectRegistry().addProjectConfiguration(new CppSharedLibraryVisualStudioTargetBinary(project.getName(), project.getPath(), cppLibrary, library, project.getLayout()));
                 });
                 cppLibrary.getBinaries().whenElementFinalized(CppStaticLibrary.class, library -> {
-                    extension.getProjectRegistry().addProjectConfiguration(new CppStaticLibraryVisualStudioTargetBinary(project.getName(), project.getPath(), cppLibrary, library));
+                    extension.getProjectRegistry().addProjectConfiguration(new CppStaticLibraryVisualStudioTargetBinary(project.getName(), project.getPath(), cppLibrary, library, project.getLayout()));
                 });
             });
         });

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/AbstractCppBinaryVisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/AbstractCppBinaryVisualStudioTargetBinary.java
@@ -18,7 +18,7 @@ package org.gradle.ide.visualstudio.internal;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.internal.DefaultCppBinary;
@@ -44,11 +44,13 @@ abstract public class AbstractCppBinaryVisualStudioTargetBinary implements Visua
     protected final String projectName;
     private final String projectPath;
     private final CppComponent component;
+    private final ProjectLayout projectLayout;
 
-    protected AbstractCppBinaryVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component) {
+    protected AbstractCppBinaryVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, ProjectLayout projectLayout) {
         this.projectName = projectName;
         this.projectPath = projectPath;
         this.component = component;
+        this.projectLayout = projectLayout;
     }
 
     abstract CppBinary getBinary();
@@ -131,7 +133,7 @@ abstract public class AbstractCppBinaryVisualStudioTargetBinary implements Visua
 
     @Override
     public FileCollection getResourceFiles() {
-        return ImmutableFileCollection.of();
+        return projectLayout.files();
     }
 
     @Override

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/CppApplicationVisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/CppApplicationVisualStudioTargetBinary.java
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.visualstudio.internal;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.CppExecutable;
@@ -25,8 +26,8 @@ import java.io.File;
 public class CppApplicationVisualStudioTargetBinary extends AbstractCppBinaryVisualStudioTargetBinary {
     private final CppExecutable binary;
 
-    public CppApplicationVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, CppExecutable binary) {
-        super(projectName, projectPath, component);
+    public CppApplicationVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, CppExecutable binary, ProjectLayout projectLayout) {
+        super(projectName, projectPath, component, projectLayout);
         this.binary = binary;
     }
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/CppSharedLibraryVisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/CppSharedLibraryVisualStudioTargetBinary.java
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.visualstudio.internal;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.CppSharedLibrary;
@@ -25,8 +26,8 @@ import java.io.File;
 public class CppSharedLibraryVisualStudioTargetBinary extends AbstractCppBinaryVisualStudioTargetBinary {
     private final CppSharedLibrary binary;
 
-    public CppSharedLibraryVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, CppSharedLibrary binary) {
-        super(projectName, projectPath, component);
+    public CppSharedLibraryVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, CppSharedLibrary binary, ProjectLayout projectLayout) {
+        super(projectName, projectPath, component, projectLayout);
         this.binary = binary;
     }
 

--- a/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/CppStaticLibraryVisualStudioTargetBinary.java
+++ b/subprojects/ide-native/src/main/java/org/gradle/ide/visualstudio/internal/CppStaticLibraryVisualStudioTargetBinary.java
@@ -16,6 +16,7 @@
 
 package org.gradle.ide.visualstudio.internal;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.language.cpp.CppBinary;
 import org.gradle.language.cpp.CppComponent;
 import org.gradle.language.cpp.CppStaticLibrary;
@@ -25,8 +26,8 @@ import java.io.File;
 public class CppStaticLibraryVisualStudioTargetBinary extends AbstractCppBinaryVisualStudioTargetBinary {
     private final CppStaticLibrary binary;
 
-    public CppStaticLibraryVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, CppStaticLibrary binary) {
-        super(projectName, projectPath, component);
+    public CppStaticLibraryVisualStudioTargetBinary(String projectName, String projectPath, CppComponent component, CppStaticLibrary binary, ProjectLayout projectLayout) {
+        super(projectName, projectPath, component, projectLayout);
         this.binary = binary;
     }
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/compile/GroovyCompile.java
@@ -23,7 +23,6 @@ import org.gradle.api.JavaVersion;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.ClassPathRegistry;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.tasks.JavaToolChainFactory;
 import org.gradle.api.internal.tasks.compile.CleaningGroovyCompiler;
 import org.gradle.api.internal.tasks.compile.CompilerForkUtils;
@@ -104,7 +103,7 @@ public class GroovyCompile extends AbstractCompile {
         spec.setCompileClasspath(ImmutableList.copyOf(getClasspath()));
         spec.setSourceCompatibility(getSourceCompatibility());
         spec.setTargetCompatibility(getTargetCompatibility());
-        spec.setAnnotationProcessorPath(Lists.newArrayList(compileOptions.getAnnotationProcessorPath() == null ? ImmutableFileCollection.of() : compileOptions.getAnnotationProcessorPath()));
+        spec.setAnnotationProcessorPath(Lists.newArrayList(compileOptions.getAnnotationProcessorPath() == null ? getProject().getLayout().files() : compileOptions.getAnnotationProcessorPath()));
         spec.setGroovyClasspath(Lists.newArrayList(getGroovyClasspath()));
         spec.setCompileOptions(compileOptions);
         spec.setGroovyCompileOptions(groovyCompileOptions);

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -22,7 +22,6 @@ import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.internal.ErroringAction;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.jvm.Jvm;
@@ -164,7 +163,7 @@ public class JavaInstallationProbe {
         exec.executable(javaExe(jdkPath, "java"));
         File workingDir = Files.createTempDir();
         exec.setWorkingDir(workingDir);
-        exec.setClasspath(ImmutableFileCollection.of(workingDir));
+        exec.classpath(workingDir);
         try {
             writeProbe(workingDir);
             exec.setMain(JavaProbe.CLASSNAME);


### PR DESCRIPTION
### Context

This PR replaces some direct usages of `FileCollection` implementations with a factory method, either using the public API when the usage is from a plugin or `FileCollectionFactory` when the usage is a bit deeper.

This PR also adds some test coverage for support for various `FileCollection` implementations as artifact transform parameters. The tests just document the current behaviour.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
