### PR TITLE
Allow selection of both the library and platform of a component

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.integtests.resolve.maven
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.maven.MavenModule
-import spock.lang.Ignore
+import spock.lang.Issue
 
 class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def resolve = new ResolveTestFixture(buildFile).expectDefaultConfiguration('runtime')
@@ -137,8 +137,8 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         }
     }
 
-    @Ignore("This isn't true anymore: a POM is either a platform (BOM) or a library")
-    def "a bom can declare dependencies"() {
+    @Issue("gradle/gradle#8420")
+    def "can depend on both platform and library if a published POM represents both of them"() {
         given:
         mavenHttpRepo.module('group', 'moduleC', '1.0').allowAll().publish()
         bomDependency('moduleA')
@@ -156,7 +156,8 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
 
         buildFile << """
             dependencies {
-                compile "group:bom:1.0"
+                compile platform("group:bom:1.0") // dependency on the platform
+                compile "group:bom:1.0" // dependency on library
                 compile "group:moduleA"
             }
         """
@@ -168,7 +169,12 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0") {
-                    module("group:moduleA:2.0")
+                    variant("platform-runtime", ['org.gradle.component.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
+                    constraint("group:moduleA:2.0")
+                    noArtifacts()
+                }
+                module("group:bom:1.0") {
+                    variant("runtime", ['org.gradle.component.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/DefaultConfigurationMetadata.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.Factory;
 import org.gradle.internal.component.model.DependencyMetadata;
@@ -81,6 +82,24 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
                                          Factory<List<ModuleDependencyMetadata>> configDependenciesFactory,
                                          DependencyFilter dependencyFilter) {
         super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependenciesFactory, ImmutableCapabilities.EMPTY);
+        this.componentMetadataRules = componentMetadataRules;
+        this.componentLevelAttributes = attributes;
+        this.dependencyFilter = dependencyFilter;
+    }
+
+    private DefaultConfigurationMetadata(ModuleComponentIdentifier componentId,
+                                         String name,
+                                         boolean transitive,
+                                         boolean visible,
+                                         ImmutableSet<String> hierarchy,
+                                         ImmutableList<? extends ModuleComponentArtifactMetadata> artifacts,
+                                         VariantMetadataRules componentMetadataRules,
+                                         ImmutableList<ExcludeMetadata> excludes,
+                                         ImmutableAttributes attributes,
+                                         Factory<List<ModuleDependencyMetadata>> configDependenciesFactory,
+                                         DependencyFilter dependencyFilter,
+                                         List<Capability> capabilities) {
+        super(componentId, name, transitive, visible, artifacts, hierarchy, excludes, attributes, configDependenciesFactory, ImmutableCapabilities.of(capabilities));
         this.componentMetadataRules = componentMetadataRules;
         this.componentLevelAttributes = attributes;
         this.dependencyFilter = dependencyFilter;
@@ -163,6 +182,10 @@ public class DefaultConfigurationMetadata extends AbstractConfigurationMetadata 
 
     public DefaultConfigurationMetadata withForcedDependencies() {
         return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), getHierarchy(), getArtifacts(), componentMetadataRules, getExcludes(), componentLevelAttributes, lazyConfigDependencies(), dependencyFilter.forcing());
+    }
+
+    public DefaultConfigurationMetadata withCapabilities(List<Capability> capabilities) {
+        return new DefaultConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(), getHierarchy(), getArtifacts(), componentMetadataRules, getExcludes(), super.getAttributes(), lazyConfigDependencies(), dependencyFilter, capabilities);
     }
 
     private ImmutableList<ModuleDependencyMetadata> force(ImmutableList<ModuleDependencyMetadata> configDependencies) {


### PR DESCRIPTION
### Context

For published POM files, we want to allow selecting both the
library and platform variants of a component. They are effectively
different things. This commit makes it possible by assigning a
different capability to the platform variants.

Fixes #8420
