### PR TITLE
Fix Asciidoctor deprecation warnings

### DIFF
--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api("com.google.guava:guava:26.0-jre")
-    api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.9.2")
+    api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
 
     implementation(project(":buildPlatform"))
     implementation("org.asciidoctor:asciidoctorj:1.5.8.1")

--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -352,6 +352,7 @@ def distDocs = tasks.register("distDocs", CacheableAsciidoctorTask) {
 }
 
 asciidoctorj {
+    version = '1.5.8.1'
     noDefaultRepositories = true
 }
 


### PR DESCRIPTION
This meant upgrading to version 1.5.10 of the Asciidoctor Gradle Plugin and
*also* specifying the version of AsciidoctorJ to use in the build because
version 1.5.10 of the plugin uses a version of AsciidoctorJ that is binary
incompatible with our Asciidoctor extension.
