### PR TITLE
Re-enable :kotlinCompilerEmbeddable:clean

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/CheckKotlinCompilerEmbeddableDependencies.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/CheckKotlinCompilerEmbeddableDependencies.kt
@@ -21,8 +21,6 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
-import java.io.File
-
 
 /**
  * Used to validate that :kotlinCompilerEmbeddable dependencies are aligned with the original dependencies.
@@ -41,8 +39,8 @@ open class CheckKotlinCompilerEmbeddableDependencies : DefaultTask() {
     @Classpath
     val expected = project.files()
 
-    val receiptFile: File
-        @OutputFile get() = temporaryDir.resolve("output")
+    @OutputFile
+    val receiptFile = project.buildDir.resolve("receipts/$name/receipt.txt")
 
     @TaskAction
     @Suppress("unused")
@@ -57,6 +55,9 @@ open class CheckKotlinCompilerEmbeddableDependencies : DefaultTask() {
             message += "Please fix dependency declarations in ${project.buildFile.relativeTo(project.rootDir)}"
             message
         }
-        receiptFile.writeText("OK")
+        receiptFile.apply {
+            parentFile.mkdirs()
+            writeText("OK")
+        }
     }
 }

--- a/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
+++ b/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
@@ -74,8 +74,4 @@ tasks {
     sourceSets.main {
         output.dir(files(classesDir).builtBy(unpackPatched))
     }
-    
-    clean {
-        enabled = false
-    }
 }


### PR DESCRIPTION
The `CheckKotlinCompilerEmbeddableDependencies` task had a property getter calling `DefaultTask.getTemporaryDir()` which has the side effect of creating that directory on each invocation. It happened very often that this getter was called concurrently to the clean task, by overlapping outputs detection maybe, causing the clean task to fail with "unable to delete file".

This commit changes that task property to a simple field with no side effects, moving the directory creation to the task action.
