### PR TITLE
Some initial support for @PathSensitive on the properties of a transform action

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValidationAccess.java
@@ -34,7 +34,7 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.internal.Cast;
 import org.gradle.internal.event.DefaultListenerManager;
-import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.instantiation.DefaultInstantiatorFactory;
 import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.internal.reflect.PropertyMetadata;
 import org.gradle.internal.service.DefaultServiceLocator;
@@ -75,8 +75,9 @@ public class PropertyValidationAccess {
         // For now, re-implement the discovery here
         builder.provider(new Object() {
             void configure(ServiceRegistration registration) {
-                registration.add(ListenerManager.class, new DefaultListenerManager());
+                registration.add(DefaultListenerManager.class, new DefaultListenerManager());
                 registration.add(DefaultCrossBuildInMemoryCacheFactory.class);
+                registration.add(DefaultInstantiatorFactory.class);
                 List<PluginServiceRegistry> pluginServiceFactories = new DefaultServiceLocator(false, getClass().getClassLoader()).getAll(PluginServiceRegistry.class);
                 for (PluginServiceRegistry pluginServiceFactory : pluginServiceFactories) {
                     pluginServiceFactory.registerGlobalServices(registration);
@@ -85,7 +86,7 @@ public class PropertyValidationAccess {
         });
         ServiceRegistry services = builder.build();
         taskClassInfoStore = services.get(TaskClassInfoStore.class);
-        metadataStore = services.get(InspectionScheme.class).getMetadataStore();
+        metadataStore = services.get(TaskScheme.class).getInspectionScheme().getMetadataStore();
     }
 
     @SuppressWarnings("unused")

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/TaskScheme.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/TaskScheme.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.properties;
+
+import org.gradle.internal.instantiation.InstantiationScheme;
+
+public class TaskScheme {
+    private final InstantiationScheme instantiationScheme;
+    private final InspectionScheme inspectionScheme;
+
+    public TaskScheme(InstantiationScheme instantiationScheme, InspectionScheme inspectionScheme) {
+        this.instantiationScheme = instantiationScheme;
+        this.inspectionScheme = inspectionScheme;
+    }
+
+    public InstantiationScheme getInstantiationScheme() {
+        return instantiationScheme;
+    }
+
+    public InspectionScheme getInspectionScheme() {
+        return inspectionScheme;
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathFingerprintingStrategy.java
@@ -93,6 +93,11 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
     }
 
     @Override
+    public String normalizePath(FileSystemLocationSnapshot snapshot) {
+        return "";
+    }
+
+    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(Iterable<FileSystemSnapshot> roots) {
         ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         HashSet<String> processedEntries = new HashSet<String>();
@@ -174,7 +179,6 @@ public class ClasspathFingerprintingStrategy extends AbstractFingerprintingStrat
             delegate.postVisitDirectory();
         }
     }
-
 
     @Nullable
     private HashCode fingerprintRootFile(RegularFileSnapshot fileSnapshot) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -64,6 +64,7 @@ import org.gradle.api.internal.tasks.DefaultTaskContainerFactory;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.internal.tasks.TaskStatistics;
+import org.gradle.api.internal.tasks.properties.TaskScheme;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.util.PatternSet;
 import org.gradle.configuration.ConfigurationTargetIdentifier;
@@ -188,8 +189,8 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return instantiator.newInstance(DefaultPluginManager.class, get(PluginRegistry.class), instantiatorFactory.inject(this), target, buildOperationExecutor, userCodeApplicationContext, decorator);
     }
 
-    protected ITaskFactory createTaskFactory(ITaskFactory parentFactory, InstantiatorFactory instantiatorFactory) {
-        return parentFactory.createChild(project, instantiatorFactory.injectAndDecorate(this));
+    protected ITaskFactory createTaskFactory(ITaskFactory parentFactory, TaskScheme taskScheme) {
+        return parentFactory.createChild(project, taskScheme.getInstantiationScheme().withServices(this));
     }
 
     protected TaskInstantiator createTaskInstantiator(ITaskFactory taskFactory) {

--- a/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/service/scopes/ProjectScopeServicesTest.groovy
@@ -46,6 +46,8 @@ import org.gradle.api.internal.project.taskfactory.ITaskFactory
 import org.gradle.api.internal.tasks.DefaultTaskContainer
 import org.gradle.api.internal.tasks.TaskContainerInternal
 import org.gradle.api.internal.tasks.TaskStatistics
+import org.gradle.api.internal.tasks.properties.InspectionScheme
+import org.gradle.api.internal.tasks.properties.TaskScheme
 import org.gradle.api.logging.LoggingManager
 import org.gradle.configuration.project.DefaultProjectConfigurationActionContainer
 import org.gradle.configuration.project.ProjectConfigurationActionContainer
@@ -54,6 +56,7 @@ import org.gradle.initialization.ProjectAccessListener
 import org.gradle.internal.Factory
 import org.gradle.internal.hash.FileHasher
 import org.gradle.internal.hash.StreamHasher
+import org.gradle.internal.instantiation.InstantiationScheme
 import org.gradle.internal.instantiation.InstantiatorFactory
 import org.gradle.internal.logging.LoggingManagerInternal
 import org.gradle.internal.nativeintegration.filesystem.FileSystem
@@ -64,7 +67,6 @@ import org.gradle.internal.service.ServiceRegistration
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.model.internal.inspect.ModelRuleExtractor
 import org.gradle.model.internal.inspect.ModelRuleSourceDetector
-import org.gradle.model.internal.registry.ModelRegistry
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.tooling.provider.model.internal.DefaultToolingModelBuilderRegistry
@@ -83,7 +85,6 @@ class ProjectScopeServicesTest extends Specification {
     PluginRegistry pluginRegistry = Mock() {
         createChild(_) >> Mock(PluginRegistry)
     }
-    ModelRegistry modelRegistry = Mock()
     ModelRuleSourceDetector modelRuleSourceDetector = Mock()
     def classLoaderScope = Mock(ClassLoaderScope)
     DependencyResolutionServices dependencyResolutionServices = Stub()
@@ -105,6 +106,7 @@ class ProjectScopeServicesTest extends Specification {
         parent.get(PluginRegistry) >> pluginRegistry
         parent.get(DependencyManagementServices) >> dependencyManagementServices
         parent.get(Instantiator) >> TestUtil.instantiatorFactory().decorateLenient()
+        parent.get(TaskScheme) >> new TaskScheme(Stub(InstantiationScheme), Stub(InspectionScheme))
         parent.get(FileSystem) >> Stub(FileSystem)
         parent.get(ProjectAccessListener) >> Stub(ProjectAccessListener)
         parent.get(FileLookup) >> Stub(FileLookup)
@@ -148,9 +150,7 @@ class ProjectScopeServicesTest extends Specification {
     }
 
     private expectTaskContainerCreated() {
-        def instantiator = Stub(Instantiator)
-        1 * instantiatorFactory.injectAndDecorate(registry) >> instantiator
-        1 * taskFactory.createChild({ it.is project }, instantiator) >> Stub(ITaskFactory)
+        1 * taskFactory.createChild({ it.is project }, _) >> Stub(ITaskFactory)
     }
 
     def "provides a ToolingModelBuilderRegistry"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformArtifactInputIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformArtifactInputIntegrationTest.groovy
@@ -1,0 +1,546 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.transform
+
+
+import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
+
+class ArtifactTransformArtifactInputIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
+    def "reruns transform when project artifact content or name or path changes"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        setupBuildWithConfigurableProducers()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+            
+            abstract class MakeGreen implements ArtifactTransformAction {
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":a:resolve")
+
+        then:
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerContent=new")
+        succeeds(":a:resolve")
+
+        then: // new content, should run
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerContent=new")
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerContent=new", "-PproducerOutputDir=out")
+        succeeds(":a:resolve")
+
+        then: // path has changed, should run
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerContent=new", "-PproducerOutputDir=out")
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerContent=new", "-PproducerOutputDir=out", "-PproducerFileName=blue")
+        succeeds(":a:resolve")
+
+        then: // new file name, should run
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b-blue.jar")
+        outputContains("processing c-blue.jar")
+        outputContains("result = [b-blue.jar.green, c-blue.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerContent=new", "-PproducerOutputDir=out", "-PproducerFileName=blue")
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b-blue.jar.green, c-blue.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // have already seen these artifacts before
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
+    def "reruns transform when input artifact changes from file to missing"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        setupBuildWithConfigurableProducers()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+            
+            abstract class MakeGreen implements ArtifactTransformAction {
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    if (input.exists()) {
+                        println "processing \${input.name}"
+                    } else {
+                        println "processing missing \${input.name}"
+                    }
+                    def output = outputs.file(input.name + ".green")
+                    output.text = "green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":a:resolve")
+
+        then:
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then:
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        succeeds(":a:resolve", "-PproduceNothing")
+
+        then:
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing missing b.jar")
+        outputContains("processing missing c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // seen these before
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
+    def "can attach @PathSensitive(NONE) to input artifact property for project artifact"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        setupBuildWithConfigurableProducers()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+            
+            abstract class MakeGreen implements ArtifactTransformAction {
+                @PathSensitive(PathSensitivity.NONE)
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.text + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":a:resolve")
+
+        then:
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("result = [b.green, c.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out")
+        succeeds(":a:resolve")
+
+        then: // path has changed, but should be up to date
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.green, c.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out", "-PproducerFileName=blue")
+        succeeds(":a:resolve")
+
+        then: // name has changed, but should be up to date
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.green, c.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out", "-PproducerFileName=blue", "-PproducerContent=new")
+        succeeds(":a:resolve")
+
+        then: // new content, should run
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b-blue.jar")
+        outputContains("processing c-blue.jar")
+        outputContains("result = [b-new.green, c-new.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out", "-PproducerFileName=blue", "-PproducerContent=new")
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b-new.green, c-new.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // have already seen these artifacts before
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.green, c.green]")
+    }
+
+    def "can attach @PathSensitive(NAME_ONLY) to input artifact property for project artifact"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        setupBuildWithConfigurableProducers()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+            
+            abstract class MakeGreen implements ArtifactTransformAction {
+                @PathSensitive(PathSensitivity.NAME_ONLY)
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":a:resolve")
+
+        then:
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b.jar")
+        outputContains("processing c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out")
+        succeeds(":a:resolve")
+
+        then: // path has changed, but should be up to date
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out", "-PproducerFileName=blue")
+        succeeds(":a:resolve")
+
+        then: // name has changed, should run
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b-blue.jar")
+        outputContains("processing c-blue.jar")
+        outputContains("result = [b-blue.jar.green, c-blue.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out", "-PproducerFileName=blue", "-PproducerContent=new")
+        succeeds(":a:resolve")
+
+        then: // new content, should run
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputContains("processing b-blue.jar")
+        outputContains("processing c-blue.jar")
+        outputContains("result = [b-blue.jar.green, c-blue.jar.green]")
+
+        when:
+        executer.withArguments("-PproducerOutputDir=out", "-PproducerFileName=blue", "-PproducerContent=new")
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksSkipped(":b:producer", ":c:producer")
+        outputDoesNotContain("processing")
+        outputContains("result = [b-blue.jar.green, c-blue.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // have already seen these artifacts before
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        outputDoesNotContain("processing")
+        outputContains("result = [b.jar.green, c.jar.green]")
+    }
+
+    def "can attach @PathSensitive(NONE) to input artifact property for external artifact"() {
+        setupBuildWithConfigurableProducers()
+        def lib1 = mavenRepo.module("group1", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib1.artifactFile.text = "lib"
+        def lib2 = mavenRepo.module("group2", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib2.artifactFile.text = "lib"
+        def lib3 = mavenRepo.module("group2", "lib", "1.1").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib3.artifactFile.text = "lib"
+        def lib4 = mavenRepo.module("group2", "lib2", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib4.artifactFile.text = "lib2"
+
+        buildFile << """
+            repositories {
+                maven { 
+                    url = '${mavenRepo.uri}' 
+                    metadataSources { gradleMetadata() }
+                }
+            }
+            dependencies {
+                if (project.hasProperty('externalCoords')) {
+                    implementation project.externalCoords
+                } else {
+                    implementation 'group1:lib:1.0'
+                }
+                implementation 'group2:lib2:1.0'
+            }
+            
+            abstract class MakeGreen implements ArtifactTransformAction {
+                @PathSensitive(PathSensitivity.NONE)
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.text + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":resolve")
+
+        then:
+        outputContains("processing lib-1.0.jar")
+        outputContains("processing lib2-1.0.jar")
+        outputContains("result = [lib.green, lib2.green]")
+
+        when:
+        succeeds(":resolve")
+
+        then: // no change, should be up-to-date
+        outputDoesNotContain("processing")
+        outputContains("result = [lib.green, lib2.green]")
+
+        when:
+        succeeds(":resolve", "-PexternalCoords=group2:lib:1.0")
+
+        then: // path change, should be up-to-date
+        outputDoesNotContain("processing")
+        outputContains("result = [lib.green, lib2.green]")
+
+        when:
+        succeeds(":resolve", "-PexternalCoords=group2:lib:1.1")
+
+        then: // name change, should be up-to-date
+        outputDoesNotContain("processing")
+        outputContains("result = [lib.green, lib2.green]")
+
+        when:
+        lib1.artifactFile.text = "new-lib"
+        succeeds(":resolve")
+
+        then: // content change, should run
+        outputContains("processing lib-1.0.jar")
+        outputDoesNotContain("processing lib2")
+        outputContains("result = [new-lib.green, lib2.green]")
+
+        when:
+        lib4.artifactFile.text = "new-lib"
+        succeeds(":resolve")
+
+        then: // duplicate content
+        outputDoesNotContain("processing")
+        outputContains("result = [new-lib.green]")
+    }
+
+    def "can attach @PathSensitive(NAME_ONLY) to input artifact property for external artifact"() {
+        setupBuildWithConfigurableProducers()
+        def lib1 = mavenRepo.module("group1", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib1.artifactFile.text = "lib"
+        def lib2 = mavenRepo.module("group2", "lib", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib2.artifactFile.text = "lib"
+        def lib3 = mavenRepo.module("group2", "lib", "1.1").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib3.artifactFile.text = "lib"
+        def lib4 = mavenRepo.module("group2", "lib2", "1.0").adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata().publish()
+        lib4.artifactFile.text = "lib2"
+
+        buildFile << """
+            repositories {
+                maven { 
+                    url = '${mavenRepo.uri}' 
+                    metadataSources { gradleMetadata() }
+                }
+            }
+            dependencies {
+                if (project.hasProperty('externalCoords')) {
+                    implementation project.externalCoords
+                } else {
+                    implementation 'group1:lib:1.0'
+                }
+                implementation 'group2:lib2:1.0'
+            }
+            
+            abstract class MakeGreen implements ArtifactTransformAction {
+                @PathSensitive(PathSensitivity.NAME_ONLY)
+                @PrimaryInput
+                abstract File getInput()
+                
+                void transform(ArtifactTransformOutputs outputs) {
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":resolve")
+
+        then:
+        outputContains("processing lib-1.0.jar")
+        outputContains("processing lib2-1.0.jar")
+        outputContains("result = [lib-1.0.jar.green, lib2-1.0.jar.green]")
+
+        when:
+        succeeds(":resolve")
+
+        then: // no change, should be up-to-date
+        outputDoesNotContain("processing")
+        outputContains("result = [lib-1.0.jar.green, lib2-1.0.jar.green]")
+
+        when:
+        succeeds(":resolve", "-PexternalCoords=group2:lib:1.0")
+
+        then: // path change, should be up-to-date
+        outputDoesNotContain("processing")
+        outputContains("result = [lib-1.0.jar.green, lib2-1.0.jar.green]")
+
+        when:
+        succeeds(":resolve", "-PexternalCoords=group2:lib:1.1")
+
+        then: // name change, should run
+        outputContains("processing lib-1.1.jar")
+        outputContains("result = [lib-1.1.jar.green, lib2-1.0.jar.green]")
+
+        when:
+        lib1.artifactFile.text = "new-lib"
+        succeeds(":resolve")
+
+        then: // content change, should run
+        outputContains("processing lib-1.0.jar")
+        outputDoesNotContain("processing lib2")
+        outputContains("result = [lib-1.0.jar.green, lib2-1.0.jar.green]")
+    }
+
+    /**
+     * Caller should provide an implementation of `MakeGreen` transform action
+     */
+    void setupBuildWithConfigurableProducers() {
+        setupBuildWithColorTransformAction()
+        buildFile << """
+            allprojects {
+                afterEvaluate {
+                    if (project.hasProperty('producerOutputDir')) {
+                        buildDir = project.file(producerOutputDir)
+                    }
+                    tasks.withType(Producer) {
+                        if (project.hasProperty('produceNothing')) {
+                            content = ""
+                        } else if (project.hasProperty('producerContent')) {
+                            content = project.name + '-' + project.producerContent
+                        } else {
+                            content = project.name
+                        }
+                        if (project.hasProperty('producerFileName')) {
+                            outputFile = layout.buildDir.file("\${project.name}-\${producerFileName}.jar")
+                        } else {
+                            outputFile = layout.buildDir.file("\${project.name}.jar")
+                        }
+                    }
+                }
+            }
+        """
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -23,7 +23,7 @@ import spock.lang.IgnoreIf
 /**
  * Ensures that artifact transform parameters are isolated from one another and the surrounding project state.
  */
-class ArtifactTransformIsolationTest extends AbstractHttpDependencyResolutionTest {
+class ArtifactTransformIsolationIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def setup() {
         settingsFile << """
             rootProject.name = 'root'

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -22,7 +22,7 @@ trait ArtifactTransformTestFixture {
     abstract TestFile getBuildFile()
 
     /**
-     * Each project produces 'blue' variants, and has a task that resolves the 'green' variant.
+     * Each project produces 'blue' variants, and has a `resolve` task that resolves the 'green' variant.
      * Caller will need to register transforms that produce 'green' from 'blue'
      */
     void setupBuildWithColorAttributes() {
@@ -37,7 +37,7 @@ allprojects {
         }
     }
     task producer(type: Producer) {
-        outputFile = file("build/\${project.name}.jar")
+        outputFile = layout.buildDir.file("\${project.name}.jar")
     }
     artifacts {
         implementation producer.outputFile
@@ -56,10 +56,17 @@ allprojects {
 class Producer extends DefaultTask {
     @OutputFile
     RegularFileProperty outputFile = project.objects.fileProperty()
+    @Input
+    String content = "content" // set to empty string to delete file
 
     @TaskAction
     def go() {
-        outputFile.get().asFile.text = "output"
+        def file = outputFile.get().asFile
+        if (content.empty) {
+            file.delete()
+        } else {
+            file.text = content
+        }
     }
 }
 
@@ -67,7 +74,7 @@ class Producer extends DefaultTask {
     }
 
     /**
-     * Each project produces 'blue' variants, and has a task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Each project produces 'blue' variants, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
      * Caller will need to provide an implementation of 'MakeGreen' transform action
      */
     void setupBuildWithColorTransformAction() {
@@ -85,7 +92,7 @@ allprojects {
     }
 
     /**
-     * Each project produces 'blue' variants, and has a task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Each project produces 'blue' variants, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
      * Caller will need to provide an implementation of 'MakeGreen' transform configuration and a `makeGreenParameters()` method to apply to the configuration object
      */
     void setupBuildWithColorTransform() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -17,15 +17,42 @@
 package org.gradle.integtests.resolve.transform
 
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.test.fixtures.maven.MavenModule
 
 trait ArtifactTransformTestFixture {
     abstract TestFile getBuildFile()
 
     /**
-     * Each project produces 'blue' variants, and has a `resolve` task that resolves the 'green' variant.
+     * Defines a 'blue' variant for the given module.
+     */
+    MavenModule withColorVariants(MavenModule module) {
+        module.adhocVariants().variant('runtime', [color: 'blue']).withModuleMetadata()
+        return module
+    }
+
+    /**
+     * Each project produces a 'blue' variant containing a single file, and has a `resolve` task that resolves the 'green' variant.
      * Caller will need to register transforms that produce 'green' from 'blue'
      */
     void setupBuildWithColorAttributes() {
+        setupBuildWithColorAttributes(new Builder())
+    }
+
+    /**
+     * Each project produces 'blue' variants and has a `resolve` task that resolves the 'green' variant. The 'blue' variant will contain
+     * whatever is defined by the given closure on the supplied {@link Builder}. Defaults to producing a file.
+     * Caller will need to register transforms that produce 'green' from 'blue'
+     */
+    void setupBuildWithColorAttributes(@DelegatesTo(Builder) Closure cl) {
+        def builder = new Builder()
+        builder.produceFiles()
+        cl.delegate = builder
+        cl.call()
+        setupBuildWithColorAttributes(builder)
+    }
+
+    void setupBuildWithColorAttributes(Builder builder) {
+
         buildFile << """
 import ${javax.inject.Inject.name}
 
@@ -36,11 +63,11 @@ allprojects {
             attributes.attribute(color, 'blue')
         }
     }
-    task producer(type: Producer) {
-        outputFile = layout.buildDir.file("\${project.name}.jar")
+    task producer(type: ${builder.producerTaskClassName}) {
+        ${builder.producerConfig}
     }
     artifacts {
-        implementation producer.outputFile
+        implementation producer.output
     }
     task resolve {
         def view = configurations.implementation.incoming.artifactView {
@@ -53,15 +80,15 @@ allprojects {
     }
 }
 
-class Producer extends DefaultTask {
+class FileProducer extends DefaultTask {
     @OutputFile
-    RegularFileProperty outputFile = project.objects.fileProperty()
+    final RegularFileProperty output = project.objects.fileProperty()
     @Input
     String content = "content" // set to empty string to delete file
 
     @TaskAction
     def go() {
-        def file = outputFile.get().asFile
+        def file = output.get().asFile
         if (content.empty) {
             file.delete()
         } else {
@@ -70,15 +97,45 @@ class Producer extends DefaultTask {
     }
 }
 
+class DirProducer extends DefaultTask {
+    @OutputDirectory
+    final DirectoryProperty output = project.objects.directoryProperty()
+    @Input
+    final ListProperty<String> names = project.objects.listProperty(String)
+    @Input
+    String content = "content" // set to empty string to delete directory
+
+    @TaskAction
+    def go() {
+        def dir = output.get().asFile
+        if (content.empty) {
+            project.delete(dir)
+        } else {
+            project.delete(dir)
+            dir.mkdirs()
+            names.get().forEach {
+                new File(dir, it).text = content
+            }
+        }
+    }
+}
 """
     }
 
     /**
-     * Each project produces 'blue' variants, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Each project produces a 'blue' variant that contains a single file, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
      * Caller will need to provide an implementation of 'MakeGreen' transform action
      */
     void setupBuildWithColorTransformAction() {
-        setupBuildWithColorAttributes()
+        setupBuildWithColorTransformAction {}
+    }
+
+    /**
+     * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Caller will need to provide an implementation of 'MakeGreen' transform action
+     */
+    void setupBuildWithColorTransformAction(@DelegatesTo(Builder) Closure cl) {
+        setupBuildWithColorAttributes(cl)
         buildFile << """
 allprojects {
     dependencies {
@@ -92,11 +149,24 @@ allprojects {
     }
 
     /**
-     * Each project produces 'blue' variants, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
-     * Caller will need to provide an implementation of 'MakeGreen' transform configuration and a `makeGreenParameters()` method to apply to the configuration object
+     * Each project produces a 'blue' variant containing a single file, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Caller will need to provide an implementation of 'MakeGreen' transform configuration. Does not apply any configuration to this type.
      */
     void setupBuildWithColorTransform() {
-        setupBuildWithColorAttributes()
+        setupBuildWithColorTransform {}
+    }
+
+    /**
+     * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
+     * Caller will need to provide an implementation of 'MakeGreen' transform configuration and use {@link TransformBuilder#paramsConfig(java.lang.String)} to specify the configuration to
+     * apply to the parameters.
+     */
+    void setupBuildWithColorTransform(@DelegatesTo(TransformBuilder) Closure cl) {
+        def builder = new TransformBuilder()
+        cl.delegate = builder
+        cl.call()
+
+        setupBuildWithColorAttributes(builder)
         buildFile << """
 allprojects { p ->
     dependencies {
@@ -104,11 +174,52 @@ allprojects { p ->
             from.attribute(color, 'blue')
             to.attribute(color, 'green')
             parameters {
-                makeGreenParameters(p, it)
+                ${builder.transformParamsConfig}
             }
         }
     }
 }
 """
+    }
+
+    static class Builder {
+        String producerTaskClassName
+        String producerConfig
+
+        Builder() {
+            produceFiles()
+        }
+
+        /**
+         * Specifies that each project produce a single file as output.
+         */
+        void produceFiles() {
+            producerTaskClassName = "FileProducer"
+            producerConfig = """
+                output = layout.buildDir.file("\${project.name}.jar")
+            """.stripIndent()
+        }
+
+        /**
+         * Specifies that each project produce a single directory as output.
+         */
+        void produceDirs() {
+            producerTaskClassName = "DirProducer"
+            producerConfig = """
+                output = layout.buildDir.dir("\${project.name}-dir")
+            """.stripIndent()
+        }
+    }
+
+    static class TransformBuilder extends Builder {
+        String transformParamsConfig = ""
+
+        /**
+         * Specifies the configuration that should be applied to the parameters object of the 'blue' -> 'green' artifact transform
+         * @param config
+         */
+        void params(String config) {
+            transformParamsConfig = config
+        }
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -98,12 +98,12 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                extension = 'green'
+            """)
+        }
         buildFile << """
-            def makeGreenParameters(project, params) {
-                params.extension = 'green'
-            }
-            
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -149,12 +149,12 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                extension = 'green'
+            """)
+        }
         buildFile << """
-            def makeGreenParameters(project, params) {
-                params.extension = 'green'
-            }
-            
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -199,12 +199,12 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                extension = 'green'
+            """)
+        }
         buildFile << """
-            def makeGreenParameters(project, params) {
-                params.extension = 'green'
-            }
-            
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -248,12 +248,12 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                extension = 'green'
+            """)
+        }
         buildFile << """
-            def makeGreenParameters(project, params) {
-                params.extension = 'green'
-            }
-            
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -303,12 +303,12 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                extension = 'green'
+            """)
+        }
         buildFile << """
-            def makeGreenParameters(project, params) {
-                params.extension = 'green'
-            }
-            
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -443,12 +443,12 @@ abstract class MakeGreen extends ArtifactTransform {
         settingsFile << """
             include 'a', 'b', 'c'
         """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                extension = 'green'
+            """)
+        }
         buildFile << """
-            def makeGreenParameters(project, params) {
-                params.extension = 'green'
-            }
-            
             project(':a') {
                 dependencies {
                     implementation project(':b')

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -20,10 +20,12 @@ import org.gradle.api.artifacts.transform.PrimaryInput
 import org.gradle.api.artifacts.transform.PrimaryInputDependencies
 import org.gradle.api.artifacts.transform.TransformParameters
 import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.Destroys
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
@@ -340,7 +342,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasCause("Property 'bad' is annotated with unsupported annotation @${annotation.simpleName}.")
 
         where:
-        annotation << [Input, InputFile, InputDirectory, OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues]
+        annotation << [Input, InputFile, InputDirectory, OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues, Console, Internal]
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -60,8 +60,6 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
             allprojects {
                 ext.inputFiles = files('a.txt', 'b.txt')
             }
-        """
-        buildFile << """
             
             project(':a') {
                 dependencies {
@@ -99,12 +97,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 dependencies {
                     tools 'test:tool-a:1.2'
                     tools 'test:tool-b:1.2'
-                }
-            }
-"""
-        buildFile << """
-            project(':a') {
-                dependencies {
+
                     implementation project(':b')
                     implementation project(':c')
                 }
@@ -132,8 +125,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 }
                 ext.inputFiles = files(tool.outputFile)                
             }
-        """
-        buildFile << """
+
             project(':a') {
                 dependencies {
                     implementation project(':b')
@@ -191,12 +183,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 dependencies {
                     tools project(':d')
                     tools project(':e')
-                }
-            }
-"""
-        buildFile << """
-            project(':a') {
-                dependencies {
+
                     implementation project(':b')
                     implementation project(':c')
                 }
@@ -254,12 +241,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 dependencies {
                     tools 'test:tool-a:1.2'
                     tools 'test:tool-b:1.2'
-                }
-            }
-"""
-        buildFile << """
-            project(':a') {
-                dependencies {
+
                     implementation project(':b')
                     implementation project(':c')
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -23,12 +23,11 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
      * Caller should add elements to the 'inputFiles' property to make them inputs to the transform
      */
     def setupBuildWithTransformFileInputs() {
-        buildFile << """
-            def makeGreenParameters(project, params) { 
-                params.someFiles.from { project.inputFiles }
-            }
-        """
-        setupBuildWithColorTransform()
+        setupBuildWithColorTransform {
+            params("""
+                someFiles.from { project.inputFiles }
+            """)
+        }
         buildFile << """
             @TransformAction(MakeGreenAction)
             interface MakeGreen {
@@ -120,10 +119,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         setupBuildWithTransformFileInputs()
         buildFile << """
             allprojects {
-                task tool(type: Producer) {
-                    outputFile = file("build/tool-\${project.name}.jar")
+                task tool(type: FileProducer) {
+                    output = file("build/tool-\${project.name}.jar")
                 }
-                ext.inputFiles = files(tool.outputFile)                
+                ext.inputFiles = files(tool.output)                
             }
 
             project(':a') {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -67,7 +67,9 @@ import org.gradle.api.internal.artifacts.repositories.DefaultBaseRepositoryFacto
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory;
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme;
 import org.gradle.api.internal.artifacts.transform.ArtifactTransformListener;
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformParameterScheme;
 import org.gradle.api.internal.artifacts.transform.ConsumerProvidedVariantFinder;
 import org.gradle.api.internal.artifacts.transform.DefaultArtifactTransforms;
 import org.gradle.api.internal.artifacts.transform.DefaultTransformationRegistrationFactory;
@@ -93,7 +95,6 @@ import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskResolver;
-import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.ProjectAccessListener;
@@ -279,12 +280,12 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             );
         }
 
-        TransformationRegistrationFactory createTransformationRegistrationFactory(IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, InstantiatorFactory instantiatorFactory, TransformerInvoker transformerInvoker, ValueSnapshotter valueSnapshotter, ProjectStateRegistry projectStateRegistry, DomainObjectContext domainObjectContext, ProjectFinder projectFinder, InspectionSchemeFactory inspectionSchemeFactory) {
-            return new DefaultTransformationRegistrationFactory(isolatableFactory, classLoaderHierarchyHasher, instantiatorFactory, transformerInvoker, valueSnapshotter, inspectionSchemeFactory, new DomainObjectProjectStateHandler(projectStateRegistry, domainObjectContext, projectFinder));
+        TransformationRegistrationFactory createTransformationRegistrationFactory(IsolatableFactory isolatableFactory, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, InstantiatorFactory instantiatorFactory, TransformerInvoker transformerInvoker, ValueSnapshotter valueSnapshotter, ProjectStateRegistry projectStateRegistry, DomainObjectContext domainObjectContext, ProjectFinder projectFinder, ArtifactTransformParameterScheme parameterScheme, ArtifactTransformActionScheme actionScheme) {
+            return new DefaultTransformationRegistrationFactory(isolatableFactory, classLoaderHierarchyHasher, transformerInvoker, valueSnapshotter, new DomainObjectProjectStateHandler(projectStateRegistry, domainObjectContext, projectFinder), parameterScheme, actionScheme);
         }
 
-        VariantTransformRegistry createArtifactTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory attributesFactory, ServiceRegistry services, TransformationRegistrationFactory transformationRegistrationFactory) {
-            return new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, services, transformationRegistrationFactory);
+        VariantTransformRegistry createArtifactTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory attributesFactory, ServiceRegistry services, TransformationRegistrationFactory transformationRegistrationFactory, ArtifactTransformParameterScheme parameterScheme) {
+            return new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, services, transformationRegistrationFactory, parameterScheme.getInstantiationScheme());
         }
 
         BaseRepositoryFactory createBaseRepositoryFactory(LocalMavenRepositoryLocator localMavenRepositoryLocator,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.transform.PrimaryInput;
 import org.gradle.api.artifacts.transform.PrimaryInputDependencies;
 import org.gradle.api.artifacts.transform.TransformParameters;
@@ -33,11 +34,28 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExternalModuleIvyDependencyDescriptorFactory;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ProjectIvyDependencyDescriptorFactory;
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformActionScheme;
+import org.gradle.api.internal.artifacts.transform.ArtifactTransformParameterScheme;
+import org.gradle.api.internal.artifacts.transform.PrimaryInputAnnotationHandler;
+import org.gradle.api.internal.artifacts.transform.PrimaryInputDependenciesAnnotationHandler;
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory;
 import org.gradle.api.internal.tasks.properties.annotations.NoOpPropertyAnnotationHandler;
 import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHandler;
+import org.gradle.api.tasks.Classpath;
+import org.gradle.api.tasks.CompileClasspath;
+import org.gradle.api.tasks.Console;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputDirectory;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.instantiation.DefaultInjectAnnotationHandler;
 import org.gradle.internal.instantiation.InjectAnnotationHandler;
+import org.gradle.internal.instantiation.InstantiationScheme;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.resource.ExternalResourceName;
 import org.gradle.internal.resource.connector.ResourceConnectorFactory;
@@ -45,8 +63,10 @@ import org.gradle.internal.resource.local.FileResourceConnector;
 import org.gradle.internal.resource.local.FileResourceRepository;
 import org.gradle.internal.resource.transport.file.FileConnectorFactory;
 
+import javax.inject.Inject;
+
 class DependencyManagementGlobalScopeServices {
-    FileResourceRepository createFileResourceRepository(FileSystem fileSystem){
+    FileResourceRepository createFileResourceRepository(FileSystem fileSystem) {
         return new FileResourceConnector(fileSystem);
     }
 
@@ -93,27 +113,33 @@ class DependencyManagementGlobalScopeServices {
         return ProducerGuard.adaptive();
     }
 
-    InjectAnnotationHandler createPrimaryInputAnnotationHandler() {
-        return new DefaultInjectAnnotationHandler(PrimaryInput.class);
+    PrimaryInputAnnotationHandler createPrimaryInputAnnotationHandler() {
+        return new PrimaryInputAnnotationHandler();
     }
 
-    InjectAnnotationHandler createPrimaryInputDependenciesAnnotationHandler() {
-        return new DefaultInjectAnnotationHandler(PrimaryInputDependencies.class);
+    PrimaryInputDependenciesAnnotationHandler createPrimaryInputDependenciesAnnotationHandler() {
+        return new PrimaryInputDependenciesAnnotationHandler();
     }
 
     InjectAnnotationHandler createTransformParametersAnnotationHandler() {
         return new DefaultInjectAnnotationHandler(TransformParameters.class);
     }
 
-    PropertyAnnotationHandler createPrimaryInputPropertyAnnotationHandler() {
-        return new NoOpPropertyAnnotationHandler(PrimaryInput.class);
-    }
-
-    PropertyAnnotationHandler createPrimaryInputDependenciesPropertyAnnotationHandler() {
-        return new NoOpPropertyAnnotationHandler(PrimaryInputDependencies.class);
-    }
-
     PropertyAnnotationHandler createTransformParametersPropertyAnnotationHandler() {
         return new NoOpPropertyAnnotationHandler(TransformParameters.class);
+    }
+
+    ArtifactTransformParameterScheme createArtifactTransformParameterScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {
+        // TODO - should decorate
+        InstantiationScheme instantiationScheme = instantiatorFactory.injectScheme();
+        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, Classpath.class, CompileClasspath.class, Nested.class, Inject.class, Console.class, Internal.class));
+        return new ArtifactTransformParameterScheme(instantiationScheme, inspectionScheme);
+    }
+
+    ArtifactTransformActionScheme createArtifactTransformActionScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {
+        InstantiationScheme instantiationScheme = instantiatorFactory.injectScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class));
+        InstantiationScheme legacyInstantiationScheme = instantiatorFactory.injectScheme();
+        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class, Inject.class));
+        return new ArtifactTransformActionScheme(instantiationScheme, inspectionScheme, legacyInstantiationScheme);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformActionScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformActionScheme.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.internal.instantiation.InstantiationScheme;
+
+public class ArtifactTransformActionScheme {
+    private final InstantiationScheme instantiationScheme;
+    private final InspectionScheme inspectionScheme;
+    private final InstantiationScheme legacyInstantiationScheme;
+
+    public ArtifactTransformActionScheme(InstantiationScheme instantiationScheme, InspectionScheme inspectionScheme, InstantiationScheme legacyInstantiationScheme) {
+        this.instantiationScheme = instantiationScheme;
+        this.inspectionScheme = inspectionScheme;
+        this.legacyInstantiationScheme = legacyInstantiationScheme;
+    }
+
+    public InspectionScheme getInspectionScheme() {
+        return inspectionScheme;
+    }
+
+    public InstantiationScheme getInstantiationScheme() {
+        return instantiationScheme;
+    }
+
+    public InstantiationScheme getLegacyInstantiationScheme() {
+        return legacyInstantiationScheme;
+    }
+}
+
+

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformParameterScheme.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ArtifactTransformParameterScheme.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.internal.tasks.properties.InspectionScheme;
+import org.gradle.internal.instantiation.InstantiationScheme;
+
+public class ArtifactTransformParameterScheme {
+    private final InstantiationScheme instantiationScheme;
+    private final InspectionScheme inspectionScheme;
+
+    public ArtifactTransformParameterScheme(InstantiationScheme instantiationScheme, InspectionScheme inspectionScheme) {
+        this.instantiationScheme = instantiationScheme;
+        this.inspectionScheme = inspectionScheme;
+    }
+
+    public InstantiationScheme getInstantiationScheme() {
+        return instantiationScheme;
+    }
+
+    public InspectionScheme getInspectionScheme() {
+        return inspectionScheme;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -16,32 +16,19 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.artifacts.transform.ArtifactTransformAction;
-import org.gradle.api.artifacts.transform.PrimaryInput;
-import org.gradle.api.artifacts.transform.PrimaryInputDependencies;
-import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.properties.DefaultParameterValidationContext;
-import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory;
 import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
 import org.gradle.api.internal.tasks.properties.TypeMetadataStore;
-import org.gradle.api.tasks.Classpath;
-import org.gradle.api.tasks.CompileClasspath;
-import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.InputDirectory;
-import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.InputFiles;
-import org.gradle.api.tasks.Nested;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
 import org.gradle.internal.instantiation.InstantiationScheme;
-import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.model.internal.type.ModelType;
@@ -55,32 +42,32 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
 
     private final IsolatableFactory isolatableFactory;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
-    private final InstantiatorFactory instantiatorFactory;
     private final TransformerInvoker transformerInvoker;
     private final ValueSnapshotter valueSnapshotter;
-    private final PropertyWalker propertyWalker;
+    private final PropertyWalker parametersPropertyWalker;
     private final DomainObjectProjectStateHandler domainObjectProjectStateHandler;
     private final TypeMetadataStore actionMetadataStore;
-    private final InstantiationScheme instantiationScheme;
+    private final InstantiationScheme actionInstantiationScheme;
+    private final InstantiationScheme legacyActionInstantiationScheme;
 
     public DefaultTransformationRegistrationFactory(
         IsolatableFactory isolatableFactory,
         ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
-        InstantiatorFactory instantiatorFactory,
         TransformerInvoker transformerInvoker,
         ValueSnapshotter valueSnapshotter,
-        InspectionSchemeFactory inspectionSchemeFactory,
-        DomainObjectProjectStateHandler domainObjectProjectStateHandler
+        DomainObjectProjectStateHandler domainObjectProjectStateHandler,
+        ArtifactTransformParameterScheme parameterScheme,
+        ArtifactTransformActionScheme actionScheme
     ) {
         this.isolatableFactory = isolatableFactory;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
-        this.instantiatorFactory = instantiatorFactory;
         this.transformerInvoker = transformerInvoker;
         this.valueSnapshotter = valueSnapshotter;
-        this.instantiationScheme = instantiatorFactory.injectScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class));
-        this.propertyWalker = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, Classpath.class, CompileClasspath.class, Nested.class)).getPropertyWalker();
+        this.actionInstantiationScheme = actionScheme.getInstantiationScheme();
+        this.actionMetadataStore = actionScheme.getInspectionScheme().getMetadataStore();
+        this.legacyActionInstantiationScheme = actionScheme.getLegacyInstantiationScheme();
+        this.parametersPropertyWalker = parameterScheme.getInspectionScheme().getPropertyWalker();
         this.domainObjectProjectStateHandler = domainObjectProjectStateHandler;
-        this.actionMetadataStore = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(PrimaryInput.class, PrimaryInputDependencies.class, TransformParameters.class)).getMetadataStore();
     }
 
     @Override
@@ -101,16 +88,16 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
             classLoaderHierarchyHasher,
             isolatableFactory,
             valueSnapshotter,
-            propertyWalker,
+            parametersPropertyWalker,
             domainObjectProjectStateHandler,
-            instantiationScheme);
+            actionInstantiationScheme);
 
         return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvoker));
     }
 
     @Override
     public ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransform> implementation, Object[] params) {
-        Transformer transformer = new LegacyTransformer(implementation, params, instantiatorFactory, from, classLoaderHierarchyHasher, isolatableFactory);
+        Transformer transformer = new LegacyTransformer(implementation, params, legacyActionInstantiationScheme, from, classLoaderHierarchyHasher, isolatableFactory);
         return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvoker));
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -71,7 +71,7 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final IsolatableFactory isolatableFactory;
     private final ValueSnapshotter valueSnapshotter;
-    private final PropertyWalker propertyWalker;
+    private final PropertyWalker parameterPropertyWalker;
     private final boolean requiresDependencies;
     private final InstanceFactory<? extends ArtifactTransformAction> instanceFactory;
     private final DomainObjectProjectStateHandler projectStateHandler;
@@ -80,14 +80,14 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
 
     private IsolatableParameters isolatable;
 
-    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker propertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme instantiationScheme) {
+    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
         super(implementationClass, fromAttributes);
         this.parameterObject = parameterObject;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.isolatableFactory = isolatableFactory;
         this.valueSnapshotter = valueSnapshotter;
-        this.propertyWalker = propertyWalker;
-        this.instanceFactory = instantiationScheme.forType(implementationClass);
+        this.parameterPropertyWalker = parameterPropertyWalker;
+        this.instanceFactory = actionInstantiationScheme.forType(implementationClass);
         this.requiresDependencies = instanceFactory.serviceInjectionTriggeredByAnnotation(PrimaryInputDependencies.class);
         this.projectStateHandler = projectStateHandler;
         this.isolationLock = projectStateHandler.newExclusiveOperationLock();
@@ -154,7 +154,7 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
 
         if (parameterObject != null) {
             // TODO wolfs - schedule fingerprinting separately, it can be done without having the project lock
-            fingerprintParameters(valueSnapshotter, propertyWalker, hasher, isolatableParameterObject.isolate());
+            fingerprintParameters(valueSnapshotter, parameterPropertyWalker, hasher, isolatableParameterObject.isolate());
         }
         HashCode secondaryInputsHash = hasher.hash();
         return new IsolatableParameters(isolatableParameterObject, secondaryInputsHash);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -41,12 +41,13 @@ import org.gradle.api.reflect.InjectionPointQualifier;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.exceptions.DefaultMultiCauseException;
+import org.gradle.internal.fingerprint.FingerprintingStrategy;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.instantiation.InstanceFactory;
-import org.gradle.internal.instantiation.Managed;
 import org.gradle.internal.instantiation.InstantiationScheme;
+import org.gradle.internal.instantiation.Managed;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.service.ServiceLookup;
@@ -68,6 +69,7 @@ import java.util.stream.Collectors;
 public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAction> {
 
     private final Object parameterObject;
+    private final FingerprintingStrategy fingerprintingStrategy;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final IsolatableFactory isolatableFactory;
     private final ValueSnapshotter valueSnapshotter;
@@ -80,9 +82,10 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
 
     private IsolatableParameters isolatable;
 
-    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
+    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, FingerprintingStrategy fingerprintingStrategy, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
         super(implementationClass, fromAttributes);
         this.parameterObject = parameterObject;
+        this.fingerprintingStrategy = fingerprintingStrategy;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.isolatableFactory = isolatableFactory;
         this.valueSnapshotter = valueSnapshotter;
@@ -103,6 +106,11 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
                 isolateExclusively();
             }
         };
+    }
+
+    @Override
+    public FingerprintingStrategy getPrimaryInputFingerprintingStrategy() {
+        return fingerprintingStrategy;
     }
 
     public boolean requiresDependencies() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -34,6 +34,7 @@ import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.internal.Cast;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.model.internal.type.ModelType;
@@ -48,13 +49,15 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
     private final ImmutableAttributesFactory immutableAttributesFactory;
     private final ServiceRegistry services;
     private final InstantiatorFactory instantiatorFactory;
+    private final InstantiationScheme parametersInstantiationScheme;
     private final TransformationRegistrationFactory registrationFactory;
 
-    public DefaultVariantTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory immutableAttributesFactory, ServiceRegistry services, TransformationRegistrationFactory registrationFactory) {
+    public DefaultVariantTransformRegistry(InstantiatorFactory instantiatorFactory, ImmutableAttributesFactory immutableAttributesFactory, ServiceRegistry services, TransformationRegistrationFactory registrationFactory, InstantiationScheme parametersInstantiationScheme) {
         this.instantiatorFactory = instantiatorFactory;
         this.immutableAttributesFactory = immutableAttributesFactory;
         this.services = services;
         this.registrationFactory = registrationFactory;
+        this.parametersInstantiationScheme = parametersInstantiationScheme;
     }
 
     @Override
@@ -76,8 +79,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
 
     @Override
     public <T> void registerTransform(Class<T> parameterType, Action<? super ParameterizedArtifactTransformSpec<T>> registrationAction) {
-        // TODO - should decorate
-        T parameterObject = instantiatorFactory.inject(services).newInstance(parameterType);
+        T parameterObject = parametersInstantiationScheme.withServices(services).newInstance(parameterType);
         TypedRegistration<T> registration = Cast.uncheckedNonnullCast(instantiatorFactory.decorateLenient().newInstance(TypedRegistration.class, parameterObject, immutableAttributesFactory));
         registrationAction.execute(registration);
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
+import org.gradle.internal.fingerprint.FingerprintingStrategy;
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
@@ -74,6 +76,11 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
     @Override
     public HashCode getSecondaryInputHash() {
         return secondaryInputsHash;
+    }
+
+    @Override
+    public FingerprintingStrategy getPrimaryInputFingerprintingStrategy() {
+        return AbsolutePathFingerprintingStrategy.INCLUDE_MISSING;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -25,7 +25,7 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
-import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.isolation.Isolatable;
 import org.gradle.internal.isolation.IsolatableFactory;
 import org.gradle.internal.reflect.Instantiator;
@@ -39,9 +39,9 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
     private final HashCode secondaryInputsHash;
     private final Isolatable<Object[]> isolatableParameters;
 
-    public LegacyTransformer(Class<? extends ArtifactTransform> implementationClass, Object[] parameters, InstantiatorFactory instantiatorFactory, ImmutableAttributes fromAttributes, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory) {
+    public LegacyTransformer(Class<? extends ArtifactTransform> implementationClass, Object[] parameters, InstantiationScheme actionInstantiationScheme, ImmutableAttributes fromAttributes, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory) {
         super(implementationClass, fromAttributes);
-        this.instantiator = instantiatorFactory.inject();
+        this.instantiator = actionInstantiationScheme.instantiator();
         this.isolatableParameters = isolatableFactory.isolate(parameters);
         this.secondaryInputsHash = hashSecondaryInputs(isolatableParameters, implementationClass, classLoaderHierarchyHasher);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/PrimaryInputAnnotationHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/PrimaryInputAnnotationHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.transform.PrimaryInput;
+import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
+import org.gradle.api.internal.tasks.properties.annotations.AbstractInputFilePropertyAnnotationHandler;
+import org.gradle.internal.instantiation.InjectAnnotationHandler;
+
+import java.lang.annotation.Annotation;
+
+public class PrimaryInputAnnotationHandler extends AbstractInputFilePropertyAnnotationHandler implements InjectAnnotationHandler {
+    @Override
+    public Class<? extends Annotation> getAnnotationType() {
+        return PrimaryInput.class;
+    }
+
+    @Override
+    public Class<? extends Annotation> getAnnotation() {
+        return PrimaryInput.class;
+    }
+
+    @Override
+    protected InputFilePropertyType getFilePropertyType() {
+        return InputFilePropertyType.FILE;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/PrimaryInputDependenciesAnnotationHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/PrimaryInputDependenciesAnnotationHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.transform;
+
+import org.gradle.api.artifacts.transform.PrimaryInputDependencies;
+import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
+import org.gradle.api.internal.tasks.properties.annotations.AbstractInputFilePropertyAnnotationHandler;
+import org.gradle.internal.instantiation.InjectAnnotationHandler;
+
+import java.lang.annotation.Annotation;
+
+public class PrimaryInputDependenciesAnnotationHandler extends AbstractInputFilePropertyAnnotationHandler implements InjectAnnotationHandler {
+    @Override
+    public Class<? extends Annotation> getAnnotationType() {
+        return PrimaryInputDependencies.class;
+    }
+
+    @Override
+    public Class<? extends Annotation> getAnnotation() {
+        return PrimaryInputDependencies.class;
+    }
+
+    @Override
+    protected InputFilePropertyType getFilePropertyType() {
+        return InputFilePropertyType.FILES;
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -21,6 +21,7 @@ import org.gradle.api.Describable;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.internal.fingerprint.FingerprintingStrategy;
 import org.gradle.internal.hash.HashCode;
 
 import java.io.File;
@@ -50,4 +51,6 @@ public interface Transformer extends Describable, TaskDependencyContainer {
     HashCode getSecondaryInputHash();
 
     void isolateParameters();
+
+    FingerprintingStrategy getPrimaryInputFingerprintingStrategy();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -31,7 +31,9 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.execution.TestExecutionHistoryStore
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter
+import org.gradle.internal.fingerprint.FingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprinter
+import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.service.ServiceRegistry
@@ -132,6 +134,11 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         @Override
         HashCode getSecondaryInputHash() {
             return secondaryInputsHash
+        }
+
+        @Override
+        FingerprintingStrategy getPrimaryInputFingerprintingStrategy() {
+            return AbsolutePathFingerprintingStrategy.INCLUDE_MISSING
         }
 
         @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistryTest.groovy
@@ -24,7 +24,6 @@ import org.gradle.api.artifacts.transform.VariantTransformConfigurationException
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.internal.DynamicObjectAware
 import org.gradle.api.internal.tasks.properties.InspectionScheme
-import org.gradle.api.internal.tasks.properties.InspectionSchemeFactory
 import org.gradle.api.internal.tasks.properties.PropertyWalker
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
@@ -51,17 +50,15 @@ class DefaultVariantTransformRegistryTest extends Specification {
     def transformerInvoker = Mock(TransformerInvoker)
     def valueSnapshotter = Mock(ValueSnapshotter)
     def propertyWalker = Mock(PropertyWalker)
-    def inspectionSchemeFactory = Stub(InspectionSchemeFactory) {
-        inspectionScheme(_) >> Stub(InspectionScheme) {
-            getPropertyWalker() >> propertyWalker
-        }
+    def inspectionScheme = Stub(InspectionScheme) {
+        getPropertyWalker() >> propertyWalker
     }
     def isolatableFactory = new TestIsolatableFactory()
     def classLoaderHierarchyHasher = Mock(ClassLoaderHierarchyHasher)
     def attributesFactory = AttributeTestUtil.attributesFactory()
     def domainObjectContextProjectStateHandler = Mock(DomainObjectProjectStateHandler)
-    def registryFactory = new DefaultTransformationRegistrationFactory(isolatableFactory, classLoaderHierarchyHasher, instantiatorFactory, transformerInvoker, valueSnapshotter, inspectionSchemeFactory, domainObjectContextProjectStateHandler)
-    def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, Stub(ServiceRegistry), registryFactory)
+    def registryFactory = new DefaultTransformationRegistrationFactory(isolatableFactory, classLoaderHierarchyHasher, transformerInvoker, valueSnapshotter, domainObjectContextProjectStateHandler, new ArtifactTransformParameterScheme(instantiatorFactory.injectScheme(), inspectionScheme), new ArtifactTransformActionScheme(instantiatorFactory.injectScheme(), inspectionScheme, instantiatorFactory.injectScheme()))
+    def registry = new DefaultVariantTransformRegistry(instantiatorFactory, attributesFactory, Stub(ServiceRegistry), registryFactory, instantiatorFactory.injectScheme())
 
     def "setup"() {
         _ * classLoaderHierarchyHasher.getClassLoaderHash(_) >> HashCode.fromInt(123)

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiatorFactory.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/InstantiatorFactory.java
@@ -29,23 +29,30 @@ import java.util.Collection;
  */
 public interface InstantiatorFactory {
     /**
-     * Creates an {@link Instantiator} that can inject services and user provided values into the instances it creates, but does not decorate the instances.
+     * Creates an {@link Instantiator} that can inject services and user provided values into the instances it creates, but does not decorate the instances. Is not lenient.
      *
-     * <p>Use for any non-model types for which services or user provided constructor values need to injected.
+     * <p>Use for any non-model types for which services or user provided constructor values need to injected. This is simply a convenience for {@link #injectScheme()}.
      *
      * @param services The services to make available to instances.
      */
     Instantiator inject(ServiceLookup services);
 
     /**
-     * Creates an {@link Instantiator} that can inject user provided values into the instances it creates, but does not decorate the instances.
+     * Creates an {@link Instantiator} that can inject user provided values into the instances it creates, but does not decorate the instances. Is not lenient.
      *
-     * <p>Use for any non-model types for which user provided values, but no services, need to be injected. This is simply a convenience for {@link #inject(ServiceLookup)}.
+     * <p>Use for any non-model types for which user provided values, but no services, need to be injected. This is simply a convenience for {@link #injectScheme()}.
      */
     Instantiator inject();
 
     /**
-     * Create an {@link InstantiationScheme} that can inject services and user provided values into the instances it creates, but does not decorate the instances. Supports using the {@link javax.inject.Inject} annotation plus the given custom inject annotations.
+     * Create an {@link InstantiationScheme} that can inject services and user provided values into the instances it creates, but does not decorate the instances. Supports using the {@link javax.inject.Inject} annotation only. Is not lenient.
+     *
+     * <p>Use for any non-model types for which services or user provided constructor values need to injected.
+     */
+    InstantiationScheme injectScheme();
+
+    /**
+     * Create an {@link InstantiationScheme} that can inject services and user provided values into the instances it creates, but does not decorate the instances. Supports using the {@link javax.inject.Inject} annotation plus the given custom inject annotations. Is not lenient.
      *
      * @param injectAnnotations Zero or more annotations that mark properties whose value will be injected on creation. Each annotation must be known to this factory via a {@link InjectAnnotationHandler}.
      */
@@ -74,27 +81,25 @@ public interface InstantiatorFactory {
     Instantiator injectLenient();
 
     /**
-     * Creates an {@link Instantiator} that decorates the instances created.
-     *
-     * <p>Use for any model types for which no user provided constructor values or services need to be injected. This is a convenience for {@link #injectAndDecorateLenient(ServiceLookup)} and will also be retired.
-     */
-    Instantiator decorateLenient();
-
-    /**
      * Creates an {@link Instantiator} that can inject services and user provided values into the instances it creates and also decorates the instances.
      *
-     * <p>Use for any model types for which services or user provided constructor values need to injected.
+     * <p>Use for any model types for which services or user provided constructor values need to injected. This is simply a convenient for {@link #decorateScheme()}.
      *
      * @param services The services to make available to instances.
      */
     Instantiator injectAndDecorate(ServiceLookup services);
 
     /**
-     * Creates an {@link Instantiator} that can inject user provided values into the instances it creates and also decorates the instances.
-     *
-     * <p>Use for any model types for which services or user provided constructor values need to injected.
+     * Create an {@link InstantiationScheme} that can inject services and user provided values into the instances it creates and also decorates the instances. Supports using the {@link javax.inject.Inject} annotation only. Is not lenient.
      */
-    Instantiator injectAndDecorate();
+    InstantiationScheme decorateScheme();
+
+    /**
+     * Creates an {@link Instantiator} that decorates the instances created.
+     *
+     * <p>Use for any model types for which no user provided constructor values or services need to be injected. This is a convenience for {@link #injectAndDecorateLenient(ServiceLookup)} and will also be retired.
+     */
+    Instantiator decorateLenient();
 
     /**
      * Creates an {@link Instantiator} that can inject services and user provided values into the instances it creates and also decorates the instances.

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiatorFactoryTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/DefaultInstantiatorFactoryTest.groovy
@@ -41,9 +41,11 @@ class DefaultInstantiatorFactoryTest extends Specification {
         instantiatorFactory.injectScheme([Annotation2, Annotation1]).is(instantiatorFactory.injectScheme([Annotation1, Annotation2]))
     }
 
-    def "uses Instantiator from inject scheme"() {
+    def "uses Instantiators from inject schemes"() {
         expect:
+        instantiatorFactory.injectScheme().instantiator().is(instantiatorFactory.inject())
         instantiatorFactory.injectScheme([]).instantiator().is(instantiatorFactory.inject())
+        !instantiatorFactory.decorateScheme().instantiator().is(instantiatorFactory.inject())
     }
 
     def "fails for unknown annotation"() {

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/FingerprintingStrategy.java
@@ -41,4 +41,6 @@ public interface FingerprintingStrategy {
     String getIdentifier();
 
     CurrentFileCollectionFingerprint getEmptyFingerprint();
+
+    String normalizePath(FileSystemLocationSnapshot snapshot);
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintingStrategy.java
@@ -43,6 +43,11 @@ public class AbsolutePathFingerprintingStrategy extends AbstractFingerprintingSt
     }
 
     @Override
+    public String normalizePath(FileSystemLocationSnapshot snapshot) {
+        return snapshot.getAbsolutePath();
+    }
+
+    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(Iterable<FileSystemSnapshot> roots) {
         final ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         final HashSet<String> processedEntries = new HashSet<String>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -40,6 +40,11 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
     }
 
     @Override
+    public String normalizePath(FileSystemLocationSnapshot snapshot) {
+        return "";
+    }
+
+    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(Iterable<FileSystemSnapshot> roots) {
         final ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         final HashSet<String> processedEntries = new HashSet<String>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NameOnlyFingerprintingStrategy.java
@@ -40,6 +40,11 @@ public class NameOnlyFingerprintingStrategy extends AbstractFingerprintingStrate
     }
 
     @Override
+    public String normalizePath(FileSystemLocationSnapshot snapshot) {
+        return snapshot.getName();
+    }
+
+    @Override
     public Map<String, FileSystemLocationFingerprint> collectFingerprints(Iterable<FileSystemSnapshot> roots) {
         final ImmutableMap.Builder<String, FileSystemLocationFingerprint> builder = ImmutableMap.builder();
         final HashSet<String> processedEntries = new HashSet<String>();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/RelativePathFingerprintingStrategy.java
@@ -18,6 +18,7 @@ package org.gradle.internal.fingerprint.impl;
 
 import com.google.common.collect.ImmutableMap;
 import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.internal.file.FileType;
 import org.gradle.internal.fingerprint.FileSystemLocationFingerprint;
 import org.gradle.internal.snapshot.DirectorySnapshot;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
@@ -39,6 +40,15 @@ public class RelativePathFingerprintingStrategy extends AbstractFingerprintingSt
     public RelativePathFingerprintingStrategy(StringInterner stringInterner) {
         super("RELATIVE_PATH", NormalizedPathFingerprintCompareStrategy.INSTANCE);
         this.stringInterner = stringInterner;
+    }
+
+    @Override
+    public String normalizePath(FileSystemLocationSnapshot snapshot) {
+        if (snapshot.getType() == FileType.Directory) {
+            return "";
+        } else {
+            return snapshot.getName();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Context

Some initial support for `@PathSensitive` on the primary input property of an artifact transform action.

The implementation adds a bunch of duplication that should be refactored out in a later PR. It also does not support `Relative` sensitivity correctly yet.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
