### PR TITLE
Fix equals/hashcode of mutable classloaders

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/classloader/MultiParentClassLoader.java
@@ -138,23 +138,4 @@ public class MultiParentClassLoader extends ClassLoader implements ClassLoaderHi
             return getClass().getName().hashCode();
         }
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof MultiParentClassLoader)) {
-            return false;
-        }
-
-        MultiParentClassLoader that = (MultiParentClassLoader) o;
-
-        return parents.equals(that.parents);
-    }
-
-    @Override
-    public int hashCode() {
-        return parents.hashCode();
-    }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/MultiParentClassLoaderTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/classloader/MultiParentClassLoaderTest.groovy
@@ -127,14 +127,29 @@ class MultiParentClassLoaderTest extends Specification {
         0 * visitor._
     }
 
-    def "equals and hashcode"() {
+    def "hash code is identity based"() {
+        given:
         def c1 = new URLClassLoader()
         def c2 = new CachingClassLoader(c1)
-        expect:
-        new MultiParentClassLoader(c1, c2) == new MultiParentClassLoader(c1, c2)
-        new MultiParentClassLoader(c1, c2).hashCode() == new MultiParentClassLoader(c1, c2).hashCode()
+        def loader = new MultiParentClassLoader(c1)
+        def hash = loader.hashCode()
 
-        new MultiParentClassLoader(c1, c2) != new MultiParentClassLoader(c1, c2, new URLClassLoader())
-        new MultiParentClassLoader(c1, c2).hashCode() != new MultiParentClassLoader(c1, c2, new URLClassLoader()).hashCode()
+        when:
+        loader.addParent(c2)
+
+        then:
+        loader.hashCode() == hash
+    }
+
+    def "equality is identity based"() {
+        given:
+        def c1 = new URLClassLoader()
+        def c2 = new CachingClassLoader(c1)
+        def loader1 = new MultiParentClassLoader(c1, c2)
+        def loader2 = new MultiParentClassLoader(c1, c2)
+
+        expect:
+        loader1 == loader1
+        loader2 != loader1
     }
 }


### PR DESCRIPTION
When a parent was added to a MultiParentClassLoader, its hashcode
would change, meaning that it could no longer be found in any Sets
or Maps we put it in. This lead to severe memory leaks when used in
conjunction with configure-on-demand, where adding parents late is common.

These classloaders now use an identity hashcode and equals implementation.
