### PR TITLE
Fix typos in JavaDoc

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/NamedDomainObjectContainer.java
@@ -98,7 +98,7 @@ public interface NamedDomainObjectContainer<T> extends NamedDomainObjectSet<T>, 
     /**
      * Defines a new object, which will be created when it is required. A object is 'required' when the object is located using query methods such as {@link NamedDomainObjectCollection#getByName(java.lang.String)} or when {@link Provider#get()} is called on the return value of this method.
      *
-     * <p>It is generally more efficient to use this method instead of {@link #create(java.lang.String)}, as that methods will eagerly create he object, regardless of whether that object is required for the current build or not. This method, on the other hand, will defer creation until required.</p>
+     * <p>It is generally more efficient to use this method instead of {@link #create(java.lang.String)}, as that method will eagerly create the object, regardless of whether that object is required for the current build or not. This method, on the other hand, will defer creation until required.</p>
      *
      * @param name The name of the object.
      * @return A {@link Provider} that whose value will be the object, when queried.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Nested.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Nested.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  * <p>This annotation supports {@link Iterable} values by treating each element as a separate nested bean.
  * As a property name, the index of the element in the iterable prefixed by {@code $} is used, e.g. {@code $0}.
  * If the element implements {@link org.gradle.api.Named}, then the property name is composed of {@link org.gradle.api.Named#getName()} and the index, e.g. {@code name$1}.
- * The ordering of the elements in the iterable is crucial for for reliable up-to-date checks and caching.</p>
+ * The ordering of the elements in the iterable is crucial for reliable up-to-date checks and caching.</p>
  *
  * <p>This annotation supports ${@link java.util.Map} values by treating each value of the map as a separate nested bean.
  * The keys of the map are used as property names.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskContainer.java
@@ -253,7 +253,7 @@ public interface TaskContainer extends TaskCollection<Task>, PolymorphicDomainOb
     /**
      * Defines a new task, which will be created when it is required. A task is 'required' when the task is located using query methods such as {@link TaskCollection#getByName(java.lang.String)}, when the task is added to the task graph for execution or when {@link Provider#get()} is called on the return value of this method.
      *
-     * <p>It is generally more efficient to use this method instead of {@link #create(java.lang.String)}, as that methods will eagerly create he task, regardless of whether that task is required for the current build or not. This method, on the other hand, will defer creation until required.</p>
+     * <p>It is generally more efficient to use this method instead of {@link #create(java.lang.String)}, as that method will eagerly create the task, regardless of whether that task is required for the current build or not. This method, on the other hand, will defer creation until required.</p>
      *
      * @param name The name of the task.
      * @return A {@link Provider} that whose value will be the task, when queried.


### PR DESCRIPTION
Fix typos in `Nested` and `TaskContainer` (`he` -> `the` and
`that methods` -> `that method`).
Remove duplicated word in `NamedDomainObjectContainer`.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Ensure that tests pass locally: `./gradlew :docs:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
