### PR TITLE
WIP - Introduce ecosystem registration

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributesSchema.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributesSchema.java
@@ -17,7 +17,9 @@
 package org.gradle.api.attributes;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 /**
@@ -69,4 +71,17 @@ public interface AttributesSchema {
      * Returns true when this schema contains the given attribute.
      */
     boolean hasAttribute(Attribute<?> key);
+
+    /**
+     * Registers an ecosystem. This method is called whenever a plugin or build script
+     * wants to declare that it recognizes a specific ecosystem. In particular, it is
+     * expected that when registering an ecosystem, a plugin would also declare attributes
+     * in the schema.
+     *
+     * @param name the name of the ecosystem
+     *
+     * @since 5.3
+     */
+    @Incubating
+    void registerEcosystem(String name, @Nullable String description);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/AdhocComponentWithVariants.java
@@ -19,6 +19,8 @@ import org.gradle.api.Action;
 import org.gradle.api.Incubating;
 import org.gradle.api.artifacts.Configuration;
 
+import javax.annotation.Nullable;
+
 /**
  * A component which can declare additional variants corresponding to
  * features. When published to Maven POMs, the dependencies of those variants
@@ -28,7 +30,7 @@ import org.gradle.api.artifacts.Configuration;
  * @since 5.3
  */
 @Incubating
