### PR TITLE
Make capability conflict errors lenient

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ResolveConfigurationDependenciesBuildOperationIntegrationTest.groovy
@@ -397,9 +397,8 @@ class ResolveConfigurationDependenciesBuildOperationIntegrationTest extends Abst
         def op = operations.first(ResolveConfigurationDependenciesBuildOperationType)
         op.details.configurationName == "compile"
         op.failure == "org.gradle.api.artifacts.ResolveException: Could not resolve all dependencies for configuration ':compile'."
-        failure.assertHasCause("""A conflict was found between the following modules:
-  - org:leaf:1.0
-  - org:leaf:2.0""")
+        failure.assertHasCause("""Conflict(s) found for the following module(s):
+  - org:leaf between versions 1.0 and 2.0""")
         op.result != null
         op.result.resolvedDependenciesCount == 2
     }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/VersionConflictResolutionIntegrationTest.groovy
@@ -70,7 +70,7 @@ project(':tool') {
 
         expect:
         runAndFail("tool:dependencies")
-        failure.assertThatCause(containsString('A conflict was found between the following modules:'))
+        failure.assertThatCause(containsString('Conflict(s) found for the following module(s):'))
     }
 
     void "strict conflict resolution should pass when no conflicts"() {
@@ -1104,7 +1104,7 @@ task checkDeps(dependsOn: configurations.compile) {
         fails 'checkDeps'
 
         then:
-        failure.assertThatCause(containsString('A conflict was found between the following modules:'))
+        failure.assertThatCause(containsString('Conflict(s) found for the following module(s):'))
     }
 
     def "upgrades version when one of the ranges is disjoint"() {
@@ -1175,7 +1175,7 @@ task checkDeps(dependsOn: configurations.compile) {
         fails 'checkDeps'
 
         then:
-        failure.assertThatCause(containsString('A conflict was found between the following modules:'))
+        failure.assertThatCause(containsString('Conflict(s) found for the following module(s):'))
     }
 
     def "chooses highest version of all versions fully included within range"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -199,7 +199,8 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Cannot choose between org:test:1.0 variant api and org:test:1.0 variant runtime because they provide the same capability: org:test:1.0""")
+        failure.assertHasCause("""Module 'org:test' has been rejected:
+   Cannot select module with conflict on capability 'org:test:1.0' also provided by [org:test:1.0(api), org:test:1.0(runtime)]""")
     }
 
     @RequiredFeatures(

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/MultipleVariantSelectionIntegrationTest.groovy
@@ -198,7 +198,8 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("Cannot choose between org:test:1.0 variant api and org:test:1.0 variant runtime because they provide the same capability: org:test:1.0")
+        failure.assertHasCause("""Module 'org:test' has been rejected:
+   Cannot select module with conflict on capability 'org:test:1.0' also provided by [org:test:1.0(api), org:test:1.0(runtime)]""")
     }
 
     @Unroll("can select distinct variants of the same component by using different attributes with capabilities (conflict=#conflict)")
@@ -255,7 +256,8 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
 
         then:
         if (conflict) {
-            failure.assertHasCause("Cannot choose between org:test:1.0 variant api and org:test:1.0 variant runtime because they provide the same capability: org.test:cap:1.0")
+            failure.assertHasCause("""Module 'org:test' has been rejected:
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:test:1.0(runtime), org:test:1.0(api)]""")
         } else {
             resolve.expectGraph {
                 root(":", ":test:") {
@@ -512,7 +514,8 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("Cannot choose between org:foo:1.1 variant api and org:foo:1.1 variant runtime because they provide the same capability: org:foo:1.1")
+        failure.assertHasCause("""Module 'org:foo' has been rejected:
+   Cannot select module with conflict on capability 'org:foo:1.1' also provided by [org:foo:1.1(runtime), org:foo:1.1(api)]""")
 
     }
 
@@ -676,7 +679,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause('Cannot choose between org:bar:1.0 and org:foo:1.0 because they provide the same capability: org:foo:1.0')
+        failure.assertHasCause("""Module 'org:foo' has been rejected:
+   Cannot select module with conflict on capability 'org:foo:1.0' also provided by [org:bar:1.0(runtime)]""")
+        failure.assertHasCause("""Module 'org:bar' has been rejected:
+   Cannot select module with conflict on capability 'org:foo:1.0' also provided by [org:foo:1.0(runtime)]""")
     }
 
     def "detects conflicts between 2 variants of 2 different components with the same capability"() {
@@ -722,7 +728,10 @@ class MultipleVariantSelectionIntegrationTest extends AbstractModuleDependencyRe
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause('Cannot choose between org:bar:1.0 and org:foo:1.0 because they provide the same capability: org:blah:1.0')
+        failure.assertHasCause("""Module 'org:foo' has been rejected:
+   Cannot select module with conflict on capability 'org:blah:1.0' also provided by [org:bar:1.0(runtime)]""")
+        failure.assertHasCause("""Module 'org:bar' has been rejected:
+   Cannot select module with conflict on capability 'org:blah:1.0' also provided by [org:foo:1.0(runtime)]""")
     }
 
     @Ignore

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesLocalComponentIntegrationTest.groovy
@@ -48,10 +48,11 @@ class CapabilitiesLocalComponentIntegrationTest extends AbstractIntegrationSpec 
         """
 
         when:
-        fails 'dependencies'
+        fails 'compileJava'
 
         then:
-        failure.assertHasCause("Cannot choose between :test:unspecified and test:b:unspecified because they provide the same capability: org:capability:1.0")
+        failure.assertHasCause("""Module 'test:b' has been rejected:
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(compileClasspath)]""")
     }
 
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesRulesIntegrationTest.groovy
@@ -66,7 +66,14 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause("Cannot choose between cglib:cglib-nodep:3.2.5 and cglib:cglib:3.2.5 because they provide the same capability: cglib:cglib:3.2.5")
+        def variant = 'runtime'
+        if (!isGradleMetadataEnabled() && useIvy()) {
+            variant = 'default'
+        }
+        failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5($variant)]""")
+        failure.assertHasCause("""Module 'cglib:cglib' has been rejected:
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5($variant)]""")
     }
 
     def "can detect conflict with capability in different versions and upgrade automatically to latest version"() {
@@ -168,7 +175,8 @@ class CapabilitiesRulesIntegrationTest extends AbstractModuleDependencyResolveTe
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause("Cannot choose between :test:unspecified and org:test:1.0 because they provide the same capability: org:capability:1.0")
+        failure.assertHasCause("""Module 'org:test' has been rejected:
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(conf)]""")
     }
 
     @RequiredFeatures(

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -107,7 +107,12 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 }
             }
         } else {
-            failure.assertHasCause("Cannot choose between cglib:cglib-nodep:3.2.5 and cglib:cglib:3.2.5 because they provide the same capability: cglib:cglib:3.2.5")
+            def variant = 'runtime'
+            if (!isGradleMetadataEnabled() && useIvy()) {
+                variant = 'default'
+            }
+            failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5($variant)]""")
         }
 
         where:
