### PR TITLE
Fix #3987: Process execution hangs on Windows if child processes are still alive

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/DefaultExecHandle.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.TimeUnit;
 
 import static java.lang.String.format;
 
@@ -428,6 +429,12 @@ public class DefaultExecHandle implements ExecHandle, ProcessSettings {
         public void stop() {
             outputHandler.stop();
             inputHandler.stop();
+        }
+
+        @Override
+        public void disconnect(long timeout, TimeUnit unit) {
+            outputHandler.disconnect(timeout, unit);
+            inputHandler.disconnect(timeout, unit);
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/ExecHandleRunner.java
@@ -23,6 +23,8 @@ import org.gradle.api.logging.Logging;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.TimeUnit;
+
 
 public class ExecHandleRunner implements Runnable {
     private static final Logger LOGGER = Logging.getLogger(ExecHandleRunner.class);
@@ -79,7 +81,7 @@ public class ExecHandleRunner implements Runnable {
                 detached();
             } else {
                 int exitValue = process.waitFor();
-                streamsHandler.stop();
+                streamsHandler.disconnect(1, TimeUnit.SECONDS);
                 completed(exitValue);
             }
         } catch (Throwable t) {

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/EmptyStdInStreamsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/EmptyStdInStreamsHandler.java
@@ -21,6 +21,7 @@ import org.gradle.process.internal.StreamsHandler;
 
 import java.io.IOException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A handler that writes nothing to the process' stdin
@@ -41,6 +42,10 @@ public class EmptyStdInStreamsHandler implements StreamsHandler {
 
     @Override
     public void stop() {
+    }
+
+    @Override
+    public void disconnect(long timeout, TimeUnit unit) {
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Forwards the contents of an {@link InputStream} to the process' stdin
@@ -63,6 +64,16 @@ public class ForwardStdinStreamsHandler implements StreamsHandler {
         } catch (InterruptedException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    @Override
+    public void disconnect(long timeout, TimeUnit unit) {
+        try {
+            completed.await(timeout, unit);
+        } catch (InterruptedException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+        disconnect();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/ForwardStdinStreamsHandler.java
@@ -69,11 +69,13 @@ public class ForwardStdinStreamsHandler implements StreamsHandler {
     @Override
     public void disconnect(long timeout, TimeUnit unit) {
         try {
-            completed.await(timeout, unit);
+            boolean gracefulExit = completed.await(timeout, unit);
+            if (!gracefulExit) {
+                disconnect();
+            }
         } catch (InterruptedException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
-        disconnect();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
@@ -75,11 +75,13 @@ public class OutputStreamsForwarder implements StreamsHandler {
     @Override
     public void disconnect(long timeout, TimeUnit unit) {
         try {
-            completed.await(timeout, unit);
+            boolean gracefulExit = completed.await(timeout, unit);
+            if (!gracefulExit) {
+                disconnect();
+            }
         } catch (InterruptedException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
-        disconnect();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/streams/OutputStreamsForwarder.java
@@ -23,6 +23,7 @@ import org.gradle.process.internal.StreamsHandler;
 import java.io.OutputStream;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Reads from the process' stdout and stderr (if not merged into stdout) and forwards to {@link OutputStream}.
@@ -69,6 +70,16 @@ public class OutputStreamsForwarder implements StreamsHandler {
         } catch (InterruptedException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    @Override
+    public void disconnect(long timeout, TimeUnit unit) {
+        try {
+            completed.await(timeout, unit);
+        } catch (InterruptedException e) {
+            throw UncheckedException.throwAsUncheckedException(e);
+        }
+        disconnect();
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/DefaultExecHandleSpec.groovy
@@ -31,6 +31,7 @@ import spock.lang.Timeout
 
 import java.util.concurrent.Callable
 import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
 
 @UsesNativeServices
 @Timeout(60)
@@ -401,7 +402,7 @@ class DefaultExecHandleSpec extends ConcurrentSpec {
         result.rethrowFailure()
         1 * streamsHandler.connectStreams(_ as Process, "foo proc", _ as Executor)
         1 * streamsHandler.start()
-        1 * streamsHandler.stop()
+        1 * streamsHandler.disconnect(1, TimeUnit.SECONDS)
         0 * streamsHandler._
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonOutputConsumer.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/bootstrap/DaemonOutputConsumer.java
@@ -25,6 +25,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Scanner;
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 public class DaemonOutputConsumer implements StreamsHandler {
 
@@ -72,6 +73,10 @@ public class DaemonOutputConsumer implements StreamsHandler {
     }
 
     public void stop() {
+    }
+
+    @Override
+    public void disconnect(long timeout, TimeUnit unit) {
     }
 
     @Override

--- a/subprojects/process-services/src/main/java/org/gradle/process/internal/StreamsHandler.java
+++ b/subprojects/process-services/src/main/java/org/gradle/process/internal/StreamsHandler.java
@@ -19,6 +19,7 @@ package org.gradle.process.internal;
 import org.gradle.internal.concurrent.Stoppable;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 
 public interface StreamsHandler extends Stoppable {
     /**
@@ -35,6 +36,11 @@ public interface StreamsHandler extends Stoppable {
      * Disconnects from the process without waiting for further work.
      */
     void disconnect();
+
+    /**
+     * Disconnects from the process after waiting specified timeout.
+     */
+    void disconnect(long timeout, TimeUnit unit);
 
     /**
      * Stops doing work with the process's streams. Should block until no further asynchronous work is happening on the streams.


### PR DESCRIPTION
Issue: #3987

### Context
On windows, when a process exit and leave child processes running, gradle Exec tasks are stuck. This is because the output stream is not closed until child process exit.
Proposed solution times out and disconnects 1 second after the process exit if the stream is not closed. This should enough to handle remaining output.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
    Tested with the specific windows setup that causes test process to leave child processes after exit.
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
