### PR TITLE
Fix cache-hit in flakiness detection performance test

### DIFF
--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation("com.google.code.gson:gson:2.7")
     testImplementation("junit:junit:4.12")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
+    testImplementation("io.mockk:mockk:1.8.13")
 }
 
 gradlePlugin {

--- a/buildSrc/subprojects/plugins/plugins.gradle.kts
+++ b/buildSrc/subprojects/plugins/plugins.gradle.kts
@@ -11,7 +11,6 @@ dependencies {
     implementation("org.ow2.asm:asm-commons:6.0")
     implementation("com.google.code.gson:gson:2.7")
     testImplementation("junit:junit:4.12")
-    testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
     testImplementation("io.mockk:mockk:1.8.13")
 }
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
@@ -55,6 +55,12 @@ open class DetermineBaselines(isDistributed: Boolean) : DefaultTask() {
         }
     }
 
+    /**
+     * Coordinator build doesn't resolve to real commit version, they just pass "flakiness-detection-commit" as it is to worker build
+     * "flakiness-detection-commit" is resolved to real commit id in worker build to disable build cache.
+     *
+     * @see PerformanceTest#NON_CACHEABLE_VERSIONS
+     */
     private
     fun determineFlakinessDetectionBaseline() = if (distributed) flakinessDetectionCommitBaseline else currentCommitBaseline()
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
@@ -21,6 +21,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.*
+import javax.inject.Inject
 
 
 const val defaultBaseline = "defaults"
@@ -32,7 +33,7 @@ const val forceDefaultBaseline = "force-defaults"
 const val flakinessDetectionCommitBaseline = "flakiness-detection-commit"
 
 