@@ -217,7 +222,16 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             }
         } else {
             fails ':checkDeps'
-            failure.assertHasCause("Cannot choose between org.apache:groovy-all:1.0 and org.apache:groovy:1.0 because they provide the same capability: org.apache:groovy:1.0")
+            def variant = 'runtime'
+            if (!isGradleMetadataEnabled() && useIvy()) {
+                variant = 'default'
+            }
+            failure.assertHasCause("""Module 'org.apache:groovy' has been rejected:
+   Cannot select module with conflict on capability 'org.apache:groovy:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+            failure.assertHasCause("""Module 'org.apache:groovy-json' has been rejected:
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+            failure.assertHasCause("""Module 'org.apache:groovy-all' has been rejected:
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-json:1.0($variant)]""")
         }
 
         where:
@@ -330,7 +344,16 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
             }
         } else {
             fails ':checkDeps'
-            failure.assertHasCause("Cannot choose between org.apache:groovy-all:1.0 and org.apache:groovy:1.0 because they provide the same capability: org.apache:groovy:1.0")
+            def variant = 'runtime'
+            if (!isGradleMetadataEnabled() && useIvy()) {
+                variant = 'default'
+            }
+            failure.assertHasCause("""Module 'org.apache:groovy' has been rejected:
+   Cannot select module with conflict on capability 'org.apache:groovy:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+            failure.assertHasCause("""Module 'org.apache:groovy-json' has been rejected:
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-all:1.0($variant)]""")
+            failure.assertHasCause("""Module 'org.apache:groovy-all' has been rejected:
+   Cannot select module with conflict on capability 'org.apache:groovy-json:1.0' also provided by [org.apache:groovy-json:1.0($variant)]""")
         }
 
         where:
@@ -480,7 +503,10 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
                 }
             }
         } else {
-            failure.assertHasCause("Cannot choose between org:testA:1.0 and org:testB:1.0 because they provide the same capability: org.test:cap:1.0")
+            failure.assertHasCause("""Module 'org:testA' has been rejected:
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testB:1.0(runtime)]""")
+            failure.assertHasCause("""Module 'org:testB' has been rejected:
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testA:1.0(runtime)]""")
         }
 
         where:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/CapabilitiesUseCasesIntegrationTest.groovy
@@ -392,7 +392,7 @@ class CapabilitiesUseCasesIntegrationTest extends AbstractModuleDependencyResolv
 
         then:
         if (failOnVersionConflict) {
-            failure.assertHasCause("Cannot choose between asm:asm:3.0 and org.ow2.asm:asm:4.0 because they provide the same capability: asm:asm:3.0, asm:asm:4.0")
+            failure.assertHasCause("Conflict(s) found for the following module(s):\n  - org.ow2.asm:asm latest version of capability asm:asm")
         } else {
             resolve.expectGraph {
                 root(":", ":test:") {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/capabilities/PublishedCapabilitiesIntegrationTest.groovy
@@ -57,7 +57,10 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause("Cannot choose between cglib:cglib-nodep:3.2.5 and cglib:cglib:3.2.5 because they provide the same capability: cglib:cglib:3.2.5")
+        failure.assertHasCause("""Module 'cglib:cglib-nodep' has been rejected:
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5(runtime)]""")
+        failure.assertHasCause("""Module 'cglib:cglib' has been rejected:
+   Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5(runtime)]""")
     }
 
     def "can detect conflict with capability in different versions and upgrade automatically to latest version"() {
@@ -136,7 +139,8 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         fails ':checkDeps'
 
         then:
-        failure.assertHasCause("Cannot choose between :test:unspecified and org:test:1.0 because they provide the same capability: org:capability:1.0")
+        failure.assertHasCause("""Module 'org:test' has been rejected:
+   Cannot select module with conflict on capability 'org:capability:1.0' also provided by [:test:unspecified(conf)]""")
     }
 
     /**
@@ -179,7 +183,10 @@ class PublishedCapabilitiesIntegrationTest extends AbstractModuleDependencyResol
         fails ":checkDeps"
 
         then:
-        failure.assertHasCause("Cannot choose between org:testA:1.0 and org:testB:1.0 because they provide the same capability: org.test:cap:1.0")
+        failure.assertHasCause("""Module 'org:testA' has been rejected:
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testB:1.0(runtime)]""")
+        failure.assertHasCause("""Module 'org:testB' has been rejected:
+   Cannot select module with conflict on capability 'org.test:cap:1.0' also provided by [org:testA:1.0(runtime)]""")
     }
 
     def "considers all candidates for conflict resolution"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/constraints/DependencyConstraintsAndResolutionStrategiesIntegrationTest.groovy
@@ -90,9 +90,8 @@ class DependencyConstraintsAndResolutionStrategiesIntegrationTest extends Abstra
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause """A conflict was found between the following modules:
-  - org:foo:1.0
-  - org:foo:1.1"""
+        failure.assertHasCause """Conflict(s) found for the following module(s):
+  - org:foo between versions 1.0 and 1.1"""
     }
 
     void "dependency substitution rules are applied to dependency constraints"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -128,7 +128,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
 
         ResolveContextToComponentResolver requestResolver = createResolveContextConverter();
         ModuleConflictHandler conflictHandler = createModuleConflictHandler(resolutionStrategy, globalRules);
-        DefaultCapabilitiesConflictHandler capabilitiesConflictHandler = createCapabilitiesConflictHandler(resolutionStrategy);
+        DefaultCapabilitiesConflictHandler capabilitiesConflictHandler = createCapabilitiesConflictHandler();
 
         DependencySubstitutionApplicator applicator = createDependencySubstitutionApplicator(resolutionStrategy);
         return new DependencyGraphBuilder(componentIdResolver, componentMetaDataResolver, requestResolver, conflictHandler, capabilitiesConflictHandler, edgeFilter, attributesSchema, moduleExclusions, buildOperationExecutor, globalRules.getModuleMetadataProcessor().getModuleReplacements(), applicator, componentSelectorConverter, attributesFactory, versionSelectorScheme, versionComparator.asVersionComparator(), versionParser);
@@ -167,12 +167,10 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         return new DefaultConflictHandler(conflictResolver, metadataHandler.getModuleMetadataProcessor().getModuleReplacements());
     }
 
-    private DefaultCapabilitiesConflictHandler createCapabilitiesConflictHandler(ResolutionStrategyInternal resolutionStrategy) {
+    private DefaultCapabilitiesConflictHandler createCapabilitiesConflictHandler() {
         DefaultCapabilitiesConflictHandler handler = new DefaultCapabilitiesConflictHandler();
-        if (resolutionStrategy.getConflictResolution() != ConflictResolution.strict) {
-            handler.registerResolver(new UpgradeCapabilityResolver());
-            handler.registerResolver(new LastCandidateCapabilityResolver());
-        }
+        handler.registerResolver(new UpgradeCapabilityResolver());
+        handler.registerResolver(new LastCandidateCapabilityResolver());
         return handler;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DefaultArtifactDependencyResolver.java
@@ -47,6 +47,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflict
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.DefaultConflictHandler;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.LastCandidateCapabilityResolver;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.ModuleConflictHandler;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.RejectRemainingCandidates;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.UpgradeCapabilityResolver;
 import org.gradle.api.internal.artifacts.repositories.ResolutionAwareRepository;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
@@ -171,6 +172,7 @@ public class DefaultArtifactDependencyResolver implements ArtifactDependencyReso
         DefaultCapabilitiesConflictHandler handler = new DefaultCapabilitiesConflictHandler();
         handler.registerResolver(new UpgradeCapabilityResolver());
         handler.registerResolver(new LastCandidateCapabilityResolver());
+        handler.registerResolver(new RejectRemainingCandidates());
         return handler;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CandidateModule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CandidateModule.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflic
 
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResolutionState;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ComponentState;
 
 import java.util.Collection;
 
@@ -34,4 +35,6 @@ public interface CandidateModule {
      * Candidate versions of this module. Many times, it has only single version.
      */
     Collection<? extends ComponentResolutionState> getVersions();
+
+    void restart(ComponentState selected);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/CapabilitiesConflictHandler.java
@@ -38,6 +38,7 @@ public interface CapabilitiesConflictHandler extends ConflictHandler<Capabilitie
         ComponentIdentifier getId();
         void evict();
         void select();
+        void reject();
     }
 
     interface Resolver {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -29,6 +29,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
 import org.gradle.internal.Describables;
+import org.gradle.internal.Pair;
 import org.gradle.internal.component.external.model.CapabilityInternal;
 
 import java.util.ArrayDeque;
@@ -40,7 +41,7 @@ import java.util.Set;
 import java.util.TreeSet;
 
 public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictHandler {
-    private final List<Resolver> resolvers = Lists.newArrayListWithExpectedSize(2);
+    private final List<Resolver> resolvers = Lists.newArrayListWithExpectedSize(3);
     private final Map<String, Set<NodeState>> capabilityWithoutVersionToNodes = Maps.newHashMap();
     private final Deque<CapabilityConflict> conflicts = new ArrayDeque<CapabilityConflict>();
 
@@ -128,7 +129,6 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                 return;
             }
         }
-        throw new RuntimeException("Cannot choose between " + prettifyCandidates(conflict) + " because they provide the same capability: " + prettifyCapabilities(conflict));
     }
 
     @Override
@@ -206,11 +206,24 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                             public void select() {
                                 selected = node;
                             }
+
+                            @Override
+                            public void reject() {
+                                ComponentState component = node.getComponent();
+                                component.rejectForCapabilityConflict(Pair.of(capability, conflictedNodes(node, conflict.nodes)));
+                                component.selectAndRestartModule();
+                            }
                         });
                     }
                 }
             }
             return candidates.build();
+        }
+
+        private Collection<NodeState> conflictedNodes(NodeState node, Collection<NodeState> nodes) {
+            List<NodeState> conflictedNodes = Lists.newArrayList(nodes);
+            conflictedNodes.remove(node);
+            return conflictedNodes;
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/DefaultCapabilitiesConflictHandler.java
@@ -29,7 +29,6 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.NodeState;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.ComponentSelectionReasons;
 import org.gradle.internal.Describables;
-import org.gradle.internal.Pair;
 import org.gradle.internal.component.external.model.CapabilityInternal;
 
 import java.util.ArrayDeque;
@@ -210,7 +209,7 @@ public class DefaultCapabilitiesConflictHandler implements CapabilitiesConflictH
                             @Override
                             public void reject() {
                                 ComponentState component = node.getComponent();
-                                component.rejectForCapabilityConflict(Pair.of(capability, conflictedNodes(node, conflict.nodes)));
+                                component.rejectForCapabilityConflict(capability, conflictedNodes(node, conflict.nodes));
                                 component.selectAndRestartModule();
                             }
                         });

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/RejectRemainingCandidates.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/conflicts/RejectRemainingCandidates.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts;
+
+import org.gradle.api.capabilities.Capability;
+
+import java.util.Collection;
+
+public class RejectRemainingCandidates implements CapabilitiesConflictHandler.Resolver {
+    @Override
+    public void resolve(CapabilitiesConflictHandler.ResolutionDetails details) {
+        Collection<? extends Capability> capabilityVersions = details.getCapabilityVersions();
+        for (Capability capabilityVersion : capabilityVersions) {
+            Collection<? extends CapabilitiesConflictHandler.CandidateDetails> candidates = details.getCandidates(capabilityVersion);
+            if (!candidates.isEmpty()) {
+                // Arbitrarily select and mark all as rejected
+                for (CapabilitiesConflictHandler.CandidateDetails candidate : candidates) {
+                    candidate.reject();
+                }
+            }
+        }
+
+    }
+}

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -329,10 +329,8 @@ org:leaf:1.0
         run "dependencyInsight", "--dependency", "leaf2", "--configuration", "conf"
 
         then:
-        outputContains """Dependency resolution failed because of conflicts between the following modules:
-   - org:leaf2:1.5
-   - org:leaf2:2.5
-   - org:leaf2:1.0
+        outputContains """Dependency resolution failed because of conflict(s) on the following module(s):
+   - org:leaf2 between versions 1.5, 2.5 and 1.0
 
 org:leaf2:2.5
    variant "runtime" [
@@ -404,10 +402,8 @@ org:leaf2:1.5 -> 2.5
         run "dependencyInsight", "--dependency", "leaf2", "--configuration", "conf"
 
         then:
-        outputContains """Dependency resolution failed because of conflicts between the following modules:
-   - org:leaf2:1.5
-   - org:leaf2:2.5
-   - org:leaf2:1.0
+        outputContains """Dependency resolution failed because of conflict(s) on the following module(s):
+   - org:leaf2 between versions 1.5, 2.5 and 1.0
 
 org:leaf2:2.5
    variant "runtime" [

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/ResolutionErrorRenderer.java
@@ -24,6 +24,7 @@ import org.gradle.api.artifacts.result.DependencyResult;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.conflicts.VersionConflictException;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.Pair;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.locking.LockOutOfDateException;
@@ -81,20 +82,18 @@ class ResolutionErrorRenderer implements Action<Throwable> {
         registerError(new Action<StyledTextOutput>() {
             @Override
             public void execute(StyledTextOutput output) {
-                for (List<ModuleVersionIdentifier> moduleVersionIdentifiers : conflict.getConflicts()) {
-                    boolean matchesSpec = hasVersionConflictOnRequestedDependency(moduleVersionIdentifiers);
+                output.text("Dependency resolution failed because of conflict(s) on the following module(s):");
+                output.println();
+                for (Pair<List<? extends ModuleVersionIdentifier>, String> identifierStringPair : conflict.getConflicts()) {
+                    boolean matchesSpec = hasVersionConflictOnRequestedDependency(identifierStringPair.getLeft());
                     if (!matchesSpec) {
                         continue;
                     }
-                    output.text("Dependency resolution failed because of conflicts between the following modules:");
-                    output.println();
-                    for (ModuleVersionIdentifier moduleVersionIdentifier : moduleVersionIdentifiers) {
-                        output.text("   - ");
-                        output.withStyle(StyledTextOutput.Style.Error).text(moduleVersionIdentifier.toString());
-                        output.println();
-                    }
+                    output.text("   - ");
+                    output.withStyle(StyledTextOutput.Style.Error).text(identifierStringPair.getRight());
                     output.println();
                 }
+                output.println();
             }
         });
 
@@ -110,27 +109,32 @@ class ResolutionErrorRenderer implements Action<Throwable> {
         errorActions.add(errorAction);
     }
 
-    private boolean hasVersionConflictOnRequestedDependency(List<ModuleVersionIdentifier> moduleVersionIdentifiers) {
-        boolean matchesSpec = false;
-        for (final ModuleVersionIdentifier mvi : moduleVersionIdentifiers) {
-            matchesSpec |= dependencySpec.isSatisfiedBy(new DependencyResult() {
-                @Override
-                public ComponentSelector getRequested() {
-                    return DefaultModuleComponentSelector.newSelector(mvi.getModule(), mvi.getVersion());
-                }
-
-                @Override
-                public ResolvedComponentResult getFrom() {
-                    return null;
-                }
-
-                @Override
-                public boolean isConstraint() {
-                    return false;
-                }
-            });
+    private boolean hasVersionConflictOnRequestedDependency(final List<? extends ModuleVersionIdentifier> versionIdentifiers) {
+        for (final ModuleVersionIdentifier versionIdentifier : versionIdentifiers) {
+            if (dependencySpec.isSatisfiedBy(asDependencyResult(versionIdentifier))) {
+                return true;
+            }
         }
-        return matchesSpec;
+        return false;
+    }
+
+    private DependencyResult asDependencyResult(final ModuleVersionIdentifier versionIdentifier) {
+        return new DependencyResult() {
+            @Override
+            public ComponentSelector getRequested() {
+                return DefaultModuleComponentSelector.newSelector(versionIdentifier.getModule(), versionIdentifier.getVersion());
+            }
+
+            @Override
+            public ResolvedComponentResult getFrom() {
+                return null;
+            }
+
+            @Override
+            public boolean isConstraint() {
+                return false;
+            }
+        };
     }
 
 }

--- a/subprojects/docs/src/samples/java-feature-variant/incompatible-variants/imcompatibleFeatureVariants.sample.conf
+++ b/subprojects/docs/src/samples/java-feature-variant/incompatible-variants/imcompatibleFeatureVariants.sample.conf
@@ -2,14 +2,14 @@ commands: [{
     execution-subdirectory: groovy
     executable: gradle
     args: "consumer:dependencyInsight"
-    flags: "--configuration runtimeClasspath --dependency mysql"
+    flags: "--configuration runtimeClasspath --dependency producer"
     expected-output-file: runtimeClasspath.out
-    expect-failure: true
+    expect-failure: false
 },{
     execution-subdirectory: kotlin
     executable: gradle
     args: "consumer:dependencyInsight"
-    flags: "--configuration runtimeClasspath --dependency mysql"
+    flags: "--configuration runtimeClasspath --dependency producer"
     expected-output-file: runtimeClasspath.out
-    expect-failure: true
+    expect-failure: false
 }]

--- a/subprojects/docs/src/samples/java-feature-variant/incompatible-variants/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/incompatible-variants/runtimeClasspath.out
@@ -1,16 +1,21 @@
-> Task :consumer:dependencyInsight FAILED
 
-FAILURE: Build failed with an exception.
+> Task :consumer:dependencyInsight
+project :producer FAILED
+   Failures:
+      - Could not resolve project :producer.
+          - Module 'org.gradle.demo:producer' has been rejected:
+               Cannot select module with conflict on capability 'org.gradle.demo:producer-db-support:1.0' also provided by [org.gradle.demo:producer:1.0(postgresSupportRuntimeElements), org.gradle.demo:producer:1.0(mysqlSupportRuntimeElements)]
 
-* What went wrong:
-Execution failed for task ':consumer:dependencyInsight'.
-> Could not resolve all dependencies for configuration ':consumer:runtimeClasspath'.
-   > Cannot choose between org.gradle.demo:producer:1.0 variant mysqlSupportRuntimeElements and org.gradle.demo:producer:1.0 variant postgresSupportRuntimeElements because they provide the same capability: org.gradle.demo:producer-db-support:1.0
+project :producer FAILED
+\--- runtimeClasspath
 
-* Try:
-Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+project :producer FAILED
+\--- runtimeClasspath
 
-* Get more help at https://help.gradle.org
+project :producer FAILED
+\--- runtimeClasspath
 
-BUILD FAILED in 0s
+A web-based, searchable dependency report is available by adding the --scan option.
+
+BUILD SUCCESSFUL in 0s
 1 actionable task: 1 executed

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/declaring-capabilities.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/declaring-capabilities.sample.conf
@@ -4,11 +4,12 @@ commands: [{
     args: "dependencyInsight --configuration compileClasspath --dependency log4j"
     flags: "--quiet"
     expected-output-file: dependencyReport.out
-    expect-failure: true
+    expect-failure: false
 }, {
     execution-subdirectory: kotlin
     executable: gradle
     args: "dependencyInsight --configuration compileClasspath --dependency log4j"
     flags: --quiet
-    expect-failure: true
+    expect-failure: false
 }]
+

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -1,14 +1,31 @@
+log4j:log4j:1.2.16 FAILED
+   Failures:
+      - Could not resolve log4j:log4j:1.2.16.
+          - Module 'log4j:log4j' has been rejected:
+               Cannot select module with conflict on capability 'org.slf4j:slf4j-capability:1.0' also provided by [org.slf4j:log4j-over-slf4j:1.7.10(compile)]
 
-FAILURE: Build failed with an exception.
+log4j:log4j:1.2.16 FAILED
+\--- org.apache.zookeeper:zookeeper:3.4.9
+     \--- compileClasspath
 
-* What went wrong:
-Execution failed for task ':dependencyInsight'.
-> Could not resolve all dependencies for configuration ':compileClasspath'.
-   > Cannot choose between log4j:log4j:1.2.16 and org.slf4j:log4j-over-slf4j:1.7.10 because they provide the same capability: org.slf4j:slf4j-capability:1.0
+org.slf4j:log4j-over-slf4j:1.7.10 FAILED
+   Failures:
+      - Could not resolve org.slf4j:log4j-over-slf4j:1.7.10.
+          - Module 'org.slf4j:log4j-over-slf4j' has been rejected:
+               Cannot select module with conflict on capability 'org.slf4j:slf4j-capability:1.0' also provided by [log4j:log4j:1.2.16(compile)]
 
-* Try:
-Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
+org.slf4j:log4j-over-slf4j:1.7.10 FAILED
+\--- compileClasspath
 
-* Get more help at https://help.gradle.org
+org.slf4j:slf4j-log4j12:1.6.1
+   variant "compile" [
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-api
+      org.gradle.component.category = library (not requested)
+   ]
 
-BUILD FAILED in 0s
+org.slf4j:slf4j-log4j12:1.6.1
+\--- org.apache.zookeeper:zookeeper:3.4.9
+     \--- compileClasspath
+
+A web-based, searchable dependency report is available by adding the --scan option.


### PR DESCRIPTION
This PR changes the way unresolved capability conflicts are handled by making them follow the same path as unresolved version conflicts, including the lenient aspect.

A number of changes around conflicts and capabilities error reporting were also made:

* For `failOnVersionConflict`, classical version conflicts are no longer reported as
```
A conflict was found between the following modules:
  - org:foo:1.0
  - org:foo:1.1
A conflict was found between the following modules:
  - org:bar:1.0
  - org:bar:1.1
```
but instead as
```
Conflict(s) found for the following module(s):
   - org:foo between versions 1.0 and 1.1
   - org:bar between versions 1.0 and 1.1
```
* For capabilities conflicts, they are no longer reported as
```
Cannot choose between cglib:cglib-nodep:3.2.5 and cglib:cglib:3.2.5 because they provide the same capability: cglib:cglib:3.2.5
```
but instead as
```
> Could not resolve cglib:cglib-nodep:3.2.5.
  Required by:
      project :
   > Module 'cglib:cglib-nodep' has been rejected:
        Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib:3.2.5(runtime)]
> Could not resolve cglib:cglib:3.2.5.
  Required by:
      project :
   > Module 'cglib:cglib' has been rejected:
        Cannot select module with conflict on capability 'cglib:cglib:3.2.5' also provided by [cglib:cglib-nodep:3.2.5(runtime)]
```

It is probably easier to review the PR by commit as the different step needed to make capabilities error lenient have been separated.