### PR TITLE
Make Gradle metadata format 1.0

### DIFF
--- a/subprojects/dependency-management/dependency-management.gradle.kts
+++ b/subprojects/dependency-management/dependency-management.gradle.kts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import org.gradle.build.ClasspathManifest
 import org.gradle.gradlebuild.testing.integrationtests.cleanup.WhenNotEmpty
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
 
@@ -56,6 +55,8 @@ dependencies {
 
     testFixturesApi(project(":resourcesHttp", "testFixturesApiElements"))
     testFixturesImplementation(project(":internalIntegTesting"))
+
+    crossVersionTestRuntimeOnly(project(":maven"))
 }
 
 gradlebuildJava {

--- a/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/crossVersionTest/groovy/org/gradle/integtests/resolve/GradleMetadataJavaLibraryCrossVersionIntegrationTest.groovy
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve
+
+import org.gradle.integtests.fixtures.CrossVersionIntegrationSpec
+import org.gradle.integtests.fixtures.TargetVersions
+import org.gradle.util.GradleVersion
+
+import static org.gradle.integtests.fixtures.AbstractIntegrationSpec.jcenterRepository
+
+@TargetVersions("5.2.1+")
+class GradleMetadataJavaLibraryCrossVersionIntegrationTest extends CrossVersionIntegrationSpec {
+
+    // The version in which Gradle metadata became "stable"
+    private static final GradleVersion STABLE_METADATA_VERSION = GradleVersion.version("5.3")
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+            enableFeaturePreview('GRADLE_METADATA')
+            include 'consumer'
+            include 'producer'
+        """
+        buildFile << """
+            allprojects {
+               apply plugin: 'java-library'
+    
+                group = 'com.acme'
+                version = '1.0'
+    
+                repositories {
+                    maven { url "\${rootProject.buildDir}/repo" }
+                    ${jcenterRepository()}
+                }
+            }
+        """
+
+        file('producer/build.gradle') << """
+            apply plugin: 'maven-publish'
+
+            dependencies {
+                constraints {
+                    api 'org.apache.commons:commons-lang3:3.8.1'
+                }
+                implementation('org.apache.commons:commons-lang3') {
+                    version {
+                        strictly '[3.8, 3.9['
+                        because "Doesn't work with other versions than 3.8"
+                    }
+                }
+            }
+
+            java {
+                if (JavaPluginExtension.metaClass.respondsTo(delegate, 'registerFeature')) {
+                    registerFeature("hibernateSupport") {
+                        usingSourceSet(sourceSets.main)
+                        capability("com.acme", "producer-hibernate-support", "1.0")
+                    }
+                }
+            }
+
+            publishing {
+                repositories {
+                    maven { url "\${rootProject.buildDir}/repo" }
+                }
+                
+                publications {
+                    producerLib(MavenPublication) {
+                        from components.java
+                    }
+                }           
+            } 
+        """
+
+        file('consumer/build.gradle') << """
+            dependencies {
+                api 'com.acme:producer:1.0'
+            }
+            
+            task resolve {
+                doLast {
+                    println configurations.runtimeClasspath.files
+                }
+            }
+        """
+    }
+
+    def "can consume library published with previous version of Gradle"() {
+        expect:
+        version previous withTasks ':producer:publish' run()
+        version current withTasks ':consumer:resolve' run()
+    }
+
+    def "previous Gradle can consume library published with current version of Gradle"() {
+        expect:
+        version current withTasks ':producer:publish' run()
+        if (previous.version.compareTo(STABLE_METADATA_VERSION) >= 0) {
+            version previous withTasks ':consumer:resolve' run()
+        }
+    }
+
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
-import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser.FORMAT_VERSION
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser.FORMAT_VERSION
 
 class MavenLocalDependencyWithGradleMetadataResolutionIntegrationTest extends AbstractDependencyResolutionTest {
     def resolve = new ResolveTestFixture(buildFile)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
-import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser.FORMAT_VERSION
+import static org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser.FORMAT_VERSION
 
 class MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest extends AbstractHttpDependencyResolutionTest {
     def resolve = new ResolveTestFixture(buildFile).expectDefaultConfiguration("runtime")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenRemoteDependencyWithGradleMetadataResolutionIntegrationTest.groovy
@@ -774,47 +774,6 @@ dependencies {
         failure.assertHasCause("Could not parse module metadata ${m.moduleMetadata.uri}")
     }
 
-    def "reports failure to accept module metadata with unexpected format version"() {
-        def m = mavenHttpRepo.module("test", "a", "1.2").withModuleMetadata().publish()
-        m.moduleMetadata.file.text = m.moduleMetadata.file.text.replace(FORMAT_VERSION, "123.67")
-
-        given:
-        buildFile << """
-repositories {
-    maven { 
-        url = '${mavenHttpRepo.uri}' 
-    }
-}
-configurations { compile }
-dependencies {
-    compile 'test:a:1.2'
-}
-"""
-
-        m.moduleMetadata.expectGet()
-
-        when:
-        fails("checkDeps")
-
-        then:
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
-        failure.assertHasCause("Could not resolve test:a:1.2.")
-        failure.assertHasCause("Could not parse module metadata ${m.moduleMetadata.uri}")
-        failure.assertHasCause("Unsupported format version '123.67' specified in module metadata. This version of Gradle supports format version ${FORMAT_VERSION} only.")
-
-        when:
-        server.resetExpectations()
-        m.moduleMetadata.expectHead()
-
-        fails("checkDeps")
-
-        then:
-        failure.assertHasCause("Could not resolve all dependencies for configuration ':compile'.")
-        failure.assertHasCause("Could not resolve test:a:1.2.")
-        failure.assertHasCause("Could not parse module metadata ${m.moduleMetadata.uri}")
-        failure.assertHasCause("Unsupported format version '123.67' specified in module metadata. This version of Gradle supports format version ${FORMAT_VERSION} only.")
-    }
-
     def "reports failure to locate files"() {
         def m = mavenHttpRepo.module("test", "a", "1.2").withModuleMetadata()
         m.artifact(classifier: 'extra')

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -54,7 +54,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ShortCircuitEmptyConfigurati
 import org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution.DependencySubstitutionRules;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ResolveIvyFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomModuleDescriptorParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
@@ -333,7 +333,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 artifactIdentifierFileStore,
                 externalResourceFileStore,
                 new GradlePomModuleDescriptorParser(versionSelectorScheme, moduleIdentifierFactory, fileResourceRepository, metadataFactory),
-                new ModuleMetadataParser(attributesFactory, moduleIdentifierFactory, NamedObjectInstantiator.INSTANCE),
+                new GradleModuleMetadataParser(attributesFactory, moduleIdentifierFactory, NamedObjectInstantiator.INSTANCE),
                 authenticationSchemeRegistry,
                 ivyContextManager,
                 moduleIdentifierFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -34,6 +34,8 @@ import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.internal.component.external.model.MutableComponentVariant;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
@@ -41,6 +43,7 @@ import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.resource.local.LocallyAvailableExternalResource;
 import org.gradle.internal.snapshot.impl.CoercingStringValueSnapshot;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -55,6 +58,8 @@ import static com.google.gson.stream.JsonToken.NUMBER;
 import static org.apache.commons.lang.StringUtils.capitalize;
 
 public class GradleModuleMetadataParser {
+    private final static Logger LOGGER = Logging.getLogger(GradleModuleMetadataParser.class);
+
     public static final String FORMAT_VERSION = "1.0";
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator instantiator;
@@ -70,6 +75,7 @@ public class GradleModuleMetadataParser {
         resource.withContent(new Transformer<Void, InputStream>() {
             @Override
             public Void transform(InputStream inputStream) {
+                String version = null;
                 try {
                     JsonReader reader = new JsonReader(new InputStreamReader(inputStream, "utf-8"));
                     reader.beginObject();
@@ -83,14 +89,18 @@ public class GradleModuleMetadataParser {
                     if (reader.peek() != JsonToken.STRING) {
                         throw new RuntimeException("The 'formatVersion' value should have a string value.");
                     }
-                    String version = reader.nextString();
-                    if (!version.equals(FORMAT_VERSION)) {
-                        throw new RuntimeException(String.format("Unsupported format version '%s' specified in module metadata. This version of Gradle supports format version %s only.", version, FORMAT_VERSION));
-                    }
+                    version = reader.nextString();
                     consumeTopLevelElements(reader, metadata);
-                    metadata.setContentHash(HashUtil.createHash(resource.getFile(), "MD5"));
+                    File file = resource.getFile();
+                    metadata.setContentHash(HashUtil.createHash(file, "MD5"));
+                    if (!FORMAT_VERSION.equals(version)) {
+                        LOGGER.debug("Unrecognized metadata format version '%s' found in '%s'. Parsing succeeded but it may lead to unexpected resolution results. Try upgrading to a newer version of Gradle", version, file);
+                    }
                     return null;
                 } catch (Exception e) {
+                    if (version != null && !FORMAT_VERSION.equals(version)) {
+                        throw new MetaDataParseException("module metadata", resource, String.format("unsupported format version '%s' specified in module metadata. This version of Gradle supports format version %s.", version, FORMAT_VERSION), e);
+                    }
                     throw new MetaDataParseException("module metadata", resource, e);
                 }
             }
@@ -162,7 +172,6 @@ public class GradleModuleMetadataParser {
             }
         }
         reader.endObject();
-
         MutableComponentVariant variant = metadata.addVariant(variantName, attributes);
         populateVariant(files, dependencies, dependencyConstraints, capabilities, variant);
         AttributeValue<String> entry = attributes.findEntry(PlatformSupport.COMPONENT_CATEGORY);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -54,13 +54,13 @@ import static com.google.gson.stream.JsonToken.END_OBJECT;
 import static com.google.gson.stream.JsonToken.NUMBER;
 import static org.apache.commons.lang.StringUtils.capitalize;
 
-public class ModuleMetadataParser {
+public class GradleModuleMetadataParser {
     public static final String FORMAT_VERSION = "1.0";
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator instantiator;
     private final ExcludeRuleConverter excludeRuleConverter;
 
-    public ModuleMetadataParser(ImmutableAttributesFactory attributesFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, NamedObjectInstantiator instantiator) {
+    public GradleModuleMetadataParser(ImmutableAttributesFactory attributesFactory, ImmutableModuleIdentifierFactory moduleIdentifierFactory, NamedObjectInstantiator instantiator) {
         this.attributesFactory = attributesFactory;
         this.instantiator = instantiator;
         this.excludeRuleConverter = new DefaultExcludeRuleConverter(moduleIdentifierFactory);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/MetaDataParseException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/MetaDataParseException.java
@@ -29,4 +29,8 @@ public class MetaDataParseException extends GradleException {
     public MetaDataParseException(String typeName, ExternalResource resource, Throwable cause) {
         super(String.format("Could not parse %s %s", typeName, resource.getDisplayName()), cause);
     }
+
+    public MetaDataParseException(String typeName, ExternalResource resource, String details, Throwable cause) {
+        super(String.format("Could not parse %s %s: %s", typeName, resource.getDisplayName(), details), cause);
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -55,7 +55,7 @@ import static com.google.gson.stream.JsonToken.NUMBER;
 import static org.apache.commons.lang.StringUtils.capitalize;
 
 public class ModuleMetadataParser {
-    public static final String FORMAT_VERSION = "0.4";
+    public static final String FORMAT_VERSION = "1.0";
     private final ImmutableAttributesFactory attributesFactory;
     private final NamedObjectInstantiator instantiator;
     private final ExcludeRuleConverter excludeRuleConverter;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactory.java
@@ -32,7 +32,7 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory;
@@ -64,7 +64,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
     private final FileStore<ModuleComponentArtifactIdentifier> artifactFileStore;
     private final FileStore<String> externalResourcesFileStore;
     private final MetaDataParser<MutableMavenModuleResolveMetadata> pomParser;
-    private final ModuleMetadataParser metadataParser;
+    private final GradleModuleMetadataParser metadataParser;
     private final AuthenticationSchemeRegistry authenticationSchemeRegistry;
     private final IvyContextManager ivyContextManager;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
@@ -84,7 +84,7 @@ public class DefaultBaseRepositoryFactory implements BaseRepositoryFactory {
                                         FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                                         FileStore<String> externalResourcesFileStore,
                                         MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
-                                        ModuleMetadataParser metadataParser,
+                                        GradleModuleMetadataParser metadataParser,
                                         AuthenticationSchemeRegistry authenticationSchemeRegistry,
                                         IvyContextManager ivyContextManager,
                                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepository.java
@@ -39,7 +39,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleC
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyXmlModuleDescriptorParser;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.repositories.descriptor.IvyRepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.layout.AbstractRepositoryLayout;
@@ -98,7 +98,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final InstantiatorFactory instantiatorFactory;
     private final FileResourceRepository fileResourceRepository;
-    private final ModuleMetadataParser moduleMetadataParser;
+    private final GradleModuleMetadataParser moduleMetadataParser;
     private final IvyMutableModuleMetadataFactory metadataFactory;
     private final IsolatableFactory isolatableFactory;
     private final IvyMetadataSources metadataSources = new IvyMetadataSources();
@@ -112,7 +112,7 @@ public class DefaultIvyArtifactRepository extends AbstractAuthenticationSupporte
                                         ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                         InstantiatorFactory instantiatorFactory,
                                         FileResourceRepository fileResourceRepository,
-                                        ModuleMetadataParser moduleMetadataParser,
+                                        GradleModuleMetadataParser moduleMetadataParser,
                                         FeaturePreviews featurePreviews,
                                         IvyMutableModuleMetadataFactory metadataFactory,
                                         IsolatableFactory isolatableFactory,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepository.java
@@ -33,7 +33,7 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ModuleVersionPublisher;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ConfiguredModuleComponentRepository;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.repositories.descriptor.MavenRepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.descriptor.RepositoryDescriptor;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
@@ -86,7 +86,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
     private final LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder;
     private final FileStore<ModuleComponentArtifactIdentifier> artifactFileStore;
     private final MetaDataParser<MutableMavenModuleResolveMetadata> pomParser;
-    private final ModuleMetadataParser metadataParser;
+    private final GradleModuleMetadataParser metadataParser;
     private final ImmutableModuleIdentifierFactory moduleIdentifierFactory;
     private final FileStore<String> resourcesFileStore;
     private final FileResourceRepository fileResourceRepository;
@@ -100,7 +100,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           InstantiatorFactory instantiatorFactory,
                                           FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                                           MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
-                                          ModuleMetadataParser metadataParser,
+                                          GradleModuleMetadataParser metadataParser,
                                           AuthenticationContainer authenticationContainer,
                                           ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                           FileStore<String> resourcesFileStore,
@@ -120,7 +120,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
                                           InstantiatorFactory instantiatorFactory,
                                           FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                                           MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
-                                          ModuleMetadataParser metadataParser,
+                                          GradleModuleMetadataParser metadataParser,
                                           AuthenticationContainer authenticationContainer,
                                           ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                           FileStore<String> resourcesFileStore,
@@ -273,7 +273,7 @@ public class DefaultMavenArtifactRepository extends AbstractAuthenticationSuppor
         return pomParser;
     }
 
-    private ModuleMetadataParser getMetadataParser() {
+    private GradleModuleMetadataParser getMetadataParser() {
         return metadataParser;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalArtifactRepository.java
@@ -22,7 +22,7 @@ import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.repositories.maven.MavenMetadataLoader;
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenPomMetadataSource;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMetadataArtifactProvider;
@@ -56,7 +56,7 @@ public class DefaultMavenLocalArtifactRepository extends DefaultMavenArtifactRep
                                                LocallyAvailableResourceFinder<ModuleComponentArtifactMetadata> locallyAvailableResourceFinder, InstantiatorFactory instantiatorFactory,
                                                FileStore<ModuleComponentArtifactIdentifier> artifactFileStore,
                                                MetaDataParser<MutableMavenModuleResolveMetadata> pomParser,
-                                               ModuleMetadataParser metadataParser,
+                                               GradleModuleMetadataParser metadataParser,
                                                AuthenticationContainer authenticationContainer,
                                                ImmutableModuleIdentifierFactory moduleIdentifierFactory,
                                                FileResourceRepository fileResourceRepository,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultGradleModuleMetadataSource.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.ComponentResolvers;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.repositories.resolver.ExternalResourceArtifactResolver;
 import org.gradle.api.internal.artifacts.repositories.resolver.ResourcePattern;
 import org.gradle.api.internal.artifacts.repositories.resolver.VersionLister;
@@ -40,12 +40,12 @@ import java.util.List;
  * Because of this, we will generate an empty instance (either a Ivy or Maven) based on the repository type.
  */
 public class DefaultGradleModuleMetadataSource extends AbstractMetadataSource<MutableModuleComponentResolveMetadata> {
-    private final ModuleMetadataParser metadataParser;
+    private final GradleModuleMetadataParser metadataParser;
     private final MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory;
     private final boolean listVersions;
 
     @Inject
-    public DefaultGradleModuleMetadataSource(ModuleMetadataParser metadataParser, MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory, boolean listVersions) {
+    public DefaultGradleModuleMetadataSource(GradleModuleMetadataParser metadataParser, MutableModuleMetadataFactory<? extends MutableModuleComponentResolveMetadata> mutableModuleMetadataFactory, boolean listVersions) {
         this.metadataParser = metadataParser;
         this.mutableModuleMetadataFactory = mutableModuleMetadataFactory;
         this.listVersions = listVersions;

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParserTest.groovy
@@ -34,12 +34,12 @@ import spock.lang.Specification
 
 import static org.gradle.util.AttributeTestUtil.attributes
 
-class ModuleMetadataParserTest extends Specification {
+class GradleModuleMetadataParserTest extends Specification {
     @Rule
     final TestNameTestDirectoryProvider temporaryFolder = new TestNameTestDirectoryProvider()
 
     def identifierFactory = new DefaultImmutableModuleIdentifierFactory()
-    def parser = new ModuleMetadataParser(AttributeTestUtil.attributesFactory(), identifierFactory, NamedObjectInstantiator.INSTANCE)
+    def parser = new GradleModuleMetadataParser(AttributeTestUtil.attributesFactory(), identifierFactory, NamedObjectInstantiator.INSTANCE)
 
     VersionConstraint emptyConstraint() {
         DefaultImmutableVersionConstraint.of()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParserTest.groovy
@@ -80,7 +80,7 @@ class ModuleMetadataParserTest extends Specification {
         def metadata = Mock(MutableModuleComponentResolveMetadata)
 
         when:
-        parser.parse(resource('{ "formatVersion": "0.4" }'), metadata)
+        parser.parse(resource('{ "formatVersion": "1.0" }'), metadata)
 
         then:
         1 * metadata.setContentHash(_)
@@ -93,7 +93,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v" },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
@@ -110,7 +110,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "component": { "url": "elsewhere", "group": "g", "module": "m", "version": "v", "attributes": {"foo": "bar", "org.gradle.status": "release" } },
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } }
     }
@@ -129,7 +129,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -157,7 +157,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -186,7 +186,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -227,7 +227,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -284,7 +284,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -335,7 +335,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -376,7 +376,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -416,7 +416,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "builtBy": { "gradle": { "version": "123", "buildId": "abc" } },
         "variants": [
             {
@@ -441,7 +441,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api"
@@ -471,7 +471,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -522,7 +522,7 @@ class ModuleMetadataParserTest extends Specification {
 
         when:
         parser.parse(resource('''{ 
-            "formatVersion": "0.4",
+            "formatVersion": "1.0",
             "otherString": "string",
             "otherNumber": 123,
             "otherBoolean": true,
@@ -542,7 +542,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -570,7 +570,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -602,7 +602,7 @@ class ModuleMetadataParserTest extends Specification {
         when:
         parser.parse(resource('''
     { 
-        "formatVersion": "0.4", 
+        "formatVersion": "1.0", 
         "variants": [
             {
                 "name": "api",
@@ -685,7 +685,7 @@ class ModuleMetadataParserTest extends Specification {
         then:
         def e = thrown(MetaDataParseException)
         e.message == "Could not parse module metadata <resource>"
-        e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 0.4 only."
+        e.cause.message == "Unsupported format version '123.4' specified in module metadata. This version of Gradle supports format version 1.0 only."
     }
 
     def resource(String content) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -26,7 +26,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradlePomM
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyModuleDescriptorConverter
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.IvyXmlModuleDescriptorParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionComparator
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.DefaultVersionSelectorScheme
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.MavenVersionSelectorScheme
@@ -59,7 +59,7 @@ class ModuleMetadataSerializerTest extends Specification {
     private final ModuleMetadataSerializer serializer = moduleMetadataSerializer()
     private GradlePomModuleDescriptorParser pomModuleDescriptorParser = pomParser()
     private MetaDataParser<MutableIvyModuleResolveMetadata> ivyDescriptorParser = ivyParser()
-    private ModuleMetadataParser gradleMetadataParser = gradleMetadataParser()
+    private GradleModuleMetadataParser gradleMetadataParser = gradleMetadataParser()
 
     def "all samples are different"() {
         given:
@@ -175,8 +175,8 @@ class ModuleMetadataSerializerTest extends Specification {
         )
     }
 
-    private ModuleMetadataParser gradleMetadataParser() {
-        new ModuleMetadataParser(
+    private GradleModuleMetadataParser gradleMetadataParser() {
+        new GradleModuleMetadataParser(
             AttributeTestUtil.attributesFactory(),
             moduleIdentifierFactory,
             NamedObjectInstantiator.INSTANCE

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultBaseRepositoryFactoryTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
@@ -50,7 +50,7 @@ class DefaultBaseRepositoryFactoryTest extends Specification {
     final ArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final ExternalResourceFileStore externalResourceFileStore = Stub()
     final MetaDataParser pomParser = Mock()
-    final ModuleMetadataParser metadataParser = Mock()
+    final GradleModuleMetadataParser metadataParser = Mock()
     final ivyContextManager = Mock(IvyContextManager)
     final AuthenticationSchemeRegistry authenticationSchemeRegistry = new DefaultAuthenticationSchemeRegistry()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultIvyArtifactRepositoryTest.groovy
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.IvyContextManager
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.repositories.metadata.IvyMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.IvyResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -58,7 +58,7 @@ class DefaultIvyArtifactRepositoryTest extends Specification {
     final AuthenticationContainer authenticationContainer = Stub()
     final ivyContextManager = Mock(IvyContextManager)
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
-    final ModuleMetadataParser moduleMetadataParser = new ModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
+    final GradleModuleMetadataParser moduleMetadataParser = new GradleModuleMetadataParser(Mock(ImmutableAttributesFactory), moduleIdentifierFactory, Mock(NamedObjectInstantiator))
     final IvyMutableModuleMetadataFactory metadataFactory = new IvyMutableModuleMetadataFactory(new DefaultImmutableModuleIdentifierFactory(), AttributeTestUtil.attributesFactory())
 
     final DefaultIvyArtifactRepository repository = instantiator.newInstance(DefaultIvyArtifactRepository.class, fileResolver, transportFactory, locallyAvailableResourceFinder, artifactIdentifierFileStore, externalResourceFileStore, authenticationContainer, ivyContextManager, moduleIdentifierFactory, TestUtil.instantiatorFactory(), Mock(FileResourceRepository), moduleMetadataParser, TestUtil.featurePreviews(), metadataFactory, SnapshotTestUtil.valueSnapshotter(), Mock(ObjectFactory))

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenArtifactRepositoryTest.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.ComponentMetadataVersionLister
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.resolver.MavenResolver
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
@@ -50,7 +50,7 @@ class DefaultMavenArtifactRepositoryTest extends Specification {
     final ArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final ExternalResourceFileStore externalResourceFileStore = Stub()
     final MetaDataParser pomParser = Stub()
-    final ModuleMetadataParser metadataParser = Stub()
+    final GradleModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Stub()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/DefaultMavenLocalRepositoryTest.groovy
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.repositories
 import org.gradle.api.artifacts.repositories.AuthenticationContainer
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransport
 import org.gradle.api.internal.artifacts.repositories.transport.RepositoryTransportFactory
@@ -41,7 +41,7 @@ class DefaultMavenLocalRepositoryTest extends Specification {
     final ExternalResourceRepository resourceRepository = Mock()
     final ArtifactIdentifierFileStore artifactIdentifierFileStore = Stub()
     final MetaDataParser pomParser = Stub()
-    final ModuleMetadataParser metadataParser = Stub()
+    final GradleModuleMetadataParser metadataParser = Stub()
     final AuthenticationContainer authenticationContainer = Stub()
     final ImmutableModuleIdentifierFactory moduleIdentifierFactory = Mock()
     final MavenMutableModuleMetadataFactory mavenMetadataFactory = new MavenMutableModuleMetadataFactory(moduleIdentifierFactory, AttributeTestUtil.attributesFactory(), TestUtil.objectInstantiator(), TestUtil.featurePreviews())

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/boolean-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/boolean-attributes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "builtBy": { "gradle": { "version": "123", "buildId": "abc" } },
     "variants": [
         {

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/dependencies-with-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/dependencies-with-attributes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/java-library-with-excludes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/java-library-with-excludes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "component": {
         "group": "org.gradle.test",
         "module": "publishTest",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-capabilities.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-capabilities.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-constraints.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-dependencies.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-variants.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/module-with-variants.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "variants": [
         {
             "name": "api",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-custom-attributes.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-custom-attributes.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "component": {
         "group": "org.gradle.test",
         "module": "publishTest",

--- a/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-nondefault-status.module
+++ b/subprojects/dependency-management/src/test/resources/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest/gradle/with-nondefault-status.module
@@ -1,5 +1,5 @@
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "component": {
         "group": "org.gradle.test",
         "module": "publishTest",

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
@@ -90,7 +90,7 @@ This value must contain an array of 0 or more capabilities. Each capability is a
 #### Java Ecosystem specific attributes
 
 - `org.gradle.dependency.bundling` indicates how dependencies of the variant are bundled. Either externally, embedded or shadowed. See the `org.gradle.api.attributes.java.Bundling` for more details. Value must be a string.
-- `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library.
+- `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library. Value must be a string.
 
 #### Native ecosystem specific attributes
 

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
@@ -87,10 +87,11 @@ This value must contain an array of 0 or more capabilities. Each capability is a
 - `org.gradle.usage` indicates the purpose of the variant. See the `org.gradle.api.attributes.Usage` class for more details. Value must be a string.
 - `org.gradle.status` indicates the kind of release: one of `release` or `integration`.
 - `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library. Value must be a string.
+- `org.gradle.dependency.bundling` indicates how dependencies of the variant are bundled. Either externally, embedded or shadowed. See the `org.gradle.api.attributes.Bundling` for more details. Value must be a string.
 
 #### Java Ecosystem specific attributes
 
-- `org.gradle.dependency.bundling` indicates how dependencies of the variant are bundled. Either externally, embedded or shadowed. See the `org.gradle.api.attributes.java.Bundling` for more details. Value must be a string.
+- `org.gradle.jvm.version` indicated the minimal target JVM version of a library. For example is built for java 8, its minimal target is `8`. If it's a multi-release jar for Java 9, 10 and 11, it's minimal target is `9`. Value must be an integer corresponding to the Java version.
 
 #### Native ecosystem specific attributes
 

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
@@ -86,11 +86,11 @@ This value must contain an array of 0 or more capabilities. Each capability is a
 
 - `org.gradle.usage` indicates the purpose of the variant. See the `org.gradle.api.attributes.Usage` class for more details. Value must be a string.
 - `org.gradle.status` indicates the kind of release: one of `release` or `integration`.
+- `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library. Value must be a string.
 
 #### Java Ecosystem specific attributes
 
 - `org.gradle.dependency.bundling` indicates how dependencies of the variant are bundled. Either externally, embedded or shadowed. See the `org.gradle.api.attributes.java.Bundling` for more details. Value must be a string.
-- `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library. Value must be a string.
 
 #### Native ecosystem specific attributes
 

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
@@ -1,8 +1,8 @@
-# Gradle module metadata specification
+# Gradle module metadata 1.0 specification
 
-_Note: this format is not yet stable and may change at any time. Gradle does not guarantee to offer any long term support for this version of the format. Any version before 1.0 is intentionally assumed not backwards compatible, and the parsers are not required to support pre 1.0 releases._
+Consumption of Gradle metadata is automatic. However publication needs to be enabled explicitly for any Gradle version prior to Gradle 6.
 
-Support for Gradle metadata can be enabled in Gradle settings file (`settings.gradle`):
+Publishing Gradle metadata can be enabled in Gradle settings file (`settings.gradle`):
 
 ```
 enableFeaturePreview("GRADLE_METADATA")
@@ -10,7 +10,7 @@ enableFeaturePreview("GRADLE_METADATA")
 
 ## Goal
 
-This document describes version 0.4 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
+This document describes version 1.0 of the Gradle module metadata file. A module metadata file describes the contents of a _module_, which is the unit of publication for a particular repository format, such as a module in a Maven repository. This is often called a "package" in many repository formats.
 
 The module metadata file is a JSON file published alongside the existing repository specific metadata files, such as a Maven POM or Ivy descriptor. It adds additional metadata that can be used by Gradle versions and other tooling that understand the format. This allows the rich Gradle model to be mapped to and "tunnelled" through existing repository formats, while continuing to support existing Gradle versions and tooling that does not understand the format. 
 
@@ -18,7 +18,7 @@ The module metadata file is intended to be machine generated rather than written
 
 The module metadata file is also intended to fully describe the binaries in the module where it is present so that it can replace the existing metadata files. This would allow a Gradle repository format to be added, for example.
 
-In version 0.4, the module metadata file can describe only those modules that contain a single _component_, which is some piece of software such as a library or application. Support for more sophisticated mappings will be added by later versions.
+In version 1.0, the module metadata file can describe only those modules that contain a single _component_, which is some piece of software such as a library or application. Support for more sophisticated mappings may be added by later versions.
 
 ## Usage in a Maven repository
 
@@ -32,7 +32,7 @@ The file must be encoded using UTF-8.
 
 The file must contain a JSON object with the following values:
 
-- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"0.4"`
+- `formatVersion`: must be present and the first value of the JSON object. Its value must be `"1.0"`
 - `component`: optional. Describes the identity of the component contained in the module.
 - `builtBy`: optional. Describes the producer of this metadata file and the contents of the module.
 - `variants`: optional. Describes the variants of the component packaged in the module, if any.
@@ -85,6 +85,15 @@ This value must contain an array of 0 or more capabilities. Each capability is a
 #### Standard attributes
 
 - `org.gradle.usage` indicates the purpose of the variant. See the `org.gradle.api.attributes.Usage` class for more details. Value must be a string.
+- `org.gradle.status` indicates the kind of release: one of `release` or `integration`.
+
+#### Java Ecosystem specific attributes
+
+- `org.gradle.dependency.bundling` indicates how dependencies of the variant are bundled. Either externally, embedded or shadowed. See the `org.gradle.api.attributes.java.Bundling` for more details. Value must be a string.
+- `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library.
+
+#### Native ecosystem specific attributes
+
 - `org.gradle.native.debuggable` indicates native binaries that are debuggable. Value must be a boolean.
 
 ### `available-at` value
@@ -151,7 +160,7 @@ This value must contain an array with zero or more elements. Each element must b
 
 ```
 {
-    "formatVersion": "0.4",
+    "formatVersion": "1.0",
     "component": {
         "group": "my.group",
         "module": "mylib",

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/repo/org/gradle/demo/producer/1.0/producer-1.0.module
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/repo/org/gradle/demo/producer/1.0/producer-1.0.module
@@ -1,5 +1,5 @@
 {
-  "formatVersion": "0.4",
+  "formatVersion": "1.0",
   "component": {
     "group": "org.gradle.demo",
     "module": "producer",

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -35,7 +35,7 @@ class GradleModuleMetadata {
             JsonReader reader = new JsonReader(r)
             values = readObject(reader)
         }
-        assert values.formatVersion == '0.4'
+        assert values.formatVersion == '1.0'
         assert values.createdBy.gradle.version == GradleVersion.current().version
         assert values.createdBy.gradle.buildId
         variants = (values.variants ?: []).collect { new Variant(it.name, it) }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/GradleFileModuleAdapter.groovy
@@ -17,7 +17,7 @@
 package org.gradle.test.fixtures.gradle
 
 import groovy.json.JsonBuilder
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.test.fixtures.file.TestFile
 
 class GradleFileModuleAdapter {
@@ -40,7 +40,7 @@ class GradleFileModuleAdapter {
         def file = moduleDir.file("$module-${version}.module")
         def jsonBuilder = new JsonBuilder()
         jsonBuilder {
-            formatVersion ModuleMetadataParser.FORMAT_VERSION
+            formatVersion GradleModuleMetadataParser.FORMAT_VERSION
             builtBy {
                 gradle { }
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -17,6 +17,7 @@ package org.gradle.api.plugins.internal;
 
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
+import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
@@ -103,6 +104,9 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
     }
 
     private void setupConfigurations(SourceSet sourceSet) {
+        if (sourceSet == null) {
+            throw new InvalidUserCodeException("You must specify which source set to use for feature '" + name + "'");
+        }
         String apiConfigurationName;
         String implConfigurationName;
         String apiElementsConfigurationName;

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/GradleModuleMetadataWriter.java
@@ -38,7 +38,7 @@ import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.artifacts.DefaultExcludeRule;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -69,17 +69,17 @@ import java.util.TreeMap;
  * <p>Whenever you change this class, make sure you also:</p>
  *
  * <ul>
- * <li>Update the corresponding {@link ModuleMetadataParser module metadata parser}</li>
+ * <li>Update the corresponding {@link GradleModuleMetadataParser module metadata parser}</li>
  * <li>Update the module metadata specification (subprojects/docs/src/docs/design/gradle-module-metadata-specification.md)</li>
  * <li>Update {@link org.gradle.api.internal.artifacts.ivyservice.modulecache.ModuleMetadataSerializer the module metadata serializer} </li>
  * <li>Add a sample for the module metadata serializer test, to make sure that serialized metadata is idempotent</li>
  * </ul>
  */
-public class ModuleMetadataFileGenerator {
+public class GradleModuleMetadataWriter {
     private final BuildInvocationScopeId buildInvocationScopeId;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
 
-    public ModuleMetadataFileGenerator(BuildInvocationScopeId buildInvocationScopeId, ProjectDependencyPublicationResolver projectDependencyResolver) {
+    public GradleModuleMetadataWriter(BuildInvocationScopeId buildInvocationScopeId, ProjectDependencyPublicationResolver projectDependencyResolver) {
         this.buildInvocationScopeId = buildInvocationScopeId;
         this.projectDependencyResolver = projectDependencyResolver;
     }
@@ -257,7 +257,7 @@ public class ModuleMetadataFileGenerator {
 
     private void writeFormat(JsonWriter jsonWriter) throws IOException {
         jsonWriter.name("formatVersion");
-        jsonWriter.value(ModuleMetadataParser.FORMAT_VERSION);
+        jsonWriter.value(GradleModuleMetadataParser.FORMAT_VERSION);
     }
 
     private void writeVariantHostedInAnotherModule(ModuleVersionIdentifier coordinates, ModuleVersionIdentifier targetCoordinates, UsageContext variant, JsonWriter jsonWriter) throws IOException {

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/tasks/GenerateModuleMetadata.java
@@ -35,7 +35,7 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.publish.Publication;
-import org.gradle.api.publish.internal.ModuleMetadataFileGenerator;
+import org.gradle.api.publish.internal.GradleModuleMetadataWriter;
 import org.gradle.api.publish.internal.PublicationInternal;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
@@ -167,7 +167,7 @@ public class GenerateModuleMetadata extends DefaultTask {
         try {
             Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(file), "utf8"));
             try {
-                new ModuleMetadataFileGenerator(getBuildInvocationScopeId(), getProjectDependencyPublicationResolver()).generateTo(publication, publications, writer);
+                new GradleModuleMetadataWriter(getBuildInvocationScopeId(), getProjectDependencyPublicationResolver()).generateTo(publication, publications, writer);
             } finally {
                 writer.close();
             }

--- a/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
+++ b/subprojects/publish/src/test/groovy/org/gradle/api/publish/internal/ModuleMetadataFileGeneratorTest.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.internal.artifacts.DefaultExcludeRule
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint
-import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.ModuleMetadataParser
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModuleMetadataParser
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
@@ -64,7 +64,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
     def buildId = UniqueId.generate()
     def id = DefaultModuleVersionIdentifier.newId("group", "module", "1.2")
     def projectDependencyResolver = Mock(ProjectDependencyPublicationResolver)
-    def generator = new ModuleMetadataFileGenerator(new BuildInvocationScopeId(buildId), projectDependencyResolver)
+    def generator = new GradleModuleMetadataWriter(new BuildInvocationScopeId(buildId), projectDependencyResolver)
 
     def "writes file for component with no variants"() {
         def writer = new StringWriter()
@@ -76,7 +76,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -104,7 +104,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -162,7 +162,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -292,7 +292,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -463,7 +463,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -559,7 +559,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -619,7 +619,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",
@@ -684,7 +684,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "url": "../../module/1.2/module-1.2.module",
     "group": "group",
@@ -745,7 +745,7 @@ class ModuleMetadataFileGeneratorTest extends Specification {
 
         then:
         writer.toString() == """{
-  "formatVersion": "${ModuleMetadataParser.FORMAT_VERSION}",
+  "formatVersion": "${GradleModuleMetadataParser.FORMAT_VERSION}",
   "component": {
     "group": "group",
     "module": "module",


### PR DESCRIPTION
### Context

This commit bumps the Gradle metadata format to 1.0.
The specification file of the format has been changed
so that the name of the file indicates which version
it covers.

Starting from this commit, it is illegal to change
the metadata file format _without_ backwards compatibility
in mind.