-public interface AdhocComponentWithVariants extends SoftwareComponent {
+public interface AdhocComponentWithVariants extends ComponentWithEcosystems {
 
     /**
      * Declares an additional variant to publish, corresponding to an additional feature.
@@ -37,4 +39,16 @@ public interface AdhocComponentWithVariants extends SoftwareComponent {
      */
     void addVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action);
 
+    /**
+     * By default, an adhoc component will be published with a list of ecosystems corresponding
+     * to the ecosystems which have been registered on the project. If for some reason the default
+     * ecosystems are not suitable, this method can be called, in which case the defaults are ignored.
+     *
+     * It may be the case when a plugin registers an ecosystem which is only suitable for testing,
+     * but should not be used when publishing.
+     *
+     * @param name the name of the ecosystem
+     * @param description a description of the ecosystem
+     */
+    void registerEcosystem(String name, @Nullable String description);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithEcosystems.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ComponentWithEcosystems.java
@@ -13,14 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.component;
+package org.gradle.api.component;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.ecosystem.Ecosystem;
 
-import java.util.Set;
+import java.util.List;
 
-public class IncompatibleVariantsSelectionException extends VariantSelectionException {
-    public IncompatibleVariantsSelectionException(String message, Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
-        super(message, knownEcosystems, requiredEcosystems);
-    }
+/**
+ * A software component which belongs to one or more specific ecosystems.
+ * Ecosystems are used to determine what plugins need to be applied for
+ * the dependency resolution engine to understand the attributes of
+ * a variant.
+ *
+ * @since 5.3
+ */
+@Incubating
+public interface ComponentWithEcosystems extends SoftwareComponent {
+    /**
+     * The list of ecosystems this component requires.
+     */
+    List<Ecosystem> getEcosystems();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/ecosystem/Ecosystem.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ecosystem/Ecosystem.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.ecosystem;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+
+import javax.annotation.Nullable;
+
+/**
+ * An ecosystem is used for consumers to discover that they need
+ * a specific plugin to be applied in order for Gradle (and potentially
+ * other build tools) to understand metadata of components.
+ *
+ * For example, the Java ecosystem configures the attribute schema in
+ * such a way that we can disambiguate usages. Similarly, a plugin that
+ * enhances the Gradle metadata format with custom attributes needs to
+ * declare its ecosystem, so that when dependency resolution happens,
+ * we can warn if no plugin providing the ecosystem support has been
+ * applied.
+ *
+ * @since 5.3
+ */
+@Incubating
+public interface Ecosystem extends Named {
+
+    /**
+     * A description for this ecosystem. The description will
+     * appear in published metadata, and may appear in error
+     * messages when dependency resolution fails.
+     *
+     * @return a human readable description of the ecosystem
+     */
+    @Nullable
+    String getDescription();
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/ecosystem/package-info.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ecosystem/package-info.java
@@ -13,14 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.internal.component;
 
-import org.gradle.api.ecosystem.Ecosystem;
-
-import java.util.Set;
-
-public class IncompatibleVariantsSelectionException extends VariantSelectionException {
-    public IncompatibleVariantsSelectionException(String message, Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
-        super(message, knownEcosystems, requiredEcosystems);
-    }
-}
+/**
+ * Types for declaring ecosystems.
+ *
+ * @since 5.3
+ */
+@org.gradle.api.NonNullApi
+package org.gradle.api.ecosystem;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -26,13 +26,20 @@ import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.ReusableAction;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.internal.component.ImmutableEcosystem;
 
 import javax.inject.Inject;
 import java.util.Set;
 
 public abstract class JavaEcosystemSupport {
+    private static final Ecosystem JAVA_ECOSYSTEM = new ImmutableEcosystem(
+            "org.gradle.ecosystem.java",
+            "The JVM ecosystem providing support for the usage and dependency packing attributes"
+    );
+
     public static void configureSchema(AttributesSchema attributesSchema, final ObjectFactory objectFactory) {
         AttributeMatchingStrategy<Usage> matchingStrategy = attributesSchema.attribute(Usage.USAGE_ATTRIBUTE);
         matchingStrategy.getCompatibilityRules().add(UsageCompatibilityRules.class);
@@ -48,6 +55,7 @@ public abstract class JavaEcosystemSupport {
                 actionConfiguration.params(objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_RESOURCES));
             }
         });
+        attributesSchema.registerEcosystem(JAVA_ECOSYSTEM.getName(), JAVA_ECOSYSTEM.getDescription());
     }
 
 

--- a/subprojects/core/src/main/java/org/gradle/internal/component/ImmutableEcosystem.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/component/ImmutableEcosystem.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.component;
+
+import org.gradle.api.ecosystem.Ecosystem;
+
+import javax.annotation.Nullable;
+
+public class ImmutableEcosystem implements Ecosystem {
+    private final String name;
+    private final String description;
+
+    public ImmutableEcosystem(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    @Nullable
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ImmutableEcosystem that = (ImmutableEcosystem) o;
+
+        return name.equals(that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return name.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        if (description == null) {
+            return name;
+        }
+        return name + " - " + description;
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MissingEcosystemSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MissingEcosystemSelectionIntegrationTest.groovy
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.attributes
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class MissingEcosystemSelectionIntegrationTest extends AbstractDependencyResolutionTest {
+
+    ResolveTestFixture resolve
+
+    def setup() {
+        buildFile << """
+            allprojects {
+                apply plugin: 'java-library'
+            }
+        """
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.prepare()
+    }
+
+    def "fails with a reasonable error message when consumer needs to apply an ecosystem plugin"() {
+        given:
+        mavenRepo.module("org", "foo")
+                .withModuleMetadata()
+                .withGradleMetadataRedirection()
+                .variant('api', ['custom': 'v1'])
+                .variant('runtime', [custom: 'v2'])
+                .ecosystem('dummy')
+                .publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            dependencies {
+                api("org:foo:1.0")
+            }
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot choose between the following variants of org:foo:1.0:
+  - api
+  - runtime
+All of them match the consumer attributes:
+  - Variant 'api' capability org:foo:1.0:
+      - Found custom 'v1' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+  - Variant 'runtime' capability org:foo:1.0:
+      - Found custom 'v2' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+This error might be fixed by applying a plugin understanding the 'dummy' ecosystem."""
+
+    }
+
+    def "fails with a reasonable error message when consumer needs to apply an ecosystem plugin using transitive dependency"() {
+        given:
+        mavenRepo.module("org", "direct")
+            .dependsOn("org", "foo", "1.0")
+            .publish()
+        mavenRepo.module("org", "foo")
+                .withModuleMetadata()
+                .withGradleMetadataRedirection()
+                .variant('api', ['custom': 'v1'])
+                .variant('runtime', [custom: 'v2'])
+                .ecosystem('dummy')
+                .publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            dependencies {
+                api("org:direct:1.0")
+            }
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot choose between the following variants of org:foo:1.0:
+  - api
+  - runtime
+All of them match the consumer attributes:
+  - Variant 'api' capability org:foo:1.0:
+      - Found custom 'v1' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+  - Variant 'runtime' capability org:foo:1.0:
+      - Found custom 'v2' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+This error might be fixed by applying a plugin understanding the 'dummy' ecosystem."""
+
+    }
+
+    def "doesn't warn about missing ecosystem if registered"() {
+        given:
+        mavenRepo.module("org", "foo")
+                .withModuleMetadata()
+                .withGradleMetadataRedirection()
+                .variant('api', ['custom': 'v1'])
+                .variant('runtime', [custom: 'v2'])
+                .ecosystem('dummy')
+                .publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            dependencies {
+                api("org:foo:1.0")
+                attributesSchema.registerEcosystem('dummy', 'usually done by a plugin')
+            }
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot choose between the following variants of org:foo:1.0:
+  - api
+  - runtime
+All of them match the consumer attributes:
+  - Variant 'api' capability org:foo:1.0:
+      - Found custom 'v1' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+  - Variant 'runtime' capability org:foo:1.0:
+      - Found custom 'v2' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided."""
+
+        and:
+        !failure.error.contains('This error might be fixed by applying a plugin understanding the \'dummy\' ecosystem.')
+
+    }
+
+    def "can declare more than one ecosystem"() {
+        given:
+        mavenRepo.module("org", "foo")
+                .withModuleMetadata()
+                .withGradleMetadataRedirection()
+                .variant('api', ['custom': 'v1'])
+                .variant('runtime', [custom: 'v2'])
+                .ecosystem('dummy')
+                .ecosystem('other')
+                .ecosystem('another')
+                .publish()
+
+        buildFile << """
+            repositories {
+                maven { url "${mavenRepo.uri}" }
+            }
+            dependencies {
+                api("org:foo:1.0")
+            }
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause """Cannot choose between the following variants of org:foo:1.0:
+  - api
+  - runtime
+All of them match the consumer attributes:
+  - Variant 'api' capability org:foo:1.0:
+      - Found custom 'v1' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+  - Variant 'runtime' capability org:foo:1.0:
+      - Found custom 'v2' but wasn't required.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' but no value provided.
+This error might be fixed by applying plugins understanding the 'another', 'dummy' and 'other' ecosystems."""
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -53,7 +53,7 @@ public enum CacheLayout {
         .changedTo(63, "4.10-rc-1")
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
-        .changedTo(70, "5.3-rc-1")
+        .changedTo(71, "5.3-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/clientmodule/ClientModuleResolver.java
@@ -27,6 +27,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DependencyDescriptorFactory;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -47,6 +48,7 @@ import org.gradle.internal.resolve.resolver.ComponentMetaDataResolver;
 import org.gradle.internal.resolve.result.BuildableComponentResolveResult;
 
 import javax.annotation.Nullable;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -177,6 +179,11 @@ public class ClientModuleResolver implements ComponentMetaDataResolver {
         @Override
         public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
             return ImmutableList.of();
+        }
+
+        @Override
+        public Set<Ecosystem> getEcosystems() {
+            return Collections.emptySet();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.internal.component.ImmutableEcosystem;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -115,11 +116,35 @@ public class ModuleMetadataParser {
             String name = reader.nextName();
             if ("attributes".equals(name)) {
                 metadata.setAttributes(consumeAttributes(reader));
+            } else if ("ecosystems".equals(name)) {
+                consumeEcosystems(metadata, reader);
             } else {
                 consumeAny(reader);
             }
         }
         reader.endObject();
+    }
+
+    private void consumeEcosystems(MutableModuleComponentResolveMetadata metadata, JsonReader reader) throws IOException {
+        reader.beginArray();
+        while (reader.peek() != JsonToken.END_ARRAY) {
+            reader.beginObject();
+            String ecosystemName = null;
+            String ecosystemDescription = null;
+            while (reader.peek() != END_OBJECT) {
+                String name = reader.nextName();
+                if ("name".equals(name)) {
+                    ecosystemName = reader.nextString();
+                } else if ("description".equals(name)) {
+                    ecosystemDescription = reader.nextString();
+                } else {
+                    consumeAny(reader);
+                }
+            }
+            reader.endObject();
+            metadata.addEcosystem(new ImmutableEcosystem(ecosystemName, ecosystemDescription));
+        }
+        reader.endArray();
     }
 
     private void consumeVariants(JsonReader reader, MutableModuleComponentResolveMetadata metadata) throws IOException {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -133,7 +133,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
     @Override
     public ArtifactSet resolveArtifacts(final ComponentResolveMetadata component, final ConfigurationMetadata configuration, final ArtifactTypeRegistry artifactTypeRegistry, final ModuleExclusion exclusions, final ImmutableAttributes overriddenAttributes) {
         if (isProjectModule(component.getId())) {
-            return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes);
+            return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), self, allProjectArtifacts, artifactTypeRegistry, overriddenAttributes, component.getEcosystems());
         } else {
             return null;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/LocalFileDependencyBackedArtifactSet.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.transform.VariantSelector;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
@@ -146,6 +147,11 @@ public class LocalFileDependencyBackedArtifactSet implements ResolvedArtifactSet
         @Override
         public ImmutableAttributes getOverriddenAttributes() {
             return ImmutableAttributes.EMPTY;
+        }
+
+        @Override
+        public Set<Ecosystem> getEcosystems() {
+            return Collections.emptySet();
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariantSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/ResolvedVariantSet.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact;
 
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 
@@ -46,4 +47,6 @@ public interface ResolvedVariantSet {
      * @return attributes which will override the consumer attributes
      */
     ImmutableAttributes getOverriddenAttributes();
+
+    Set<Ecosystem> getEcosystems();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -386,7 +386,9 @@ public class DependencyGraphBuilder {
         }
         if (!incompatibleNodes.isEmpty()) {
             IncompatibleVariantsSelectionException variantsSelectionException = new IncompatibleVariantsSelectionException(
-                    IncompatibleVariantsSelectionMessageBuilder.buildMessage(selected, incompatibleNodes)
+                    IncompatibleVariantsSelectionMessageBuilder.buildMessage(selected, incompatibleNodes),
+                    attributesSchema.getEcosystems(),
+                    selected.getMetadata().getEcosystems()
             );
             for (EdgeState edge : module.getIncomingEdges()) {
                 edge.failWith(variantsSelectionException);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/LenientPlatformResolveMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -178,6 +179,11 @@ class LenientPlatformResolveMetadata implements ModuleComponentResolveMetadata {
     @Override
     public VariantMetadataRules getVariantMetadataRules() {
         return VariantMetadataRules.noOp();
+    }
+
+    @Override
+    public Set<Ecosystem> getEcosystems() {
+        return Collections.emptySet();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AmbiguousTransformException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AmbiguousTransformException.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.Lists;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.Pair;
@@ -26,13 +27,17 @@ import org.gradle.internal.logging.text.TreeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.gradle.internal.component.AmbiguousVariantSelectionException.formatAttributes;
 
 public class AmbiguousTransformException extends VariantSelectionException {
-    public AmbiguousTransformException(String producerDisplayName, AttributeContainerInternal requested, List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates) {
-        super(format(producerDisplayName, requested, candidates));
+    public AmbiguousTransformException(String producerDisplayName,
+                                       AttributeContainerInternal requested,
+                                       List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates,
+                                       Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
+        super(format(producerDisplayName, requested, candidates), knownEcosystems, requiredEcosystems);
     }
 
     private static String format(String producerDisplayName, AttributeContainerInternal requested, List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -85,7 +85,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             return matches.get(0).getArtifacts();
         }
         if (matches.size() > 1) {
-            throw new AmbiguousVariantSelectionException(producer.asDescribable().getDisplayName(), componentRequested, matches, matcher);
+            throw new AmbiguousVariantSelectionException(producer.asDescribable().getDisplayName(), componentRequested, matches, matcher, schema.getEcosystems(), producer.getEcosystems());
         }
 
         List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates = new ArrayList<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>>();
@@ -109,13 +109,13 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         }
 
         if (!candidates.isEmpty()) {
-            throw new AmbiguousTransformException(producer.asDescribable().getDisplayName(), componentRequested, candidates);
+            throw new AmbiguousTransformException(producer.asDescribable().getDisplayName(), componentRequested, candidates, schema.getEcosystems(), producer.getEcosystems());
         }
 
         if (ignoreWhenNoMatches) {
             return ResolvedArtifactSet.EMPTY;
         }
-        throw new NoMatchingVariantSelectionException(producer.asDescribable().getDisplayName(), componentRequested, producer.getVariants(), matcher);
+        throw new NoMatchingVariantSelectionException(producer.asDescribable().getDisplayName(), componentRequested, producer.getVariants(), matcher, schema.getEcosystems(), producer.getEcosystems());
     }
 
     private List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> tryDisambiguate(AttributeMatcher matcher, List<Pair<ResolvedVariant, ConsumerVariantMatchResult.ConsumerVariant>> candidates) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/AttributesSchemaInternal.java
@@ -18,7 +18,10 @@ package org.gradle.api.internal.attributes;
 
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.internal.component.model.AttributeMatcher;
+
+import java.util.Set;
 
 public interface AttributesSchemaInternal extends AttributesSchema {
     /**
@@ -34,4 +37,6 @@ public interface AttributesSchemaInternal extends AttributesSchema {
     CompatibilityRule<Object> compatibilityRules(Attribute<?> attribute);
 
     DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute);
+
+    Set<Ecosystem> getEcosystems();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultAttributesSchema.java
@@ -18,20 +18,23 @@ package org.gradle.api.internal.attributes;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.HasAttributes;
-import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.internal.Cast;
+import org.gradle.internal.component.ImmutableEcosystem;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.component.model.AttributeSelectionSchema;
 import org.gradle.internal.component.model.AttributeSelectionUtils;
 import org.gradle.internal.component.model.ComponentAttributeMatcher;
 import org.gradle.internal.component.model.DefaultCompatibilityCheckResult;
 import org.gradle.internal.component.model.DefaultMultipleCandidateResult;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 
 import javax.annotation.Nullable;
@@ -51,6 +54,7 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
     private final DefaultAttributeMatcher matcher;
     private final IsolatableFactory isolatableFactory;
     private final Map<ExtraAttributesEntry, Attribute<?>[]> extraAttributesCache = Maps.newHashMap();
+    private final Set<Ecosystem> ecosystems = Sets.newHashSet();
 
     public DefaultAttributesSchema(ComponentAttributeMatcher componentAttributeMatcher, InstantiatorFactory instantiatorFactory, IsolatableFactory isolatableFactory) {
         this.componentAttributeMatcher = componentAttributeMatcher;
@@ -128,6 +132,16 @@ public class DefaultAttributesSchema implements AttributesSchemaInternal, Attrib
             return Cast.uncheckedCast(matchingStrategy.getDisambiguationRules());
         }
         return EmptySchema.INSTANCE.disambiguationRules(attribute);
+    }
+
+    @Override
+    public Set<Ecosystem> getEcosystems() {
+        return Collections.unmodifiableSet(ecosystems);
+    }
+
+    @Override
+    public void registerEcosystem(String name, String description) {
+        ecosystems.add(new ImmutableEcosystem(name, description));
     }
 
     private static class DefaultAttributeMatcher implements AttributeMatcher {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/EmptySchema.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.attributes;
 import org.gradle.api.Action;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.internal.component.model.AttributeMatcher;
 
 import java.util.Collections;
@@ -41,6 +42,11 @@ public class EmptySchema implements AttributesSchemaInternal {
     @Override
     public DisambiguationRule<Object> disambiguationRules(Attribute<?> attribute) {
         return disambiguationRule;
+    }
+
+    @Override
+    public Set<Ecosystem> getEcosystems() {
+        return Collections.emptySet();
     }
 
     @Override
@@ -75,6 +81,11 @@ public class EmptySchema implements AttributesSchemaInternal {
 
     @Override
     public boolean hasAttribute(Attribute<?> key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerEcosystem(String name, String description) {
         throw new UnsupportedOperationException();
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousVariantSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/AmbiguousVariantSelectionException.java
@@ -19,19 +19,21 @@ package org.gradle.internal.component;
 import com.google.common.collect.Ordering;
 import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.gradle.internal.component.AmbiguousConfigurationSelectionException.formatAttributeMatches;
 
 public class AmbiguousVariantSelectionException extends VariantSelectionException {
 
-    public AmbiguousVariantSelectionException(String producerDisplayName, AttributeContainerInternal requested, List<? extends ResolvedVariant> matches, AttributeMatcher matcher) {
-        super(format(producerDisplayName, requested, matches, matcher));
+    public AmbiguousVariantSelectionException(String producerDisplayName, AttributeContainerInternal requested, List<? extends ResolvedVariant> matches, AttributeMatcher matcher, Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
+        super(format(producerDisplayName, requested, matches, matcher), knownEcosystems, requiredEcosystems);
     }
 
     private static String format(String producerDisplayName, AttributeContainerInternal consumer, List<? extends ResolvedVariant> variants, AttributeMatcher matcher) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingVariantSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/NoMatchingVariantSelectionException.java
@@ -16,18 +16,20 @@
 
 package org.gradle.internal.component;
 
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.internal.component.model.AttributeMatcher;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.Collection;
+import java.util.Set;
 
 import static org.gradle.internal.component.AmbiguousConfigurationSelectionException.formatAttributeMatches;
 
 public class NoMatchingVariantSelectionException extends VariantSelectionException {
-    public NoMatchingVariantSelectionException(String producerDisplayName, AttributeContainerInternal consumer, Collection<? extends ResolvedVariant> candidates, AttributeMatcher matcher) {
-        super(format(producerDisplayName, consumer, candidates, matcher));
+    public NoMatchingVariantSelectionException(String producerDisplayName, AttributeContainerInternal consumer, Collection<? extends ResolvedVariant> candidates, AttributeMatcher matcher, Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
+        super(format(producerDisplayName, consumer, candidates, matcher), knownEcosystems, requiredEcosystems);
     }
 
     private static String format(String producerDisplayName, AttributeContainerInternal consumer, Collection<? extends ResolvedVariant> candidates, AttributeMatcher matcher) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/VariantSelectionException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/VariantSelectionException.java
@@ -16,16 +16,67 @@
 
 package org.gradle.internal.component;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedVariantSet;
 import org.gradle.internal.exceptions.Contextual;
+import org.gradle.util.TextUtil;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
 
 @Contextual
 public class VariantSelectionException extends RuntimeException {
-    public VariantSelectionException(String message) {
-        super(message);
+    public VariantSelectionException(String message, Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
+        super(amendMessageWithEcosystems(message, knownEcosystems, requiredEcosystems));
     }
 
-    public VariantSelectionException(String message, Throwable cause) {
+    static String amendMessageWithEcosystems(String message, Set<Ecosystem> knownEcosystems, Set<Ecosystem> requiredEcosystems) {
+        Set<Ecosystem> missingEcosystems = Sets.difference(requiredEcosystems, knownEcosystems);
+        if (missingEcosystems.isEmpty()) {
+            return message;
+        }
+        StringBuilder sb = new StringBuilder(message);
+        sb.append(TextUtil.getPlatformLineSeparator());
+        sb.append("This error might be fixed by applying ");
+        int size = missingEcosystems.size();
+        if (size == 1) {
+            Ecosystem ecosystem = missingEcosystems.iterator().next();
+            sb.append("a plugin understanding the ");
+            formatEcosystem(sb, ecosystem);
+            sb.append(" ecosystem.");
+        } else {
+            sb.append("plugins understanding the ");
+            List<Ecosystem> sorted = Lists.newArrayList(missingEcosystems);
+            Collections.sort(sorted, Comparator.comparing(Ecosystem::getName));
+            for (int i = 0; i < size; i++) {
+                Ecosystem missingEcosystem = sorted.get(i);
+                formatEcosystem(sb, missingEcosystem);
+                if (i < size - 2) {
+                    sb.append(", ");
+                } else if (i == size - 2) {
+                    sb.append(" and ");
+                }
+            }
+            sb.append(" ecosystems.");
+        }
+        return sb.toString();
+    }
+
+    private static void formatEcosystem(StringBuilder sb, Ecosystem ecosystem) {
+        sb.append("'");
+        sb.append(ecosystem.getName());
+        sb.append("'");
+        String description = ecosystem.getDescription();
+        if (description != null) {
+            sb.append(" (").append(description).append(")");
+        }
+    }
+
+    private VariantSelectionException(String message, Throwable cause) {
         super(message, cause);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractModuleComponentResolveMetadata.java
@@ -19,9 +19,11 @@ package org.gradle.internal.component.external.model;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -35,6 +37,7 @@ import org.gradle.internal.hash.HashValue;
 
 import javax.annotation.Nullable;
 import java.util.List;
+import java.util.Set;
 
 abstract class AbstractModuleComponentResolveMetadata implements ModuleComponentResolveMetadata {
 
@@ -55,6 +58,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     private final HashValue originalContentHash;
     private final ImmutableAttributes attributes;
     private final ImmutableList<? extends ComponentIdentifier> platformOwners;
+    private final ImmutableSet<Ecosystem> ecosystems;
 
     public AbstractModuleComponentResolveMetadata(AbstractMutableModuleComponentResolveMetadata metadata) {
         this.componentIdentifier = metadata.getId();
@@ -68,48 +72,52 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
         attributes = extractAttributes(metadata);
         variants = metadata.getVariants();
         platformOwners = metadata.getPlatformOwners() == null ? ImmutableList.<ComponentIdentifier>of() : ImmutableList.copyOf(metadata.getPlatformOwners());
+        ecosystems = ImmutableSet.copyOf(metadata.getEcosystems());
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ImmutableList<? extends ComponentVariant> variants) {
         this.componentIdentifier = metadata.getId();
         this.moduleVersionIdentifier = metadata.getModuleVersionId();
-        changing = metadata.isChanging();
-        missing = metadata.isMissing();
-        statusScheme = metadata.getStatusScheme();
-        moduleSource = metadata.getSource();
-        attributesFactory = metadata.getAttributesFactory();
-        originalContentHash = metadata.getOriginalContentHash();
-        attributes = metadata.getAttributes();
+        this.changing = metadata.isChanging();
+        this.missing = metadata.isMissing();
+        this.statusScheme = metadata.getStatusScheme();
+        this.moduleSource = metadata.getSource();
+        this.attributesFactory = metadata.getAttributesFactory();
+        this.originalContentHash = metadata.getOriginalContentHash();
+        this.attributes = metadata.getAttributes();
         this.variants = variants;
         this.platformOwners = metadata.getPlatformOwners();
+        this.ecosystems = ImmutableSet.copyOf(metadata.getEcosystems());
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata) {
         this.componentIdentifier = metadata.componentIdentifier;
         this.moduleVersionIdentifier = metadata.moduleVersionIdentifier;
-        changing = metadata.changing;
-        missing = metadata.missing;
-        statusScheme = metadata.statusScheme;
-        moduleSource = metadata.moduleSource;
-        attributesFactory = metadata.attributesFactory;
-        originalContentHash = metadata.originalContentHash;
-        attributes = metadata.attributes;
-        variants = metadata.variants;
-        platformOwners = metadata.platformOwners;
+        this.changing = metadata.changing;
+        this.missing = metadata.missing;
+        this.statusScheme = metadata.statusScheme;
+        this.moduleSource = metadata.moduleSource;
+        this.attributesFactory = metadata.attributesFactory;
+        this.originalContentHash = metadata.originalContentHash;
+        this.attributes = metadata.attributes;
+        this.variants = metadata.variants;
+        this.platformOwners = metadata.platformOwners;
+        this.ecosystems = metadata.ecosystems;
     }
 
     public AbstractModuleComponentResolveMetadata(AbstractModuleComponentResolveMetadata metadata, ModuleSource source) {
         this.componentIdentifier = metadata.componentIdentifier;
         this.moduleVersionIdentifier = metadata.moduleVersionIdentifier;
-        changing = metadata.changing;
-        missing = metadata.missing;
-        statusScheme = metadata.statusScheme;
-        attributesFactory = metadata.attributesFactory;
-        originalContentHash = metadata.originalContentHash;
-        attributes = metadata.attributes;
-        variants = metadata.variants;
-        platformOwners = metadata.platformOwners;
-        moduleSource = source;
+        this.changing = metadata.changing;
+        this.missing = metadata.missing;
+        this.statusScheme = metadata.statusScheme;
+        this.attributesFactory = metadata.attributesFactory;
+        this.originalContentHash = metadata.originalContentHash;
+        this.attributes = metadata.attributes;
+        this.variants = metadata.variants;
+        this.platformOwners = metadata.platformOwners;
+        this.moduleSource = source;
+        this.ecosystems = metadata.ecosystems;
     }
 
     @Override
@@ -198,6 +206,11 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
     }
 
     @Override
+    public Set<Ecosystem> getEcosystems() {
+        return ecosystems;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -215,7 +228,8 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             && Objects.equal(moduleSource, that.moduleSource)
             && Objects.equal(attributes, that.attributes)
             && Objects.equal(variants, that.variants)
-            && Objects.equal(originalContentHash, that.originalContentHash);
+            && Objects.equal(originalContentHash, that.originalContentHash)
+            && Objects.equal(ecosystems, that.ecosystems);
     }
 
     @Override
@@ -229,6 +243,7 @@ abstract class AbstractModuleComponentResolveMetadata implements ModuleComponent
             moduleSource,
             attributes,
             variants,
-            originalContentHash);
+            originalContentHash,
+            ecosystems);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractMutableModuleComponentResolveMetadata.java
@@ -28,6 +28,7 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.capabilities.Capability;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -47,6 +48,7 @@ import org.gradle.internal.hash.HashValue;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -73,6 +75,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     private List<MutableVariantImpl> newVariants;
     private ImmutableList<? extends ComponentVariant> variants;
     private Set<ComponentIdentifier> owners;
+    private Set<Ecosystem> ecosystems;
 
     protected AbstractMutableModuleComponentResolveMetadata(ImmutableAttributesFactory attributesFactory, ModuleVersionIdentifier moduleVersionId, ModuleComponentIdentifier componentIdentifier) {
         this.attributesFactory = attributesFactory;
@@ -95,6 +98,7 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
         this.componentLevelAttributes = attributesFactory.mutable((AttributeContainerInternal) metadata.getAttributes());
         this.variantMetadataRules = new VariantMetadataRules(attributesFactory, moduleVersionId);
         this.variantMetadataRules.setVariantDerivationStrategy(metadata.getVariantMetadataRules().getVariantDerivationStrategy());
+        this.ecosystems = Sets.newHashSet(metadata.getEcosystems());
     }
 
     private static AttributeContainerInternal defaultAttributes(ImmutableAttributesFactory attributesFactory) {
@@ -277,6 +281,19 @@ public abstract class AbstractMutableModuleComponentResolveMetadata implements M
     @Override
     public Set<? extends ComponentIdentifier> getPlatformOwners() {
         return owners;
+    }
+
+    @Override
+    public Set<Ecosystem> getEcosystems() {
+        return ecosystems == null ? Collections.emptySet() : ecosystems;
+    }
+
+    @Override
+    public void addEcosystem(Ecosystem ecosystem) {
+        if (ecosystems == null) {
+            ecosystems = Sets.newHashSet();
+        }
+        ecosystems.add(ecosystem);
     }
 
     protected static class MutableVariantImpl implements MutableComponentVariant {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/FixedComponentArtifacts.java
@@ -49,6 +49,6 @@ public class FixedComponentArtifacts implements ComponentArtifacts {
 
     @Override
     public ArtifactSet getArtifactsFor(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ModuleExclusion exclusions, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), configuration.asDescribable(), artifacts, component.getSource(), exclusions, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes);
+        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), configuration.asDescribable(), artifacts, component.getSource(), exclusions, component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes, component.getEcosystems());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MetadataSourcedComponentArtifacts.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MetadataSourcedComponentArtifacts.java
@@ -36,6 +36,6 @@ import java.util.Map;
 public class MetadataSourcedComponentArtifacts implements ComponentArtifacts {
     @Override
     public ArtifactSet getArtifactsFor(ComponentResolveMetadata component, ConfigurationMetadata configuration, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ModuleExclusion exclusions, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes);
+        return DefaultArtifactSet.multipleVariants(component.getId(), component.getModuleVersionId(), component.getSource(), exclusions, configuration.getVariants(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes, component.getEcosystems());
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/MutableModuleComponentResolveMetadata.java
@@ -19,6 +19,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.component.model.ModuleSource;
@@ -106,4 +107,8 @@ public interface MutableModuleComponentResolveMetadata {
 
     @Nullable
     Set<? extends ComponentIdentifier> getPlatformOwners();
+
+    Set<Ecosystem> getEcosystems();
+
+    void addEcosystem(Ecosystem ecosystem);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -31,6 +31,7 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
@@ -215,6 +216,11 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     @Override
     public ImmutableList<? extends ComponentIdentifier> getPlatformOwners() {
         return ImmutableList.of();
+    }
+
+    @Override
+    public Set<Ecosystem> getEcosystems() {
+        return attributesSchema.getEcosystems();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/AttributeConfigurationSelector.java
@@ -62,9 +62,9 @@ public abstract class AttributeConfigurationSelector {
         if (matches.size() == 1) {
             return singleVariant(variantsForGraphTraversal, matches);
         } else if (!matches.isEmpty()) {
-            throw new AmbiguousConfigurationSelectionException(consumerAttributes, attributeMatcher, matches, targetComponent, variantsForGraphTraversal.isPresent());
+            throw new AmbiguousConfigurationSelectionException(consumerAttributes, attributeMatcher, matches, targetComponent, variantsForGraphTraversal.isPresent(), consumerSchema);
         } else {
-            throw new NoMatchingConfigurationSelectionException(consumerAttributes, attributeMatcher, targetComponent, variantsForGraphTraversal.isPresent());
+            throw new NoMatchingConfigurationSelectionException(consumerAttributes, attributeMatcher, targetComponent, variantsForGraphTraversal.isPresent(), consumerSchema);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/ComponentResolveMetadata.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.HasAttributes;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 
 import javax.annotation.Nullable;
@@ -94,5 +95,7 @@ public interface ComponentResolveMetadata extends HasAttributes {
     List<String> getStatusScheme();
 
     ImmutableList<? extends ComponentIdentifier> getPlatformOwners();
+
+    Set<Ecosystem> getEcosystems();
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/resolver/DefaultArtifactSelector.java
@@ -70,6 +70,6 @@ public class DefaultArtifactSelector implements ArtifactSelector {
 
     @Override
     public ArtifactSet resolveArtifacts(ComponentResolveMetadata component, Collection<? extends ComponentArtifactMetadata> artifacts, ImmutableAttributes overriddenAttributes) {
-        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), Describables.of(component.getId()), artifacts, component.getSource(), ModuleExclusions.excludeNone(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes);
+        return DefaultArtifactSet.singleVariant(component.getId(), component.getModuleVersionId(), Describables.of(component.getId()), artifacts, component.getSource(), ModuleExclusions.excludeNone(), component.getAttributesSchema(), artifactResolver, allResolvedArtifacts, artifactTypeRegistry, overriddenAttributes, component.getEcosystems());
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 70
+        expectedVersion = 71
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSetTest.groovy
@@ -29,7 +29,9 @@ import spock.lang.Specification
 class DefaultArtifactSetTest extends Specification {
     def componentId = Stub(ComponentIdentifier)
     def exclusions = Stub(ModuleExclusions)
-    def schema = Stub(AttributesSchemaInternal)
+    def schema = Stub(AttributesSchemaInternal) {
+        getEcosystems() >> []
+    }
     def artifactTypeRegistry = Stub(ArtifactTypeRegistry)
 
 
@@ -42,9 +44,9 @@ class DefaultArtifactSetTest extends Specification {
         def variant2 = Stub(VariantResolveMetadata)
 
         given:
-        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
+        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, [] as Set)
+        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, [] as Set)
+        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, [] as Set)
 
         expect:
         artifacts1.select({false}, Stub(VariantSelector)) == ResolvedArtifactSet.EMPTY
@@ -59,9 +61,9 @@ class DefaultArtifactSetTest extends Specification {
         def selector = Stub(VariantSelector)
 
         given:
-        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
-        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY)
+        def artifacts1 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1, variant2] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, [] as Set)
+        def artifacts2 = DefaultArtifactSet.multipleVariants(componentId, null, null, null, [variant1] as Set, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, [] as Set)
+        def artifacts3 = DefaultArtifactSet.singleVariant(componentId, null, Mock(DisplayName), [] as Set, null, null, schema, null, null, artifactTypeRegistry, ImmutableAttributes.EMPTY, [] as Set)
 
         selector.select(_) >> resolvedVariant1
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -35,6 +35,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
     def attributeMatcher = Mock(AttributeMatcher)
     def attributesSchema = Mock(AttributesSchemaInternal) {
         withProducer(_) >> attributeMatcher
+        getEcosystems() >> []
     }
     def attributesFactory = Mock(ImmutableAttributesFactory) {
         concat(_, _) >> { args -> return args[0]}
@@ -50,6 +51,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
     def variantSet = Mock(ResolvedVariantSet) {
         asDescribable() >> Describables.of("mock producer")
         getVariants() >> [variant]
+        getEcosystems() >> []
     }
 
     def 'direct match on variant means no finder interaction'() {
@@ -376,6 +378,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def multiVariantSet = Mock(ResolvedVariantSet) {
             asDescribable() >> Describables.of("mock multi producer")
             getVariants() >> [variant, otherVariant, yetAnotherVariant]
+            getEcosystems() >> []
         }
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -46,8 +46,8 @@ import static org.gradle.util.TextUtil.toPlatformLineSeparators
 
 class DefaultArtifactTransformsTest extends Specification {
     def matchingCache = Mock(ConsumerProvidedVariantFinder)
-    def producerSchema = Mock(AttributesSchemaInternal)
-    def consumerSchema = Mock(AttributesSchemaInternal)
+    def producerSchema = mockSchema()
+    def consumerSchema = mockSchema()
     def attributeMatcher = Mock(AttributeMatcher)
     def dependenciesResolver = Stub(ExtraExecutionGraphDependenciesResolverFactory)
     def transforms = new DefaultArtifactTransforms(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory())
@@ -112,6 +112,7 @@ class DefaultArtifactTransformsTest extends Specification {
     private ResolvedVariantSet resolvedVariantSet() {
         Stub(ResolvedVariantSet) {
             getOverriddenAttributes() >> ImmutableAttributes.EMPTY
+            getEcosystems() >> []
         }
     }
 
@@ -294,6 +295,12 @@ Found the following transforms:
         def attributeContainer = new DefaultMutableAttributeContainer(AttributeTestUtil.attributesFactory())
         attributeContainer.attribute(ARTIFACT_FORMAT, artifactType)
         attributeContainer.asImmutable()
+    }
+
+    private AttributesSchemaInternal mockSchema() {
+        Mock(AttributesSchemaInternal) {
+            getEcosystems() >> []
+        }
     }
 
     interface TestArtifact extends ResolvableArtifact, Buildable {}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/AbstractModule.groovy
@@ -33,6 +33,8 @@ abstract class AbstractModule implements Module {
 
     Map<String, String> attributes = [:]
 
+    Set<String> ecosystems = []
+
     /**
      * @param cl A closure that is passed a writer to use to generate the content.
      */
@@ -123,5 +125,10 @@ abstract class AbstractModule implements Module {
 
     boolean isHasModuleMetadata() {
         hasModuleMetadata
+    }
+
+    Module ecosystem(String name) {
+        ecosystems << name
+        this
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/Module.groovy
@@ -38,4 +38,6 @@ interface Module {
     void withVariant(String name, @DelegatesTo(value=VariantMetadataSpec.class, strategy = Closure.DELEGATE_FIRST) groovy.lang.Closure<?> action)
 
     Map<String, String> getAttributes()
+
+    Module ecosystem(String name)
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -26,13 +26,15 @@ class GradleFileModuleAdapter {
     private final String version
     private final List<VariantMetadataSpec> variants
     private final Map<String, String> attributes
+    private final Set<String> ecosystems
 
-    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadataSpec> variants, Map<String, String> attributes = [:]) {
+    GradleFileModuleAdapter(String group, String module, String version, List<VariantMetadataSpec> variants, Map<String, String> attributes = [:], Set<String> ecosystems = []) {
         this.group = group
         this.module = module
         this.version = version
         this.variants = variants
         this.attributes = attributes
+        this.ecosystems = ecosystems
     }
 
     void publishTo(TestFile moduleDir) {
@@ -53,6 +55,11 @@ class GradleFileModuleAdapter {
                         "$key" value
                     }
                 }
+                ecosystems(
+                    this.ecosystems.collect { ecosystem ->
+                        { -> name(ecosystem) }
+                    }
+                )
             }
             variants(this.variants.collect { v ->
                 { ->

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyFileModule.groovy
@@ -228,6 +228,12 @@ class IvyFileModule extends AbstractModule implements IvyModule {
         return this
     }
 
+    @Override
+    IvyFileModule ecosystem(String name) {
+        super.ecosystem(name)
+        this
+    }
+
     IvyFileModule nonTransitive(String config) {
         configurations[config].transitive = false
         return this
@@ -414,7 +420,8 @@ class IvyFileModule extends AbstractModule implements IvyModule {
                     v.capabilities
                 )
             },
-            attributes + ['org.gradle.status': status]
+            attributes + ['org.gradle.status': status],
+            ecosystems
         )
 
         adapter.publishTo(moduleDir)

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyModule.java
@@ -144,4 +144,7 @@ public interface IvyModule extends Module {
     void assertPublishedAsJavaModule();
 
     void assertPublishedAsWebModule();
+
+    @Override
+    IvyModule ecosystem(String name);
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/AbstractMavenModule.groovy
@@ -467,7 +467,8 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
                     v.capabilities
                 )
             },
-            attributes + ['org.gradle.status': version.endsWith('-SNAPSHOT') ? 'integration' : 'release']
+            attributes + ['org.gradle.status': version.endsWith('-SNAPSHOT') ? 'integration' : 'release'],
+            ecosystems
         )
 
         adapter.publishTo(moduleDir)
@@ -679,6 +680,11 @@ abstract class AbstractMavenModule extends AbstractModule implements MavenModule
     @Override
     MavenModule withModuleMetadata() {
         super.withModuleMetadata()
+    }
+
+    @Override
+    MavenModule ecosystem(String name) {
+        super.ecosystem(name)
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/DelegatingMavenModule.java
@@ -116,6 +116,12 @@ public abstract class DelegatingMavenModule<T extends MavenModule> implements Ma
     }
 
     @Override
+    public MavenModule ecosystem(String name) {
+        backingModule.ecosystem(name);
+        return t();
+    }
+
+    @Override
     public TestFile getArtifactFile() {
         return backingModule.getArtifactFile();
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenModule.groovy
@@ -157,4 +157,7 @@ interface MavenModule extends Module {
      * If created {@link #withModuleMetadata()}, module file is also expected.
      */
     void assertPublishedAsJavaModule()
+
+    @Override
+    MavenModule ecosystem(String name)
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/DelegatingIvyModule.java
@@ -200,6 +200,12 @@ public abstract class DelegatingIvyModule<T extends IvyModule> implements IvyMod
         return t();
     }
 
+    @Override
+    public T ecosystem(String name) {
+        backingModule.ecosystem(name);
+        return t();
+    }
+
     public T configuration(String name) {
         backingModule.configuration(Collections.<String, Object>emptyMap(), name);
         return t();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultSoftwareComponentFactory.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultSoftwareComponentFactory.java
@@ -15,14 +15,42 @@
  */
 package org.gradle.api.plugins.internal;
 
+import com.google.common.collect.Lists;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
+import org.gradle.api.ecosystem.Ecosystem;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.internal.Factory;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 
 public class DefaultSoftwareComponentFactory implements SoftwareComponentFactory {
 
+    private final AttributesSchemaInternal attributesSchema;
+
+    public DefaultSoftwareComponentFactory(AttributesSchemaInternal attributesSchema) {
+        this.attributesSchema = attributesSchema;
+    }
+
     @Override
     public AdhocComponentWithVariants adhoc(String name) {
-        return new DefaultAdhocSoftwareComponent(name);
+        return new DefaultAdhocSoftwareComponent(name, new Factory<List<Ecosystem>>() {
+            @Override
+            public List<Ecosystem> create() {
+                List<Ecosystem> ecosystems = Lists.newArrayList(attributesSchema.getEcosystems());
+                Collections.sort(ecosystems, new EcosystemComparator());
+                return ecosystems;
+            }
+        });
+    }
 
+    private static class EcosystemComparator implements Comparator<Ecosystem> {
+
+        @Override
+        public int compare(Ecosystem o1, Ecosystem o2) {
+            return o1.getName().compareTo(o2.getName());
+        }
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/PluginAuthorServices.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/PluginAuthorServices.java
@@ -16,6 +16,7 @@
 package org.gradle.api.plugins.internal;
 
 import org.gradle.api.component.SoftwareComponentFactory;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.internal.service.ServiceRegistration;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 
@@ -24,13 +25,13 @@ import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
  */
 public class PluginAuthorServices extends AbstractPluginServiceRegistry {
     @Override
-    public void registerGlobalServices(ServiceRegistration registration) {
-        registration.addProvider(new GlobalcopeServices());
+    public void registerProjectServices(ServiceRegistration registration) {
+        registration.addProvider(new ProjectScopeServices());
     }
 
-    private static class GlobalcopeServices {
-        SoftwareComponentFactory createSoftwareComponentFactory() {
-            return new DefaultSoftwareComponentFactory();
+    private static class ProjectScopeServices {
+        SoftwareComponentFactory createSoftwareComponentFactory(AttributesSchemaInternal attributesSchema) {
+            return new DefaultSoftwareComponentFactory(attributesSchema);
         }
     }
 }

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -34,8 +34,10 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ComponentWithCoordinates;
+import org.gradle.api.component.ComponentWithEcosystems;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
+import org.gradle.api.ecosystem.Ecosystem;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
@@ -185,6 +187,7 @@ public class ModuleMetadataFileGenerator {
             jsonWriter.name("version");
             jsonWriter.value(coordinates.getVersion());
             writeAttributes(attributes, jsonWriter);
+            writeEcosystems(component, jsonWriter);
             jsonWriter.endObject();
         } else {
             ComponentData componentData = componentCoordinates.get(owner);
@@ -200,7 +203,27 @@ public class ModuleMetadataFileGenerator {
             jsonWriter.name("version");
             jsonWriter.value(ownerCoordinates.getVersion());
             writeAttributes(componentData.attributes, jsonWriter);
+            writeEcosystems(owner, jsonWriter);
             jsonWriter.endObject();
+        }
+    }
+
+    private void writeEcosystems(SoftwareComponent owner, JsonWriter jsonWriter) throws IOException {
+        if (owner instanceof ComponentWithEcosystems) {
+            jsonWriter.name("ecosystems");
+            jsonWriter.beginArray();
+            for (Ecosystem ecosystem : ((ComponentWithEcosystems) owner).getEcosystems()) {
+                jsonWriter.beginObject();
+                jsonWriter.name("name");
+                jsonWriter.value(ecosystem.getName());
+                String description = ecosystem.getDescription();
+                if (description != null) {
+                    jsonWriter.name("description");
+                    jsonWriter.value(description);
+                }
+                jsonWriter.endObject();
+            }
+            jsonWriter.endArray();
         }
     }
 


### PR DESCRIPTION
### Context

This PR introduces the concept of "ecosystem", that can be
registered on an attributes schema. When a component is published,
it may provide a list of ecosystems. This list is used by consumers
when resolving. If, for some reason, variant resolution fails, and
that the consumer didn't use a plugin which provides the expected
ecosystem, the error message will indicate that they probably
miss a plugin that understands that ecosystem.

This is useful when a plugin extends an existing ecosystem with
additional attributes, that consumers may not be aware of. In
this case it is expected that the plugin declares an ecosystem.

Currently the error message will only indicate what ecosystem
is missing, and an optional description. It will not tell _how_
such plugin can be found, nor what plugins provide it.

By default, for adhoc components, publishing will use the
ecosystems of the producer. For example, for a Java project,
the published Gradle metadata file will include the java
ecosystem requirement.

For components which are not adhoc, they must implement the
`ComponentWithEcosystems` interface in order to tell which
ecosystems are in use.
