### PR TITLE
Implement Gradle metadata marker in published pom/ivy files

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/IvyArtifactRepository.java
@@ -283,6 +283,9 @@ public interface IvyArtifactRepository extends ArtifactRepository, Authenticatio
 
         /**
          * Indicates that this repository will contain Ivy descriptors.
+         * If the Ivy file contains a marker telling that Gradle metadata exists
+         * for this component, Gradle will <i>also</i> look for the Gradle metadata
+         * file.
          */
         void ivyDescriptor();
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/repositories/MavenArtifactRepository.java
@@ -117,6 +117,9 @@ public interface MavenArtifactRepository extends ArtifactRepository, Authenticat
 
         /**
          * Indicates that this repository will contain Maven POM files.
+         * If the POM file contains a marker telling that Gradle metadata exists
+         * for this component, Gradle will <i>also</i> look for the Gradle metadata
+         * file.
          */
         void mavenPom();
 

--- a/subprojects/core/src/main/java/org/gradle/internal/xml/SimpleMarkupWriter.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/xml/SimpleMarkupWriter.java
@@ -230,6 +230,20 @@ public class SimpleMarkupWriter extends Writer {
         return this;
     }
 
+    public SimpleMarkupWriter comment(String comment) throws IOException {
+        maybeFinishStartTag();
+        if (indent != null) {
+            writeRaw(LINE_SEPARATOR);
+            for (int i = 0; i < elements.size(); i++) {
+                writeRaw(indent);
+            }
+        }
+        writeRaw("<!-- ");
+        writeXmlEncoded(comment);
+        writeRaw(" -->");
+        return this;
+    }
+
     public SimpleMarkupWriter attribute(String name, String value) throws IOException {
         if (!XmlValidation.isValidXmlName(name)) {
             throw new IllegalArgumentException(String.format("Invalid attribute name: '%s'", name));

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
@@ -40,7 +40,7 @@ class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependency
         resolve.prepare()
     }
 
-    def "doesn't try to fetch Gradle metadata even if published if marker is not present"() {
+    def "doesn't try to fetch Gradle metadata if published and marker is not present"() {
         given:
         createIvyFile(false)
 
@@ -63,7 +63,7 @@ class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependency
         }
     }
 
-    def "prefers Gradle metadata even if published and marker is present"() {
+    def "prefers Gradle metadata if published and marker is present"() {
         given:
         createIvyFile(true)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.ivy
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.fixtures.server.http.IvyHttpModule
+
+class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    IvyHttpModule mainModule
+    IvyHttpModule dep
+    ResolveTestFixture resolve
+
+    def setup() {
+        mainModule = ivyHttpRepo.module("org", "main", "1.0").withModuleMetadata()
+        dep = ivyHttpRepo.module("org", "foo", "1.9").publish()
+        settingsFile << "rootProject.name = 'test'"
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            repositories {
+                ivy { url "${ivyHttpRepo.uri}" }
+            }
+        """
+        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.prepare()
+    }
+
+    def "doesn't try to fetch Gradle metadata even if published if marker is not present"() {
+        given:
+        createIvyFile(false)
+
+        buildFile << """
+            dependencies {
+                api "org:main:1.0"
+            }
+        """
+
+        when:
+        mainModule.ivy.expectGet()
+        mainModule.artifact.expectGet()
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0')
+            }
+        }
+    }
+
+    def "prefers Gradle metadata even if published and marker is present"() {
+        given:
+        createIvyFile(true)
+
+        buildFile << """
+            dependencies {
+                api "org:main:1.0"
+            }
+        """
+
+        when:
+        mainModule.ivy.expectGet()
+        mainModule.moduleMetadata.expectGet()
+        mainModule.artifact.expectGet()
+        dep.ivy.expectGet()
+        dep.artifact.expectGet()
+
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0') {
+                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api'])
+                    edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
+                }
+            }
+        }
+    }
+
+    def "reasonable behavior when Ivy file says Gradle metadata is present but is not"() {
+        given:
+        createIvyFile(true)
+
+        buildFile << """
+            dependencies {
+                api "org:main:1.0"
+            }
+        """
+
+        when:
+        mainModule.ivy.expectGet()
+        mainModule.moduleMetadata.expectGetMissing()
+        mainModule.artifact.expectGet()
+
+        run ':checkDeps'
+
+        then:
+        // falls back to Ivy file, since we have one
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0')
+            }
+        }
+    }
+
+    private void createIvyFile(boolean marker) {
+        if (marker) {
+            mainModule.withGradleMetadataRedirection()
+        }
+        mainModule.publish()
+        // and now we manually patch the Gradle metadata so that its dependencies
+        // are different. This is done so that we can check that it's really the
+        // metadata issued from the Gradle metadata file which is used
+        def moduleFile = mainModule.moduleMetadata.file
+        moduleFile.replace('"dependencies":[]', '''"dependencies":[
+            { "group": "org", "module": "foo", "version": { "prefers": "1.9" } }
+        ]''')
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 @RequiredFeatures(
     @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
 )
-class MavenDependencyResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+class  MavenDependencyResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     String getRootProjectName() { 'testproject' }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDependencyResolveIntegrationTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 @RequiredFeatures(
     @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value = "maven")
 )
-class  MavenDependencyResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+class MavenDependencyResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
 
     String getRootProjectName() { 'testproject' }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -41,7 +41,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         resolve.prepare()
     }
 
-    def "doesn't try to fetch Gradle metadata even if published if marker is not present"() {
+    def "doesn't try to fetch Gradle metadata if published and marker is not present"() {
         given:
         createPomFile(false)
 
@@ -64,7 +64,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         }
     }
 
-    def "prefers Gradle metadata even if published and marker is present"() {
+    def "prefers Gradle metadata if published and marker is present"() {
         given:
         createPomFile(true)
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.maven
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+
+class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    MavenHttpModule mainModule
+    MavenHttpModule dep
+    ResolveTestFixture resolve
+
+    def setup() {
+        mainModule = mavenHttpRepo.module("org", "main", "1.0").withModuleMetadata()
+        dep = mavenHttpRepo.module("org", "foo", "1.9").publish()
+        settingsFile << "rootProject.name = 'test'"
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            repositories {
+                maven { url "${mavenHttpRepo.uri}" }
+            }
+        """
+        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.expectDefaultConfiguration('compile')
+        resolve.prepare()
+    }
+
+    def "doesn't try to fetch Gradle metadata even if published if marker is not present"() {
+        given:
+        createPomFile(false)
+
+        buildFile << """
+            dependencies {
+                api "org:main:1.0"
+            }
+        """
+
+        when:
+        mainModule.pom.expectGet()
+        mainModule.artifact.expectGet()
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0')
+            }
+        }
+    }
+
+    def "prefers Gradle metadata even if published and marker is present"() {
+        given:
+        createPomFile(true)
+
+        buildFile << """
+            dependencies {
+                api "org:main:1.0"
+            }
+        """
+
+        when:
+        mainModule.pom.expectGet()
+        mainModule.moduleMetadata.expectGet()
+        mainModule.artifact.expectGet()
+        dep.pom.expectGet()
+        dep.artifact.expectGet()
+
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0') {
+                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api'])
+                    edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
+                }
+            }
+        }
+    }
+
+    def "reasonable behavior when POM file says Gradle metadata is present but is not"() {
+        given:
+        createPomFile(true)
+
+        buildFile << """
+            dependencies {
+                api "org:main:1.0"
+            }
+        """
+
+        when:
+        mainModule.pom.expectGet()
+        mainModule.moduleMetadata.expectGetMissing()
+        mainModule.artifact.expectGet()
+
+        run ':checkDeps'
+
+        then:
+        // falls back to POM file, since we have one
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:main:1.0')
+            }
+        }
+    }
+
+    private void createPomFile(boolean marker) {
+        if (marker) {
+            mainModule.withGradleMetadataRedirection()
+        }
+        mainModule.publish()
+        // and now we manually patch the Gradle metadata so that its dependencies
+        // are different. This is done so that we can check that it's really the
+        // metadata issued from the Gradle metadata file which is used
+        def moduleFile = mainModule.moduleMetadata.file
+        moduleFile.replace('"dependencies":[]', '''"dependencies":[
+            { "group": "org", "module": "foo", "version": { "prefers": "1.9" } }
+        ]''')
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/IvyContextualMetaDataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/IvyContextualMetaDataParser.java
@@ -36,30 +36,30 @@ public class IvyContextualMetaDataParser<T extends MutableModuleComponentResolve
     }
 
     @Override
