### PR TITLE
Introduce fallback logic to attach output from external threads to root build operation

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -149,8 +149,25 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
             it.hasDetailsOfType(ExecuteTaskBuildOperationType.Details) && it.details.taskPath == ":resolve"
         }
 
+        println "#### roots ="
+        operations.operations.roots.each{
+            println it
+        }
+
+
+        println "#### roots ="
+        operations.operations.each {}.each{
+            println it
+        }
+
         def runBuildProgress = operations.only('Run build').progress
-        def threadedProgress = runBuildProgress.find {it.details.spans[0].text == "from classes task external thread${getPlatformLineSeparator()}" }
+        operations.operations.records.values().each {
+            println "it.displayName = $it.displayName"
+            it.progress.each {
+                println "it.details. = $it.details"
+            }
+        }
+        def threadedProgress = runBuildProgress.find { it.details.spans[0].text == "from classes task external thread${getPlatformLineSeparator()}" }
         threadedProgress.details.category == 'system.out'
         threadedProgress.details.spans.size == 1
         threadedProgress.details.spans[0].styleName == 'Normal'

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -150,14 +150,11 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
         }
 
         def runBuildProgress = operations.only('Run build').progress
-        runBuildProgress.size() > 0
-        runBuildProgress[0].details.logLevel == 'QUIET'
-        runBuildProgress[0].details.category == 'system.out'
-        runBuildProgress[0].details.spans.size == 1
-        runBuildProgress[0].details.spans[0].styleName == 'Normal'
-        runBuildProgress[0].details.spans[0].text == "from classes task external thread${getPlatformLineSeparator()}"
-
-
+        def threadedProgress = runBuildProgress.find {it.details.spans[0].text == "from classes task external thread${getPlatformLineSeparator()}" }
+        threadedProgress.details.category == 'system.out'
+        threadedProgress.details.spans.size == 1
+        threadedProgress.details.spans[0].styleName == 'Normal'
+        threadedProgress.details.spans[0].text == "from classes task external thread${getPlatformLineSeparator()}"
     }
 
     def "captures output from buildSrc"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressIntegTest.groovy
@@ -149,24 +149,7 @@ class LoggingBuildOperationProgressIntegTest extends AbstractIntegrationSpec {
             it.hasDetailsOfType(ExecuteTaskBuildOperationType.Details) && it.details.taskPath == ":resolve"
         }
 
-        println "#### roots ="
-        operations.operations.roots.each{
-            println it
-        }
-
-
-        println "#### roots ="
-        operations.operations.each {}.each{
-            println it
-        }
-
         def runBuildProgress = operations.only('Run build').progress
-        operations.operations.records.values().each {
-            println "it.displayName = $it.displayName"
-            it.progress.each {
-                println "it.details. = $it.details"
-            }
-        }
         def threadedProgress = runBuildProgress.find { it.details.spans[0].text == "from classes task external thread${getPlatformLineSeparator()}" }
         threadedProgress.details.category == 'system.out'
         threadedProgress.details.spans.size == 1

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
@@ -76,8 +76,12 @@ public class LoggingBuildOperationProgressBroadcaster implements Stoppable, Outp
             RenderableOutputEvent renderableOutputEvent = (RenderableOutputEvent) event;
             OperationIdentifier operationIdentifier = renderableOutputEvent.getBuildOperationId();
             if (operationIdentifier == null) {
+                if (rootBuildOperation == null) {
+                    return;
+                }
                 operationIdentifier = rootBuildOperation;
             }
+
             if (renderableOutputEvent instanceof StyledTextOutputEvent || renderableOutputEvent instanceof LogEvent) {
                 emit(renderableOutputEvent, operationIdentifier);
             }
@@ -87,7 +91,7 @@ public class LoggingBuildOperationProgressBroadcaster implements Stoppable, Outp
                 return; // If the event has no logging header, it doesn't manifest as console output.
             }
             OperationIdentifier operationIdentifier = progressStartEvent.getBuildOperationId();
