### PR TITLE
Introduce a `JAVA_API_JARS` usage

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Usage.java
@@ -45,6 +45,14 @@ public interface Usage extends Named {
     String JAVA_API_CLASSES = "java-api-classes";
 
     /**
+     * The Java API of a library, packaged as a JAR only. Must not include classes directories.
+     *
+     * @since 5.3
+     */
+    @Incubating
+    String JAVA_API_JARS = "java-api-jars";
+
+    /**
      * The Java runtime of a component, packaged as class path elements, either a JAR or a classes directory.
      *
      * @since 4.0

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/DependencyResolutionServices.java
@@ -19,7 +19,9 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
+import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.model.ObjectFactory;
 
 public interface DependencyResolutionServices {
     RepositoryHandler getResolveRepositoryHandler();
@@ -31,4 +33,8 @@ public interface DependencyResolutionServices {
     DependencyLockingHandler getDependencyLockingHandler();
 
     ImmutableAttributesFactory getAttributesFactory();
+
+    AttributesSchema getAttributesSchema();
+
+    ObjectFactory getObjectFactory();
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.internal.artifacts;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import org.gradle.api.Action;
+import org.gradle.api.ActionConfiguration;
+import org.gradle.api.attributes.AttributeCompatibilityRule;
+import org.gradle.api.attributes.AttributeDisambiguationRule;
+import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.CompatibilityCheckDetails;
+import org.gradle.api.attributes.MultipleCandidatesDetails;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.ReusableAction;
+import org.gradle.api.model.ObjectFactory;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+public abstract class JavaEcosystemSupport {
+    public static void configureSchema(AttributesSchema attributesSchema, final ObjectFactory objectFactory) {
+        AttributeMatchingStrategy<Usage> matchingStrategy = attributesSchema.attribute(Usage.USAGE_ATTRIBUTE);
+        matchingStrategy.getCompatibilityRules().add(UsageCompatibilityRules.class);
+        matchingStrategy.getDisambiguationRules().add(UsageDisambiguationRules.class, new Action<ActionConfiguration>() {
+            @Override
+            public void execute(ActionConfiguration actionConfiguration) {
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_API));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_API_JARS));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_API_CLASSES));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_CLASSES));
+                actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_RESOURCES));
+            }
+        });
+    }
+
+
+
+    @VisibleForTesting
+    public static class UsageDisambiguationRules implements AttributeDisambiguationRule<Usage>, ReusableAction {
+        final Usage javaApi;
+        final Usage javaRuntime;
+        final Usage javaApiJars;
+        final Usage javaApiClasses;
+        final Usage javaRuntimeJars;
+        final Usage javaRuntimeClasses;
+        final Usage javaRuntimeResources;
+
+        final ImmutableSet<Usage> apiVariants;
+        final ImmutableSet<Usage> runtimeVariants;
+
+        @Inject
+        UsageDisambiguationRules(Usage javaApi,
+                                 Usage javaApiJars,
+                                 Usage javaApiClasses,
+                                 Usage javaRuntime,
+                                 Usage javaRuntimeJars,
+                                 Usage javaRuntimeClasses,
+                                 Usage javaRuntimeResources) {
+            this.javaApi = javaApi;
+            this.javaApiJars = javaApiJars;
+            this.javaApiClasses = javaApiClasses;
+            this.apiVariants = ImmutableSet.of(javaApi, javaApiJars, javaApiClasses);
+            this.javaRuntime = javaRuntime;
+            this.javaRuntimeJars = javaRuntimeJars;
+            this.javaRuntimeClasses = javaRuntimeClasses;
+            this.javaRuntimeResources = javaRuntimeResources;
+            this.runtimeVariants = ImmutableSet.of(javaRuntime, javaRuntimeJars, javaRuntimeClasses, javaRuntimeResources);
+        }
+
+        @Override
+        public void execute(MultipleCandidatesDetails<Usage> details) {
+            Set<Usage> candidateValues = details.getCandidateValues();
+            Usage consumerValue = details.getConsumerValue();
+            if (consumerValue == null) {
+                if (candidateValues.contains(javaRuntimeJars)) {
+                    // Use the Jars when nothing has been requested
+                    details.closestMatch(javaRuntimeJars);
+                } else if (candidateValues.contains(javaRuntime)) {
+                    // Use the runtime when nothing has been requested
+                    details.closestMatch(javaRuntime);
+                }
+            } else {
+                if (candidateValues.contains(consumerValue)) {
+                    details.closestMatch(consumerValue);
+                } else if (apiVariants.contains(consumerValue)) {
+                    // we're asking for an API variant, but no exact match was found
+                    if (candidateValues.contains(javaApiClasses)) {
+                        // prefer the most lightweight API
+                        details.closestMatch(javaApiClasses);
+                    } else if (candidateValues.contains(javaApiJars)) {
+                        details.closestMatch(javaApiJars);
+                    } else if (candidateValues.contains(javaApi)) {
+                        // Prefer the API over the runtime when the API has been requested
+                        details.closestMatch(javaApi);
+                    }
+                } else if (runtimeVariants.contains(consumerValue)) {
+                    // we're asking for a runtime variant, but no exact match was found
+                    if (candidateValues.contains(javaRuntimeJars)) {
+                        details.closestMatch(javaRuntimeJars);
+                    } else if (candidateValues.contains(javaRuntime)) {
+                        details.closestMatch(javaRuntime);
+                    }
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    public static class UsageCompatibilityRules implements AttributeCompatibilityRule<Usage>, ReusableAction {
+        private static final Set<String> COMPATIBLE_WITH_JAVA_API = ImmutableSet.of(
+                Usage.JAVA_API_JARS,
+                Usage.JAVA_API_CLASSES,
+                Usage.JAVA_RUNTIME_JARS,
+                Usage.JAVA_RUNTIME_CLASSES,
+                Usage.JAVA_RUNTIME
+        );
+        private static final Set<String> COMPATIBLE_WITH_JAVA_API_JARS = ImmutableSet.of(
+                Usage.JAVA_API,
+                Usage.JAVA_RUNTIME_JARS,
+                Usage.JAVA_RUNTIME
+        );
+        private static final Set<String> COMPATIBLE_WITH_JAVA_API_CLASSES = ImmutableSet.of(
+                Usage.JAVA_API,
+                Usage.JAVA_API_JARS,
+                Usage.JAVA_RUNTIME_JARS,
+                Usage.JAVA_RUNTIME_CLASSES,
+                Usage.JAVA_RUNTIME
+        );
+        private static final Set<String> COMPATIBLE_WITH_JAVA_RUNTIME_CLASSES = ImmutableSet.of(
+                Usage.JAVA_RUNTIME,
+                Usage.JAVA_RUNTIME_JARS
+        );
+        private static final Set<String> COMPATIBLE_WITH_JAVA_RUNTIME_RESOURCES = ImmutableSet.of(
+                Usage.JAVA_RUNTIME,
+                Usage.JAVA_RUNTIME_JARS
+        );
+
+        @Override
+        public void execute(CompatibilityCheckDetails<Usage> details) {
+            String consumerValue = details.getConsumerValue().getName();
+            String producerValue = details.getProducerValue().getName();
+            if (consumerValue.equals(Usage.JAVA_API)) {
+                if (COMPATIBLE_WITH_JAVA_API.contains(producerValue)) {
+                    details.compatible();
+                }
+                return;
+            }
+            if (consumerValue.equals(Usage.JAVA_API_CLASSES)) {
+                if (COMPATIBLE_WITH_JAVA_API_CLASSES.contains(producerValue)) {
+                    details.compatible();
+                }
+                return;
+            }
+            if (consumerValue.equals(Usage.JAVA_API_JARS)) {
+                if (COMPATIBLE_WITH_JAVA_API_JARS.contains(producerValue)) {
+                    details.compatible();
+                }
+                return;
+            }
+            if (consumerValue.equals(Usage.JAVA_RUNTIME) && producerValue.equals(Usage.JAVA_RUNTIME_JARS)) {
+                details.compatible();
+                return;
+            }
+            if (consumerValue.equals(Usage.JAVA_RUNTIME_CLASSES)) {
+                if (COMPATIBLE_WITH_JAVA_RUNTIME_CLASSES.contains(producerValue)) {
+                    // Can use the Java runtime jars if present, but prefer Java runtime classes
+                    details.compatible();
+                    return;
+                }
+            }
+            if (consumerValue.equals(Usage.JAVA_RUNTIME_RESOURCES)) {
+                if (COMPATIBLE_WITH_JAVA_RUNTIME_RESOURCES.contains(producerValue)) {
+                    // Can use the Java runtime jars if present, but prefer Java runtime resources
+                    details.compatible();
+                    return;
+                }
+            }
+            if (consumerValue.equals(Usage.JAVA_RUNTIME_JARS) && producerValue.equals(Usage.JAVA_RUNTIME)) {
+                // Can use the Java runtime if present, but prefer Java runtime jar
+                details.compatible();
+            }
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -24,6 +24,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -57,6 +58,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         this.scriptResource = scriptSource.getResource().getLocation();
         this.classLoaderScope = classLoaderScope;
         this.scriptClassPathResolver = scriptClassPathResolver;
+        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getObjectFactory());
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.dsl.DependencyHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.attributes.AttributeContainerInternal
@@ -33,7 +34,9 @@ class DefaultScriptHandlerTest extends Specification {
     def configurationContainer = Mock(ConfigurationContainer)
     def configuration = Mock(Configuration)
     def scriptSource = Stub(ScriptSource)
-    def depMgmtServices = Mock(DependencyResolutionServices)
+    def depMgmtServices = Mock(DependencyResolutionServices) {
+        getAttributesSchema() >> Stub(AttributesSchema)
+    }
     def baseClassLoader = new ClassLoader() {}
     def classLoaderScope = Stub(ClassLoaderScope) {
         getLocalClassLoader() >> baseClassLoader

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/RepositoryInteractionDependencyResolveIntegrationTest.groovy
@@ -30,6 +30,16 @@ class RepositoryInteractionDependencyResolveIntegrationTest extends AbstractHttp
         'api':              'configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_API))',
     ]
 
+    def setup() {
+        // apply Java ecosystem rules
+        buildFile << """
+            org.gradle.api.internal.artifacts.JavaEcosystemSupport.configureSchema(
+                dependencies.attributesSchema,
+                project.objects
+            )
+        """
+    }
+
     private static boolean leaksRuntime(testVariant, repoType, prevRepoType = null) {
         if (testVariant == 'runtime' || testVariant == 'default') {
             // the runtime variant is supposed to include everything

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -46,7 +46,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeResolved = false
                     canBeConsumed = true
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                     }
                     outgoing.capability('org:lib-fixtures:1.0')
                 }
@@ -62,7 +62,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                 implementation project(':lib')
                 implementation (project(':lib')) {
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                     }
                     capabilities {
                         requireCapability('org:lib-fixtures')
@@ -78,11 +78,11 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api']
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars']
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'java-api']
+                    variant "testFixtures", ['org.gradle.usage':'java-api-jars']
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }
@@ -99,7 +99,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeResolved = false
                     canBeConsumed = true
                     attributes {
-                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api'))
+                        attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                     }
                     outgoing.capability('test:lib:1.0')
                     outgoing.capability('test:lib-fixtures:1.0')
@@ -124,7 +124,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api']
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars']
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -153,8 +153,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -258,8 +258,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', lifecycle: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', lifecycle: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', lifecycle: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', lifecycle: 'c2']
     }
 
     @RequiredFeatures(
@@ -355,7 +355,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:test:1.0') {
                     configuration = 'api'
-                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1'])
+                    variant('api', ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1'])
                 }
             }
         }
@@ -378,12 +378,12 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         }
 
         buildFile << """
-            configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "java-api"))
+            configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "java-runtime"))
 
             dependencies {
                 conf('org:test:1.0') {
                     attributes {
-                        attribute(CUSTOM_ATTRIBUTE, 'c2')
+                        attribute(CUSTOM_ATTRIBUTE, 'c1')
                     }
                 }
             }
@@ -400,13 +400,13 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
   - Variant 'api' capability org:test:1.0:
-      - Required custom 'c2' and found incompatible value 'c1'.
+      - Required custom 'c1' and found compatible value 'c1'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
-      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
+      - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api-jars'.
   - Variant 'runtime' capability org:test:1.0:
-      - Required custom 'c2' and found compatible value 'c2'.
+      - Required custom 'c1' and found incompatible value 'c2'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
-      - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'""")
+      - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime-jars'""")
     }
 
     @RequiredFeatures(
@@ -458,8 +458,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1']
-        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
+        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -518,8 +518,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         configurationValue | dependencyValue | expectedVariant | expectedAttributes
-        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1']
-        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2']
+        'c2'               | 'c1'            | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
+        'c1'               | 'c2'            | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -539,13 +539,13 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         }
 
         buildFile << """
-            configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "java-api"))
+            configurations.conf.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, "java-runtime"))
 
             dependencies {
                 constraints {
                     conf('org:test:1.0') {
                         attributes {
-                            attribute(CUSTOM_ATTRIBUTE, 'c2')
+                            attribute(CUSTOM_ATTRIBUTE, 'c1')
                         }
                     }
                 }
@@ -564,13 +564,13 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         then:
         failure.assertHasCause("""Unable to find a matching variant of org:test:1.0:
   - Variant 'api' capability org:test:1.0:
-      - Required custom 'c2' and found incompatible value 'c1'.
+      - Required custom 'c1' and found compatible value 'c1'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
-      - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
+      - Required org.gradle.usage 'java-runtime' and found incompatible value 'java-api-jars'.
   - Variant 'runtime' capability org:test:1.0:
-      - Required custom 'c2' and found compatible value 'c2'.
+      - Required custom 'c1' and found incompatible value 'c2'.
       - Found org.gradle.status '${defaultStatus()}' but wasn't required.
-      - Required org.gradle.usage 'java-api' and found incompatible value 'java-runtime'""")
+      - Required org.gradle.usage 'java-runtime' and found compatible value 'java-runtime-jars'""")
     }
 
     @RequiredFeatures(
@@ -700,8 +700,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
     }
 
 
@@ -850,8 +850,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
 
         where:
         attributeValue | expectedVariant | expectedAttributes
-        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api', custom: 'c1']
-        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2']
+        'c1'           | 'api'           | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-api-jars', custom: 'c1']
+        'c2'           | 'runtime'       | ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2']
     }
 
     @RequiredFeatures(
@@ -940,25 +940,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedDirectVariant", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedTransitiveVariantA", custom: transitiveAttributeValueA])
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}-jars", custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedLeafVariant", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedDirectVariant", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedTransitiveVariantB", custom: transitiveAttributeValueB])
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}-jars", custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedLeafVariant", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
                         }
                     }
                 }
@@ -1037,25 +1037,25 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
             root(":", ":test:") {
                 module('org:directA:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedDirectVariant", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
                     module('org:transitiveA:1.0') {
                         configuration = expectedTransitiveVariantA
-                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedTransitiveVariantA", custom: transitiveAttributeValueA])
+                        variant(expectedTransitiveVariantA, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantA}-jars", custom: transitiveAttributeValueA])
                         module('org:leafA:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedLeafVariant", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
                         }
                     }
                 }
                 module('org:directB:1.0') {
                     configuration = expectedDirectVariant
-                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedDirectVariant", custom: configurationAttributeValue])
+                    variant(expectedDirectVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedDirectVariant}-jars", custom: configurationAttributeValue])
                     module('org:transitiveB:1.0') {
                         configuration = expectedTransitiveVariantB
-                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedTransitiveVariantB", custom: transitiveAttributeValueB])
+                        variant(expectedTransitiveVariantB, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedTransitiveVariantB}-jars", custom: transitiveAttributeValueB])
                         module('org:leafB:1.0') {
                             configuration = expectedLeafVariant
-                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-$expectedLeafVariant", custom: configurationAttributeValue])
+                            variant(expectedLeafVariant, ['org.gradle.status': DependenciesAttributesIntegrationTest.defaultStatus(), 'org.gradle.usage': "java-${expectedLeafVariant}-jars", custom: configurationAttributeValue])
                         }
                     }
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -260,10 +260,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             resolve.expectGraph {
                 root(":", ":test:") {
                     edge('org:test:1.0', 'org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2'])
+                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2'])
                     }
                     module('org:test:1.0') {
-                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime', custom: 'c2'])
+                        variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars', custom: 'c2'])
                     }
                 }
             }
@@ -356,7 +356,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
                     byConflictResolution('between versions 1.0 and 1.1')
                     // the following assertion is true but limitations to the test fixtures make it hard to check
                     //variant('altruntime', [custom: 'c3', 'org.gradle.status': defaultStatus()])
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c2'
                     artifact group: 'org', module: 'foo', version: '1.1', classifier: 'c3'
                 }
@@ -445,7 +445,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         then:
         failure.assertHasCause("""Multiple incompatible variants of org:foo:1.1 were selected:
    - Variant org:foo:1.1 variant altruntime has attributes {custom=c3, org.gradle.status=${defaultStatus()}}
-   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime}""")
+   - Variant org:foo:1.1 variant runtime has attributes {custom=c2, org.gradle.status=${defaultStatus()}, org.gradle.usage=java-runtime-jars}""")
 
     }
 
@@ -584,7 +584,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
             root(":", ":test:") {
                 edge('org:foo:1.0', 'org:foo:1.1') {
                     byConflictResolution('between versions 1.0 and 1.1')
-                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('runtime', [custom: 'c2', 'org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'c2'
                 }
                 module('org:bar:1.0') {
@@ -631,7 +631,7 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/features/FeaturesResolveIntegrationTest.groovy
@@ -34,12 +34,12 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('runtime') {}
                 variant('feature1') {
                     capability('org', 'feature-1', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.usage', 'java-runtime-jars')
                     artifact('feat1')
                 }
                 variant('feature2') {
                     capability('org', 'feature-2', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.usage', 'java-runtime-jars')
                     artifact('feat2')
                 }
             }
@@ -69,11 +69,11 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {
-                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('feature1', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                 }
             }
@@ -88,12 +88,12 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('runtime') {}
                 variant('feature1') {
                     capability('org', 'feature-1', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.usage', 'java-runtime-jars')
                     artifact('feat1')
                 }
                 variant('feature2') {
                     capability('org', 'feature-2', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.usage', 'java-runtime-jars')
                     artifact('feat2')
                 }
             }
@@ -135,14 +135,14 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
                 variant('v1') {
                     capability('org', 'feature-1', '1.0')
                     capability('org', 'feature-2', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.usage', 'java-runtime-jars')
                     artifact('feat1')
                     artifact('feat2')
                 }
                 variant('v2') {
                     capability('org', 'feature-1', '1.0')
                     capability('org', 'feature-3', '1.0')
-                    attribute('org.gradle.usage', 'java-runtime')
+                    attribute('org.gradle.usage', 'java-runtime-jars')
                     artifact('feat1')
                     artifact('feat3')
                 }
@@ -173,11 +173,11 @@ class FeaturesResolveIntegrationTest extends AbstractModuleDependencyResolveTest
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:foo:1.0') {
-                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('runtime', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.0'
                 }
                 module('org:foo:1.0') {
-                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime'])
+                    variant('v2', ['org.gradle.status': defaultStatus(), 'org.gradle.usage': 'java-runtime-jars'])
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat1'
                     artifact group: 'org', module: 'foo', version: '1.0', classifier: 'feat3'
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/ComponentSelectionRulesErrorHandlingIntegTest.groovy
@@ -49,7 +49,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failure.assertHasDescription("Execution failed for task ':checkDeps'.")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(38)
+        failure.assertHasLineNumber(45)
         failure.assertHasCause("There was an error while evaluating a component selection rule for org.utils:api:1.2.")
         failure.assertHasCause("Could not find method foo()")
     }
@@ -80,7 +80,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failureDescriptionStartsWith("A problem occurred evaluating root project")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(37)
+        failure.assertHasLineNumber(44)
         failureHasCause("The closure provided is not valid as a rule for 'ComponentSelectionRules'.")
         failureHasCause(message)
 
@@ -118,7 +118,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failure.assertHasDescription("Execution failed for task ':checkDeps'.")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(37)
+        failure.assertHasLineNumber(44)
         failure.assertHasCause("There was an error while evaluating a component selection rule for org.utils:api:1.2.")
         failure.assertHasCause("From test")
     }
@@ -149,7 +149,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failureDescriptionStartsWith("A problem occurred evaluating root project")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(37)
+        failure.assertHasLineNumber(44)
         failureHasCause("Could not add a component selection rule for module 'org.utils'.")
         failureHasCause("Cannot convert the provided notation to an object of type ModuleIdentifier: org.utils")
     }
@@ -176,7 +176,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failureDescriptionStartsWith("A problem occurred evaluating root project")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(33)
+        failure.assertHasLineNumber(40)
         failureHasCause("""Type BadRuleSource is not a valid rule source:
 - Method select(java.lang.String) is not a valid rule method: First parameter of a rule method must be of type org.gradle.api.artifacts.ComponentSelection""")
     }
@@ -218,7 +218,7 @@ class ComponentSelectionRulesErrorHandlingIntegTest extends AbstractComponentSel
         fails ':checkDeps'
         failure.assertHasDescription("Execution failed for task ':checkDeps'.")
         failure.assertHasFileName("Build file '$buildFile.path'")
-        failure.assertHasLineNumber(49)
+        failure.assertHasLineNumber(56)
         failure.assertHasCause("There was an error while evaluating a component selection rule for org.utils:api:1.2.")
         failure.assertHasCause("java.lang.Exception: thrown from rule")
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ivy/IvyGradleMetadataRedirectionIntegrationTest.groovy
@@ -86,7 +86,7 @@ class IvyGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependency
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api'])
+                    variant('api', ['org.gradle.status': 'integration', 'org.gradle.usage': 'java-api-jars'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenGradleMetadataRedirectionIntegrationTest.groovy
@@ -87,7 +87,7 @@ class MavenGradleMetadataRedirectionIntegrationTest extends AbstractHttpDependen
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org:main:1.0') {
-                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api'])
+                    variant('api', ['org.gradle.status': 'release', 'org.gradle.usage': 'java-api-jars'])
                     edge('org:foo:{prefer 1.9}', 'org:foo:1.9')
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentMetadataRulesCachingIntegrationTest.groovy
@@ -343,7 +343,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.test:projectA:1.0') {
-                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'thing': 'Bar'])
+                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime-jars', 'thing': 'Bar'])
                 }
             }
         }
@@ -355,7 +355,7 @@ dependencies {
         resolve.expectGraph {
             root(":", ":test:") {
                 module('org.test:projectA:1.0') {
-                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime', 'thing': 'Bar'])
+                    variant('runtime', ['org.gradle.status': expectedStatus, 'org.gradle.usage': 'java-runtime-jars', 'thing': 'Bar'])
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/IvySpecificComponentMetadataRulesIntegrationTest.groovy
@@ -141,7 +141,7 @@ dependencies {
 
         then:
         failure.assertHasDescription("Execution failed for task ':resolve'.")
-        failure.assertHasLineNumber(51)
+        failure.assertHasLineNumber(58)
         failure.assertHasCause("Could not resolve all files for configuration ':conf'.")
         failure.assertHasCause("Could not resolve org.test:projectA:1.0.")
         failure.assertHasCause("Cannot get extra info element named 'foo' by name since elements with this name were found from multiple namespaces (http://my.extra.info/foo, http://some.other.ns).  Use get(String namespace, String name) instead.")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -514,6 +514,16 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         public ImmutableAttributesFactory getAttributesFactory() {
             return services.get(ImmutableAttributesFactory.class);
         }
+
+        @Override
+        public AttributesSchema getAttributesSchema() {
+            return services.get(AttributesSchema.class);
+        }
+
+        @Override
+        public ObjectFactory getObjectFactory() {
+            return services.get(ObjectFactory.class);
+        }
     }
 
     private static class DefaultArtifactPublicationServices implements ArtifactPublicationServices {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -40,12 +40,18 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
             DefaultConfigurationMetadata compileConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("compile");
             DefaultConfigurationMetadata runtimeConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("runtime");
             return ImmutableList.of(
-                    libraryWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API),
-                    libraryWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME),
-                    platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false),
-                    platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false),
-                    platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true),
-                    platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true));
+                    // When deriving variants for the Java ecosystem, we actually have 2 components "mixed together": the library and the platform
+                    // and there's no way to figure out what was the intent when it was published. So we derive variants, but we also need
+                    // to use generic JAVA_API and JAVA_RUNTIME attributes, instead of more precise JAVA_API_JARS and JAVA_RUNTIME_JARS
+                    // because of the platform aspect (which aren't jars but "something"). Using JAVA_API_JARS for the library part and
+                    // JAVA_API for the platform would lead to selection of the platform when we don't want them (in other words in a single
+                    // component we cannot mix precise usages with more generic ones)
+                libraryWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API),
+                libraryWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME),
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false),
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true));
         }
         return null;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/PreferJavaRuntimeVariant.java
@@ -38,6 +38,7 @@ import java.util.Set;
  */
 public class PreferJavaRuntimeVariant extends EmptySchema {
     private static final Usage RUNTIME_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME);
+    private static final Usage RUNTIME_JARS_USAGE = NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS);
     private static final Set<Attribute<?>> SUPPORTED_ATTRIBUTES = Collections.<Attribute<?>>singleton(Usage.USAGE_ATTRIBUTE);
     private static final PreferJavaRuntimeVariant SCHEMA_DEFAULT_JAVA_VARIANTS = new PreferJavaRuntimeVariant();
 
