### PR TITLE
Honour `AbstractKotlinIntegrationTest.customProjectRoot`

### DIFF
--- a/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -76,7 +76,7 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
 
     protected
     fun withFolders(folders: FoldersDslExpression) =
-        testDirectory.withFolders(folders)
+        projectRoot.withFolders(folders)
 
     protected
     fun withDefaultSettings() =
@@ -166,10 +166,10 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
 
     private
     fun canonicalFile(relativePath: String) =
-        File(testDirectory, relativePath).canonicalFile
+        File(projectRoot, relativePath).canonicalFile
 
     fun build(vararg arguments: String): ExecutionResult =
-        executer.withArguments(*arguments).run()
+        gradleExecuterFor(arguments).run()
 
     protected
     fun buildFailureOutput(vararg arguments: String): String =
@@ -177,11 +177,15 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
 
     protected
     fun buildAndFail(vararg arguments: String): ExecutionFailure =
-        executer.withArguments(*arguments).runWithFailure()
+        gradleExecuterFor(arguments).runWithFailure()
 
     protected
     fun build(rootDir: File, vararg arguments: String): ExecutionResult =
-        executer.inDirectory(rootDir).withArguments(*arguments).run()
+        gradleExecuterFor(arguments, rootDir).run()
+
+    private
+    fun gradleExecuterFor(arguments: Array<out String>, rootDir: File = projectRoot) =
+        inDirectory(rootDir).withArguments(*arguments)
 
     protected
     fun assumeJavaLessThan9() {

--- a/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractKotlinIntegrationTest.kt
@@ -183,7 +183,7 @@ abstract class AbstractKotlinIntegrationTest : AbstractIntegrationTest() {
     fun build(rootDir: File, vararg arguments: String): ExecutionResult =
         gradleExecuterFor(arguments, rootDir).run()
 
-    private
+    protected
     fun gradleExecuterFor(arguments: Array<out String>, rootDir: File = projectRoot) =
         inDirectory(rootDir).withArguments(*arguments)
 

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/AbstractScriptCachingIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/AbstractScriptCachingIntegrationTest.kt
@@ -52,9 +52,9 @@ abstract class AbstractScriptCachingIntegrationTest : AbstractKotlinIntegrationT
 
     private
     fun executerForCacheInspection(vararg arguments: String): GradleExecuter =
-        executer.withArguments(
+        gradleExecuterFor(arrayOf(
             "-d",
             "-Dorg.gradle.internal.operations.trace=${newFile("operation-trace")}",
             *arguments
-        )
+        ))
 }

--- a/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
+++ b/subprojects/kotlin-dsl/src/integTest/kotlin/org/gradle/kotlin/dsl/caching/BuildCacheIntegrationTest.kt
@@ -81,7 +81,6 @@ class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
             // Cache miss with a fresh Gradle home, script cache will be pushed to build cache
             executer.withGradleUserHomeDir(newDir("guh-1"))
-            executer.requireIsolatedDaemons()
             buildForCacheInspection("--build-cache").apply {
 
                 compilationCache {
@@ -99,7 +98,6 @@ class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
 
             // Cache hit from build cache
             executer.withGradleUserHomeDir(newDir("guh-2"))
-            executer.requireIsolatedDaemons()
             buildForCacheInspection("--build-cache").apply {
 
                 compilationCache {
@@ -116,7 +114,6 @@ class BuildCacheIntegrationTest : AbstractScriptCachingIntegrationTest() {
                     "systemProp.org.gradle.kotlin.dsl.caching.buildcache=false"
                 )
             })
-            executer.requireIsolatedDaemons()
             buildForCacheInspection("--build-cache").apply {
 
                 compilationCache {


### PR DESCRIPTION
The behaviour of Kotlin DSL tests with regards to `customProjectRoot` was slightly changed with the migration to the Gradle testing infrastructure.

This commit restores the expected behaviour.