### PR TITLE
Expected CACHE_MISSes for asciidoctor tasks

### DIFF
--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -82,11 +82,14 @@ open class BuildScanPlugin : Plugin<Project> {
     private
     fun Project.monitorUnexpectedCacheMisses() {
         gradle.taskGraph.afterTask {
-            if (isCacheMiss() && isNotTaggedYet()) {
+            if (buildCacheEnabled() && isCacheMiss() && isNotTaggedYet()) {
                 buildScan.tag("CACHE_MISS")
             }
         }
     }
+
+    private
+    fun Project.buildCacheEnabled() = gradle.startParameter.isBuildCacheEnabled
 
     private
     fun isNotTaggedYet() = cacheMissTagged.compareAndSet(false, true)
@@ -113,15 +116,11 @@ open class BuildScanPlugin : Plugin<Project> {
     // 2. Gradle_Check_BuildDistributions is the seed build for other asciidoctor tasks
     // 3. buildScanPerformance test, which doesn't depend on compileAll
     // 4. buildScanPerformance test, which doesn't depend on compileAll
-    // 5. Gradle/Promotion/Release - Release Nightly Snapshot
-    // 6. Gradle/Promotion/Master - Nightly Snapshot
         isInBuild(
             "Gradle_Check_CompileAll",
             "Gradle_Check_BuildDistributions",
             "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
-            "Enterprise_Release_Components_BuildScansPlugin_Performance_PerformanceLinux",
-            "bt61",
-            "bt39"
+            "Enterprise_Release_Components_BuildScansPlugin_Performance_PerformanceLinux"
         )
 
     private
@@ -131,15 +130,11 @@ open class BuildScanPlugin : Plugin<Project> {
     // 2. Gradleception which re-builds Gradle with a new Gradle version
     // 3. buildScanPerformance test, which doesn't depend on compileAll
     // 4. buildScanPerformance test, which doesn't depend on compileAll
-    // 5. Gradle/Promotion/Release - Release Nightly Snapshot
-    // 6. Gradle/Promotion/Master - Nightly Snapshot
         isInBuild(
             "Gradle_Check_CompileAll",
             "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
             "Enterprise_Release_Components_BuildScansPlugin_Performance_PerformanceLinux",
-            "Gradle_Check_Gradleception",
-            "bt61",
-            "bt39"
+            "Gradle_Check_Gradleception"
         )
 
     private

--- a/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/org/gradle/gradlebuild/profiling/buildscan/BuildScanPlugin.kt
@@ -111,7 +111,18 @@ open class BuildScanPlugin : Plugin<Project> {
     // Expected cache-miss for asciidoctor task:
     // 1. CompileAll is the seed build for docs:distDocs
     // 2. Gradle_Check_BuildDistributions is the seed build for other asciidoctor tasks
-        isInBuild("Gradle_Check_CompileAll", "Gradle_Check_BuildDistributions")
+    // 3. buildScanPerformance test, which doesn't depend on compileAll
+    // 4. buildScanPerformance test, which doesn't depend on compileAll
+    // 5. Gradle/Promotion/Release - Release Nightly Snapshot
+    // 6. Gradle/Promotion/Master - Nightly Snapshot
+        isInBuild(
+            "Gradle_Check_CompileAll",
+            "Gradle_Check_BuildDistributions",
+            "Enterprise_Master_Components_GradleBuildScansPlugin_Performance_PerformanceLinux",
+            "Enterprise_Release_Components_BuildScansPlugin_Performance_PerformanceLinux",
+            "bt61",
+            "bt39"
+        )
 
     private
     fun Task.isExpectedCompileCacheMiss() =


### PR DESCRIPTION
### Context

I noticed several `CACHE_MISS`es caused by asciidoctor tasks:

https://e.grdev.net/s/tyu532yqh7hcy/timeline?outcomeFilter=SUCCESS&typeFilter=org.gradle.build.docs.CacheableAsciidoctorTask

https://e.grdev.net/s/amdzmjkm2y5li/timeline?outcomeFilter=SUCCESS&typeFilter=org.gradle.build.docs.CacheableAsciidoctorTask

There're two issues:

- The GE performance tests are running `CacheableAsciidoctorTask` without seed builds. 
- The promotion builds' build cache is disabled so they can't fetch data from cache.

This PR fixes these two issues.