### PR TITLE
Let `Delete` tasks and `project.delete {}` report helpful message on "unable to delete" issues

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/file/UnableToDeleteFileException.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/file/UnableToDeleteFileException.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.file;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.UncheckedIOException;
 
 import java.io.File;
@@ -27,10 +28,23 @@ public class UnableToDeleteFileException extends UncheckedIOException {
 
     private final File file;
 
+    /**
+     * Creates exception with file, a reasonable message is used.
+     */
     public UnableToDeleteFileException(File file) {
         super(toMessage(file));
         this.file = file;
+    }
 
+    /**
+     * Creates exception with file and message.
+     *
+     * @since 5.3
+     */
+    @Incubating
+    public UnableToDeleteFileException(File file, String message) {
+        super(message);
+        this.file = file;
     }
 
     public File getFile() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
@@ -44,6 +44,9 @@ public class Deleter {
 
     private static final int MAX_REPORTED_PATHS = 32;
 
+    static final String HELP_FAILED_DELETE_CHILDREN = "Failed to delete some children. This might happen because a process has files open or has its working directory set in the target directory.";
+    static final String HELP_NEW_CHILDREN = "New files were found. This might happen because a process is still writing to the target directory.";
+
     public Deleter(FileResolver fileResolver, FileSystem fileSystem) {
         this.fileResolver = fileResolver;
         this.fileSystem = fileSystem;
@@ -161,7 +164,7 @@ public class Deleter {
             String absolutePath = file.getAbsolutePath();
             failedPaths.remove(absolutePath);
             if (!failedPaths.isEmpty()) {
-                help.append("\n  Child files failed to delete! Is something holding files in the target directory?");
+                help.append("\n  ").append(HELP_FAILED_DELETE_CHILDREN);
                 for (String failed : failedPaths) {
                     help.append("\n  - ").append(failed);
                 }
@@ -172,7 +175,7 @@ public class Deleter {
 
             Collection<String> newPaths = listNewPaths(startTime, file);
             if (!newPaths.isEmpty()) {
-                help.append("\n  New files were found after failure! Is something concurrently writing into the target directory?");
+                help.append("\n  ").append(HELP_NEW_CHILDREN);
                 for (String newPath : newPaths) {
                     help.append("\n  - ").append(newPath);
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/delete/Deleter.java
@@ -42,7 +42,7 @@ public class Deleter {
 
     private static final int DELETE_RETRY_SLEEP_MILLIS = 10;
 
-    private static final int MAX_REPORTED_PATHS = 32;
+    static final int MAX_REPORTED_PATHS = 16;
 
     static final String HELP_FAILED_DELETE_CHILDREN = "Failed to delete some children. This might happen because a process has files open or has its working directory set in the target directory.";
     static final String HELP_NEW_CHILDREN = "New files were found. This might happen because a process is still writing to the target directory.";

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/delete/DeleterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/delete/DeleterTest.groovy
@@ -243,7 +243,7 @@ class DeleterTest extends Specification {
         def ex = thrown UnableToDeleteFileException
         normaliseLineSeparators(ex.message) == """
             Unable to delete directory '$targetDir'
-              Child files failed to delete! Is something holding files in the target directory?
+              ${Deleter.HELP_FAILED_DELETE_CHILDREN}
               - $nonDeletable
         """.stripIndent().trim()
     }
@@ -279,7 +279,7 @@ class DeleterTest extends Specification {
         def ex = thrown UnableToDeleteFileException
         normaliseLineSeparators(ex.message) == """
             Unable to delete directory '$targetDir'
-              New files were found after failure! Is something concurrently writing into the target directory?
+              ${Deleter.HELP_NEW_CHILDREN}
               - $newFile
         """.stripIndent().trim()
     }
@@ -314,9 +314,9 @@ class DeleterTest extends Specification {
         def ex = thrown UnableToDeleteFileException
         normaliseLineSeparators(ex.message) == """
             Unable to delete directory '$targetDir'
-              Child files failed to delete! Is something holding files in the target directory?
+              ${Deleter.HELP_FAILED_DELETE_CHILDREN}
               - $nonDeletable
-              New files were found after failure! Is something concurrently writing into the target directory?
+              ${Deleter.HELP_NEW_CHILDREN}
               - $newFile
         """.stripIndent().trim()
     }
@@ -356,12 +356,12 @@ class DeleterTest extends Specification {
         def normalizedMessage = normaliseLineSeparators(ex.message)
         normalizedMessage.startsWith("""
             Unable to delete directory '$targetDir'
-              Child files failed to delete! Is something holding files in the target directory?
+              ${Deleter.HELP_FAILED_DELETE_CHILDREN}
               - $targetDir${File.separator}zzz-
         """.stripIndent().trim())
         normalizedMessage.contains("-zzz.txt\n  " + """
               - and more ...
-              New files were found after failure! Is something concurrently writing into the target directory?
+              ${Deleter.HELP_NEW_CHILDREN}
               - $targetDir${File.separator}aaa-
         """.stripIndent(12).trim())
         normalizedMessage.endsWith("-aaa.txt\n  - and more ...")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/delete/DeleterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/delete/DeleterTest.groovy
@@ -149,6 +149,30 @@ class DeleterTest extends Specification {
         didWork
     }
 
+    @Unroll
+    def "does not follow symlink to a file when followSymlinks is #followSymlinks"() {
+        given:
+        def originalFile = tmpDir.createFile("originalFile", "keep.txt")
+        def link = new File(tmpDir.getTestDirectory(), "link")
+
+        when:
+        fileSystem().createSymbolicLink(link, originalFile)
+
+        then:
+        link.exists()
+
+        when:
+        boolean didWork = delete.delete(deleteAction(followSymlinks, link)).getDidWork()
+
+        then:
+        !link.exists()
+        originalFile.assertExists()
+        didWork
+
+        where:
+        followSymlinks << [true, false]
+    }
+
     def Action<? super DeleteSpec> deleteAction(final boolean followSymlinks, final Object... paths) {
         return new Action<DeleteSpec>() {
             @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/file/delete/DeleterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/file/delete/DeleterTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.file.DeleteSpec
 import org.gradle.api.file.UnableToDeleteFileException
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.time.Time
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.util.Requires
@@ -29,6 +30,8 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.api.internal.file.TestFiles.fileSystem
+import static org.gradle.util.TextUtil.normaliseLineSeparators
+import static org.junit.Assume.assumeTrue
 
 class DeleterTest extends Specification {
     static final boolean FOLLOW_SYMLINKS = true;
@@ -152,6 +155,7 @@ class DeleterTest extends Specification {
     }
 
     @Unroll
+    @Requires([TestPrecondition.SYMLINKS])
     def "does not follow symlink to a file when followSymlinks is #followSymlinks"() {
         given:
         def originalFile = tmpDir.createFile("originalFile", "keep.txt")
@@ -177,6 +181,10 @@ class DeleterTest extends Specification {
 
     @Unroll
     def "reports reasonable help message when failing to delete single #description"() {
+
+        if (isSymlink) {
+            assumeTrue(TestPrecondition.SYMLINKS.isFulfilled())
+        }
 
         given:
         delete = new Deleter(resolver, fileSystem()) {
@@ -233,7 +241,7 @@ class DeleterTest extends Specification {
 
         and:
         def ex = thrown UnableToDeleteFileException
-        ex.message == """
+        normaliseLineSeparators(ex.message) == """
             Unable to delete directory '$targetDir'
               Child files failed to delete! Is something holding files in the target directory?
               - $nonDeletable
@@ -253,6 +261,7 @@ class DeleterTest extends Specification {
             protected boolean deleteFile(File file) {
                 if (file.canonicalFile == triggerFile.canonicalFile) {
                     newFile.text = ""
+                    newFile.setLastModified(Time.currentTimeMillis() + 1)
                 }
                 return super.deleteFile(file)
             }
@@ -268,7 +277,7 @@ class DeleterTest extends Specification {
 
         and:
         def ex = thrown UnableToDeleteFileException
-        ex.message == """
+        normaliseLineSeparators(ex.message) == """
             Unable to delete directory '$targetDir'
               New files were found after failure! Is something concurrently writing into the target directory?
               - $newFile
@@ -303,7 +312,7 @@ class DeleterTest extends Specification {
 
         and:
         def ex = thrown UnableToDeleteFileException
-        ex.message == """
+        normaliseLineSeparators(ex.message) == """
             Unable to delete directory '$targetDir'
               Child files failed to delete! Is something holding files in the target directory?
               - $nonDeletable
@@ -344,18 +353,19 @@ class DeleterTest extends Specification {
 
         and: 'the report size is capped'
         def ex = thrown UnableToDeleteFileException
-        ex.message.startsWith("""
+        def normalizedMessage = normaliseLineSeparators(ex.message)
+        normalizedMessage.startsWith("""
             Unable to delete directory '$targetDir'
               Child files failed to delete! Is something holding files in the target directory?
-              - $targetDir/zzz-
+              - $targetDir${File.separator}zzz-
         """.stripIndent().trim())
-        ex.message.contains("-zzz.txt\n  " + """
+        normalizedMessage.contains("-zzz.txt\n  " + """
               - and more ...
               New files were found after failure! Is something concurrently writing into the target directory?
-              - $targetDir/aaa-
+              - $targetDir${File.separator}aaa-
         """.stripIndent(12).trim())
-        ex.message.endsWith("-aaa.txt\n  - and more ...")
-        ex.message.readLines().size() == Deleter.MAX_REPORTED_PATHS * 2 + 5
+        normalizedMessage.endsWith("-aaa.txt\n  - and more ...")
+        normalizedMessage.readLines().size() == Deleter.MAX_REPORTED_PATHS * 2 + 5
     }
 
     def Action<? super DeleteSpec> deleteAction(final boolean followSymlinks, final Object... paths) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -56,9 +56,9 @@ In this release, plugin authors can use the `ObjectFactory.fileCollection()` met
 
 ## Better help message on delete operation failure
 
-The `:clean` task, all `Delete` tasks, and `project.delete {}` operations now provide with a better help message when failing to delete files. The most frequent and hard to troubleshoot causes for failing to delete files are other processes holding file descriptors open, and, concurrent writes.
+The `:clean` task, all `Delete` tasks, and `project.delete {}` operations now provide a better help message when failing to delete files. The most frequent and hard to troubleshoot causes for failing to delete files are other processes holding file descriptors open, and concurrent writes.
 
-The help message now displays each failed path, handy to identify which process might be holding files, and also new paths found in a directory after failure, handy to spot concurrent writes.
+The help message now displays each failed path, which may be helpful in identifying which process might be holding files open, and will also display any files that were created in the target directory after a delete failure, which may be helpful in identifying when a process is still writing to the directory.
 
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -58,7 +58,7 @@ In this release, plugin authors can use the `ObjectFactory.fileCollection()` met
 
 The `:clean` task, all `Delete` tasks, and `project.delete {}` operations now provide with a better help message when failing to delete files. The most frequent and hard to troubleshoot causes for failing to delete files are other processes holding file descriptors open, and, concurrent writes.
 
-The help message now displays each failed path, handy to identify which process might be holing files, and also new paths found in a directory after failure, handy to spot concurrent writes.
+The help message now displays each failed path, handy to identify which process might be holding files, and also new paths found in a directory after failure, handy to spot concurrent writes.
 
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -54,6 +54,12 @@ In this release, plugin authors can use the `ObjectFactory.fileCollection()` met
 
 [The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.3](http://www.jacoco.org/jacoco/trunk/doc/changes.html) instead of 0.8.2 by default.
 
+## Better help message on delete operation failure
+
+The `:clean` task, all `Delete` tasks, and `project.delete {}` operations now provide with a better help message when failing to delete files. The most frequent and hard to troubleshoot causes for failing to delete files are other processes holding file descriptors open, and, concurrent writes.
+
+The help message now displays each failed path, handy to identify which process might be holing files, and also new paths found in a directory after failure, handy to spot concurrent writes.
+
 ## Promoted features
 Promoted features are features that were incubating in previous versions of Gradle but are now supported and subject to backwards compatibility.
 See the User Manual section on the “[Feature Lifecycle](userguide/feature_lifecycle.html)” for more information.

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.plugins
 
+import org.gradle.api.internal.file.delete.Deleter
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
@@ -40,6 +41,7 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         failure.assertHasCause("Unable to delete directory '${file('build')}'")
+        failure.assertThatCause(containsString(Deleter.HELP_FAILED_DELETE_CHILDREN))
         failure.assertThatCause(containsString(file("build/newFile").absolutePath))
 
         cleanup:

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/api/plugins/BasePluginIntegrationTest.groovy
@@ -19,6 +19,8 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
+import static org.hamcrest.CoreMatchers.containsString
+
 class BasePluginIntegrationTest extends AbstractIntegrationSpec {
 
     @Requires(TestPrecondition.MANDATORY_FILE_LOCKING)
@@ -37,7 +39,8 @@ class BasePluginIntegrationTest extends AbstractIntegrationSpec {
         fails "clean"
 
         then:
-        failure.assertHasCause("Unable to delete file")
+        failure.assertHasCause("Unable to delete directory '${file('build')}'")
+        failure.assertThatCause(containsString(file("build/newFile").absolutePath))
 
         cleanup:
         lock?.release()


### PR DESCRIPTION
The `:clean` task, all `Delete` tasks, and `project.delete {}` operations now provide with a better help message when failing to delete files. The most frequent and hard to troubleshoot causes for failing to delete files are other processes holding file descriptors open, and, concurrent writes.

The help message now displays each failed path, handy to identify which process might be holding files, and also new paths found in a directory after failure, handy to spot concurrent writes.

Path collection is limited in order not to make failing deletions slower.
