### PR TITLE
[WIP] Fix apiElements declaration

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -435,7 +435,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         apiElementsConfiguration.setCanBeResolved(false);
         apiElementsConfiguration.setCanBeConsumed(true);
         apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS));
-        apiElementsConfiguration.extendsFrom(runtimeConfiguration);
+        apiElementsConfiguration.extendsFrom(compileConfiguration);
 
         Configuration runtimeElementsConfiguration = configurations.maybeCreate(RUNTIME_ELEMENTS_CONFIGURATION_NAME);
         runtimeElementsConfiguration.setVisible(false);


### PR DESCRIPTION
It was extending the `runtime` configuration, but instead needs to extend
the `compile` one.
This was causing dependencies declared in the `runtime` configuration to
appear as `compile` in produced metadata.
This change is however a breaking one as it will impact projects that
relied on dependencies declared in the `runtime` configuration to be
available for compiling dependent projects.