### PR TITLE
Inspect and validate the annotations attached to artifact transform actions

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -438,7 +438,7 @@ public abstract class CollectionUtils {
      * @param <T> The element type of t1
      * @return t1
      */
-    public static <T> Collection<T> addAll(Collection<T> t1, Iterable<? extends T> t2) {
+    public static <T, C extends Collection<? super T>> C addAll(C t1, Iterable<? extends T> t2) {
         for (T t : t2) {
             t1.add(t);
         }
@@ -453,7 +453,7 @@ public abstract class CollectionUtils {
      * @param <T> The element type of t1
      * @return t1
      */
-    public static <T> Collection<T> addAll(Collection<T> t1, T... t2) {
+    public static <T, C extends Collection<? super T>> C addAll(C t1, T... t2) {
         Collections.addAll(t1, t2);
         return t1;
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskPropertyUtils.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.tasks;
 
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.TaskInternal;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskValidationContext.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks;
 
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 
 public interface TaskValidationContext extends ParameterValidationContext {
     FileResolver getResolver();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultParameterValidationContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultParameterValidationContext.java
@@ -16,18 +16,25 @@
 
 package org.gradle.api.internal.tasks.properties;
 
+import org.gradle.internal.reflect.ParameterValidationContext;
+
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 public class DefaultParameterValidationContext implements ParameterValidationContext {
-
-    public static String propertyValidationMessage(String propertyName, String validationMessage) {
-        return String.format("Property '%s' %s.", propertyName, validationMessage);
-    }
-
     private final Collection<String> messages;
 
     public DefaultParameterValidationContext(Collection<String> messages) {
         this.messages = messages;
+    }
+
+    @Override
+    public void recordValidationMessage(@Nullable String ownerPath, String propertyName, String message) {
+        if (ownerPath == null) {
+            recordValidationMessage("Property '" + propertyName + "' " + message + ".");
+        } else {
+            recordValidationMessage("Property '" + ownerPath + '.' + propertyName + "' " + message + ".");
+        }
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultPropertyWalker.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.tasks.properties;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.tasks.properties.bean.RuntimeBeanNode;
 import org.gradle.api.internal.tasks.properties.bean.RuntimeBeanNodeFactory;
+import org.gradle.internal.reflect.ParameterValidationContext;
 
 import java.util.ArrayDeque;
 import java.util.Queue;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
@@ -85,7 +85,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         }
     };
 
-    public DefaultTypeMetadataStore(Iterable<? extends PropertyAnnotationHandler> annotationHandlers, CrossBuildInMemoryCacheFactory cacheFactory) {
+    public DefaultTypeMetadataStore(Iterable<? extends PropertyAnnotationHandler> annotationHandlers, Set<Class<? extends Annotation>> otherKnownAnnotations, CrossBuildInMemoryCacheFactory cacheFactory) {
         Iterable<PropertyAnnotationHandler> allAnnotationHandlers = Iterables.concat(HANDLERS, annotationHandlers);
         this.annotationHandlers = Maps.uniqueIndex(allAnnotationHandlers, new Function<PropertyAnnotationHandler, Class<? extends Annotation>>() {
             @Override
@@ -101,7 +101,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
             }
         })).keySet());
         String displayName = calculateDisplayName(allAnnotationHandlers);
-        this.propertyExtractor = new PropertyExtractor(displayName, this.annotationHandlers.keySet(), relevantAnnotationTypes, annotationOverrides, IGNORED_SUPER_CLASSES, IGNORED_METHODS);
+        this.propertyExtractor = new PropertyExtractor(displayName, this.annotationHandlers.keySet(), relevantAnnotationTypes, annotationOverrides, otherKnownAnnotations, IGNORED_SUPER_CLASSES, IGNORED_METHODS);
         this.cache = cacheFactory.newClassCache();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.properties;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
@@ -44,10 +45,14 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
+import org.gradle.internal.Pair;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.internal.reflect.PropertyExtractor;
 import org.gradle.internal.reflect.PropertyMetadata;
+import org.gradle.internal.reflect.ValidationProblem;
 import org.gradle.internal.scripts.ScriptOrigin;
 
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
@@ -134,16 +139,26 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
     }
 
     private <T> TypeMetadata createTypeMetadata(Class<T> type) {
-        return new DefaultTypeMetadata(propertyExtractor.extractPropertyMetadata(type), annotationHandlers);
+        Pair<ImmutableSet<PropertyMetadata>, ImmutableList<ValidationProblem>> properties = propertyExtractor.extractPropertyMetadata(type);
+        return new DefaultTypeMetadata(properties.left, properties.right, annotationHandlers);
     }
 
     private static class DefaultTypeMetadata implements TypeMetadata {
         private final ImmutableSet<PropertyMetadata> propertiesMetadata;
+        private final ImmutableList<ValidationProblem> validationProblems;
         private final ImmutableMap<Class<? extends Annotation>, PropertyAnnotationHandler> annotationHandlers;
 
-        DefaultTypeMetadata(ImmutableSet<PropertyMetadata> propertiesMetadata, ImmutableMap<Class<? extends Annotation>, PropertyAnnotationHandler> annotationHandlers) {
+        DefaultTypeMetadata(ImmutableSet<PropertyMetadata> propertiesMetadata, ImmutableList<ValidationProblem> validationProblems, ImmutableMap<Class<? extends Annotation>, PropertyAnnotationHandler> annotationHandlers) {
             this.propertiesMetadata = propertiesMetadata;
+            this.validationProblems = validationProblems;
             this.annotationHandlers = annotationHandlers;
+        }
+
+        @Override
+        public void collectValidationFailures(@Nullable String ownerPropertyPath, ParameterValidationContext validationContext) {
+            for (ValidationProblem problem : validationProblems) {
+                problem.collect(ownerPropertyPath, validationContext);
+            }
         }
 
         @Override
@@ -153,12 +168,7 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
         @Override
         public boolean hasAnnotatedProperties() {
-            for (PropertyMetadata metadata : propertiesMetadata) {
-                if (metadata.getPropertyType() != null) {
-                    return true;
-                }
-            }
-            return false;
+            return !propertiesMetadata.isEmpty();
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
@@ -46,7 +46,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.util.ArrayDeque;
 import java.util.List;
@@ -177,9 +176,6 @@ public class PropertyValidationAccess {
                 }
                 Class<? extends Annotation> propertyType = propertyMetadata.getPropertyType();
                 if (propertyType == null) {
-                    if (!Modifier.isPrivate(propertyMetadata.getGetterMethod().getModifiers())) {
-                        problems.put(propertyValidationMessage(topLevelBean, qualifiedPropertyName, "is not annotated with an input or output annotation"), Boolean.FALSE);
-                    }
                     continue;
                 }
                 PropertyValidator validator = PROPERTY_VALIDATORS.get(propertyType);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
@@ -35,6 +35,7 @@ import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.event.DefaultListenerManager;
 import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.internal.reflect.PropertyMetadata;
 import org.gradle.internal.service.DefaultServiceLocator;
 import org.gradle.internal.service.ServiceRegistration;
@@ -168,21 +169,18 @@ public class PropertyValidationAccess {
         }
 
         @Override
-        public void visit(Class<?> topLevelBean, boolean stricterValidation, Map<String, Boolean> problems, Queue<BeanTypeNode<?>> queue, BeanTypeNodeFactory nodeFactory) {
-            for (PropertyMetadata propertyMetadata : getTypeMetadata().getPropertiesMetadata()) {
+        public void visit(final Class<?> topLevelBean, boolean stricterValidation, final Map<String, Boolean> problems, Queue<BeanTypeNode<?>> queue, BeanTypeNodeFactory nodeFactory) {
+            TypeMetadata typeMetadata = getTypeMetadata();
+            ParameterValidationContext validationContext = new CollectingParameterValidationContext(topLevelBean, problems);
+            typeMetadata.collectValidationFailures(getPropertyName(), validationContext);
+            for (PropertyMetadata propertyMetadata : typeMetadata.getPropertiesMetadata()) {
                 String qualifiedPropertyName = getQualifiedPropertyName(propertyMetadata.getPropertyName());
-                for (String validationMessage : propertyMetadata.getValidationMessages()) {
-                    problems.put(propertyValidationMessage(topLevelBean, qualifiedPropertyName, validationMessage), Boolean.FALSE);
-                }
                 Class<? extends Annotation> propertyType = propertyMetadata.getPropertyType();
-                if (propertyType == null) {
-                    continue;
-                }
                 PropertyValidator validator = PROPERTY_VALIDATORS.get(propertyType);
                 if (validator != null) {
                     String validationMessage = validator.validate(stricterValidation, propertyMetadata);
                     if (validationMessage != null) {
-                        problems.put(propertyValidationMessage(topLevelBean, qualifiedPropertyName, validationMessage), Boolean.FALSE);
+                        validationContext.recordValidationMessage(null, propertyMetadata.getPropertyName(), validationMessage);
                     }
                 }
                 if (propertyMetadata.isAnnotationPresent(Nested.class)) {
@@ -201,8 +199,24 @@ public class PropertyValidationAccess {
             return genericReturnType;
         }
 
-        private static String propertyValidationMessage(Class<?> task, String qualifiedPropertyName, String validationMessage) {
-            return String.format("Task type '%s': property '%s' %s.", task.getName(), qualifiedPropertyName, validationMessage);
+        private class CollectingParameterValidationContext implements ParameterValidationContext {
+            private final Class<?> topLevelBean;
+            private final Map<String, Boolean> problems;
+
+            public CollectingParameterValidationContext(Class<?> topLevelBean, Map<String, Boolean> problems) {
+                this.topLevelBean = topLevelBean;
+                this.problems = problems;
+            }
+
+            @Override
+            public void recordValidationMessage(@Nullable String ownerPath, String propertyName, String message) {
+                recordValidationMessage(String.format("Task type '%s': property '%s' %s.", topLevelBean.getName(), getQualifiedPropertyName(propertyName), message));
+            }
+
+            @Override
+            public void recordValidationMessage(String message) {
+                problems.put(message, Boolean.FALSE);
+            }
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyWalker.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyWalker.java
@@ -16,6 +16,8 @@
 
 package org.gradle.api.internal.tasks.properties;
 
+import org.gradle.internal.reflect.ParameterValidationContext;
+
 /**
  * Walks properties declared by the type.
  */

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/TypeMetadata.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/TypeMetadata.java
@@ -17,14 +17,21 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHandler;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.internal.reflect.PropertyMetadata;
 
 import javax.annotation.Nullable;
 import java.util.Set;
 
 public interface TypeMetadata {
+    void collectValidationFailures(@Nullable String ownerPropertyPath, ParameterValidationContext validationContext);
+
+    /**
+     * Returns the set of relevant properties, that is, those properties annotated with a relevant annotation.
+     */
     Set<PropertyMetadata> getPropertiesMetadata();
+
     boolean hasAnnotatedProperties();
-    @Nullable
+
     PropertyAnnotationHandler getAnnotationHandlerFor(PropertyMetadata propertyMetadata);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -51,9 +51,10 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
         for (PropertyMetadata propertyMetadata : typeMetadata.getPropertiesMetadata()) {
             PropertyAnnotationHandler annotationHandler = typeMetadata.getAnnotationHandlerFor(propertyMetadata);
             String propertyName = getQualifiedPropertyName(propertyMetadata.getPropertyName());
-            if (annotationHandler == null) {
-                validationContext.recordValidationMessage(propertyValidationMessage(propertyName, "is not annotated with an input or output annotation"));
-            } else if (annotationHandler.shouldVisit(visitor)) {
+            for (String validationMessage : propertyMetadata.getValidationMessages()) {
+                validationContext.recordValidationMessage(propertyValidationMessage(propertyName, validationMessage));
+            }
+            if (annotationHandler != null && annotationHandler.shouldVisit(visitor)) {
                 PropertyValue value = new BeanPropertyValue(getBean(), propertyMetadata.getGetterMethod());
                 annotationHandler.visitPropertyValue(propertyName, value, propertyMetadata, visitor, new BeanPropertyContext() {
                     @Override
@@ -61,10 +62,6 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
                         queue.add(nodeFactory.create(AbstractNestedRuntimeBeanNode.this, propertyName, bean));
                     }
                 });
-                for (String validationMessage : propertyMetadata.getValidationMessages()) {
-                    validationContext.recordValidationMessage(propertyValidationMessage(propertyName, validationMessage));
-                }
-
             }
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -23,7 +23,6 @@ import org.gradle.api.Task;
 import org.gradle.api.internal.provider.ProducerAwareProperty;
 import org.gradle.api.internal.provider.PropertyInternal;
 import org.gradle.api.internal.tasks.properties.BeanPropertyContext;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
@@ -31,6 +30,7 @@ import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHa
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.internal.reflect.PropertyMetadata;
 import org.gradle.util.DeprecationLogger;
 
@@ -39,8 +39,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Queue;
 
-import static org.gradle.api.internal.tasks.properties.DefaultParameterValidationContext.propertyValidationMessage;
-
 public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Object> {
     protected AbstractNestedRuntimeBeanNode(@Nullable RuntimeBeanNode<?> parentNode, @Nullable String propertyName, Object bean, TypeMetadata typeMetadata) {
         super(parentNode, propertyName, bean, typeMetadata);
@@ -48,13 +46,11 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
 
     public void visitProperties(PropertyVisitor visitor, final Queue<RuntimeBeanNode<?>> queue, final RuntimeBeanNodeFactory nodeFactory, ParameterValidationContext validationContext) {
         TypeMetadata typeMetadata = getTypeMetadata();
+        typeMetadata.collectValidationFailures(getPropertyName(), validationContext);
         for (PropertyMetadata propertyMetadata : typeMetadata.getPropertiesMetadata()) {
             PropertyAnnotationHandler annotationHandler = typeMetadata.getAnnotationHandlerFor(propertyMetadata);
-            String propertyName = getQualifiedPropertyName(propertyMetadata.getPropertyName());
-            for (String validationMessage : propertyMetadata.getValidationMessages()) {
-                validationContext.recordValidationMessage(propertyValidationMessage(propertyName, validationMessage));
-            }
-            if (annotationHandler != null && annotationHandler.shouldVisit(visitor)) {
+            if (annotationHandler.shouldVisit(visitor)) {
+                String propertyName = getQualifiedPropertyName(propertyMetadata.getPropertyName());
                 PropertyValue value = new BeanPropertyValue(getBean(), propertyMetadata.getGetterMethod());
                 annotationHandler.visitPropertyValue(propertyName, value, propertyMetadata, visitor, new BeanPropertyContext() {
                     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/IterableRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/IterableRuntimeBeanNode.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks.properties.bean;
 
 import org.gradle.api.Named;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/MapRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/MapRuntimeBeanNode.java
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.tasks.properties.bean;
 
 import com.google.common.base.Preconditions;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.properties.bean;
 import com.google.common.annotations.VisibleForTesting;
 import org.codehaus.groovy.runtime.ConvertedClosure;
 import org.gradle.api.Task;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/RootRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/RootRuntimeBeanNode.java
@@ -16,7 +16,7 @@
 
 package org.gradle.api.internal.tasks.properties.bean;
 
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/RuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/RuntimeBeanNode.java
@@ -19,7 +19,7 @@ package org.gradle.api.internal.tasks.properties.bean;
 import com.google.common.base.Equivalence;
 import com.google.common.base.Preconditions;
 import org.gradle.api.internal.tasks.properties.AbstractPropertyNode;
-import org.gradle.api.internal.tasks.properties.ParameterValidationContext;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -91,7 +91,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
     private ITaskFactory delegate
     def services = ServiceRegistryBuilder.builder().provider(new ExecutionGlobalServices()).build()
     def taskClassInfoStore = new DefaultTaskClassInfoStore(new TestCrossBuildInMemoryCacheFactory())
-    def propertyWalker = new DefaultPropertyWalker(new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler), new TestCrossBuildInMemoryCacheFactory()))
+    def propertyWalker = new DefaultPropertyWalker(new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler), [] as Set, new TestCrossBuildInMemoryCacheFactory()))
 
     @SuppressWarnings("GroovyUnusedDeclaration")
     private String inputValue = "value"

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -60,7 +60,7 @@ class DefaultTaskInputsTest extends Specification {
         getDestroyables() >> Stub(TaskDestroyablesInternal)
         getLocalState() >> Stub(TaskLocalStateInternal)
     }
-    def walker = new DefaultPropertyWalker(new DefaultTypeMetadataStore([], new TestCrossBuildInMemoryCacheFactory()))
+    def walker = new DefaultPropertyWalker(new DefaultTypeMetadataStore([], [] as Set, new TestCrossBuildInMemoryCacheFactory()))
     private final DefaultTaskInputs inputs = new DefaultTaskInputs(task, taskStatusNagger, walker, fileCollectionFactory)
 
     def "default values"() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -63,7 +63,7 @@ class DefaultTaskOutputsTest extends Specification {
         getLocalState() >> Stub(TaskLocalStateInternal)
     }
 
-    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs(task, taskStatusNagger, new DefaultPropertyWalker(new DefaultTypeMetadataStore([], new TestCrossBuildInMemoryCacheFactory())), fileCollectionFactory)
+    private final DefaultTaskOutputs outputs = new DefaultTaskOutputs(task, taskStatusNagger, new DefaultPropertyWalker(new DefaultTypeMetadataStore([], [] as Set, new TestCrossBuildInMemoryCacheFactory())), fileCollectionFactory)
 
     void hasNoOutputsByDefault() {
         setup:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
+import org.gradle.internal.reflect.ParameterValidationContext
 import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.ExecutionGlobalServices
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
@@ -228,6 +228,6 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
     }
 
     private visitProperties(TaskInternal task) {
-        new DefaultPropertyWalker(new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler), new TestCrossBuildInMemoryCacheFactory())).visitProperties(task, validationContext, visitor)
+        new DefaultPropertyWalker(new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler), [] as Set, new TestCrossBuildInMemoryCacheFactory())).visitProperties(task, validationContext, visitor)
     }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -236,10 +236,25 @@ class DefaultTypeMetadataStoreTest extends Specification {
 
     def "can get annotated properties of simple task"() {
         when:
-        def typeMetadata = metadataStore.getTypeMetadata(SimpleTask).propertiesMetadata
+        def properties = metadataStore.getTypeMetadata(SimpleTask).propertiesMetadata
 
         then:
-        nonIgnoredProperties(typeMetadata) == ["inputDirectory", "inputFile", "inputFiles", "inputString", "outputDirectories", "outputDirectory", "outputFile", "outputFiles"]
+        nonIgnoredProperties(properties) == ["inputDirectory", "inputFile", "inputFiles", "inputString", "outputDirectories", "outputDirectory", "outputFile", "outputFiles"]
+    }
+
+    static class Unannotated extends DefaultTask {
+        String bad1
+        File bad2
+        @Inject String ignore1
+        @Input String ignore2
+    }
+
+    def "can get properties that are not annotated"() {
+        when:
+        def properties = metadataStore.getTypeMetadata(Unannotated).propertiesMetadata
+
+        then:
+        properties.propertyName == ["bad1", "bad2", "ignore1", "ignore2"]
     }
 
     @SuppressWarnings("GroovyUnusedDeclaration")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -63,7 +63,7 @@ class DefaultTypeMetadataStoreTest extends Specification {
 
     @Shared GroovyClassLoader groovyClassLoader
     def services = ServiceRegistryBuilder.builder().provider(new ExecutionGlobalServices()).build()
-    def metadataStore = new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler), new TestCrossBuildInMemoryCacheFactory())
+    def metadataStore = new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler), [] as Set, new TestCrossBuildInMemoryCacheFactory())
 
     def setupSpec() {
         groovyClassLoader = new GroovyClassLoader(getClass().classLoader)
@@ -92,7 +92,7 @@ class DefaultTypeMetadataStoreTest extends Specification {
 
     def "can use custom annotation processor"() {
         def annotationHandler = new SearchPathAnnotationHandler()
-        def metadataStore = new DefaultTypeMetadataStore([annotationHandler], new TestCrossBuildInMemoryCacheFactory())
+        def metadataStore = new DefaultTypeMetadataStore([annotationHandler], [] as Set, new TestCrossBuildInMemoryCacheFactory())
 
         when:
         def typeMetadata = metadataStore.getTypeMetadata(TaskWithCustomAnnotation)
@@ -206,7 +206,7 @@ class DefaultTypeMetadataStoreTest extends Specification {
     // need to declare their @Classpath properties as @InputFiles as well
     @Issue("https://github.com/gradle/gradle/issues/913")
     def "@Classpath takes precedence over @InputFiles when both are declared on property"() {
-        def metadataStore = new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler) + [new ClasspathPropertyAnnotationHandler()], new TestCrossBuildInMemoryCacheFactory())
+        def metadataStore = new DefaultTypeMetadataStore(services.getAll(PropertyAnnotationHandler) + [new ClasspathPropertyAnnotationHandler()], [] as Set, new TestCrossBuildInMemoryCacheFactory())
 
         when:
         def typeMetadata = metadataStore.getTypeMetadata(ClasspathPropertyTask)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
@@ -16,10 +16,13 @@
 
 package org.gradle.api.internal.tasks.properties
 
+
 import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHandler
 import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import spock.lang.Specification
 
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
 
 class InspectionSchemeFactoryTest extends Specification {
     def handler1 = handler(Thing1)
@@ -31,6 +34,9 @@ class InspectionSchemeFactoryTest extends Specification {
 
         expect:
         def metadata = scheme.metadataStore.getTypeMetadata(AnnotatedBean)
+        def problems = []
+        metadata.collectValidationFailures(null, new DefaultParameterValidationContext(problems))
+        problems.empty
         metadata.propertiesMetadata.size() == 2
     }
 
@@ -44,7 +50,7 @@ class InspectionSchemeFactoryTest extends Specification {
 
     def handler(Class<?> annotation) {
         def handler = Stub(PropertyAnnotationHandler)
-        handler.annotationType >> annotation
+        _ * handler.annotationType >> annotation
         return handler
     }
 }
@@ -57,8 +63,10 @@ class AnnotatedBean {
     String prop2
 }
 
+@Retention(RetentionPolicy.RUNTIME)
 @interface Thing1 {
 }
 
+@Retention(RetentionPolicy.RUNTIME)
 @interface Thing2 {
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -134,7 +134,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         // TODO wolfs: We should report the user declared type
         failure.assertHasCause('Some problems were found with the configuration of MakeGreen$Inject.')
         failure.assertHasCause("Property 'extension' is not annotated with an input annotation.")
-        failure.assertHasCause("Property 'outputDir' is not annotated with an input annotation.")
+        failure.assertHasCause("Property 'outputDir' is annotated with unsupported annotation @OutputDirectory.")
         failure.assertHasCause("Property 'missingInput' does not have a value specified.")
     }
 
@@ -182,7 +182,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         then:
         failure.assertHasDescription('A problem occurred evaluating root project')
         failure.assertHasCause('A problem was found with the configuration of MakeGreen$Inject.')
-        failure.assertHasCause("Property 'bad' is not annotated with an input annotation.")
+        failure.assertHasCause("Property 'bad' is annotated with unsupported annotation @${annotation.simpleName}.")
 
         where:
         annotation << [OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues]

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -133,8 +133,8 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasDescription('A problem occurred evaluating root project')
         // TODO wolfs: We should report the user declared type
         failure.assertHasCause('Some problems were found with the configuration of MakeGreen$Inject.')
-        failure.assertHasCause("Property 'extension' is not annotated with an input or output annotation.")
-        failure.assertHasCause("Property 'outputDir' is not annotated with an input or output annotation.")
+        failure.assertHasCause("Property 'extension' is not annotated with an input annotation.")
+        failure.assertHasCause("Property 'outputDir' is not annotated with an input annotation.")
         failure.assertHasCause("Property 'missingInput' does not have a value specified.")
     }
 
@@ -182,7 +182,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         then:
         failure.assertHasDescription('A problem occurred evaluating root project')
         failure.assertHasCause('A problem was found with the configuration of MakeGreen$Inject.')
-        failure.assertHasCause("Property 'bad' is not annotated with an input or output annotation.")
+        failure.assertHasCause("Property 'bad' is not annotated with an input annotation.")
 
         where:
         annotation << [OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues]

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -33,6 +33,8 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleIvyDependencyDescriptorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectIvyDependencyDescriptorFactory;
+import org.gradle.api.internal.tasks.properties.annotations.NoOpPropertyAnnotationHandler;
+import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHandler;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.instantiation.DefaultInjectAnnotationHandler;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
@@ -103,4 +105,15 @@ class DependencyManagementGlobalScopeServices {
         return new DefaultInjectAnnotationHandler(TransformParameters.class);
     }
 
+    PropertyAnnotationHandler createPrimaryInputPropertyAnnotationHandler() {
+        return new NoOpPropertyAnnotationHandler(PrimaryInput.class);
+    }
+
+    PropertyAnnotationHandler createPrimaryInputDependenciesPropertyAnnotationHandler() {
+        return new NoOpPropertyAnnotationHandler(PrimaryInputDependencies.class);
+    }
+
+    PropertyAnnotationHandler createTransformParametersPropertyAnnotationHandler() {
+        return new NoOpPropertyAnnotationHandler(TransformParameters.class);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
@@ -27,7 +27,6 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.properties.DefaultParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
 import org.gradle.api.internal.tasks.properties.InputParameterUtils;
-import org.gradle.api.internal.tasks.properties.OutputFilePropertyType;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
@@ -49,8 +48,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import static org.gradle.api.internal.tasks.properties.DefaultParameterValidationContext.propertyValidationMessage;
 
 public class DefaultTransformationRegistration implements VariantTransformRegistry.Registration {
 
@@ -117,7 +114,7 @@ public class DefaultTransformationRegistration implements VariantTransformRegist
                     Object preparedValue = InputParameterUtils.prepareInputParameterValue(value);
 
                     if (preparedValue == null && !optional) {
-                        validationContext.recordValidationMessage(propertyValidationMessage(propertyName, "does not have a value specified"));
+                        validationContext.recordValidationMessage(null, propertyName, "does not have a value specified");
                     }
 
                     inputParameterFingerprintsBuilder.put(propertyName, valueSnapshotter.snapshot(preparedValue));
@@ -128,11 +125,6 @@ public class DefaultTransformationRegistration implements VariantTransformRegist
                         ModelType.of(parameterObject.getClass()).getDisplayName()
                     ), e);
                 }
-            }
-
-            @Override
-            public void visitOutputFileProperty(String propertyName, boolean optional, PropertyValue value, OutputFilePropertyType filePropertyType) {
-                validationContext.recordValidationMessage(propertyValidationMessage(propertyName, "is annotated with an output annotation"));
             }
 
             @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistration.java
@@ -30,11 +30,13 @@ import org.gradle.api.internal.tasks.properties.InputParameterUtils;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
+import org.gradle.api.internal.tasks.properties.TypeMetadata;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
@@ -55,9 +57,17 @@ public class DefaultTransformationRegistration implements VariantTransformRegist
     private final ImmutableAttributes to;
     private final TransformationStep transformationStep;
 
-    public static VariantTransformRegistry.Registration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransformAction> implementation, @Nullable Object parameterObject, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, InstantiatorFactory instantiatorFactory, TransformerInvoker transformerInvoker, ValueSnapshotter valueSnapshotter, PropertyWalker propertyWalker) {
+    public static VariantTransformRegistry.Registration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransformAction> implementation, @Nullable Object parameterObject, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, InstantiationScheme instantiationScheme, TransformerInvoker transformerInvoker, ValueSnapshotter valueSnapshotter, PropertyWalker paramsObjectWalker, TypeMetadata actionMetadata) {
         Hasher hasher = Hashing.newHasher();
         appendActionImplementation(classLoaderHierarchyHasher, hasher, implementation);
+
+        List<String> validationMessages = new ArrayList<>();
+        actionMetadata.collectValidationFailures(null, new DefaultParameterValidationContext(validationMessages));
+        if (!validationMessages.isEmpty()) {
+            throw new DefaultMultiCauseException(
+                String.format(validationMessages.size() == 1 ? "A problem was found with the configuration of %s." : "Some problems were found with the configuration of %s.", ModelType.of(implementation).getDisplayName()),
+                validationMessages.stream().map(InvalidUserDataException::new).collect(Collectors.toList()));
+        }
 
         // TODO - should isolate later
         Isolatable<?> isolatableParameterObject;
@@ -68,10 +78,10 @@ public class DefaultTransformationRegistration implements VariantTransformRegist
         }
 
         if (parameterObject != null) {
-            fingerprintParameters(valueSnapshotter, propertyWalker, hasher, isolatableParameterObject.isolate());
+            fingerprintParameters(valueSnapshotter, paramsObjectWalker, hasher, isolatableParameterObject.isolate());
         }
 
-        Transformer transformer = new DefaultTransformer(implementation, isolatableParameterObject, hasher.hash(), instantiatorFactory, from);
+        Transformer transformer = new DefaultTransformer(implementation, isolatableParameterObject, hasher.hash(), instantiationScheme, from);
 
         return new DefaultTransformationRegistration(from, to, new TransformationStep(transformer, transformerInvoker));
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.PrimaryInput;
@@ -27,7 +26,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.instantiation.InstanceFactory;
-import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.service.ServiceLookup;
 import org.gradle.internal.service.ServiceLookupException;
@@ -44,10 +43,10 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
     private final boolean requiresDependencies;
     private final InstanceFactory<? extends ArtifactTransformAction> instanceFactory;
 
-    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, Isolatable<?> parameterObject, HashCode inputsHash, InstantiatorFactory instantiatorFactory, ImmutableAttributes fromAttributes) {
+    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, Isolatable<?> parameterObject, HashCode inputsHash, InstantiationScheme instantiationScheme, ImmutableAttributes fromAttributes) {
         super(implementationClass, inputsHash, fromAttributes);
         this.parameterObject = parameterObject;
-        this.instanceFactory = instantiatorFactory.injectScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class)).forType(implementationClass);
+        this.instanceFactory = instantiationScheme.forType(implementationClass);
         this.requiresDependencies = instanceFactory.serviceInjectionTriggeredByAnnotation(PrimaryInputDependencies.class);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -25,7 +25,10 @@ import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.PrimaryInput;
+import org.gradle.api.artifacts.transform.PrimaryInputDependencies;
 import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException;
 import org.gradle.api.attributes.AttributeContainer;
@@ -35,6 +38,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
+import org.gradle.api.internal.tasks.properties.TypeMetadataStore;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.CompileClasspath;
 import org.gradle.api.tasks.Input;
@@ -44,6 +48,7 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
 import org.gradle.internal.Cast;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.service.ServiceRegistry;
@@ -62,7 +67,9 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     private final InstantiatorFactory instantiatorFactory;
     private final TransformerInvoker transformerInvoker;
     private final ValueSnapshotter valueSnapshotter;
-    private final PropertyWalker propertyWalker;
+    private final PropertyWalker parametersObjectPropertyWalker;
+    private final TypeMetadataStore actionMetadataStore;
+    private final InstantiationScheme instantiationScheme;
 
     public DefaultVariantTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory immutableAttributesFactory, IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, ServiceRegistry services, TransformerInvoker transformerInvoker, ValueSnapshotter valueSnapshotter, InspectionSchemeFactory inspectionSchemeFactory) {
         this.instantiatorFactory = instantiatorFactory;
@@ -72,7 +79,9 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         this.services = services;
         this.transformerInvoker = transformerInvoker;
         this.valueSnapshotter = valueSnapshotter;
-        this.propertyWalker = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, Classpath.class, CompileClasspath.class, Nested.class)).getPropertyWalker();
+        this.instantiationScheme = instantiatorFactory.injectScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class));
+        this.parametersObjectPropertyWalker = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, Classpath.class, CompileClasspath.class, Nested.class)).getPropertyWalker();
+        this.actionMetadataStore = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class)).getMetadataStore();
     }
 
     @Override
@@ -110,7 +119,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         validateActionType(actionType);
         validateAttributes(registration);
 
-        Registration finalizedRegistration = DefaultTransformationRegistration.create(registration.from.asImmutable(), registration.to.asImmutable(), actionType, parameterObject, isolatableFactory, classLoaderHierarchyHasher, instantiatorFactory, transformerInvoker, valueSnapshotter, propertyWalker);
+        Registration finalizedRegistration = DefaultTransformationRegistration.create(registration.from.asImmutable(), registration.to.asImmutable(), actionType, parameterObject, isolatableFactory, classLoaderHierarchyHasher, instantiationScheme, transformerInvoker, valueSnapshotter, parametersObjectPropertyWalker, actionMetadataStore.getTypeMetadata(actionType));
         transforms.add(finalizedRegistration);
     }
 

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ParameterValidationContext.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ParameterValidationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +17,19 @@
 package org.gradle.internal.reflect;
 
 import javax.annotation.Nullable;
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 
-public interface PropertyMetadata {
-    String getPropertyName();
+public interface ParameterValidationContext {
+    ParameterValidationContext NOOP = new ParameterValidationContext() {
+        @Override
+        public void recordValidationMessage(@Nullable String ownerPath, String propertyName, String message) {
+        }
 
-    boolean isAnnotationPresent(Class<? extends Annotation> annotationType);
+        @Override
+        public void recordValidationMessage(String message) {
+        }
+    };
 
-    @Nullable
-    <A extends Annotation> A getAnnotation(Class<A> annotationType);
+    void recordValidationMessage(@Nullable String ownerPath, String propertyName, String message);
 
-    Class<? extends Annotation> getPropertyType();
-
-    Class<?> getDeclaredType();
-
-    Method getGetterMethod();
+    void recordValidationMessage(String message);
 }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ValidationProblem.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/ValidationProblem.java
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-package org.gradle.api.internal.tasks.properties;
+package org.gradle.internal.reflect;
 
-public interface ParameterValidationContext {
-    ParameterValidationContext NOOP = new ParameterValidationContext() {
-        @Override
-        public void recordValidationMessage(String message) {
-        }
-    };
+import javax.annotation.Nullable;
 
-    void recordValidationMessage(String message);
+public interface ValidationProblem {
+    void collect(@Nullable String ownerPropertyPath, ParameterValidationContext validationContext);
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.plugin.devel.tasks
 
+import org.gradle.api.artifacts.transform.PrimaryInput
+import org.gradle.api.artifacts.transform.PrimaryInputDependencies
+import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.file.FileCollection
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.Console
@@ -179,6 +182,52 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         OutputDirectory   | 'OutputDirectory'             | File
         OutputDirectories | 'OutputDirectories'           | Map
         Nested            | 'Nested'                      | List
+    }
+
+    @Unroll
+    def "task cannot have property with annotation @#annotation.simpleName"() {
+        file("src/main/java/MyTask.java") << """
+            import org.gradle.api.*;
+            import org.gradle.api.tasks.*;
+            import org.gradle.api.artifacts.transform.*;
+
+            public class MyTask extends DefaultTask {
+                @${annotation.simpleName}
+                String getThing() {
+                    return null;
+                }
+
+                @Nested
+                Options getOptions() { 
+                    return null;
+                }
+
+                public static class Options {
+                    @${annotation.simpleName}
+                    String getNestedThing() {
+                        return null;
+                    }
+                }
+            }
+        """
+
+        expect:
+        fails("validateTaskProperties")
+        failure.assertHasDescription("Execution failed for task ':validateTaskProperties'.")
+        failure.assertHasCause("Task property validation failed. See")
+        failure.assertHasCause("Warning: Task type 'MyTask': property 'thing' is annotated with unsupported annotation @${annotation.simpleName}.")
+        failure.assertHasCause("Warning: Task type 'MyTask': property 'options.nestedThing' is annotated with unsupported annotation @${annotation.simpleName}.")
+
+        file("build/reports/task-properties/report.txt").text == """
+            Warning: Task type 'MyTask': property 'options.nestedThing' is annotated with unsupported annotation @${annotation.simpleName}.
+            Warning: Task type 'MyTask': property 'thing' is annotated with unsupported annotation @${annotation.simpleName}.
+        """.stripIndent().trim()
+
+        where:
+        annotation               | _
+        PrimaryInput             | _
+        PrimaryInputDependencies | _
+        TransformParameters      | _
     }
 
     def "detects missing annotation on Groovy properties"() {

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -367,6 +367,51 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         """.stripIndent().trim()
     }
 
+    def "detects annotations on private getter methods"() {
+        file("src/main/java/MyTask.java") << """
+            import org.gradle.api.*;
+            import org.gradle.api.tasks.*;
+            import java.io.File;
+
+            public class MyTask extends DefaultTask {
+                @Input
+                private long getBadTime() {
+                    return 0;
+                }
+
+                @Nested
+                public Options getOptions() {
+                    return new Options();
+                }
+
+                public static class Options {
+                    @Input
+                    private String getBadNested() {
+                        return "good";
+                    }
+                }
+                
+                @OutputDirectory
+                private File getOutputDir() {
+                    return new File("outputDir");
+                }
+                
+                @TaskAction
+                public void doStuff() { }
+            }
+        """
+
+        when:
+        fails "validateTaskProperties"
+
+        then:
+        file("build/reports/task-properties/report.txt").text == """
+            Warning: Task type 'MyTask': property 'badTime' is private and annotated with @Input.
+            Warning: Task type 'MyTask': property 'options.badNested' is private and annotated with @Input.
+            Warning: Task type 'MyTask': property 'outputDir' is private and annotated with @OutputDirectory.
+        """.stripIndent().trim()
+    }
+
     @Requires(TestPrecondition.JDK8_OR_LATER)
     def "can validate task classes using external types"() {
         buildFile << """


### PR DESCRIPTION
### Context

This PR inspects the annotations attached to artifact transform actions, and complains abut problems such as missing annotations or unsupported annotations on getters. This is a step towards extracting metadata such as path sensitivity for the various inputs of the action.

This PR also improves (a little) the error messages for problems with annotations on artifact transform parameter objects and makes the inspection and validation infrastructure a little less task specific.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
