### PR TITLE
Remove now unneeded :apiMetadata:apiParameterNames task

### DIFF
--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataExtension.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataExtension.kt
@@ -21,7 +21,6 @@ import org.gradle.kotlin.dsl.listProperty
 
 
 open class ApiMetadataExtension(project: Project) {
-    val sources = project.files()
     val includes = project.objects.listProperty<String>().empty()
     val excludes = project.objects.listProperty<String>().empty()
 }

--- a/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataPlugin.kt
+++ b/buildSrc/subprojects/packaging/src/main/kotlin/org/gradle/gradlebuild/packaging/ApiMetadataPlugin.kt
@@ -18,8 +18,6 @@ package org.gradle.gradlebuild.packaging
 
 import accessors.sourceSets
 
-import build.ParameterNamesIndex
-
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.WriteProperties
@@ -45,18 +43,9 @@ open class ApiMetadataPlugin : Plugin<Project> {
             outputFile = generatedPropertiesFileFor(apiDeclarationFilename).get().asFile
         }
 
-        val apiParameterNames by tasks.registering(ParameterNamesIndex::class) {
-            sources.from(extension.sources.asFileTree.matching {
-                include(extension.includes.get())
-                exclude(extension.excludes.get())
-            })
-            destinationFile.set(generatedPropertiesFileFor(apiParametersFilename))
-        }
-
         sourceSets {
             "main" {
                 output.dir(generatedDirFor(apiDeclarationFilename), "builtBy" to apiDeclaration)
-                output.dir(generatedDirFor(apiParametersFilename), "builtBy" to apiParameterNames)
             }
         }
     }
@@ -71,7 +60,4 @@ open class ApiMetadataPlugin : Plugin<Project> {
 
     private
     val apiDeclarationFilename = "gradle-api-declaration"
-
-    private
-    val apiParametersFilename = "gradle-api-parameter-names"
 }

--- a/subprojects/api-metadata/api-metadata.gradle.kts
+++ b/subprojects/api-metadata/api-metadata.gradle.kts
@@ -11,7 +11,6 @@ gradlebuildJava {
 }
 
 apiMetadata {
-    sources.from({ publicJavaProjects.map { it.sourceSets.main.get().allJava } })
     includes.addAll(PublicApi.includes)
     excludes.addAll(PublicApi.excludes)
 }

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegrationSpec.groovy
@@ -180,9 +180,6 @@ abstract class DistributionIntegrationSpec extends AbstractIntegrationSpec {
             assert apiDeclaration.size() == 2
             assert apiDeclaration.getProperty("includes").contains(":org/gradle/api/**:")
             assert apiDeclaration.getProperty("excludes").split(":").size() == 1
-            def parameterNames = GUtil.loadProperties(IOUtils.toInputStream(content("gradle-api-parameter-names.properties")))
-            assert parameterNames.size() > 2900
-            assert parameterNames["org.gradle.api.DomainObjectCollection.withType(java.lang.Class,org.gradle.api.Action)"] == "type,configureAction"
         }
     }
 }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleApiExtensionsIntegrationTest.kt
@@ -258,7 +258,7 @@ class GradleApiExtensionsIntegrationTest : AbstractPluginIntegrationTest() {
     fun generatedExtensionsJarFromGradleUserHome(guh: File): File =
         Regex("^\\d.*").let { startsWithDigit ->
             guh.resolve("caches")
-                .listFiles { f -> f.isDirectory && f.also { println(it) }.name.matches(startsWithDigit) }
+                .listFiles { f -> f.isDirectory && f.name.matches(startsWithDigit) }
                 .single()
                 .resolve("generated-gradle-jars")
                 .listFiles { f -> f.isFile && f.name.startsWith("gradle-kotlin-dsl-extensions-") }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensions.kt
@@ -26,7 +26,7 @@ fun writeGradleApiKotlinDslExtensionsTo(outputDirectory: File, gradleJars: Colle
 
     val gradleApiJars = gradleApiJarsFrom(gradleJars)
 
-    val gradleApiMetadata = gradleApiMetadataFrom(gradleApiMetadataJar)
+    val gradleApiMetadata = gradleApiMetadataFrom(gradleApiMetadataJar, gradleApiJars)
 
     return generateKotlinDslApiExtensionsSourceTo(
         outputDirectory,

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/codegen/GradleApiExtensionsTest.kt
@@ -392,10 +392,6 @@ class GradleApiExtensionsTest : TestWithClassPath() {
                     setProperty("excludes", "**/internal/**")
                     store(output, null)
                 }
-                output.putNextEntry(JarEntry("gradle-api-parameter-names.properties"))
-                Properties().apply {
-                    store(output, null)
-                }
             }
         }
 }

--- a/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
+++ b/subprojects/kotlin-dsl/src/test/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProviderTest.kt
@@ -61,8 +61,7 @@ class KotlinScriptClassPathProviderTest : TestWithTempFiles() {
     private
     fun mockGradleApiMetadataModule() =
         withZip("gradle-api-metadata-0.jar", sequenceOf(
-            "gradle-api-declaration.properties" to "includes=\nexcludes=\n".toByteArray(),
-            "gradle-api-parameter-names.properties" to "".toByteArray())
+            "gradle-api-declaration.properties" to "includes=\nexcludes=\n".toByteArray())
         ).let { jar ->
             mock<Module> { on { classpath } doReturn DefaultClassPath.of(listOf(jar)) }
         }


### PR DESCRIPTION
favoring existing per-jar parameter names indices. This should speed up the feedback loop when working on this repository.