-open class DetermineBaselines(isDistributed: Boolean) : DefaultTask() {
+open class DetermineBaselines @Inject constructor(isDistributed: Boolean) : DefaultTask() {
     @Internal
     val distributed: Boolean = isDistributed
 

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
@@ -44,13 +44,19 @@ open class DetermineBaselines : DefaultTask() {
         if (configuredBaselines.getOrElse("") == forceDefaultBaseline) {
             determinedBaselines.set(defaultBaseline)
         } else if (configuredBaselines.getOrElse("") == flakinessDetectionCommitBaseline) {
-            determinedBaselines.set(currentCommitBaseline())
+            determinedBaselines.set(determineFlakinessDetectionBaseline())
         } else if (!currentBranchIsMasterOrRelease() && configuredBaselines.isDefaultValue()) {
             determinedBaselines.set(forkPointCommitBaseline())
         } else {
             determinedBaselines.set(configuredBaselines)
         }
     }
+
+    private
+    fun determineFlakinessDetectionBaseline() = if (isWorker()) currentCommitBaseline() else flakinessDetectionCommitBaseline
+
+    private
+    fun isWorker() = System.getenv("BUILD_TYPE_ID") == "Gradle_Check_IndividualPerformanceScenarioWorkersLinux"
 
     private
     fun currentBranchIsMasterOrRelease() = project.determineCurrentBranch() in listOf("master", "release")

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/DetermineBaselines.kt
@@ -32,7 +32,10 @@ const val forceDefaultBaseline = "force-defaults"
 const val flakinessDetectionCommitBaseline = "flakiness-detection-commit"
 
 
-open class DetermineBaselines : DefaultTask() {
+open class DetermineBaselines(isDistributed: Boolean) : DefaultTask() {
+    @Internal
+    val distributed: Boolean = isDistributed
+
     @Internal
     val configuredBaselines = project.objects.property<String>()
 
@@ -53,10 +56,7 @@ open class DetermineBaselines : DefaultTask() {
     }
 
     private
-    fun determineFlakinessDetectionBaseline() = if (isWorker()) currentCommitBaseline() else flakinessDetectionCommitBaseline
-
-    private
-    fun isWorker() = System.getenv("BUILD_TYPE_ID") == "Gradle_Check_IndividualPerformanceScenarioWorkersLinux"
+    fun determineFlakinessDetectionBaseline() = if (distributed) flakinessDetectionCommitBaseline else currentCommitBaseline()
 
     private
     fun currentBranchIsMasterOrRelease() = project.determineCurrentBranch() in listOf("master", "release")

--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/plugins/performance/PerformanceTestPlugin.kt
@@ -323,7 +323,7 @@ class PerformanceTestPlugin : Plugin<Project> {
             teamCityPassword = stringPropertyOrNull(PropertyNames.teamCityPassword)
         }
 
-        createAndWireCommitDistributionTasks(performanceTest)
+        createAndWireCommitDistributionTasks(performanceTest, true)
 
         afterEvaluate {
             performanceTest.configure {
@@ -337,12 +337,12 @@ class PerformanceTestPlugin : Plugin<Project> {
     }
 
     private
-    fun Project.createAndWireCommitDistributionTasks(performanceTest: TaskProvider<out PerformanceTest>) {
+    fun Project.createAndWireCommitDistributionTasks(performanceTest: TaskProvider<out PerformanceTest>, isDistributed: Boolean) {
         // The data flow here is:
         // performanceTest.configuredBaselines -> determineBaselines.configuredBaselines
         // determineBaselines.determinedBaselines -> performanceTest.determinedBaselines
         // determineBaselines.determinedBaselines -> buildCommitDistribution.commitBaseline
-        val determineBaselines = tasks.register("${performanceTest.name}DetermineBaselines", DetermineBaselines::class)
+        val determineBaselines = tasks.register("${performanceTest.name}DetermineBaselines", DetermineBaselines::class, isDistributed)
         val buildCommitDistribution = tasks.register("${performanceTest.name}BuildCommitDistribution", BuildCommitDistribution::class)
 
         determineBaselines.configure {
@@ -373,7 +373,7 @@ class PerformanceTestPlugin : Plugin<Project> {
                 testLogging.showStandardStreams = true
             }
         }
-        createAndWireCommitDistributionTasks(performanceTest)
+        createAndWireCommitDistributionTasks(performanceTest, false)
 
         val testResultsZipTask = testResultsZipTaskFor(performanceTest, name)
 

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/performance/DetermineBaselinesTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/performance/DetermineBaselinesTest.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.performance
+
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import org.gradle.api.Action
+import org.gradle.kotlin.dsl.*
+import org.gradle.process.ExecResult
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Before
+import org.junit.Test
+
+
+class DetermineBaselinesTest {
+    val project = ProjectBuilder.builder().build()
+
+    @Before
+    fun setUp() {
+        // mock project.execAndGetStdout
+        mockkStatic("org.gradle.kotlin.dsl.Kotlin_dsl_upstream_candidatesKt")
+
+        // mock project.determineCurrentBranch
+        mockkStatic("org.gradle.plugins.performance.PerformanceTestPluginKt")
+
+        mockkObject(project)
+    }
+
+    @Test
+    fun `determines defaults when configured as force-defaults`() {
+        verifyBaselineDetermination(false, forceDefaultBaseline, defaultBaseline)
+    }
+
+    @Test
+    fun `keeps flakiness-detection-commit as it is in coordinator build`() {
+        verifyBaselineDetermination(true, flakinessDetectionCommitBaseline, flakinessDetectionCommitBaseline)
+    }
+
+    @Test
+    fun `resolves to current commit in worker build`() {
+        // given
+        mockGitOperation(listOf("git", "rev-parse", "HEAD"), "current")
+        mockGitOperation(listOf("git", "show", "current:version.txt"), "5.0")
+        mockGitOperation(listOf("git", "rev-parse", "--short", "current"), "current")
+
+        // then
+        verifyBaselineDetermination(false, flakinessDetectionCommitBaseline, "5.0-commit-current")
+    }
+
+    @Test
+    fun `determines fork point commit on feature branch and default configuration`() {
+        // given
+        mockCurrentBranch("my-branch")
+        mockGitOperation(listOf("git", "fetch", "origin", "master", "release"), "")
+        mockGitOperation(listOf("git", "merge-base", "origin/master", "HEAD"), "master-fork-point")
+        mockGitOperation(listOf("git", "merge-base", "origin/release", "HEAD"), "release-fork-point")
+        mockProjectExec(1)
+        mockGitOperation(listOf("git", "show", "master-fork-point:version.txt"), "5.1")
+        mockGitOperation(listOf("git", "rev-parse", "--short", "master-fork-point"), "master-fork-point")
+
+        // then
+        verifyBaselineDetermination(false, defaultBaseline, "5.1-commit-master-fork-point")
+    }
+
+    @Test
+    fun `determines fork point commit on feature branch and empty configuration`() {
+        // given
+        mockCurrentBranch("my-branch")
+        mockGitOperation(listOf("git", "fetch", "origin", "master", "release"), "")
+        mockGitOperation(listOf("git", "merge-base", "origin/master", "HEAD"), "master-fork-point")
+        mockGitOperation(listOf("git", "merge-base", "origin/release", "HEAD"), "release-fork-point")
+        mockProjectExec(1)
+        mockGitOperation(listOf("git", "show", "master-fork-point:version.txt"), "5.1")
+        mockGitOperation(listOf("git", "rev-parse", "--short", "master-fork-point"), "master-fork-point")
+
+        // then
+        verifyBaselineDetermination(false, null, "5.1-commit-master-fork-point")
+    }
+
+    @Test
+    fun `uses configured version on master branch`() {
+        // given
+        mockCurrentBranch("master")
+
+        // then
+        verifyBaselineDetermination(false, defaultBaseline, defaultBaseline)
+    }
+
+    @Test
+    fun `uses configured version when it is overwritten on feature branch`() {
+        // given
+        mockCurrentBranch("my-branch")
+
+        // then
+        verifyBaselineDetermination(false, "any", "any")
+    }
+
+    private
+    fun createDetermineBaselinesTask(isDistributed: Boolean) =
+        project.tasks.create("determineBaselines", DetermineBaselines::class.java, isDistributed)
+
+    private
+    fun mockProjectExec(expectedReturnValue: Int) {
+        val mockResult = mockk<ExecResult>()
+        every { mockResult.exitValue } returns expectedReturnValue
+        every { project.exec(any<Action<Any>>()) } returns mockResult
+    }
+
+    private
+    fun mockGitOperation(args: List<String>, expectedOutput: String) =
+        every { project.execAndGetStdout(*(args.toTypedArray())) } returns expectedOutput
+
+    private
+    fun mockCurrentBranch(branch: String) =
+        every { project.determineCurrentBranch() } returns branch
+
+    private
+    fun verifyBaselineDetermination(isCoordinatorBuild: Boolean, configuredBaseline: String?, determinedBaseline: String) {
+        // given
+        val determineBaselinesTask = createDetermineBaselinesTask(isCoordinatorBuild)
+
+        // when
+        determineBaselinesTask.configuredBaselines.set(configuredBaseline)
+        determineBaselinesTask.determineForkPointCommitBaseline()
+
+        // then
+        assert(determineBaselinesTask.determinedBaselines.get() == determinedBaseline)
+    }
+}

--- a/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/performance/DetermineBaselinesTest.kt
+++ b/buildSrc/subprojects/plugins/src/test/kotlin/org/gradle/plugins/performance/DetermineBaselinesTest.kt
@@ -21,15 +21,19 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
 import org.gradle.api.Action
 import org.gradle.kotlin.dsl.*
 import org.gradle.process.ExecResult
 import org.gradle.testfixtures.ProjectBuilder
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 
 
 class DetermineBaselinesTest {
+    private
     val project = ProjectBuilder.builder().build()
 
     @Before
@@ -41,6 +45,13 @@ class DetermineBaselinesTest {
         mockkStatic("org.gradle.plugins.performance.PerformanceTestPluginKt")
 
         mockkObject(project)
+    }
+
+    @After
+    fun cleanUp() {
+        unmockkStatic("org.gradle.kotlin.dsl.Kotlin_dsl_upstream_candidatesKt")
+        unmockkStatic("org.gradle.plugins.performance.PerformanceTestPluginKt")
+        unmockkObject(project)
     }
 
     @Test


### PR DESCRIPTION
### Context

We don't want build cache hit in performance flakiness detection, however, previously the coordinator build resolves "flakiness-detection-commit" baseline to real commit id "5.3-commit-237a600", resulting in unexpected cache hit:

https://builds.gradle.org/viewLog.html?buildId=19890587&buildTypeId=Gradle_Check_PerformanceFlakinessDetectionCoordinator&tab=report_project947_Performance&branch_Gradle_Check_Stage_HistoricalPerformance=master

This PR fixes it by:

- On coordinator's side, pass "flakiness-detection-commit" as it is to worker build. 
- On worker's side, worker build resolves "flakiness-detection-commit" to real commit version - this disables build cache.

Since `DetermineBaselines` is becoming more and more complex, this PR also adds a unit test for `DetermineBaselines` class.

Fixed report: https://builds.gradle.org/viewLog.html?buildId=19896803&buildTypeId=Gradle_Check_PerformanceFlakinessDetectionCoordinator&tab=report_project947_Performance&branch_Gradle_Check_Stage_HistoricalPerformance=blindpirate%2Fpass-baseline-to-worker