### PR TITLE
Add better change reporting for classpath inputs

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathCompareStrategy.java
@@ -101,44 +101,38 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
                 if (previous != null) {
                     removed();
                 }
-                return;
-            }
-            if (previous == null) {
+            } else if (previous == null) {
                 added();
-                return;
-            }
-            FileSystemLocationFingerprint currentFingerprint = current.getValue();
-            FileSystemLocationFingerprint previousFingerprint = previous.getValue();
-            String currentNormalizedPath = currentFingerprint.getNormalizedPath();
-            String previousNormalizedPath = previousFingerprint.getNormalizedPath();
-            if (!currentNormalizedPath.equals(previousNormalizedPath)) {
-                removed();
-                added();
-                return;
-            }
-            if (currentFingerprint.getNormalizedContentHash().equals(previousFingerprint.getNormalizedContentHash())) {
-                current = nextEntry(currentEntries);
-                previous = nextEntry(previousEntries);
-                return;
-            }
-            if (currentNormalizedPath.isEmpty()) {
-                String currentAbsolutePath = current.getKey();
-                String previousAbsolutePath = previous.getKey();
-                if (!currentAbsolutePath.equals(previousAbsolutePath)) {
-                    if (!currentSnapshots.containsKey(previousAbsolutePath)) {
-                        removed();
-                        return;
-                    }
-                    if (!previousSnapshots.containsKey(currentAbsolutePath)) {
-                        added();
-                        return;
-                    }
+            } else {
+                FileSystemLocationFingerprint currentFingerprint = current.getValue();
+                FileSystemLocationFingerprint previousFingerprint = previous.getValue();
+                String currentNormalizedPath = currentFingerprint.getNormalizedPath();
+                String previousNormalizedPath = previousFingerprint.getNormalizedPath();
+                if (!currentNormalizedPath.equals(previousNormalizedPath)) {
                     removed();
                     added();
-                    return;
+                } else if (currentFingerprint.getNormalizedContentHash().equals(previousFingerprint.getNormalizedContentHash())) {
+                    current = nextEntry(currentEntries);
+                    previous = nextEntry(previousEntries);
+                } else if (currentNormalizedPath.isEmpty()) {
+                    String currentAbsolutePath = current.getKey();
+                    String previousAbsolutePath = previous.getKey();
+                    if (!currentAbsolutePath.equals(previousAbsolutePath)) {
+                        if (!currentSnapshots.containsKey(previousAbsolutePath)) {
+                            removed();
+                        } else if (!previousSnapshots.containsKey(currentAbsolutePath)) {
+                            added();
+                        } else {
+                            removed();
+                            added();
+                        }
+                    } else {
+                        modified();
+                    }
+                } else {
+                    modified();
                 }
             }
-            modified();
         }
 
         void added() {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintCompareStrategyTest.groovy
@@ -246,7 +246,7 @@ class ClasspathFingerprintCompareStrategyTest extends Specification {
         return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, HashCode.fromInt((int) hashCode))
     }
 
-    def jar(int hashCode = 0x1234abcd) {
+    def jar(int hashCode) {
         return new DefaultFileSystemLocationFingerprint("", FileType.RegularFile, HashCode.fromInt(hashCode))
     }
 


### PR DESCRIPTION
Gradle should never return "modified" for jars which have different
absolute path and different hashes, since this makes it very hard
for incremental tasks to consume the changes.

We try to provide good changes for removed/added jars on the classpath
and modified jars with the same path as long as the order does not
change.

This addresses most of #1931.