-            if (operationIdentifier == null) {
+            if (operationIdentifier == null && rootBuildOperation != null) {
                 operationIdentifier = rootBuildOperation;
             }
             emit(progressStartEvent, operationIdentifier);

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
@@ -29,6 +29,8 @@ import org.gradle.internal.operations.BuildOperationListener;
 import org.gradle.internal.operations.OperationIdentifier;
 import org.gradle.internal.operations.OperationProgressEvent;
 
+import static org.gradle.internal.operations.DefaultBuildOperationIdFactory.ROOT_BUILD_OPERATION_ID_VALUE;
+
 /**
  * Emits build operation progress for events that represent logging.
  *
@@ -58,6 +60,8 @@ import org.gradle.internal.operations.OperationProgressEvent;
  */
 public class LoggingBuildOperationProgressBroadcaster implements Stoppable, OutputEventListener {
 
+    private final static OperationIdentifier ROOT_BUILD_OPERATION_ID = new OperationIdentifier(ROOT_BUILD_OPERATION_ID_VALUE);
+
     private final OutputEventListenerManager outputEventListenerManager;
     private final BuildOperationListener buildOperationListener;
 
@@ -72,21 +76,23 @@ public class LoggingBuildOperationProgressBroadcaster implements Stoppable, Outp
     public void onOutput(OutputEvent event) {
         if (event instanceof RenderableOutputEvent) {
             RenderableOutputEvent renderableOutputEvent = (RenderableOutputEvent) event;
-            if (renderableOutputEvent.getBuildOperationId() == null) {
-                return;
+            OperationIdentifier operationIdentifier = renderableOutputEvent.getBuildOperationId();
+            if (operationIdentifier == null) {
+                operationIdentifier = ROOT_BUILD_OPERATION_ID;
             }
             if (renderableOutputEvent instanceof StyledTextOutputEvent || renderableOutputEvent instanceof LogEvent) {
-                emit(renderableOutputEvent, renderableOutputEvent.getBuildOperationId());
+                emit(renderableOutputEvent, operationIdentifier);
             }
         } else if (event instanceof ProgressStartEvent) {
             ProgressStartEvent progressStartEvent = (ProgressStartEvent) event;
-            if (progressStartEvent.getBuildOperationId() == null) {
-                return;
-            }
             if (progressStartEvent.getLoggingHeader() == null) {
                 return; // If the event has no logging header, it doesn't manifest as console output.
             }
-            emit(progressStartEvent, progressStartEvent.getBuildOperationId());
+            OperationIdentifier operationIdentifier = progressStartEvent.getBuildOperationId();
+            if (operationIdentifier == null) {
+                operationIdentifier = ROOT_BUILD_OPERATION_ID;
+            }
+            emit(progressStartEvent, operationIdentifier);
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcaster.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.operations.logging;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.logging.events.CategorisedOutputEvent;
 import org.gradle.internal.logging.events.LogEvent;
@@ -62,7 +63,8 @@ public class LoggingBuildOperationProgressBroadcaster implements Stoppable, Outp
     private final OutputEventListenerManager outputEventListenerManager;
     private final BuildOperationListener buildOperationListener;
 
-    private OperationIdentifier rootBuildOperation;
+    @VisibleForTesting
+    OperationIdentifier rootBuildOperation;
 
     public LoggingBuildOperationProgressBroadcaster(OutputEventListenerManager outputEventListenerManager, BuildOperationListener buildOperationListener) {
         this.outputEventListenerManager = outputEventListenerManager;

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -268,7 +268,6 @@ public class BuildOperationTrace implements Stoppable {
             Files.asCharSource(logFile, Charsets.UTF_8).readLines(new LineProcessor<Void>() {
                 @Override
                 public boolean processLine(@SuppressWarnings("NullableProblems") String line) {
-                    System.out.println("line = " + line);
                     Map<String, ?> map = uncheckedCast(slurper.parseText(line));
                     if (map.containsKey("startTime")) {
                         SerializedOperationStart serialized = new SerializedOperationStart(map);

--- a/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/operations/trace/BuildOperationTrace.java
@@ -252,7 +252,8 @@ public class BuildOperationTrace implements Stoppable {
     }
 
     public static BuildOperationTree read(String basePath) {
-        List<BuildOperationRecord> roots = readLogToTreeRoots(logFile(basePath));
+        File logFile = logFile(basePath);
+        List<BuildOperationRecord> roots = readLogToTreeRoots(logFile);
         return new BuildOperationTree(roots);
     }
 
@@ -267,6 +268,7 @@ public class BuildOperationTrace implements Stoppable {
             Files.asCharSource(logFile, Charsets.UTF_8).readLines(new LineProcessor<Void>() {
                 @Override
                 public boolean processLine(@SuppressWarnings("NullableProblems") String line) {
+                    System.out.println("line = " + line);
                     Map<String, ?> map = uncheckedCast(slurper.parseText(line));
                     if (map.containsKey("startTime")) {
                         SerializedOperationStart serialized = new SerializedOperationStart(map);

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/CrossBuildSessionScopeServices.java
@@ -95,6 +95,10 @@ public class CrossBuildSessionScopeServices implements Closeable {
         return buildOperationListenerManager;
     }
 
+    LoggingBuildOperationProgressBroadcaster createLoggingBuildOperationProgressBroadcaster() {
+        return loggingBuildOperationProgressBroadcaster;
+    }
+
     BuildOperationExecutor createBuildOperationExecutor() {
         // Wrap to prevent exposing Stoppable, as we don't want to stop at this scope
         return new DelegatingBuildOperationExecutor(services.get(BuildOperationExecutor.class));

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
@@ -36,6 +36,9 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
     @Shared
     def operationId = Mock(OperationIdentifier)
 
+    @Shared
+    def fallbackOperationId = LoggingBuildOperationProgressBroadcaster.ROOT_BUILD_OPERATION_ID
+
     LoggingBuildOperationProgressBroadcaster bridge = new LoggingBuildOperationProgressBroadcaster(outputEventListenerManager, buildOperationListener)
 
     @Unroll
@@ -51,13 +54,16 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
 
 
         when:
-        bridge.onOutput(eventWithNoBuildOperationId)
+        bridge.onOutput(eventWithFallbackBuildOperationId)
 
         then:
-        0 * buildOperationListener.progress(_, _)
+        1 * buildOperationListener.progress(_, _) >> {
+            assert it[0] == fallbackOperationId
+            assert it[1].details == eventWithFallbackBuildOperationId
+        }
 
         where:
-        eventType             | eventWithBuildOperationId                                          | eventWithNoBuildOperationId
+        eventType             | eventWithBuildOperationId                                          | eventWithFallbackBuildOperationId
         LogEvent              | new LogEvent(0, 'c', LogLevel.INFO, 'm', null, operationId)        | new LogEvent(0, 'c', LogLevel.INFO, 'm', null, null)
         StyledTextOutputEvent | new StyledTextOutputEvent(0, 'c', LogLevel.INFO, operationId, 'm') | new StyledTextOutputEvent(0, 'c', LogLevel.INFO, null, 'm')
         ProgressStartEvent    | progressStartEvent(operationId)                                    | progressStartEvent(null)

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
@@ -36,9 +36,6 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
     @Shared
     def operationId = Mock(OperationIdentifier)
 
-    @Shared
-    def fallbackOperationId = LoggingBuildOperationProgressBroadcaster.ROOT_BUILD_OPERATION_ID
-
     LoggingBuildOperationProgressBroadcaster bridge = new LoggingBuildOperationProgressBroadcaster(outputEventListenerManager, buildOperationListener)
 
     @Unroll
@@ -58,7 +55,7 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
 
         then:
         1 * buildOperationListener.progress(_, _) >> {
-            assert it[0] == fallbackOperationId
+            assert it[0] != null
             assert it[1].details == eventWithFallbackBuildOperationId
         }
 

--- a/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/operations/logging/LoggingBuildOperationProgressBroadcasterTest.groovy
@@ -36,7 +36,14 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
     @Shared
     def operationId = Mock(OperationIdentifier)
 
+    @Shared
+    def fallbackOperationId = Mock(OperationIdentifier)
+
     LoggingBuildOperationProgressBroadcaster bridge = new LoggingBuildOperationProgressBroadcaster(outputEventListenerManager, buildOperationListener)
+
+    def setup() {
+        bridge.rootBuildOperation = fallbackOperationId
+    }
 
     @Unroll
     def "forwards #eventType with operationId"() {
@@ -55,7 +62,7 @@ class LoggingBuildOperationProgressBroadcasterTest extends Specification {
 
         then:
         1 * buildOperationListener.progress(_, _) >> {
-            assert it[0] != null
+            assert it[0] == fallbackOperationId
             assert it[1].details == eventWithFallbackBuildOperationId
         }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/exec/RunAsBuildOperationBuildActionRunner.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/exec/RunAsBuildOperationBuildActionRunner.java
@@ -25,6 +25,7 @@ import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.CallableBuildOperation;
+import org.gradle.internal.operations.logging.LoggingBuildOperationProgressBroadcaster;
 
 /**
  * An {@link BuildActionRunner} that wraps all work in a build operation.
@@ -46,6 +47,7 @@ public class RunAsBuildOperationBuildActionRunner implements BuildActionRunner {
             public Result call(BuildOperationContext context) {
                 checkDeprecations((StartParameterInternal)buildController.getGradle().getStartParameter());
                 buildController.getGradle().getServices().get(IncludedBuildControllers.class).rootBuildOperationStarted();
+                buildController.getGradle().getServices().get(LoggingBuildOperationProgressBroadcaster.class).rootBuildOperationStarted();
                 Result result = delegate.run(action, buildController);
                 context.setResult(RESULT);
                 if (result.getBuildFailure() != null) {


### PR DESCRIPTION
### Context

When output is generated in an external thread we currently don't tie this output to a build operation. Output tied to a build operation is currently required for the build scan plugin to show the output in the console log. 

For illustration compare the console log shown when running the kotlin compiler in an external thread: https://scans.gradle.com/s/3gvrsd6smk2l6/console-log

vs.

running the kotlin compiler in process: https://scans.gradle.com/s/s5xk5osz4j2i2/console-log

This PR is related to https://github.com/gradle/dotcom/issues/2152 and introduces a decent fallback to link output to the root build operation as a fallback. Further work is under discovery atm to allow linking outputs from external threads to their proper build operation.

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [ ] Verify test coverage and CI build status
