### PR TITLE
Clarify licensing in connection with the Application Plugin

### DIFF
--- a/subprojects/docs/src/docs/userguide/application_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/application_plugin.adoc
@@ -150,6 +150,11 @@ include::sample[dir="application/groovy",files="build.gradle[tags=executableDir-
 include::sample[dir="application/kotlin",files="build.gradle.kts[tags=executableDir-conf]"]
 ====
 
+[[sec:application_licensing]]
+== Licensing
+
+The Gradle start scripts that are bundled with your application are licensed under the https://www.apache.org/licenses/LICENSE-2.0[Apache 2.0 Software License]. This does not affect your application, which you can license as you choose.
+
 [[sec:application_convention_properties]]
 == Convention properties (deprecated)
 

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/ApplicationIntegrationSpec.groovy
@@ -305,11 +305,11 @@ installDist.destinationDir = buildDir
         then:
         File generatedWindowsStartScript = file("build/scripts/application.bat")
         generatedWindowsStartScript.exists()
-        assertLineSeparators(generatedWindowsStartScript, TextUtil.windowsLineSeparator, 84)
+        assertLineSeparators(generatedWindowsStartScript, TextUtil.windowsLineSeparator, 100)
 
         File generatedLinuxStartScript = file("build/scripts/application")
         generatedLinuxStartScript.exists()
-        assertLineSeparators(generatedLinuxStartScript, TextUtil.unixLineSeparator, 172)
+        assertLineSeparators(generatedLinuxStartScript, TextUtil.unixLineSeparator, 188)
         assertLineSeparators(generatedLinuxStartScript, TextUtil.windowsLineSeparator, 1)
 
         file("build/scripts/application").exists()

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -1,5 +1,21 @@
 #!/usr/bin/env sh
 
+#
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 ##############################################################################
 ##
 ##  ${applicationName} start up script for UN*X

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/windowsStartScript.txt
@@ -1,3 +1,19 @@
+@rem
+@rem Copyright 2015 the original author or authors.
+@rem
+@rem Licensed under the Apache License, Version 2.0 (the "License");
+@rem you may not use this file except in compliance with the License.
+@rem You may obtain a copy of the License at
+@rem
+@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem
+@rem Unless required by applicable law or agreed to in writing, software
+@rem distributed under the License is distributed on an "AS IS" BASIS,
+@rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+@rem See the License for the specific language governing permissions and
+@rem limitations under the License.
+@rem
+
 @if "%DEBUG%" == "" @echo off
 @rem ##########################################################################
 @rem

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/UnixStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class UnixStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.unixLineSeparator).length == 172
+        destination.toString().split(TextUtil.unixLineSeparator).length == 188
     }
 
     def "defaultJvmOpts is expanded properly in unix script"() {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/plugins/WindowsStartScriptGeneratorTest.groovy
@@ -46,7 +46,7 @@ class WindowsStartScriptGeneratorTest extends Specification {
         generator.generateScript(details, destination)
 
         then:
-        destination.toString().split(TextUtil.windowsLineSeparator).length == 84
+        destination.toString().split(TextUtil.windowsLineSeparator).length == 100
     }
 
     def "defaultJvmOpts is expanded properly in windows script"() {


### PR DESCRIPTION
This adds ASL 2.0 to the application start scripts (Unix and Windows) and also
clarifies that the plugin does not affect what license you can use for an
application that's packaged with them.

Resolves issue #8151.
