### PR TITLE
Don't recommend disabling the local cache on CI builds

### DIFF
--- a/subprojects/docs/src/docs/userguide/build_cache.adoc
+++ b/subprojects/docs/src/docs/userguide/build_cache.adoc
@@ -316,7 +316,7 @@ include::sample[dir="buildCache/http-build-cache/kotlin",files="settings.gradle.
 [[sec:build_cache_configure_use_cases]]
 === Configuration use cases
 
-The recommended use case for the build cache is that your continuous integration server populates the remote build cache from clean builds while developers load from the remote build cache and store in the local build cache.
+The recommended use case for the remote build cache is that your continuous integration server populates it from clean builds while developers only load from it.
 The configuration would then look as follows.
 
 .Recommended setup for CI push use case

--- a/subprojects/docs/src/samples/buildCache/developer-ci-setup/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/buildCache/developer-ci-setup/groovy/settings.gradle
@@ -18,9 +18,6 @@
 boolean isCiServer = System.getenv().containsKey("CI")
 
 buildCache {
-    local {
-        enabled = !isCiServer
-    }
     remote(HttpBuildCache) {
         url = 'https://example.com:8123/cache/'
         push = isCiServer

--- a/subprojects/docs/src/samples/buildCache/developer-ci-setup/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/buildCache/developer-ci-setup/kotlin/settings.gradle.kts
@@ -2,9 +2,6 @@
 val isCiServer = System.getenv().containsKey("CI")
 
 buildCache {
-    local {
-        isEnabled = !isCiServer
-    }
     remote<HttpBuildCache> {
         url = uri("https://example.com:8123/cache/")
         isPush = isCiServer

--- a/subprojects/docs/src/samples/buildCache/developer-ci-setup/readme.xml
+++ b/subprojects/docs/src/samples/buildCache/developer-ci-setup/readme.xml
@@ -16,7 +16,7 @@
 
 <sample>
     <para>
-        Recommended cache configuration: Developer push to a local build cache and pull from local and remote build cache,
-        continuous integration server pushes to and pulls from both the local and remote caches.
+        Recommended cache configuration: Developers store only in the local build cache, and load from both the local and remote build caches.
+        Continuous integration builds store and load from both the local and remote caches.
     </para>
 </sample>

--- a/subprojects/docs/src/samples/buildCache/developer-ci-setup/readme.xml
+++ b/subprojects/docs/src/samples/buildCache/developer-ci-setup/readme.xml
@@ -17,6 +17,6 @@
 <sample>
     <para>
         Recommended cache configuration: Developer push to a local build cache and pull from local and remote build cache,
-        continuous integration server pushes to and pulls from the remote cache.
+        continuous integration server pushes to and pulls from both the local and remote caches.
     </para>
 </sample>


### PR DESCRIPTION
While using the local cache on CI can lead to different artifacts used for the same cache key, this should not cause problems anymore. Meanwhile, using the local cache has a large impact in reducing cache overhead on CI.