@@ -72,7 +73,9 @@ public class PreferJavaRuntimeVariant extends EmptySchema {
         public void execute(MultipleCandidatesResult<Usage> details) {
             if (details.getConsumerValue() == null) {
                 Set<Usage> candidates = details.getCandidateValues();
-                if (candidates.contains(RUNTIME_USAGE)) {
+                if (candidates.contains(RUNTIME_JARS_USAGE)) {
+                    details.closestMatch(RUNTIME_JARS_USAGE);
+                } else if (candidates.contains(RUNTIME_USAGE)) {
                     details.closestMatch(RUNTIME_USAGE);
                 }
             }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/AbstractDependencyMetadataRulesTest.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -71,6 +72,7 @@ abstract class AbstractDependencyMetadataRulesTest extends Specification {
 
     private DefaultAttributesSchema createSchema() {
         def schema = new DefaultAttributesSchema(new ComponentAttributeMatcher(), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
+        JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
         PlatformSupport.configureSchema(schema)
         schema
     }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/resolve/AbstractModuleDependencyResolveTest.groovy
@@ -165,6 +165,7 @@ abstract class AbstractModuleDependencyResolveTest extends AbstractHttpDependenc
             }
         """
         resolve.addDefaultVariantDerivationStrategy()
+        resolve.addJavaEcosystemSchema()
     }
 
     void repository(@DelegatesTo(RemoteRepositorySpec) Closure<Void> spec) {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1959,7 +1959,7 @@ org:leaf2:1.0
         outputContains """
 project :api
    variant "apiElements" [
-      org.gradle.usage = java-api
+      org.gradle.usage = java-api-jars (compatible with: java-api)
    ]
 
 project :api
@@ -1974,7 +1974,7 @@ project :api
         outputContains """
 project :some:deeply:nested
    variant "apiElements" [
-      org.gradle.usage = java-api
+      org.gradle.usage = java-api-jars (compatible with: java-api)
    ]
 
 project :some:deeply:nested
@@ -1988,7 +1988,7 @@ project :some:deeply:nested
         outputContains """
 project :some:deeply:nested
    variant "apiElements" [
-      org.gradle.usage = java-api
+      org.gradle.usage = java-api-jars (compatible with: java-api)
    ]
 
 project :some:deeply:nested

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -62,7 +62,7 @@ project :$expectedProject
 
         where:
         configuration      | expectedProject | expectedVariant   | expectedAttributes
-        'compileClasspath' | 'b'             | 'apiElements'     | 'org.gradle.usage = java-api'
+        'compileClasspath' | 'b'             | 'apiElements'     | 'org.gradle.usage = java-api-jars (compatible with: java-api)'
         'runtimeClasspath' | 'c'             | 'runtimeElements' | 'org.gradle.usage = java-runtime-jars (compatible with: java-runtime)'
     }
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/resolve/ResolveTestFixture.groovy
@@ -805,6 +805,17 @@ allprojects {
             allprojects { dependencies.components.variantDerivationStrategy = new org.gradle.internal.component.external.model.JavaEcosystemVariantDerivationStrategy() }
         """
     }
+
+    void addJavaEcosystemSchema() {
+        buildFile << """
+            allprojects {
+                org.gradle.api.internal.artifacts.JavaEcosystemSupport.configureSchema(
+                    dependencies.attributesSchema,
+                    project.objects
+                )
+            }
+        """
+    }
 }
 
 class GenerateGraphTask extends DefaultTask {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -46,7 +46,7 @@ class IvyFileModule extends AbstractModule implements IvyModule {
     final Map extendsFrom = [:]
     final Map extraAttributes = [:]
     final Map extraInfo = [:]
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API_JARS]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME_JARS])]
     String branch = null
     String status = "integration"
     MetadataPublish metadataPublish = MetadataPublish.ALL

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -46,7 +46,7 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     int publishCount = 1
     private boolean hasPom = true
     private boolean gradleMetadataRedirect = false
-    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME])]
+    private final List<VariantMetadataSpec> variants = [new VariantMetadataSpec("api", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API_JARS]), new VariantMetadataSpec("runtime", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME_JARS])]
     private final List dependencies = []
     private final List artifacts = []
     final updateFormat = new SimpleDateFormat("yyyyMMddHHmmss")

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -454,7 +454,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
     private static String noop() { "" }
 
     private static String apiUsingUsage(String config = "fromResolutionResult()") {
-        """ usage("java-api") { $config } """
+        """ usage("java-api-jars") { $config } """
     }
 
     private static String runtimeUsingUsage(String config = "fromResolutionResult()") {

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/plugins/MavenPublishPlugin.java
@@ -210,7 +210,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
                     // If the Java plugin is applied, we want to express that the "compile" and "runtime" variants
                     // are mapped to some attributes, which can be used in the version mapping strategy.
                     // This is only required for POM publication, because the variants have _implicit_ attributes that we want explicit for matching
-                    generatePomTask.withCompileScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API)))
+                    generatePomTask.withCompileScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS)))
                                    .withRuntimeScopeAttributes(immutableAttributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
                 });
             }
@@ -285,7 +285,7 @@ public class MavenPublishPlugin implements Plugin<Project> {
             plugins.withPlugin("org.gradle.java", plugin -> {
                 SourceSet mainSourceSet = extensionContainer.getByType(SourceSetContainer.class).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
                 // setup the default configurations used when mapping to resolved versions
-                versionMappingStrategy.usage(Usage.JAVA_API, strategy -> {
+                versionMappingStrategy.usage(Usage.JAVA_API_JARS, strategy -> {
                     DefaultVariantVersionMappingStrategy mapping = (DefaultVariantVersionMappingStrategy) strategy;
                     mapping.setTargetConfiguration(configurations.getByName(mainSourceSet.getCompileClasspathConfigurationName()));
                 });

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginDependencyResolutionServices.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/internal/PluginDependencyResolutionServices.java
@@ -23,12 +23,14 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
+import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Factory;
 
 import java.util.ArrayList;
@@ -77,6 +79,10 @@ public class PluginDependencyResolutionServices implements DependencyResolutionS
         return getDependencyResolutionServices().getAttributesFactory();
     }
 
+    @Override
+    public AttributesSchema getAttributesSchema() {
+        return getDependencyResolutionServices().getAttributesSchema();
+    }
     public PluginRepositoryHandlerProvider getPluginRepositoryHandlerProvider() {
         return new PluginRepositoryHandlerProvider() {
             @Override
@@ -84,6 +90,11 @@ public class PluginDependencyResolutionServices implements DependencyResolutionS
                 return getResolveRepositoryHandler();
             }
         };
+    }
+
+    @Override
+    public ObjectFactory getObjectFactory() {
+        return getDependencyResolutionServices().getObjectFactory();
     }
 
     public PluginRepositoriesProvider getPluginRepositoriesProvider() {

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolver.java
@@ -26,6 +26,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
 import org.gradle.api.internal.artifacts.dependencies.DefaultExternalModuleDependency;
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.repositories.ArtifactRepositoryInternal;
 import org.gradle.plugin.management.internal.InvalidPluginRequestException;
@@ -58,6 +59,7 @@ public class ArtifactRepositoriesPluginResolver implements PluginResolver {
     public ArtifactRepositoriesPluginResolver(DependencyResolutionServices dependencyResolutionServices, VersionSelectorScheme versionSelectorScheme) {
         this.resolution = dependencyResolutionServices;
         this.versionSelectorScheme = versionSelectorScheme;
+        JavaEcosystemSupport.configureSchema(dependencyResolutionServices.getAttributesSchema(), dependencyResolutionServices.getObjectFactory());
     }
 
     @Override

--- a/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
+++ b/subprojects/plugin-use/src/test/groovy/org/gradle/plugin/use/resolve/internal/ArtifactRepositoriesPluginResolverTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.ResolvedConfiguration
 import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
@@ -56,6 +57,7 @@ class ArtifactRepositoriesPluginResolverTest extends Specification {
     def resolution = Mock(DependencyResolutionServices) {
         getResolveRepositoryHandler() >> repositories
         getConfigurationContainer() >> configurations
+        getAttributesSchema() >> Stub(AttributesSchema)
     }
     def result = Mock(PluginResolutionResult)
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -105,7 +105,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
 
@@ -118,7 +118,7 @@ project(':consumer') {
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
         outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api-jars}")
 
         when:
         buildFile << """
@@ -136,7 +136,7 @@ project(':consumer') {
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api-jars}")
 
         where:
         usage                                          | _
@@ -149,7 +149,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
         when:
@@ -209,7 +209,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
 
@@ -247,7 +247,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -107,7 +107,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
         when:
@@ -150,7 +150,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
         when:
@@ -210,7 +210,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
 
@@ -248,7 +248,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -105,7 +105,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
         when:
@@ -116,8 +116,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api-jars}")
 
         when:
         buildFile << """
@@ -134,8 +134,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.usage=java-api-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.usage=java-api-jars}")
 
         where:
         usage                                          | _
@@ -148,7 +148,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, ${usage})
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
         when:
@@ -208,7 +208,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_CLASSES))
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
         when:
@@ -245,7 +245,7 @@ project(':consumer') {
         buildFile << """
             project(':consumer') {
                 configurations.consume.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME_RESOURCES))
-                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.plugins.JavaBasePlugin.UsageCompatibilityRules)
+                dependencies.attributesSchema.attribute(Usage.USAGE_ATTRIBUTE).compatibilityRules.add(org.gradle.api.internal.artifacts.JavaEcosystemSupport.UsageCompatibilityRules)
             }
 """
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -24,6 +24,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.java.DefaultJavaPlatformExtension;
 import org.gradle.api.internal.java.JavaPlatform;
@@ -87,6 +88,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
         createSoftwareComponent(project);
         configureExtension(project);
         addPlatformDisambiguationRule(project);
+        JavaEcosystemSupport.configureSchema(project.getDependencies().getAttributesSchema(), project.getObjects());
     }
 
     private void addPlatformDisambiguationRule(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -434,7 +434,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         apiElementsConfiguration.setDescription("API elements for main.");
         apiElementsConfiguration.setCanBeResolved(false);
         apiElementsConfiguration.setCanBeConsumed(true);
-        apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
+        apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS));
         apiElementsConfiguration.extendsFrom(runtimeConfiguration);
 
         Configuration runtimeElementsConfiguration = configurations.maybeCreate(RUNTIME_ELEMENTS_CONFIGURATION_NAME);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -108,7 +108,7 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
         apiElements.extendsFrom(api);
         final Configuration runtimeElements = export(runtimeElementsConfigurationName);
         runtimeElements.extendsFrom(impl);
-        configureUsage(apiElements, Usage.JAVA_API);
+        configureUsage(apiElements, Usage.JAVA_API_JARS);
         configureUsage(runtimeElements, Usage.JAVA_RUNTIME_JARS);
         configureCapabilities(apiElements);
         configureCapabilities(runtimeElements);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaBasePluginTest.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.JavaVersion
 import org.gradle.api.attributes.CompatibilityCheckDetails
 import org.gradle.api.attributes.Usage
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport
 import org.gradle.api.reporting.ReportingExtension
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.SourceSet
@@ -423,7 +424,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
     @Unroll
     void "check Java usage compatibility rules (consumer value=#consumer, producer value=#producer, compatible=#compatible)"() {
         given:
-        JavaBasePlugin.UsageCompatibilityRules rules = new JavaBasePlugin.UsageCompatibilityRules()
+        JavaEcosystemSupport.UsageCompatibilityRules rules = new JavaEcosystemSupport.UsageCompatibilityRules()
         def details = Mock(CompatibilityCheckDetails)
         when:
         rules.execute(details)
@@ -445,6 +446,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
         consumer                     | producer                     | compatible
         Usage.JAVA_API               | Usage.JAVA_API               | true
         Usage.JAVA_API               | Usage.JAVA_API_CLASSES       | true
+        Usage.JAVA_API               | Usage.JAVA_API_JARS          | true
         Usage.JAVA_API               | Usage.JAVA_RUNTIME           | true
         Usage.JAVA_API               | Usage.JAVA_RUNTIME_CLASSES   | true
         Usage.JAVA_API               | Usage.JAVA_RUNTIME_RESOURCES | false
@@ -452,13 +454,23 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         Usage.JAVA_API_CLASSES       | Usage.JAVA_API               | true
         Usage.JAVA_API_CLASSES       | Usage.JAVA_API_CLASSES       | true
+        Usage.JAVA_API_CLASSES       | Usage.JAVA_API_JARS          | true
         Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME           | true
         Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_CLASSES   | true
         Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_RESOURCES | false
         Usage.JAVA_API_CLASSES       | Usage.JAVA_RUNTIME_JARS      | true
 
+        Usage.JAVA_API_JARS          | Usage.JAVA_API               | true
+        Usage.JAVA_API_JARS          | Usage.JAVA_API_CLASSES       | false
+        Usage.JAVA_API_JARS          | Usage.JAVA_API_JARS          | true
+        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME           | true
+        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_CLASSES   | false
+        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_RESOURCES | false
+        Usage.JAVA_API_JARS          | Usage.JAVA_RUNTIME_JARS      | true
+
         Usage.JAVA_RUNTIME           | Usage.JAVA_API               | false
         Usage.JAVA_RUNTIME           | Usage.JAVA_API_CLASSES       | false
+        Usage.JAVA_RUNTIME           | Usage.JAVA_API_JARS          | false
         Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME           | true
         Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_CLASSES   | false
         Usage.JAVA_RUNTIME           | Usage.JAVA_RUNTIME_RESOURCES | false
@@ -466,6 +478,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API               | false
         Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_CLASSES       | false
+        Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_API_JARS          | false
         Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME           | true
         Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_CLASSES   | true
         Usage.JAVA_RUNTIME_CLASSES   | Usage.JAVA_RUNTIME_RESOURCES | false
@@ -473,6 +486,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API               | false
         Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_CLASSES       | false
+        Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_API_JARS          | false
         Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME           | true
         Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_CLASSES   | false
         Usage.JAVA_RUNTIME_RESOURCES | Usage.JAVA_RUNTIME_RESOURCES | true
@@ -480,6 +494,7 @@ class JavaBasePluginTest extends AbstractProjectBuilderSpec {
 
         Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API               | false
         Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_CLASSES       | false
+        Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_API_JARS          | false
         Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME           | true
         Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_CLASSES   | false
         Usage.JAVA_RUNTIME_JARS      | Usage.JAVA_RUNTIME_RESOURCES | false


### PR DESCRIPTION
### Context

This commit introduces a new `JAVA_API_JARS` usage, mirror
to the `JAVA_RUNTIME_JARS` usage. This is both for consistency,
and to make sure that the `JAVA_API` and `JAVA_RUNTIME` usages
are limited to cases where the consumer doesn't care, or when
a producer doesn't have a more specific usage to provide.

This is, for example, the case for Java platforms. It's worth
noting than in case a producer mixes both "generic" usages
and "specific" usages, selection is likely to produce unexpected
results, because of disambiguation rules.

The Java disambiguation rule has been simplified and now
supports more cases.