-    public T parseMetaData(final DescriptorParseContext context, final LocallyAvailableExternalResource resource) throws MetaDataParseException {
-        return ivyContextManager.withIvy(new Transformer<T, Ivy>() {
+    public ParseResult<T> parseMetaData(final DescriptorParseContext context, final LocallyAvailableExternalResource resource) throws MetaDataParseException {
+        return ivyContextManager.withIvy(new Transformer<ParseResult<T>, Ivy>() {
             @Override
-            public T transform(Ivy ivy) {
+            public ParseResult<T> transform(Ivy ivy) {
                 return delegate.parseMetaData(context, resource);
             }
         });
     }
 
     @Override
-    public T parseMetaData(final DescriptorParseContext ivySettings, final File descriptorFile) throws MetaDataParseException {
-        return ivyContextManager.withIvy(new Transformer<T, Ivy>() {
+    public ParseResult<T> parseMetaData(final DescriptorParseContext ivySettings, final File descriptorFile) throws MetaDataParseException {
+        return ivyContextManager.withIvy(new Transformer<ParseResult<T>, Ivy>() {
             @Override
-            public T transform(Ivy ivy) {
+            public ParseResult<T> transform(Ivy ivy) {
                 return delegate.parseMetaData(ivySettings, descriptorFile);
             }
         });
     }
 
     @Override
-    public T parseMetaData(final DescriptorParseContext ivySettings, final File descriptorFile, final boolean validate) throws MetaDataParseException {
-        return ivyContextManager.withIvy(new Transformer<T, Ivy>() {
+    public ParseResult<T> parseMetaData(final DescriptorParseContext ivySettings, final File descriptorFile, final boolean validate) throws MetaDataParseException {
+        return ivyContextManager.withIvy(new Transformer<ParseResult<T>, Ivy>() {
             @Override
-            public T transform(Ivy ivy) {
+            public ParseResult<T> transform(Ivy ivy) {
                 return delegate.parseMetaData(ivySettings, descriptorFile, validate);
             }
         });

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractModuleDescriptorParser.java
@@ -30,24 +30,27 @@ public abstract class AbstractModuleDescriptorParser<T extends MutableModuleComp
         this.fileResourceRepository = fileResourceRepository;
     }
 
-    public T parseMetaData(DescriptorParseContext ivySettings, File descriptorFile, boolean validate) throws MetaDataParseException {
+    public ParseResult<T> parseMetaData(DescriptorParseContext ivySettings, File descriptorFile, boolean validate) throws MetaDataParseException {
         LocallyAvailableExternalResource resource = fileResourceRepository.resource(descriptorFile);
         return parseDescriptor(ivySettings, resource, validate);
     }
 
-    public T parseMetaData(DescriptorParseContext ivySettings, File descriptorFile) throws MetaDataParseException {
+    public ParseResult<T> parseMetaData(DescriptorParseContext ivySettings, File descriptorFile) throws MetaDataParseException {
         return parseMetaData(ivySettings, descriptorFile, false);
     }
 
-    public T parseMetaData(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource) throws MetaDataParseException {
+    public ParseResult<T> parseMetaData(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource) throws MetaDataParseException {
         return parseDescriptor(ivySettings, resource, false);
     }
 
-    protected T parseDescriptor(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource, boolean validate) throws MetaDataParseException {
+    protected ParseResult<T> parseDescriptor(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource, boolean validate) throws MetaDataParseException {
         try {
-            T metadata = doParseDescriptor(ivySettings, resource, validate);
-            metadata.setContentHash(HashUtil.createHash(resource.getFile(), "MD5"));
-            return metadata;
+            ParseResult<T> parseResult = doParseDescriptor(ivySettings, resource, validate);
+            T metadata = parseResult.getResult();
+            if (metadata != null) {
+                metadata.setContentHash(HashUtil.createHash(resource.getFile(), "MD5"));
+            }
+            return parseResult;
         } catch (MetaDataParseException e) {
             throw e;
         } catch (Exception e) {
@@ -57,5 +60,5 @@ public abstract class AbstractModuleDescriptorParser<T extends MutableModuleComp
 
     protected abstract String getTypeName();
 
-    protected abstract T doParseDescriptor(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource, boolean validate) throws Exception;
+    protected abstract ParseResult<T> doParseDescriptor(DescriptorParseContext ivySettings, LocallyAvailableExternalResource resource, boolean validate) throws Exception;
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradlePomModuleDescriptorParser.java
@@ -88,7 +88,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
         return POM_PACKAGING.equals(pomReader.getPackaging());
     }
 
-    protected MutableMavenModuleResolveMetadata doParseDescriptor(DescriptorParseContext parserSettings, LocallyAvailableExternalResource resource, boolean validate) throws IOException, ParseException, SAXException {
+    protected ParseResult<MutableMavenModuleResolveMetadata> doParseDescriptor(DescriptorParseContext parserSettings, LocallyAvailableExternalResource resource, boolean validate) throws IOException, ParseException, SAXException {
         PomReader pomReader = new PomReader(resource, moduleIdentifierFactory);
         GradlePomModuleDescriptorBuilder mdBuilder = new GradlePomModuleDescriptorBuilder(pomReader, gradleVersionSelectorScheme, mavenVersionSelectorScheme);
 
@@ -105,7 +105,7 @@ public final class GradlePomModuleDescriptorParser extends AbstractModuleDescrip
             metadata.setPackaging(pomReader.getPackaging());
             metadata.setRelocated(false);
         }
-        return metadata;
+        return ParseResult.of(metadata, pomReader.hasGradleMetadataMarker());
     }
 
     private void doParsePom(DescriptorParseContext parserSettings, GradlePomModuleDescriptorBuilder mdBuilder, PomReader pomReader) throws IOException, SAXException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/MetaDataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/MetaDataParser.java
@@ -21,9 +21,48 @@ import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 import java.io.File;
 
 public interface MetaDataParser<T extends MutableModuleComponentResolveMetadata> {
-    T parseMetaData(DescriptorParseContext context, LocallyAvailableExternalResource resource) throws MetaDataParseException;
+    String GRADLE_METADATA_MARKER = "do-not-remove: published-with-gradle-metadata";
+    String[] GRADLE_METADATA_MARKER_COMMENT_LINES = {
+            "This module was also published with a richer model, Gradle metadata, ",
+            "which should be used instead. Do not delete the following line which ",
+            "is to indicate to Gradle or any Gradle module metadata file consumer ",
+            "that they should prefer consuming it instead."};
 
-    T parseMetaData(DescriptorParseContext context, File descriptorFile) throws MetaDataParseException;
+    ParseResult<T> parseMetaData(DescriptorParseContext context, LocallyAvailableExternalResource resource) throws MetaDataParseException;
 
-    T parseMetaData(DescriptorParseContext context, File descriptorFile, boolean validate) throws MetaDataParseException;
+    ParseResult<T> parseMetaData(DescriptorParseContext context, File descriptorFile) throws MetaDataParseException;
+
+    ParseResult<T> parseMetaData(DescriptorParseContext context, File descriptorFile, boolean validate) throws MetaDataParseException;
+
+    interface ParseResult<T> {
+        boolean hasGradleMetadataRedirectionMarker();
+        T getResult();
+
+        static <T> ParseResult<T> of(T parsed, boolean hasGradleMetadataRedirect) {
+            return new DefaultParseResult<>(parsed, hasGradleMetadataRedirect);
+        }
+
+    }
+
+}
+
+class DefaultParseResult<T> implements MetaDataParser.ParseResult<T> {
+
+    private final T result;
+    private final boolean redirect;
+
+    DefaultParseResult(T result, boolean redirect) {
+        this.result = result;
+        this.redirect = redirect;
+    }
+
+    @Override
+    public boolean hasGradleMetadataRedirectionMarker() {
+        return redirect;
+    }
+
+    @Override
+    public T getResult() {
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/PomReader.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.data.PomPr
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
+import org.w3c.dom.Comment;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -342,6 +343,20 @@ public class PomReader implements PomParent {
             val = "jar";
         }
         return replaceProps(val);
+    }
+
+    public boolean hasGradleMetadataMarker() {
+        NodeList childNodes = projectElement.getChildNodes();
+        for (int i = 0; i < childNodes.getLength(); i++) {
+            Node node = childNodes.item(i);
+            if (node instanceof Comment) {
+                String comment = node.getNodeValue();
+                if (comment.contains(MetaDataParser.GRADLE_METADATA_MARKER)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     public ModuleVersionIdentifier getRelocation() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.repositories.IvyArtifactRepositoryMetaDataProvid
 import org.gradle.api.artifacts.repositories.IvyPatternRepositoryLayout;
 import org.gradle.api.artifacts.repositories.RepositoryLayout;
 import org.gradle.api.internal.FeaturePreviews;
+import org.gradle.api.internal.artifacts.repositories.metadata.RedirectingGradleMetadataModuleMetadataSource;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
@@ -236,11 +237,13 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
 
     private ImmutableMetadataSources createMetadataSources() {
         ImmutableList.Builder<MetadataSource<?>> sources = ImmutableList.builder();
+        DefaultGradleModuleMetadataSource gradleModuleMetadataSource = new DefaultGradleModuleMetadataSource(moduleMetadataParser, metadataFactory, true);
         if (metadataSources.gradleMetadata) {
-            sources.add(new DefaultGradleModuleMetadataSource(moduleMetadataParser, metadataFactory, true));
+            sources.add(gradleModuleMetadataSource);
         }
         if (metadataSources.ivyDescriptor) {
-            sources.add(new DefaultIvyDescriptorMetadataSource(IvyMetadataArtifactProvider.INSTANCE, createIvyDescriptorParser(), fileResourceRepository, moduleIdentifierFactory));
+            DefaultIvyDescriptorMetadataSource ivyDescriptorMetadataSource = new DefaultIvyDescriptorMetadataSource(IvyMetadataArtifactProvider.INSTANCE, createIvyDescriptorParser(), fileResourceRepository, moduleIdentifierFactory);
+            sources.add(new RedirectingGradleMetadataModuleMetadataSource(ivyDescriptorMetadataSource, gradleModuleMetadataSource));
         }
         if (metadataSources.artifact) {
             sources.add(new DefaultArtifactMetadataSource(metadataFactory));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultIvyDescriptorMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultIvyDescriptorMetadataSource.java
@@ -43,10 +43,13 @@ public class DefaultIvyDescriptorMetadataSource extends AbstractRepositoryMetada
         this.metaDataParser = metaDataParser;
     }
 
-    protected MutableIvyModuleResolveMetadata parseMetaDataFromResource(ModuleComponentIdentifier moduleComponentIdentifier, LocallyAvailableExternalResource cachedResource, ExternalResourceArtifactResolver artifactResolver, DescriptorParseContext context, String repoName) {
-        MutableIvyModuleResolveMetadata metaData = metaDataParser.parseMetaData(context, cachedResource);
-        checkMetadataConsistency(moduleComponentIdentifier, metaData);
-        return metaData;
+    protected MetaDataParser.ParseResult<MutableIvyModuleResolveMetadata> parseMetaDataFromResource(ModuleComponentIdentifier moduleComponentIdentifier, LocallyAvailableExternalResource cachedResource, ExternalResourceArtifactResolver artifactResolver, DescriptorParseContext context, String repoName) {
+        MetaDataParser.ParseResult<MutableIvyModuleResolveMetadata> parseResult = metaDataParser.parseMetaData(context, cachedResource);
+        MutableIvyModuleResolveMetadata metaData = parseResult.getResult();
+        if (metaData != null) {
+            checkMetadataConsistency(moduleComponentIdentifier, metaData);
+        }
+        return parseResult;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/RedirectingGradleMetadataModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/RedirectingGradleMetadataModuleMetadataSource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts.repositories.metadata;
+
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
+import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver;
+import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
+import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
+import org.gradle.internal.component.external.model.ModuleDependencyMetadata;
+import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
+import org.gradle.internal.component.model.ComponentOverrideMetadata;
+import org.gradle.internal.resolve.result.BuildableModuleComponentMetaDataResolveResult;
+import org.gradle.internal.resolve.result.BuildableModuleVersionListingResolveResult;
+
+import java.util.List;
+
+/**
+ * A module metadata source which is a pure performance optimization. Because today in the wild there
+ * are very few Gradle metadata sources, this source will first try to get a POM file (or an Ivy file)
+ * and if it finds a marker in the POM (Ivy), it will use Gradle metadata instead.
+ *
+ * It also means that we're going to pay a small price if Gradle metadata is present: we would fetch
+ * a POM file and parse it, then fetch Gradle metadata and parse it (doing twice the work).
+ */
+public class RedirectingGradleMetadataModuleMetadataSource extends AbstractMetadataSource<MutableModuleComponentResolveMetadata> {
+    private final MetadataSource<?> delegate;
+    private final DefaultGradleModuleMetadataSource gradleModuleMetadataSource;
+
+    public RedirectingGradleMetadataModuleMetadataSource(MetadataSource<?> delegate, DefaultGradleModuleMetadataSource gradleModuleMetadataSource) {
+        this.delegate = delegate;
+        this.gradleModuleMetadataSource = gradleModuleMetadataSource;
+    }
+
+    @Override
+    public MutableModuleComponentResolveMetadata create(String repositoryName, ComponentResolvers componentResolvers, ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata prescribedMetaData, ExternalResourceArtifactResolver artifactResolver, BuildableModuleComponentMetaDataResolveResult result) {
+        MutableModuleComponentResolveMetadata metadata = delegate.create(repositoryName, componentResolvers, moduleComponentIdentifier, prescribedMetaData, artifactResolver, result);
+        if (result.shouldUseGradleMetatada()) {
+            MutableModuleComponentResolveMetadata resolveMetadata = gradleModuleMetadataSource.create(repositoryName, componentResolvers, moduleComponentIdentifier, prescribedMetaData, artifactResolver, result);
+            if (resolveMetadata != null) {
+                return resolveMetadata;
+            }
+        }
+        return metadata;
+    }
+
+    @Override
+    public void listModuleVersions(ModuleDependencyMetadata dependency, ModuleIdentifier module, List<ResourcePattern> ivyPatterns, List<ResourcePattern> artifactPatterns, VersionLister versionLister, BuildableModuleVersionListingResolveResult result) {
+        delegate.listModuleVersions(dependency, module, ivyPatterns, artifactPatterns, versionLister, result);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/BuildableModuleComponentMetaDataResolveResult.java
@@ -26,7 +26,7 @@ import javax.annotation.Nullable;
  */
 public interface BuildableModuleComponentMetaDataResolveResult extends ResourceAwareResolveResult, ErroringResolveResult<ModuleVersionResolveException> {
     enum State {
-        Resolved, Missing, Failed, Unknown
+        Resolved, Missing, Failed, Unknown, Redirect
     }
 
     /**
@@ -71,4 +71,11 @@ public interface BuildableModuleComponentMetaDataResolveResult extends ResourceA
 
     void setAuthoritative(boolean authoritative);
 
+    /**
+     * Marks this result as being redirected to Gradle metadata, which
+     * is a temporary performance only optimization
+     */
+    void redirectToGradleMetadata();
+
+    boolean shouldUseGradleMetatada();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResult.java
@@ -96,6 +96,16 @@ public class DefaultBuildableModuleComponentMetaDataResolveResult extends Defaul
         this.authoritative = authoritative;
     }
 
+    @Override
+    public void redirectToGradleMetadata() {
+        reset(State.Redirect);
+    }
+
+    @Override
+    public boolean shouldUseGradleMetatada() {
+        return state == State.Redirect;
+    }
+
     private void assertHasResult() {
         if (!hasResult()) {
             throw new IllegalStateException("No result has been specified.");

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/AbstractGradlePomModuleDescriptorParserTest.groovy
@@ -66,7 +66,7 @@ abstract class AbstractGradlePomModuleDescriptorParserTest extends Specification
     }
 
     protected MutableMavenModuleResolveMetadata parseMetaData() {
-        parser.parseMetaData(parseContext, pomFile, true)
+        parser.parseMetaData(parseContext, pomFile, true).result
     }
 
     protected void hasDefaultDependencyArtifact(MavenDependencyDescriptor descriptor) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/IvyXmlModuleDescriptorParserTest.groovy
@@ -691,7 +691,7 @@ class IvyXmlModuleDescriptorParserTest extends Specification {
     }
 
     private void parse(DescriptorParseContext parseContext, TestFile file) {
-        metadata = parser.parseMetaData(parseContext, file)
+        metadata = parser.parseMetaData(parseContext, file).result
     }
 
     private Artifact artifact() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -131,11 +131,11 @@ class ModuleMetadataSerializerTest extends Specification {
     }
 
     MutableMavenModuleResolveMetadata parsePom(File pomFile) {
-        pomModuleDescriptorParser.parseMetaData(Mock(DescriptorParseContext), resource(pomFile))
+        pomModuleDescriptorParser.parseMetaData(Mock(DescriptorParseContext), resource(pomFile)).result
     }
 
     MutableIvyModuleResolveMetadata parseIvy(File ivyFile) {
-        ivyDescriptorParser.parseMetaData(Stub(DescriptorParseContext), resource(ivyFile))
+        ivyDescriptorParser.parseMetaData(Stub(DescriptorParseContext), resource(ivyFile)).result
     }
 
     MutableModuleComponentResolveMetadata parseGradle(File gradleFile) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -18,6 +18,7 @@ package org.gradle.test.fixtures.ivy
 import groovy.xml.MarkupBuilder
 import org.gradle.api.Action
 import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.test.fixtures.AbstractModule
 import org.gradle.test.fixtures.GradleModuleMetadata
@@ -49,6 +50,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     String branch = null
     String status = "integration"
     MetadataPublish metadataPublish = MetadataPublish.ALL
+    boolean writeGradleMetadataRedirection = false
 
     int publishCount = 1
     XmlTransformer transformer = new XmlTransformer()
@@ -217,6 +219,12 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     IvyFileModule extendsFrom(Map<String, ?> attributes) {
         this.extendsFrom.clear()
         this.extendsFrom.putAll(attributes)
+        return this
+    }
+
+    @Override
+    IvyModule withGradleMetadataRedirection() {
+        writeGradleMetadataRedirection = true
         return this
     }
 
@@ -427,6 +435,9 @@ class IvyFileModule extends AbstractModule implements IvyModule {
             infoAttrs.branch = branch
         }
         infoAttrs += extraAttributes.collectEntries { key, value -> ["e:$key", value] }
+        if (writeGradleMetadataRedirection) {
+            ivyFileWriter << "<!-- ${MetaDataParser.GRADLE_METADATA_MARKER} -->"
+        }
         builder.info(infoAttrs) {
             if (extendsFrom) {
                 "extends"(extendsFrom)
@@ -571,6 +582,17 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         assertPublished()
         assertArtifactsPublished("${module}-${revision}.ear", "ivy-${revision}.xml")
         parsedIvy.expectArtifact(module, "ear").hasAttributes("ear", "ear", ["master"])
+    }
+
+    IvyFileModule removeGradleMetadataRedirection() {
+        if (ivyFile.exists() && ivyFile.text.contains(MetaDataParser.GRADLE_METADATA_MARKER)) {
+            ivyFile.replace(MetaDataParser.GRADLE_METADATA_MARKER, '')
+        }
+        this
+    }
+
+    boolean hasGradleMetadataRedirectionMarker() {
+        ivyFile.exists() && ivyFile.text.contains(MetaDataParser.GRADLE_METADATA_MARKER)
     }
 
     interface IvyModuleArtifact extends ModuleArtifact {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.test.fixtures.ivy
 
+
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.PublishedJavaModule
 import org.gradle.test.fixtures.file.TestFile
@@ -122,5 +123,10 @@ class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements Publis
 
     TestFile getModuleDir() {
         backingModule.moduleDir
+    }
+
+    IvyJavaModule removeGradleMetadataRedirection() {
+        backingModule.removeGradleMetadataRedirection()
+        this
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
@@ -56,6 +56,8 @@ public interface IvyModule extends Module {
 
     IvyModule extendsFrom(Map<String, ?> attributes);
 
+    IvyModule withGradleMetadataRedirection();
+
     /**
      * Attributes:
      *  organisation

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -110,6 +110,12 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public MavenModule withGradleMetadataRedirection() {
+        backingModule.withGradleMetadataRedirection();
+        return t();
+    }
+
+    @Override
     public TestFile getArtifactFile() {
         return backingModule.getArtifactFile();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenFileModule.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.test.fixtures.maven
 
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.test.fixtures.Module
 import org.gradle.test.fixtures.file.TestFile
 
@@ -84,4 +85,14 @@ class MavenFileModule extends AbstractMavenModule {
         uniqueSnapshots && version.endsWith("-SNAPSHOT")
     }
 
+    MavenFileModule removeGradleMetadataRedirection() {
+        if (pomFile.exists() && pomFile.text.contains(MetaDataParser.GRADLE_METADATA_MARKER)) {
+            pomFile.replace(MetaDataParser.GRADLE_METADATA_MARKER, '')
+        }
+        this
+    }
+
+    boolean hasGradleMetadataRedirectionMarker() {
+        pomFile.exists() && pomFile.text.contains(MetaDataParser.GRADLE_METADATA_MARKER)
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -49,6 +49,8 @@ interface MavenModule extends Module {
      */
     MavenModule withModuleMetadata()
 
+    MavenModule withGradleMetadataRedirection();
+
     MavenModule parent(String group, String artifactId, String version)
 
     MavenModule dependsOnModules(String... dependencyArtifactIds)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -121,6 +121,12 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
     }
 
     @Override
+    public IvyModule withGradleMetadataRedirection() {
+        backingModule.withGradleMetadataRedirection();
+        return t();
+    }
+
+    @Override
     public IvyModule withBranch(String branch) {
         backingModule.withBranch(branch);
         return t();

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishBasicIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishBasicIntegTest.groovy
@@ -123,6 +123,7 @@ class IvyPublishBasicIntegTest extends AbstractIvyPublishIntegTest {
 
         then: "jar is published to defined ivy repository"
         javaLibrary.assertPublishedAsJavaModule()
+        javaLibrary.removeGradleMetadataRedirection()
         javaLibrary.parsedIvy.status == 'integration'
         javaLibrary.moduleDir.file('root-1.0.jar').assertIsCopyOf(file('build/libs/root-1.0.jar'))
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/artifact/SingleOutputTaskIvyArtifact.java
@@ -76,4 +76,8 @@ public class SingleOutputTaskIvyArtifact extends AbstractIvyArtifact {
     public File getFile() {
         return generator.getOutputs().getFiles().getSingleFile();
     }
+
+    public boolean isEnabled() {
+        return generator.getEnabled();
+    }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpec.java
@@ -149,6 +149,11 @@ public class DefaultIvyModuleDescriptorSpec implements IvyModuleDescriptorSpecIn
         return description;
     }
 
+    @Override
+    public boolean writeGradleMetadataMarker() {
+        return ivyPublication.writeGradleMetadataMarker();
+    }
+
     private <T> void configureAndAdd(Class<? extends T> clazz, Action<? super T> action, List<T> items) {
         T item = instantiator.newInstance(clazz, objectFactory);
         action.execute(item);

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyModuleDescriptorSpecInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyModuleDescriptorSpecInternal.java
@@ -50,4 +50,6 @@ public interface IvyModuleDescriptorSpecInternal extends IvyModuleDescriptorSpec
     List<IvyModuleDescriptorLicense> getLicenses();
 
     IvyModuleDescriptorDescription getDescription();
+
+    boolean writeGradleMetadataMarker();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyPublicationInternal.java
@@ -49,4 +49,6 @@ public interface IvyPublicationInternal extends IvyPublication, PublicationInter
     Set<IvyExcludeRule> getGlobalExcludes();
 
     IvyNormalizedPublication asNormalisedPublication();
+
+    boolean writeGradleMetadataMarker();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisher.java
@@ -25,6 +25,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.Disconnect
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.DisconnectedIvyXmlModuleDescriptorParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParseException;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
 import org.gradle.api.internal.artifacts.repositories.PublicationAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.publish.internal.PublicationFieldValidator;
@@ -84,7 +85,8 @@ public class ValidatingIvyPublisher implements IvyPublisher {
 
     private MutableIvyModuleResolveMetadata parseIvyFile(IvyNormalizedPublication publication) {
         try {
-            return moduleDescriptorParser.parseMetaData(parserSettings, publication.getIvyDescriptorFile(), true);
+            MetaDataParser.ParseResult<MutableIvyModuleResolveMetadata> parseResult = moduleDescriptorParser.parseMetaData(parserSettings, publication.getIvyDescriptorFile(), true);
+            return parseResult.getResult();
         } catch (MetaDataParseException pe) {
             throw new InvalidIvyPublicationException(publication.getName(), pe.getLocalizedMessage(), pe);
         }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
@@ -105,7 +105,7 @@ public class GenerateIvyDescriptor extends DefaultTask {
     public void doGenerate() {
         IvyModuleDescriptorSpecInternal descriptorInternal = toIvyModuleDescriptorInternal(getDescriptor());
 
-        IvyDescriptorFileGenerator ivyGenerator = new IvyDescriptorFileGenerator(descriptorInternal.getProjectIdentity());
+        IvyDescriptorFileGenerator ivyGenerator = new IvyDescriptorFileGenerator(descriptorInternal.getProjectIdentity(), descriptorInternal.writeGradleMetadataMarker());
         ivyGenerator.setStatus(descriptorInternal.getStatus());
         ivyGenerator.setBranch(descriptorInternal.getBranch());
         ivyGenerator.setExtraInfo(descriptorInternal.getExtraInfo().asMap());

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
 import org.gradle.api.publish.ivy.internal.artifact.FileBasedIvyArtifact
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyDependency
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyConfiguration
@@ -42,7 +43,7 @@ class IvyDescriptorFileGeneratorTest extends Specification {
     TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
 
     def projectIdentity = new DefaultIvyPublicationIdentity("my-org", "my-name", "my-version")
-    IvyDescriptorFileGenerator generator = new IvyDescriptorFileGenerator(projectIdentity)
+    IvyDescriptorFileGenerator generator = new IvyDescriptorFileGenerator(projectIdentity, false)
 
     def "writes correct prologue and schema declarations"() {
         expect:
@@ -50,6 +51,17 @@ class IvyDescriptorFileGeneratorTest extends Specification {
 """<?xml version="1.0" encoding="UTF-8"?>
 <ivy-module version="2.0">
 """))
+    }
+
+    def "writes Gradle metadata marker"() {
+        given:
+        generator = new IvyDescriptorFileGenerator(projectIdentity, markerPresent)
+
+        expect:
+        ivyFile.text.contains(MetaDataParser.GRADLE_METADATA_MARKER) == markerPresent
+
+        where:
+        markerPresent << [true, false]
     }
 
     def "writes empty descriptor with module values"() {
@@ -72,7 +84,7 @@ class IvyDescriptorFileGeneratorTest extends Specification {
     def "encodes coordinates for XML and unicode"() {
         when:
         def projectIdentity = new DefaultIvyPublicationIdentity('org-ぴ₦ガき∆ç√∫', 'module-<tag attrib="value"/>-markup', 'version-&"')
-        generator = new IvyDescriptorFileGenerator(projectIdentity)
+        generator = new IvyDescriptorFileGenerator(projectIdentity, false)
 
 
         then:

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -205,10 +205,11 @@ class ValidatingIvyPublisherTest extends Specification {
         "org"        | "module"     | "version-mod" | "supplied revision does not match ivy descriptor (cannot edit revision directly in the ivy descriptor file)."
     }
 
-    def "reports and fails with invalid descriptor file"() {
+    @Unroll
+    def "reports and fails with invalid descriptor file (marker = #marker)"() {
         given:
         def identity = new DefaultIvyPublicationIdentity("the-group", "the-artifact", "the-version")
-        IvyDescriptorFileGenerator ivyFileGenerator = new IvyDescriptorFileGenerator(identity)
+        IvyDescriptorFileGenerator ivyFileGenerator = new IvyDescriptorFileGenerator(identity, marker)
         def artifact = new FileBasedIvyArtifact(new File("foo.txt"), identity)
         artifact.setConf("unknown")
         ivyFileGenerator.addArtifact(artifact)
@@ -224,6 +225,9 @@ class ValidatingIvyPublisherTest extends Specification {
         then:
         def e = thrown InvalidIvyPublicationException
         e.message == "Invalid publication 'pub-name': Could not parse Ivy file ${ivyFile}"
+
+        where:
+        marker << [false, true]
     }
 
     def "validates artifact attributes"() {
@@ -362,7 +366,7 @@ class ValidatingIvyPublisherTest extends Specification {
 
     class TestIvyDescriptorFileGenerator extends IvyDescriptorFileGenerator {
         TestIvyDescriptorFileGenerator(IvyPublicationIdentity projectIdentity) {
-            super(projectIdentity)
+            super(projectIdentity, false)
         }
 
         TestIvyDescriptorFileGenerator withBranch(String branch) {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/AbstractMavenPublishFeaturesJavaIntegTest.groovy
@@ -16,11 +16,14 @@
 
 package org.gradle.api.publish.maven
 
+import org.gradle.integtests.fixtures.executer.ExecutionResult
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
+import org.gradle.test.fixtures.maven.MavenFileModule
 import org.gradle.test.fixtures.maven.MavenJavaModule
 
 abstract class AbstractMavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishIntegTest {
-    MavenJavaModule javaLibrary = javaLibrary(mavenRepo.module("org.gradle.test", "publishTest", "1.9"))
+    MavenFileModule module = mavenRepo.module("org.gradle.test", "publishTest", "1.9")
+    MavenJavaModule javaLibrary = javaLibrary(module)
 
     def setup() {
         createBuildScripts("""
@@ -52,5 +55,14 @@ abstract class AbstractMavenPublishFeaturesJavaIntegTest extends AbstractMavenPu
 $append
 """
 
+    }
+
+    @Override
+    protected ExecutionResult run(String... tasks) {
+        try {
+            return super.run(tasks)
+        } finally {
+            module.removeGradleMetadataRedirection()
+        }
     }
 }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaPluginIntegTest.groovy
@@ -99,8 +99,10 @@ class MavenPublishFeaturesJavaPluginIntegTest extends AbstractMavenPublishFeatur
         """
 
         when:
-        javaLibrary = javaLibrary(mavenRepo.module(group, name, version))
+        def mod = mavenRepo.module(group, name, version)
+        javaLibrary = javaLibrary(mod)
         run "publish"
+        mod.removeGradleMetadataRedirection()
 
         then:
         javaLibrary.parsedModuleMetadata.variant("apiElements") {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishMultiProjectIntegTest.groovy
@@ -446,8 +446,8 @@ project(":library") {
         when:
         run "publish"
 
-        def platformModule = mavenRepo.module("org.test", "platform", "1.0")
-        def libraryModule = mavenRepo.module("org.test", "library", "1.0")
+        def platformModule = mavenRepo.module("org.test", "platform", "1.0").removeGradleMetadataRedirection()
+        def libraryModule = mavenRepo.module("org.test", "library", "1.0").removeGradleMetadataRedirection()
 
         then:
         platformModule.parsedPom.packaging == 'pom'

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/artifact/SingleOutputTaskMavenArtifact.java
@@ -55,4 +55,8 @@ public class SingleOutputTaskMavenArtifact extends AbstractMavenArtifact {
     protected TaskDependencyInternal getDefaultBuildDependencies() {
         return buildDependencies;
     }
+
+    public boolean isEnabled() {
+        return generator.getEnabled();
+    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPom.java
@@ -92,6 +92,11 @@ public class DefaultMavenPom implements MavenPomInternal, MavenPomLicenseSpec, M
         return mavenPublication.getVersionMappingStrategy();
     }
 
+    @Override
+    public boolean writeGradleMetadataMarker() {
+        return mavenPublication.writeGradleMetadataMarker();
+    }
+
     public String getPackaging() {
         if (packaging == null) {
             return mavenPublication.determinePackagingFromArtifacts();

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPomInternal.java
@@ -72,4 +72,6 @@ public interface MavenPomInternal extends MavenPom {
     Action<XmlProvider> getXmlAction();
 
     VersionMappingStrategyInternal getVersionMappingStrategy();
+
+    boolean writeGradleMetadataMarker();
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/MavenPublicationInternal.java
@@ -70,5 +70,7 @@ public interface MavenPublicationInternal extends MavenPublication, PublicationI
     void publishWithOriginalFileName();
 
     VersionMappingStrategyInternal getVersionMappingStrategy();
+
+    boolean writeGradleMetadataMarker();
 }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/tasks/GenerateMavenPom.java
@@ -124,7 +124,8 @@ public class GenerateMavenPom extends DefaultTask {
                 getVersionRangeMapper(),
                 pomInternal.getVersionMappingStrategy(),
                 compileScopeAttributes,
-                runtimeScopeAttributes);
+                runtimeScopeAttributes,
+                pomInternal.writeGradleMetadataMarker());
         pomGenerator.configureFrom(pomInternal);
 
         for (MavenDependency mavenDependency : pomInternal.getApiDependencyManagement()) {

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publisher/ValidatingMavenPublisherTest.groovy
@@ -44,16 +44,20 @@ class ValidatingMavenPublisherTest extends Specification {
     def publisher = new ValidatingMavenPublisher(delegate)
     def repository = Mock(MavenArtifactRepository)
 
+    @Unroll
     def "delegates when publication is valid"() {
         when:
         def projectIdentity = makeProjectIdentity("the-group", "the-artifact", "the-version")
-        def publication = new MavenNormalizedPublication("pub-name", "pom", createPomFile(projectIdentity), projectIdentity, emptySet(), null)
+        def publication = new MavenNormalizedPublication("pub-name", "pom", createPomFile(projectIdentity, null, marker), projectIdentity, emptySet(), null)
 
         and:
         publisher.publish(publication, repository)
 
         then:
         delegate.publish(publication, repository)
+
+        where:
+        marker << [false, true]
     }
 
     def "validates project coordinates"() {
@@ -228,10 +232,10 @@ class ValidatingMavenPublisherTest extends Specification {
         }
     }
 
-    private def createPomFile(MavenProjectIdentity projectIdentity, Action<XmlProvider> withXmlAction = null) {
+    private def createPomFile(MavenProjectIdentity projectIdentity, Action<XmlProvider> withXmlAction = null, boolean marker = false) {
         def pomFile = testDir.file("pom")
         def mapper = Stub(VersionRangeMapper)
-        MavenPomFileGenerator pomFileGenerator = new MavenPomFileGenerator(projectIdentity, mapper, Stub(VersionMappingStrategyInternal), ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY)
+        MavenPomFileGenerator pomFileGenerator = new MavenPomFileGenerator(projectIdentity, mapper, Stub(VersionMappingStrategyInternal), ImmutableAttributes.EMPTY, ImmutableAttributes.EMPTY, marker)
         if (withXmlAction != null) {
             pomFileGenerator.withXml(withXmlAction)
         }


### PR DESCRIPTION
## Context

This commit implements a performance optimization for Gradle metadata.
Given that today there's no library published in any repository with
Gradle metadata, it's much more likely to find a POM (or Ivy) metadata
file for an external dependency, rather than a Gradle metadata file.

If we decided to add `gradleMetadata()` sources by default to all
repositories, then we would probably introduce a performance regression
to a lot of builds, because we would first try to get Gradle metadata,
then fail, and search for POM/Ivy files.

To avoid this, whenever a library is going to be published with Gradle
metadata, we will introduce a _marker_ in the published POM or Ivy
file. When Gradle _resolves_ such a dependency, it will parse the POM
file and look for the marker. If it finds it, then it will _redirect_
to use Gradle metadata instead. This means that when Gradle metadata is
present, we will pay the price of looking for a POM or Ivy file first,
start parsing, only to discover we should parse Gradle metadata. This
should be ok in the beginning, knowing that if `gradleMetadata()` is
added, then we would systematically look at Gradle metadata first.

This means that this is a _temporary_ solution, until Gradle metadata
becomes widespread. So "temporary" should be understood as several
months, if not years.

The marker introduced in POM and Ivy files is _neutral_ for both Ivy
and Maven. By this we mean that it uses an XML comment. While not super
nice, we couldn't use a custom namespace because both Ivy and Maven
fail when parsing this. Properties were considered too, but Ivy doesn't
support them so for consistency both models use comments.

It's worth noting that we will still _completely parse_ the POM or Ivy
descriptor. It's a waste of time, but it helps in case we find a marker
but that for some reason the Gradle metadata file is absent. In this
case we fallback on the model we found.

This change also introduces a change in the semantics of the incubating
metadata sources API: those should be considered _hints_, and not strong
statements anymore.

Finally, should a producer want to avoid publishing Gradle metadata,
it's now possible to disable the task that creates the metadata file.
