### PR TITLE
Rename artifact transform API names

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -20,9 +20,9 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
@@ -448,7 +448,7 @@ public interface DependencyHandler {
     /**
      * Registers an artifact transform with a parameter object.
      *
-     * @see org.gradle.api.artifacts.transform.ArtifactTransformAction
+     * @see TransformAction
      * @since 5.2
      */
     @Incubating
@@ -457,11 +457,11 @@ public interface DependencyHandler {
     /**
      * Registers an artifact transform without a parameter object.
      *
-     * @see org.gradle.api.artifacts.transform.ArtifactTransformAction
+     * @see TransformAction
      * @since 5.3
      */
     @Incubating
-    <T extends ArtifactTransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction);
+    <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction);
 
     /**
      * Declares a dependency on a platform. If the target coordinates represent multiple

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -20,9 +20,9 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
-import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.ParameterizedTransformSpec;
 import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
@@ -452,7 +452,7 @@ public interface DependencyHandler {
      * @since 5.2
      */
     @Incubating
-    <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedArtifactTransformSpec<T>> registrationAction);
+    <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedTransformSpec<T>> registrationAction);
 
     /**
      * Registers an artifact transform without a parameter object.
@@ -461,7 +461,7 @@ public interface DependencyHandler {
      * @since 5.3
      */
     @Incubating
-    <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction);
+    <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super TransformSpec> registrationAction);
 
     /**
      * Declares a dependency on a platform. If the target coordinates represent multiple

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/AssociatedTransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/AssociatedTransformAction.java
@@ -24,7 +24,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Attached to an artifact transform parameter type to declare the corresponding {@link ArtifactTransformAction} implementation to use.
+ * Attached to an artifact transform parameter type to declare the corresponding {@link TransformAction} implementation to use.
  *
  * @since 5.3
  */
@@ -32,5 +32,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface AssociatedTransformAction {
-    Class<? extends ArtifactTransformAction> value();
+    Class<? extends TransformAction> value();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/AssociatedTransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/AssociatedTransformAction.java
@@ -26,11 +26,11 @@ import java.lang.annotation.Target;
 /**
  * Attached to an artifact transform parameter type to declare the corresponding {@link ArtifactTransformAction} implementation to use.
  *
- * @since 5.2
+ * @since 5.3
  */
 @Incubating
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
-public @interface TransformAction {
+public @interface AssociatedTransformAction {
     Class<? extends ArtifactTransformAction> value();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ParameterizedTransformSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ParameterizedTransformSpec.java
@@ -26,7 +26,7 @@ import org.gradle.api.Incubating;
  * @since 5.3
  */
 @Incubating
-public interface ParameterizedArtifactTransformSpec<T> extends ArtifactTransformSpec {
+public interface ParameterizedTransformSpec<T> extends TransformSpec {
     /**
      * The parameters for the transform action.
      */

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
@@ -34,7 +34,7 @@ import org.gradle.api.Incubating;
  * @since 5.3
  */
 @Incubating
-public interface ArtifactTransformAction {
+public interface TransformAction {
     /**
      * Executes the transform.
      *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
@@ -25,7 +25,7 @@ import org.gradle.api.Incubating;
  *
  * <p>Implementations can receive parameters by using annotated abstract getter methods.</p>
  *
- * <p>A property annotated with {@link TransformParameters} will receive the object provided by {@link ParameterizedArtifactTransformSpec#getParameters()}.
+ * <p>A property annotated with {@link TransformParameters} will receive the object provided by {@link ParameterizedTransformSpec#getParameters()}.
  *
  * <p>A property annotated with {@link InputArtifact} will receive the <em>input artifact</em> location, which is the file or directory that the transform should be applied to.
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformAction.java
@@ -40,5 +40,5 @@ public interface TransformAction {
      *
      * @param outputs Receives the outputs of the transform.
      */
-    void transform(ArtifactTransformOutputs outputs);
+    void transform(TransformOutputs outputs);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformOutputs.java
@@ -32,7 +32,7 @@ import java.io.File;
  */
 @Incubating
 @HasInternalProtocol
-public interface ArtifactTransformOutputs {
+public interface TransformOutputs {
     /**
      * Registers an output directory.
      * For a relative path, a location for the output directory is provided.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformSpec.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/TransformSpec.java
@@ -22,10 +22,10 @@ import org.gradle.api.attributes.AttributeContainer;
 /**
  * Base configuration for artifact transform registrations.
  *
- * @since 5.2
+ * @since 5.3
  */
 @Incubating
-public interface ArtifactTransformSpec {
+public interface TransformSpec {
     /**
      * Attributes that match the variant that is consumed.
      */

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1506,7 +1506,7 @@ ${getFileSizerBody(fileValue, 'new File(outputDirectory, ', 'new File(outputDire
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
 ${getFileSizerBody(fileValue, 'outputs.dir(', 'outputs.file(')}
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1493,7 +1493,7 @@ ${getFileSizerBody(fileValue, 'new File(outputDirectory, ', 'new File(outputDire
 
     String registerFileSizerWithParameterObject(String fileValue) {
         """                 
-            @TransformAction(FileSizerAction)
+            @AssociatedTransformAction(FileSizerAction)
             interface FileSizer {
                 @Input
                 Number getValue()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1499,7 +1499,7 @@ ${getFileSizerBody(fileValue, 'new File(outputDirectory, ', 'new File(outputDire
                 Number getValue()
                 void setValue(Number value)
             }
-            abstract class FileSizerAction implements ArtifactTransformAction {
+            abstract class FileSizerAction implements TransformAction {
                 @TransformParameters
                 abstract FileSizer getParameters()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -39,7 +39,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact ${annotation}
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -149,7 +149,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact ${annotation}
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     if (input.exists()) {
                         println "processing \${input.name}"
                     } else {
@@ -269,7 +269,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     if (input.exists()) {
                         println "processing \${input.name}"
                     } else {
@@ -330,7 +330,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.text + ".green")
                     output.text = input.text + ".green"
@@ -500,7 +500,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -684,7 +684,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.text + ".green")
                     output.text = input.text + ".green"
@@ -770,7 +770,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -34,8 +34,8 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
-            abstract class MakeGreen implements ArtifactTransformAction {
+
+            abstract class MakeGreen implements TransformAction {
                 @InputArtifact ${annotation}
                 abstract File getInput()
                 
@@ -144,8 +144,8 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                     implementation project(':c')
                 }
             }
-            
-            abstract class MakeGreen implements ArtifactTransformAction {
+
+            abstract class MakeGreen implements TransformAction {
                 @InputArtifact ${annotation}
                 abstract File getInput()
                 
@@ -265,7 +265,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
             
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @InputArtifact
                 abstract File getInput()
                 
@@ -325,7 +325,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
             
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract File getInput()
@@ -405,12 +405,12 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
             
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = "green"
@@ -495,7 +495,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
             
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
                 abstract File getInput()
@@ -577,12 +577,12 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 }
             }
 
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @PathSensitive(PathSensitivity.NAME_ONLY)
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = "green"
@@ -679,7 +679,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 implementation 'group2:lib2:1.0'
             }
             
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
                 abstract File getInput()
@@ -765,7 +765,7 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
                 implementation 'group2:lib2:1.0'
             }
             
-            abstract class MakeGreen implements ArtifactTransformAction {
+            abstract class MakeGreen implements TransformAction {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
                 abstract File getInput()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -808,7 +808,7 @@ $fileSizer
                 }
             }
             
-            abstract class IdentityTransform implements ArtifactTransformAction {
+            abstract class IdentityTransform implements TransformAction {
                 @InputArtifact
                 abstract File getInput()
                 
@@ -1558,7 +1558,7 @@ Found the following transforms:
                 compile files(a)
             }
 
-            class TransformAction implements ArtifactTransformAction {
+            class FailingTransformAction implements TransformAction {
                 void transform(ArtifactTransformOutputs outputs) {
                     ${switch (type) {
                         case FileType.Missing:
@@ -1580,7 +1580,7 @@ Found the following transforms:
                     }}
                 }
             }
-            ${declareTransformAction('TransformAction')}
+            ${declareTransformAction('FailingTransformAction')}
 
             task resolve(type: Copy) {
                 def artifacts = configurations.compile.incoming.artifactView {
@@ -1628,8 +1628,8 @@ Found the following transforms:
                 compile files(a)
             }
 
-            class TransformAction implements ArtifactTransformAction {
-                void transform(ArtifactTransformOutputs outputs) {
+            class DirectoryTransformAction implements TransformAction {
+                void transform(TransformOutputs outputs) {
                     def outputFile = outputs.file("some/dir/output.txt")
                     assert outputFile.parentFile.directory
                     outputFile.text = "output"
@@ -1638,7 +1638,7 @@ Found the following transforms:
                     new File(outputDir, "in-dir.txt").text = "another output"
                 }
             }
-            ${declareTransformAction('TransformAction')}
+            ${declareTransformAction('DirectoryTransformAction')}
 
             task resolve(type: Copy) {
                 def artifacts = configurations.compile.incoming.artifactView {
@@ -1666,7 +1666,7 @@ Found the following transforms:
                 compile files(a)
             }
 
-            abstract class TransformAction implements ArtifactTransformAction {
+            abstract class MyTransformAction implements TransformAction {
                 @InputArtifact
                 abstract File getInput() 
 
@@ -1677,7 +1677,7 @@ Found the following transforms:
                 }
             }
             dependencies {
-                registerTransformAction(TransformAction) {
+                registerTransformAction(MyTransformAction) {
                     from.attribute(artifactType, 'directory')
                     to.attribute(artifactType, 'size')
                 }
@@ -1744,7 +1744,7 @@ Found the following transforms:
 
             SomewhereElseTransform.output = file("other.jar")
 
-            class SomewhereElseTransform implements ArtifactTransformAction {
+            class SomewhereElseTransform implements TransformAction {
                 static def output
                 void transform(ArtifactTransformOutputs outputs) {
                     def outputFile = outputs.file(output)
@@ -1959,7 +1959,7 @@ Found the following transforms:
                 void setInput(CustomType input)
             }
               
-            class CustomAction implements ArtifactTransformAction { 
+            class CustomAction implements TransformAction { 
                 void transform(ArtifactTransformOutputs outputs) {  }
             }
             

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1952,7 +1952,7 @@ Found the following transforms:
                 String toString() { return "<custom>" }
             }
 
-            @TransformAction(CustomAction)
+            @AssociatedTransformAction(CustomAction)
             interface Custom {
                 @Input
                 CustomType getInput()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -812,7 +812,7 @@ $fileSizer
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println("Transforming")
                     outputs.file(input)
                 }
@@ -1559,7 +1559,7 @@ Found the following transforms:
             }
 
             class FailingTransformAction implements TransformAction {
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     ${switch (type) {
                         case FileType.Missing:
                             return """
@@ -1670,7 +1670,7 @@ Found the following transforms:
                 @InputArtifact
                 abstract File getInput() 
 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "Hello?"
                     def output = outputs.${method}(new File(input, "some/dir/does-not-exist"))
                     assert !output.parentFile.directory
@@ -1746,7 +1746,7 @@ Found the following transforms:
 
             class SomewhereElseTransform implements TransformAction {
                 static def output
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     def outputFile = outputs.file(output)
                     outputFile.text = "123"
                 }
@@ -1960,7 +1960,7 @@ Found the following transforms:
             }
               
             class CustomAction implements TransformAction { 
-                void transform(ArtifactTransformOutputs outputs) {  }
+                void transform(TransformOutputs outputs) {  }
             }
             
             dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -85,7 +85,7 @@ class Resolve extends Copy {
 
         given:
         buildFile << """
-            @TransformAction(CountRecorderAction)
+            @AssociatedTransformAction(CountRecorderAction)
             interface CountRecorder {
                 @Input
                 Counter getCounter()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -105,7 +105,7 @@ class Resolve extends Copy {
                     println "Creating CountRecorder"
                 }
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     def output = outputs.file(input.name + ".txt")
                     def counter = parameters.counter
                     println "Transforming \${input.name} to \${output.name}"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -92,7 +92,7 @@ class Resolve extends Copy {
                 void setCounter(Counter counter)
             }
 
-            abstract class CountRecorderAction implements ArtifactTransformAction {
+            abstract class CountRecorderAction implements TransformAction {
                 private final Counter counter;
                             
                 @TransformParameters

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -71,7 +71,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setExtension(String value)
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 @InputArtifact
@@ -123,7 +123,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setMissingInput(String missing)
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
@@ -172,7 +172,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setBad(String value)
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
@@ -221,7 +221,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setBad(String value)
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
@@ -268,7 +268,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setExtension(String value)
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
@@ -323,7 +323,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setExtension(String value)
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @${annotation.simpleName}
                 String getBad() { }
                 
@@ -364,7 +364,7 @@ project(':b') {
     }
 }
 
-abstract class MakeGreen implements ArtifactTransformAction {
+abstract class MakeGreen implements TransformAction {
     @InputArtifactDependencies
     abstract ${targetType} getDependencies()
     @InputArtifact
@@ -463,7 +463,7 @@ abstract class MakeGreen extends ArtifactTransform {
                 void setExtension(String value)
             }
             
-            class MakeGreenAction implements ArtifactTransformAction {
+            class MakeGreenAction implements TransformAction {
                 private MakeGreen conf
                 
                 @Inject
@@ -500,7 +500,7 @@ project(':a') {
     }
 }
 
-abstract class MakeGreen implements ArtifactTransformAction {
+abstract class MakeGreen implements TransformAction {
     @InputArtifact
     abstract FileCollection getDependencies()
     
@@ -534,7 +534,7 @@ project(':a') {
     }
 }
 
-abstract class MakeGreen implements ArtifactTransformAction {
+abstract class MakeGreen implements TransformAction {
     @Inject
     abstract File getWorkspace()
     

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -64,7 +64,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 @Input
                 String getExtension()
@@ -111,7 +111,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 String getExtension()
                 void setExtension(String value)
@@ -162,7 +162,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 @Input
                 String getExtension()
@@ -212,7 +212,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 String getExtension()
                 void setExtension(String value)
@@ -261,7 +261,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 @Input
                 String getExtension()
@@ -316,7 +316,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 @Input
                 String getExtension()
@@ -456,7 +456,7 @@ abstract class MakeGreen extends ArtifactTransform {
                 }
             }
             
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 @Input
                 String getExtension()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -77,7 +77,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + "." + parameters.extension)
                     output.text = "ok"
@@ -127,7 +127,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     throw new RuntimeException()
                 }
             }
@@ -176,7 +176,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     throw new RuntimeException()
                 }
             }
@@ -225,7 +225,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     throw new RuntimeException()
                 }
             }
@@ -280,7 +280,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @InputFile @InputArtifact @InputArtifactDependencies
                 File getConflictingAnnotations() { } 
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     throw new RuntimeException()
                 }
             }
@@ -327,7 +327,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @${annotation.simpleName}
                 String getBad() { }
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     throw new RuntimeException()
                 }
             }
@@ -370,7 +370,7 @@ abstract class MakeGreen implements TransformAction {
     @InputArtifact
     abstract File getInput()
     
-    void transform(ArtifactTransformOutputs outputs) {
+    void transform(TransformOutputs outputs) {
         println "received dependencies files \${dependencies*.name} for processing \${input.name}"
         def output = outputs.file(input.name + ".green")
         output.text = "ok"
@@ -471,7 +471,7 @@ abstract class MakeGreen extends ArtifactTransform {
                     this.conf = conf
                 }
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                 }
             }
 """
@@ -504,7 +504,7 @@ abstract class MakeGreen implements TransformAction {
     @InputArtifact
     abstract FileCollection getDependencies()
     
-    void transform(ArtifactTransformOutputs outputs) {
+    void transform(TransformOutputs outputs) {
         dependencies.files
         throw new RuntimeException("broken")
     }
@@ -538,7 +538,7 @@ abstract class MakeGreen implements TransformAction {
     @Inject
     abstract File getWorkspace()
     
-    void transform(ArtifactTransformOutputs outputs) {
+    void transform(TransformOutputs outputs) {
         workspace
         throw new RuntimeException("broken")
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -103,7 +103,7 @@ project(':app') {
 
 import javax.inject.Inject
 
-abstract class TestTransformAction implements ArtifactTransformAction {
+abstract class TestTransformAction implements TransformAction {
 
     @TransformParameters
     abstract TestTransform getParameters()
@@ -126,7 +126,7 @@ abstract class TestTransformAction implements ArtifactTransformAction {
     }
 }
 
-abstract class SimpleTransform implements ArtifactTransformAction {
+abstract class SimpleTransform implements TransformAction {
 
     @InputArtifact
     abstract File getInput()
@@ -411,7 +411,7 @@ allprojects {
     }
 }
 
-abstract class NoneTransformAction implements ArtifactTransformAction {
+abstract class NoneTransformAction implements TransformAction {
     @InputArtifactDependencies @PathSensitive(PathSensitivity.NONE)
     abstract FileCollection getInputArtifactDependencies()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -48,7 +48,7 @@ class ArtifactTransformWithDependenciesIntegrationTest extends AbstractHttpDepen
         setupBuildWithColorAttributes()
         buildFile << """
                    
-@TransformAction(TestTransformAction)
+@AssociatedTransformAction(TestTransformAction)
 interface TestTransform {
     @Input
     String getTransformName()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -114,7 +114,7 @@ abstract class TestTransformAction implements TransformAction {
     @InputArtifact
     abstract File getInput()
 
-    void transform(ArtifactTransformOutputs outputs) {
+    void transform(TransformOutputs outputs) {
         println "\${parameters.transformName} received dependencies files \${inputArtifactDependencies*.name} for processing \${input.name}"
         assert inputArtifactDependencies.every { it.exists() }
 
@@ -131,7 +131,7 @@ abstract class SimpleTransform implements TransformAction {
     @InputArtifact
     abstract File getInput()
 
-    void transform(ArtifactTransformOutputs outputs) {
+    void transform(TransformOutputs outputs) {
         def output = outputs.file(input.name + ".txt")
         def workspace = output.parentFile
         assert workspace.directory && workspace.list().length == 0
@@ -418,7 +418,7 @@ abstract class NoneTransformAction implements TransformAction {
     @InputArtifact
     abstract File getInput()
 
-    void transform(ArtifactTransformOutputs outputs) {
+    void transform(TransformOutputs outputs) {
         println "Single step transform received dependencies files \${inputArtifactDependencies*.name} for processing \${input.name}"
 
         def output = outputs.file(input.name + ".txt")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -35,7 +35,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 ConfigurableFileCollection getSomeFiles()
             }
             
-            abstract class MakeGreenAction implements ArtifactTransformAction {
+            abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
                 @InputArtifact
@@ -150,7 +150,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             """
         setupBuildWithTransformFileInputs()
         buildFile << """
-            abstract class MakeRedAction implements ArtifactTransformAction {
+            abstract class MakeRedAction implements TransformAction {
                 @InputArtifact
                 abstract File getInput()
                 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -29,7 +29,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             """)
         }
         buildFile << """
-            @TransformAction(MakeGreenAction)
+            @AssociatedTransformAction(MakeGreenAction)
             interface MakeGreen {
                 @Input
                 ConfigurableFileCollection getSomeFiles()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -41,7 +41,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name} using \${parameters.someFiles*.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = "ok"
@@ -154,7 +154,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 @InputArtifact
                 abstract File getInput()
                 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     println "processing \${input.name} wit MakeRedAction"
                     def output = outputs.file(input.name + ".red")
                     output.text = "ok"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
-import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.ParameterizedTransformSpec;
 import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 
 public interface VariantTransformRegistry {
@@ -31,9 +31,9 @@ public interface VariantTransformRegistry {
      */
     void registerTransform(Action<? super VariantTransform> registrationAction);
 
-    <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedArtifactTransformSpec<T>> registrationAction);
+    <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedTransformSpec<T>> registrationAction);
 
-    <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction);
+    <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super TransformSpec> registrationAction);
 
     Iterable<ArtifactTransformRegistration> getTransforms();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/VariantTransformRegistry.java
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.artifacts;
 
 import org.gradle.api.Action;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.VariantTransform;
 
 public interface VariantTransformRegistry {
@@ -33,7 +33,7 @@ public interface VariantTransformRegistry {
 
     <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedArtifactTransformSpec<T>> registrationAction);
 
-    <T extends ArtifactTransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction);
+    <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction);
 
     Iterable<ArtifactTransformRegistration> getTransforms();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -27,9 +27,9 @@ import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
@@ -220,7 +220,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     }
 
     @Override
-    public <T extends ArtifactTransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction) {
+    public <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction) {
         transforms.registerTransformAction(actionType, registrationAction);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -27,9 +27,9 @@ import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
 import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
-import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.ParameterizedTransformSpec;
 import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
@@ -215,12 +215,12 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     }
 
     @Override
-    public <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedArtifactTransformSpec<T>> registrationAction) {
+    public <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedTransformSpec<T>> registrationAction) {
         transforms.registerTransform(parameterType, registrationAction);
     }
 
     @Override
-    public <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction) {
+    public <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super TransformSpec> registrationAction) {
         transforms.registerTransformAction(actionType, registrationAction);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformOutputs.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformOutputs.java
@@ -28,7 +28,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Consumer;
 
-public class DefaultArtifactTransformOutputs implements ArtifactTransformOutputsInternal {
+public class DefaultTransformOutputs implements TransformOutputsInternal {
 
     private final ImmutableList.Builder<File> outputsBuilder = ImmutableList.builder();
     private final Set<File> outputDirectories = new HashSet<>();
@@ -39,7 +39,7 @@ public class DefaultArtifactTransformOutputs implements ArtifactTransformOutputs
     private final String inputArtifactPrefix;
     private final String outputDirPrefix;
 
-    public DefaultArtifactTransformOutputs(File inputArtifact, File outputDir) {
+    public DefaultTransformOutputs(File inputArtifact, File outputDir) {
         this.resolver = new BaseDirFileResolver(outputDir, PatternSets.getNonCachingPatternSetFactory());
         this.inputArtifact = inputArtifact;
         this.outputDir = outputDir;
@@ -51,7 +51,7 @@ public class DefaultArtifactTransformOutputs implements ArtifactTransformOutputs
     public ImmutableList<File> getRegisteredOutputs() {
         ImmutableList<File> outputs = outputsBuilder.build();
         for (File output : outputs) {
-            ArtifactTransformOutputsInternal.validateOutputExists(output);
+            TransformOutputsInternal.validateOutputExists(output);
             if (outputFiles.contains(output) && !output.isFile()) {
                 throw new InvalidUserDataException("Transform output file " + output.getPath() + " must be a file, but is not.");
             }
@@ -78,7 +78,7 @@ public class DefaultArtifactTransformOutputs implements ArtifactTransformOutputs
 
     private File resolveAndRegister(Object path, Consumer<File> prepareOutputLocation) {
         File output = resolver.resolve(path);
-        OutputLocationType outputLocationType = ArtifactTransformOutputsInternal.determineOutputLocationType(output, inputArtifact, inputArtifactPrefix, outputDir, outputDirPrefix);
+        OutputLocationType outputLocationType = TransformOutputsInternal.determineOutputLocationType(output, inputArtifact, inputArtifactPrefix, outputDir, outputDirPrefix);
         if (outputLocationType == OutputLocationType.WORKSPACE) {
             prepareOutputLocation.accept(output);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -79,7 +79,7 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
     }
 
     @Override
-    public ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransformAction> implementation, @Nullable Object parameterObject) {
+    public ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends TransformAction> implementation, @Nullable Object parameterObject) {
         List<String> validationMessages = new ArrayList<>();
         TypeMetadata actionMetadata = actionMetadataStore.getTypeMetadata(implementation);
         actionMetadata.collectValidationFailures(null, new DefaultParameterValidationContext(validationMessages));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -21,9 +21,9 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.reflect.TypeToken;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -65,7 +65,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAction> {
+public class DefaultTransformer extends AbstractTransformer<TransformAction> {
 
     private final Object parameterObject;
     private final Class<? extends FileNormalizer> fileNormalizer;
@@ -75,14 +75,14 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
     private final ValueSnapshotter valueSnapshotter;
     private final PropertyWalker parameterPropertyWalker;
     private final boolean requiresDependencies;
-    private final InstanceFactory<? extends ArtifactTransformAction> instanceFactory;
+    private final InstanceFactory<? extends TransformAction> instanceFactory;
     private final DomainObjectProjectStateHandler projectStateHandler;
     private final ProjectStateRegistry.SafeExclusiveLock isolationLock;
     private final WorkNodeAction isolateAction;
 
     private IsolatableParameters isolatable;
 
-    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, Class<? extends FileNormalizer> inputArtifactNormalizer, Class<? extends FileNormalizer> dependenciesNormalizer, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
+    public DefaultTransformer(Class<? extends TransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, Class<? extends FileNormalizer> inputArtifactNormalizer, Class<? extends FileNormalizer> dependenciesNormalizer, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
         super(implementationClass, fromAttributes);
         this.parameterObject = parameterObject;
         this.fileNormalizer = inputArtifactNormalizer;
@@ -130,7 +130,7 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
 
     @Override
     public ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies) {
-        ArtifactTransformAction transformAction = newTransformAction(inputArtifact, dependencies);
+        TransformAction transformAction = newTransformAction(inputArtifact, dependencies);
         DefaultArtifactTransformOutputs transformOutputs = new DefaultArtifactTransformOutputs(inputArtifact, outputDir);
         transformAction.transform(transformOutputs);
         return transformOutputs.getRegisteredOutputs();
@@ -232,7 +232,7 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
         return ModelType.of(parameterClass).getDisplayName();
     }
 
-    private ArtifactTransformAction newTransformAction(File inputFile, ArtifactTransformDependencies artifactTransformDependencies) {
+    private TransformAction newTransformAction(File inputFile, ArtifactTransformDependencies artifactTransformDependencies) {
         ServiceLookup services = new TransformServiceLookup(inputFile, getIsolatable().getIsolatableParameters().isolate(), requiresDependencies ? artifactTransformDependencies : null);
         return instanceFactory.newInstance(services);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -131,7 +131,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
     @Override
     public ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies) {
         TransformAction transformAction = newTransformAction(inputArtifact, dependencies);
-        DefaultArtifactTransformOutputs transformOutputs = new DefaultArtifactTransformOutputs(inputArtifact, outputDir);
+        DefaultTransformOutputs transformOutputs = new DefaultTransformOutputs(inputArtifact, outputDir);
         transformAction.transform(transformOutputs);
         return transformOutputs.getRegisteredOutputs();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -21,10 +21,10 @@ import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.AssociatedTransformAction;
 import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException;
 import org.gradle.api.attributes.AttributeContainer;
@@ -87,14 +87,14 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     }
 
     @Override
-    public <T extends ArtifactTransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction) {
+    public <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction) {
         ActionRegistration registration = instantiatorFactory.decorateLenient().newInstance(ActionRegistration.class, immutableAttributesFactory);
         registrationAction.execute(registration);
 
         register(registration, actionType, null);
     }
 
-    private <T> void register(RecordingRegistration registration, Class<? extends ArtifactTransformAction> actionType, @Nullable T parameterObject) {
+    private <T> void register(RecordingRegistration registration, Class<? extends TransformAction> actionType, @Nullable T parameterObject) {
         validateActionType(actionType);
         validateAttributes(registration);
         try {
@@ -183,7 +183,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     @NonExtensible
     public static class TypedRegistration<T> extends RecordingRegistration implements ParameterizedArtifactTransformSpec<T> {
         private final T parameterObject;
-        Class<? extends ArtifactTransformAction> actionType;
+        Class<? extends TransformAction> actionType;
 
         public TypedRegistration(T parameterObject, ImmutableAttributesFactory immutableAttributesFactory) {
             super(immutableAttributesFactory);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -21,10 +21,10 @@ import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
 import org.gradle.api.NonExtensible;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
-import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
 import org.gradle.api.artifacts.transform.AssociatedTransformAction;
-import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.ParameterizedTransformSpec;
 import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException;
 import org.gradle.api.attributes.AttributeContainer;
@@ -78,7 +78,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     }
 
     @Override
-    public <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedArtifactTransformSpec<T>> registrationAction) {
+    public <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedTransformSpec<T>> registrationAction) {
         T parameterObject = parametersInstantiationScheme.withServices(services).newInstance(parameterType);
         TypedRegistration<T> registration = Cast.uncheckedNonnullCast(instantiatorFactory.decorateLenient().newInstance(TypedRegistration.class, parameterObject, immutableAttributesFactory));
         registrationAction.execute(registration);
@@ -87,7 +87,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     }
 
     @Override
-    public <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super ArtifactTransformSpec> registrationAction) {
+    public <T extends TransformAction> void registerTransformAction(Class<T> actionType, Action<? super TransformSpec> registrationAction) {
         ActionRegistration registration = instantiatorFactory.decorateLenient().newInstance(ActionRegistration.class, immutableAttributesFactory);
         registrationAction.execute(registration);
 
@@ -127,7 +127,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         return transforms;
     }
 
-    public static abstract class RecordingRegistration implements ArtifactTransformSpec {
+    public static abstract class RecordingRegistration implements TransformSpec {
         final AttributeContainerInternal from;
         final AttributeContainerInternal to;
 
@@ -181,7 +181,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     }
 
     @NonExtensible
-    public static class TypedRegistration<T> extends RecordingRegistration implements ParameterizedArtifactTransformSpec<T> {
+    public static class TypedRegistration<T> extends RecordingRegistration implements ParameterizedTransformSpec<T> {
         private final T parameterObject;
         Class<? extends TransformAction> actionType;
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -23,8 +23,8 @@ import org.gradle.api.NonExtensible;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformSpec;
+import org.gradle.api.artifacts.transform.AssociatedTransformAction;
 import org.gradle.api.artifacts.transform.ParameterizedArtifactTransformSpec;
-import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException;
 import org.gradle.api.attributes.AttributeContainer;
@@ -188,9 +188,9 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         public TypedRegistration(T parameterObject, ImmutableAttributesFactory immutableAttributesFactory) {
             super(immutableAttributesFactory);
             this.parameterObject = parameterObject;
-            TransformAction transformAction = parameterObject.getClass().getAnnotation(TransformAction.class);
-            if (transformAction != null) {
-                actionType = transformAction.value();
+            AssociatedTransformAction associatedTransformAction = parameterObject.getClass().getAnnotation(AssociatedTransformAction.class);
+            if (associatedTransformAction != null) {
+                actionType = associatedTransformAction.value();
             }
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -68,8 +68,8 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
         String inputFilePrefix = inputArtifact.getPath() + File.separator;
         String outputDirPrefix = outputDir.getPath() + File.separator;
         for (File output : outputs) {
-            ArtifactTransformOutputsInternal.validateOutputExists(output);
-            ArtifactTransformOutputsInternal.determineOutputLocationType(output, inputArtifact, inputFilePrefix, outputDir, outputDirPrefix);
+            TransformOutputsInternal.validateOutputExists(output);
+            TransformOutputsInternal.determineOutputLocationType(output, inputArtifact, inputFilePrefix, outputDir, outputDirPrefix);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformOutputsInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformOutputsInternal.java
@@ -18,11 +18,11 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.artifacts.transform.ArtifactTransformOutputs;
+import org.gradle.api.artifacts.transform.TransformOutputs;
 
 import java.io.File;
 
-public interface ArtifactTransformOutputsInternal extends ArtifactTransformOutputs {
+public interface TransformOutputsInternal extends TransformOutputs {
 
     static OutputLocationType determineOutputLocationType(File output, File inputArtifact, String inputArtifactPrefix, File outputDir, String outputDirPrefix) {
         if (output.equals(inputArtifact)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationRegistrationFactory.java
@@ -17,13 +17,13 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import org.gradle.api.artifacts.transform.ArtifactTransform;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import javax.annotation.Nullable;
 
 public interface TransformationRegistrationFactory {
-    ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransformAction> implementation, @Nullable Object parameterObject);
+    ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends TransformAction> implementation, @Nullable Object parameterObject);
     ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransform> implementation, Object[] params);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.io.Files;
 import org.apache.commons.io.IOUtils;
-import org.gradle.api.artifacts.transform.ArtifactTransformAction;
 import org.gradle.api.artifacts.transform.ArtifactTransformOutputs;
 import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.internal.UncheckedException;
 
 import java.io.BufferedInputStream;
@@ -38,7 +38,7 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
  * is located in the output directory of the transform and is named after the zipped file name
  * minus the extension.
  */
-public interface UnzipTransform extends ArtifactTransformAction {
+public interface UnzipTransform extends TransformAction {
 
     @InputArtifact
     File getZippedFile();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
@@ -18,9 +18,9 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.io.Files;
 import org.apache.commons.io.IOUtils;
-import org.gradle.api.artifacts.transform.ArtifactTransformOutputs;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.TransformAction;
+import org.gradle.api.artifacts.transform.TransformOutputs;
 import org.gradle.internal.UncheckedException;
 
 import java.io.BufferedInputStream;
@@ -44,7 +44,7 @@ public interface UnzipTransform extends TransformAction {
     File getZippedFile();
 
     @Override
-    default void transform(ArtifactTransformOutputs outputs) {
+    default void transform(TransformOutputs outputs) {
         String unzippedDirName = removeExtension(getZippedFile().getName());
         File unzipDir = outputs.dir(unzippedDirName);
         try {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.artifacts.transform
 
 import org.gradle.api.artifacts.transform.ArtifactTransform
-import org.gradle.api.artifacts.transform.ArtifactTransformAction
 import org.gradle.api.artifacts.transform.ArtifactTransformOutputs
 import org.gradle.api.artifacts.transform.AssociatedTransformAction
+import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.DynamicObjectAware
@@ -133,13 +133,13 @@ class DefaultVariantTransformRegistryTest extends Specification {
         def registration = registry.transforms[0]
         registration.from.getAttribute(TEST_ATTRIBUTE) == "FROM"
         registration.to.getAttribute(TEST_ATTRIBUTE) == "TO"
-        registration.transformationStep.transformer.implementationClass == TestArtifactTransformAction
+        registration.transformationStep.transformer.implementationClass == TestTransformAction
         registration.transformationStep.transformer.parameterObject instanceof TestTransform
     }
 
     def "creates registration with with action"() {
         when:
-        registry.registerTransformAction(TestArtifactTransformAction) {
+        registry.registerTransformAction(TestTransformAction) {
             it.from.attribute(TEST_ATTRIBUTE, "FROM")
             it.to.attribute(TEST_ATTRIBUTE, "TO")
         }
@@ -149,7 +149,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         def registration = registry.transforms[0]
         registration.from.getAttribute(TEST_ATTRIBUTE) == "FROM"
         registration.to.getAttribute(TEST_ATTRIBUTE) == "TO"
-        registration.transformationStep.transformer.implementationClass == TestArtifactTransformAction
+        registration.transformationStep.transformer.implementationClass == TestTransformAction
         registration.transformationStep.transformer.parameterObject == null
     }
 
@@ -248,7 +248,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         where:
         method                    | argument
         "registerTransform"       | TestTransform
-        "registerTransformAction" | TestArtifactTransformAction
+        "registerTransformAction" | TestTransformAction
     }
 
     def "fails when no to attributes are provided for legacy registration"() {
@@ -279,7 +279,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         where:
         method                    | argument
         "registerTransform"       | TestTransform
-        "registerTransformAction" | TestArtifactTransformAction
+        "registerTransformAction" | TestTransformAction
     }
 
     def "fails when to attributes are not a subset of from attributes for legacy registration"() {
@@ -316,10 +316,10 @@ class DefaultVariantTransformRegistryTest extends Specification {
         where:
         method                    | argument
         "registerTransform"       | TestTransform
-        "registerTransformAction" | TestArtifactTransformAction
+        "registerTransformAction" | TestTransformAction
     }
 
-    @AssociatedTransformAction(TestArtifactTransformAction)
+    @AssociatedTransformAction(TestTransformAction)
     static class TestTransform {
         String value
     }
@@ -335,7 +335,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         }
     }
 
-    static class TestArtifactTransformAction implements ArtifactTransformAction {
+    static class TestTransformAction implements TransformAction {
         @Override
         void transform(ArtifactTransformOutputs outputs) {
         }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -19,7 +19,7 @@ package org.gradle.api.internal.artifacts.transform
 import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.artifacts.transform.ArtifactTransformAction
 import org.gradle.api.artifacts.transform.ArtifactTransformOutputs
-import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.AssociatedTransformAction
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.DynamicObjectAware
@@ -319,7 +319,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
         "registerTransformAction" | TestArtifactTransformAction
     }
 
-    @TransformAction(TestArtifactTransformAction)
+    @AssociatedTransformAction(TestArtifactTransformAction)
     static class TestTransform {
         String value
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -17,9 +17,9 @@
 package org.gradle.api.internal.artifacts.transform
 
 import org.gradle.api.artifacts.transform.ArtifactTransform
-import org.gradle.api.artifacts.transform.ArtifactTransformOutputs
 import org.gradle.api.artifacts.transform.AssociatedTransformAction
 import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
 import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.DynamicObjectAware
@@ -337,7 +337,7 @@ class DefaultVariantTransformRegistryTest extends Specification {
 
     static class TestTransformAction implements TransformAction {
         @Override
-        void transform(ArtifactTransformOutputs outputs) {
+        void transform(TransformOutputs outputs) {
         }
     }
 

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -329,7 +329,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractIntegrati
             def usage = Attribute.of('usage', String)
             def artifactType = Attribute.of('artifactType', String)
                   
-            @TransformAction(FileSizerAction)
+            @AssociatedTransformAction(FileSizerAction)
             interface FileSizer {
                 @Input
                 String getSuffix()

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -344,7 +344,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractIntegrati
                 @InputArtifact
                 abstract File getInput()
 
-                void transform(ArtifactTransformOutputs outputs) {
+                void transform(TransformOutputs outputs) {
                     ${server.callFromBuild('size-transform')}
                     File output = outputs.registerOutput(input.name + parameters.suffix)
                     output.text = String.valueOf(input.length())

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -336,7 +336,7 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractIntegrati
                 void setSuffix(String suffix)
             }
 
-            abstract class FileSizerAction implements ArtifactTransformAction {
+            abstract class FileSizerAction implements TransformAction {
                 @TransformParameters
                 abstract FileSizer getParameters()
                 @InputArtifactDependencies


### PR DESCRIPTION
Rename the names exposed by the artifact transform API to be more consistent.