### PR TITLE
Allow @PathSensitive to be attached to @InputArtifactDependency transform action properties

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -73,7 +73,7 @@ allprojects {
         def view = configurations.implementation.incoming.artifactView {
             attributes.attribute(color, 'green')
         }.files
-        dependsOn view
+        inputs.files view
         doLast {
             println "result = \${view.files.name}"
         }
@@ -158,7 +158,7 @@ allprojects {
 
     /**
      * Each project produces a 'blue' variant, and has a `resolve` task that resolves the 'green' variant and a 'MakeGreen' transform that converts 'blue' to 'green'
-     * Caller will need to provide an implementation of 'MakeGreen' transform configuration and use {@link TransformBuilder#paramsConfig(java.lang.String)} to specify the configuration to
+     * Caller will need to provide an implementation of 'MakeGreen' transform configuration and use {@link TransformBuilder#params(java.lang.String)} to specify the configuration to
      * apply to the parameters.
      */
     void setupBuildWithColorTransform(@DelegatesTo(TransformBuilder) Closure cl) {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -30,22 +30,23 @@ import javax.annotation.Nonnull
 import java.util.regex.Pattern
 
 @IgnoreIf({ GradleContextualExecuter.parallel})
-class ArtifactTransformWithDependenciesIntegrationTest extends AbstractHttpDependencyResolutionTest {
+class ArtifactTransformWithDependenciesIntegrationTest extends AbstractHttpDependencyResolutionTest implements ArtifactTransformTestFixture {
 
     def setup() {
         settingsFile << """
             rootProject.name = 'transform-deps'
             include 'common', 'lib', 'app'
         """
-        mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.24").publish().allowAll()
-        mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.25").publish().allowAll()
-        mavenHttpRepo.module("junit", "junit", "4.11")
+        withColorVariants(mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.24")).publish().allowAll()
+        withColorVariants(mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.25")).publish().allowAll()
+        withColorVariants(mavenHttpRepo.module("junit", "junit", "4.11"))
                 .dependsOn("hamcrest", "hamcrest-core", "1.3")
-                .publish().allowAll()
-        mavenHttpRepo.module("hamcrest", "hamcrest-core", "1.3").publish().allowAll()
+                .publish()
+                .allowAll()
+        withColorVariants(mavenHttpRepo.module("hamcrest", "hamcrest-core", "1.3")).publish().allowAll()
 
+        setupBuildWithColorAttributes()
         buildFile << """
-def artifactType = Attribute.of('artifactType', String)
                    
 @TransformAction(TestTransformAction)
 interface TestTransform {
@@ -56,59 +57,26 @@ interface TestTransform {
 
 allprojects {
     repositories {
-        maven { url = '${mavenHttpRepo.uri}' }
-    }
-    configurations {
-        implementation {
-            canBeConsumed = false
-            attributes.attribute(artifactType, 'jar')
+        maven { 
+            url = '${mavenHttpRepo.uri}' 
+            metadataSources { gradleMetadata() }
         }
-        "default" { extendsFrom implementation }
-    }
-    task producer(type: Producer) {
-        outputFile = file("build/\${project.name}.jar")
-    }
-    artifacts {
-        implementation producer.outputFile
     }
 
     dependencies {
-        registerTransform(TestTransform) {
-            from.attribute(artifactType, 'jar')
-            to.attribute(artifactType, 'size')
-            parameters {
-                transformName = 'Single step transform'
+        artifactTypes {
+            jar {
+                attributes.attribute(color, 'blue')
             }
         }
+    }
 
-        // Multi step transform
-        registerTransform(TestTransform) {
-            from.attribute(artifactType, 'jar')
-            to.attribute(artifactType, 'intermediate')
-            parameters {
-                transformName = 'Transform step 1'
-            }
-        }
-        registerTransform(TestTransform) {
-            from.attribute(artifactType, 'intermediate')
-            to.attribute(artifactType, 'final')
-            parameters {
-                transformName = 'Transform step 2'
-            }
-        }
-
-        //Multi step transform, without dependencies at step 1
-        registerTransformAction(SimpleTransform) {
-            from.attribute(artifactType, 'jar')
-            to.attribute(artifactType, 'middle')
-        }
-        registerTransform(TestTransform) {
-            from.attribute(artifactType, 'middle')
-            to.attribute(artifactType, 'end')
-            parameters {
-                transformName = 'Transform step 2'
-            }
-        }
+    task resolveGreen(type: Copy) {
+        def artifacts = configurations.implementation.incoming.artifactView {
+            attributes { it.attribute(color, 'green') }
+        }.artifacts
+        from artifacts.artifactFiles
+        into "\${buildDir}/green"
     }
 }
 
@@ -134,16 +102,6 @@ project(':app') {
 }
 
 import javax.inject.Inject
-
-class Producer extends DefaultTask {
-    @OutputFile
-    RegularFileProperty outputFile = project.objects.fileProperty()
-
-    @TaskAction
-    def go() {
-        outputFile.get().asFile.text = "output"
-    }
-}
 
 abstract class TestTransformAction implements ArtifactTransformAction {
 
@@ -187,25 +145,74 @@ abstract class SimpleTransform implements ArtifactTransformAction {
 """
     }
 
-    def "transform can access artifact dependencies as a set of files when using ArtifactView"() {
-
-        given:
-
+    void setupBuildWithSingleStep() {
         buildFile << """
-project(':app') {
-    task resolve(type: Copy) {
-        def artifacts = configurations.implementation.incoming.artifactView {
-            attributes { it.attribute(artifactType, 'size') }
-        }.artifacts
-        from artifacts.artifactFiles
-        into "\${buildDir}/libs"
+allprojects {
+    dependencies {
+        registerTransform(TestTransform) {
+            from.attribute(color, 'blue')
+            to.attribute(color, 'green')
+            parameters {
+                transformName = 'Single step transform'
+            }
+        }
     }
 }
 """
+    }
+
+    void setupBuildWithFirstStepThatDoesNotUseDependencies() {
+        buildFile << """
+allprojects {
+    dependencies {
+        //Multi step transform, without dependencies at step 1
+        registerTransformAction(SimpleTransform) {
+            from.attribute(color, 'blue')
+            to.attribute(color, 'yellow')
+        }
+        registerTransform(TestTransform) {
+            from.attribute(color, 'yellow')
+            to.attribute(color, 'green')
+            parameters {
+                transformName = 'Transform step 2'
+            }
+        }
+    }
+}
+"""
+    }
+
+    void setupBuildWithTwoSteps() {
+        buildFile << """
+allprojects {
+    dependencies {
+        // Multi step transform
+        registerTransform(TestTransform) {
+            from.attribute(color, 'blue')
+            to.attribute(color, 'yellow')
+            parameters {
+                transformName = 'Transform step 1'
+            }
+        }
+        registerTransform(TestTransform) {
+            from.attribute(color, 'yellow')
+            to.attribute(color, 'green')
+            parameters {
+                transformName = 'Transform step 2'
+            }
+        }
+    }
+}
+"""
+    }
+
+    def "transform can access artifact dependencies as a set of files when using ArtifactView"() {
+        given:
+        setupBuildWithSingleStep()
 
         when:
         executer.withArgument("--parallel")
-        run "resolve"
+        run ":app:resolveGreen"
 
         then:
         output.count('Transforming') == 5
@@ -214,29 +221,19 @@ project(':app') {
     }
 
     def "transform can access file dependencies as a set of files when using ArtifactView"() {
-
         given:
-
+        setupBuildWithSingleStep()
         buildFile << """
 project(':common') {
-
     dependencies {
         implementation files("otherLib.jar")
-    }
-
-    task resolve(type: Copy) {
-        def artifacts = configurations.implementation.incoming.artifactView {
-            attributes { it.attribute(artifactType, 'size') }
-        }.artifacts
-        from artifacts.artifactFiles
-        into "\${buildDir}/libs"
     }
 }
 """
 
         when:
         executer.withArgument("--parallel")
-        run "common:resolve"
+        run "common:resolveGreen"
 
         then:
         output.count('Transforming') == 1
@@ -244,25 +241,12 @@ project(':common') {
     }
 
     def "transform can access artifact dependencies as a set of files when using ArtifactView, even if first step did not use dependencies"() {
-
         given:
-
-        buildFile << """
-project(':app') {
-    task resolve(type: Copy) {
-        def artifacts = configurations.implementation.incoming.artifactView {
-            attributes { it.attribute(artifactType, 'end') }
-        }.artifacts
-        from artifacts.artifactFiles
-        into "\${buildDir}/libs"
-    }
-}
-
-"""
+        setupBuildWithFirstStepThatDoesNotUseDependencies()
 
         when:
         executer.withArgument("--parallel")
-        run "resolve"
+        run "app:resolveGreen"
 
         then:
         assertTransformationsExecuted(
@@ -280,25 +264,12 @@ project(':app') {
     }
 
     def "transform can access artifact dependencies, in previous transform step, as set of files when using ArtifactView"() {
-
         given:
-
-        buildFile << """
-project(':app') {
-    task resolve(type: Copy) {
-        def artifacts = configurations.implementation.incoming.artifactView {
-            attributes { it.attribute(artifactType, 'final') }
-        }.artifacts
-        from artifacts.artifactFiles
-        into "\${buildDir}/libs"
-    }
-}
-
-"""
+        setupBuildWithTwoSteps()
 
         when:
         executer.withArgument("--parallel")
-        run "resolve"
+        run "app:resolveGreen"
 
         then:
         assertTransformationsExecuted(
@@ -315,58 +286,14 @@ project(':app') {
         )
     }
 
-    def "transform can access artifact dependencies as a set of files when using configuration attributes"() {
-
-        given:
-
-        buildFile << """
-project(':app') {
-    configurations {
-        sizeConf {
-            attributes.attribute(artifactType, 'size')
-            extendsFrom implementation
-        }
-    }
-
-    task resolve(type: Copy) {
-        def artifacts = configurations.sizeConf.incoming.artifacts
-        from artifacts.artifactFiles
-        into "\${buildDir}/libs"
-    }
-}
-"""
-
-        when:
-        executer.withArgument("--parallel")
-        run "resolve"
-
-        then:
-        assertTransformationsExecuted(
-            singleStep('common.jar'),
-            singleStep('hamcrest-core-1.3.jar'),
-            singleStep('lib.jar', 'slf4j-api-1.7.25.jar', 'common.jar'),
-            singleStep('junit-4.11.jar', 'hamcrest-core-1.3.jar'),
-            singleStep('slf4j-api-1.7.25.jar'),
-        )
-    }
-
     def "transform with changed dependencies are re-executed"() {
         given:
-        buildFile << """
-project(':app') {
-    task resolve(type: Copy) {
-        def artifacts = configurations.implementation.incoming.artifactView {
-            attributes { it.attribute(artifactType, 'size') }
-        }.artifacts
-        from artifacts.artifactFiles
-        into "\${buildDir}/libs"
-    }
-}
-"""
-        run "resolve", "-PuseOldDependencyVersion"
+        setupBuildWithSingleStep()
+
+        run ":app:resolveGreen", "-PuseOldDependencyVersion"
 
         when:
-        run "resolve", "-PuseOldDependencyVersion", "--info"
+        run ":app:resolveGreen", "-PuseOldDependencyVersion", "--info"
         def outputLines = output.readLines()
 
         then:
@@ -379,7 +306,7 @@ project(':app') {
         outputLines.count { it ==~ /TestTransformAction: .* is not up-to-date because:/ } == 0
 
         when:
-        run "resolve", "--info"
+        run ":app:resolveGreen", "--info"
         outputLines = output.readLines()
 
         then:
@@ -398,40 +325,11 @@ project(':app') {
 
     def "transforms with different dependencies in multiple dependency graphs are executed"() {
         given:
-        mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.26").publish().allowAll()
+        withColorVariants(mavenHttpRepo.module("org.slf4j", "slf4j-api", "1.7.26")).publish().allowAll()
         settingsFile << "include('app2')"
+        setupBuildWithTwoSteps()
         buildFile << """
-            project(':app') {
-                task resolveSize(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'size') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs/size"
-                }
-                task resolveInter(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'intermediate') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs/intermediate"
-                }         
-            }
             project(':app2') {
-                task resolveSize(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'size') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs/size"
-                }
-                task resolveFinal(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'final') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs/final"
-                }         
                 dependencies {
                     implementation 'junit:junit:4.11'
                     implementation 'org.slf4j:slf4j-api:1.7.26'
@@ -448,19 +346,10 @@ project(':app') {
         def libWithSlf4New = ['lib.jar': [slf4jNew, common]]
 
         when:
-        run "resolveSize", "resolveInter", "resolveFinal"
+        run ":app:resolveGreen", ":app2:resolveGreen"
+
         then:
         assertTransformationsExecuted(
-            singleStep(common),
-            singleStep(hamcrest),
-            singleStep(junit411),
-
-            singleStep(slf4jOld),
-            singleStep(libWithSlf4Old),
-
-            singleStep(slf4jNew),
-            singleStep(libWithSlf4New),
-
             transformStep1(common),
             transformStep2(common),
             transformStep1(hamcrest),
@@ -469,7 +358,10 @@ project(':app') {
             transformStep2(junit411),
 
             transformStep1(slf4jOld),
+            transformStep2(slf4jOld),
+
             transformStep1(libWithSlf4Old),
+            transformStep2(libWithSlf4Old),
 
             transformStep1(slf4jNew),
             transformStep2(slf4jNew),
@@ -479,10 +371,10 @@ project(':app') {
         )
 
         def outputLines = output.readLines()
-        def app1Resolve = outputLines.indexOf("> Task :app:resolveSize")
-        def app2Resolve = outputLines.indexOf("> Task :app2:resolveSize")
-        def libTransformWithOldSlf4j = outputLines.indexOf("Single step transform received dependencies files [slf4j-api-1.7.25.jar, common.jar] for processing lib.jar")
-        def libTransformWithNewSlf4j = outputLines.indexOf("Single step transform received dependencies files [slf4j-api-1.7.26.jar, common.jar] for processing lib.jar")
+        def app1Resolve = outputLines.indexOf("> Task :app:resolveGreen")
+        def app2Resolve = outputLines.indexOf("> Task :app2:resolveGreen")
+        def libTransformWithOldSlf4j = outputLines.indexOf("Transform step 1 received dependencies files [slf4j-api-1.7.25.jar, common.jar] for processing lib.jar")
+        def libTransformWithNewSlf4j = outputLines.indexOf("Transform step 1 received dependencies files [slf4j-api-1.7.26.jar, common.jar] for processing lib.jar")
         ![app1Resolve, app2Resolve, libTransformWithOldSlf4j, libTransformWithNewSlf4j].contains(-1)
         // scheduled transformations, executed before the resolve task
         assert libTransformWithOldSlf4j < app1Resolve
@@ -492,17 +384,8 @@ project(':app') {
     def "transform does not execute when dependencies cannot be found"() {
         given:
         mavenHttpRepo.module("unknown", "not-found", "4.3").allowAll().assertNotPublished()
+        setupBuildWithTwoSteps()
         buildFile << """
-            project(':app') {
-                task resolve(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'size') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs"
-                }
-            }        
-            
             project(':lib') {
                 dependencies {
                     implementation "unknown:not-found:4.3"
@@ -511,7 +394,7 @@ project(':app') {
         """
 
         when:
-        fails "resolve"
+        fails ":app:resolveGreen"
 
         then:
         assertTransformationsExecuted()
@@ -521,21 +404,12 @@ project(':app') {
 
     def "transform does not execute when dependencies cannot be downloaded"() {
         given:
-        def cantBeDownloaded = mavenHttpRepo.module("test", "cant-be-downloaded", "4.3").publish()
-        cantBeDownloaded.pom.allowGetOrHead()
+        def cantBeDownloaded = withColorVariants(mavenHttpRepo.module("test", "cant-be-downloaded", "4.3")).publish()
+        cantBeDownloaded.moduleMetadata.allowGetOrHead()
         cantBeDownloaded.artifact.expectDownloadBroken()
+        setupBuildWithTwoSteps()
 
         buildFile << """
-            project(':app') {
-                task resolve(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'size') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs"
-                }
-            }        
-            
             project(':lib') {
                 dependencies {
                     implementation "test:cant-be-downloaded:4.3"
@@ -544,40 +418,34 @@ project(':app') {
         """
 
         when:
-        fails "resolve"
+        fails ":app:resolveGreen"
 
         then:
         failure.assertResolutionFailure(":app:implementation")
-        failure.assertThatCause(Matchers.containsString("Could not download cant-be-downloaded.jar (test:cant-be-downloaded:4.3)"))
+        failure.assertThatCause(Matchers.containsString("Could not download cant-be-downloaded-4.3.jar (test:cant-be-downloaded:4.3)"))
 
         assertTransformationsExecuted(
-            singleStep('common.jar'),
-            singleStep('slf4j-api-1.7.25.jar'),
-            singleStep('hamcrest-core-1.3.jar'),
-            singleStep('junit-4.11.jar': ['hamcrest-core-1.3.jar'])
+            transformStep1('common.jar'),
+            transformStep1('slf4j-api-1.7.25.jar'),
+            transformStep1('hamcrest-core-1.3.jar'),
+            transformStep1('junit-4.11.jar': ['hamcrest-core-1.3.jar']),
+            transformStep2('common.jar'),
+            transformStep2('slf4j-api-1.7.25.jar'),
+            transformStep2('hamcrest-core-1.3.jar'),
+            transformStep2('junit-4.11.jar': ['hamcrest-core-1.3.jar'])
         )
     }
 
     def "transform does not execute when dependencies cannot be transformed"() {
         given:
-        buildFile << """
-            project(':app') {
-                task resolve(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'end') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs"
-                }
-            }        
-        """
+        setupBuildWithFirstStepThatDoesNotUseDependencies()
 
         when:
-        fails "resolve", '-DfailTransformOf=slf4j-api-1.7.25.jar'
+        fails ":app:resolveGreen", '-DfailTransformOf=slf4j-api-1.7.25.jar'
 
         then:
         failure.assertResolutionFailure(":app:implementation")
-        failure.assertThatCause(Matchers.containsString("Failed to transform artifact 'slf4j-api.jar (org.slf4j:slf4j-api:1.7.25)'"))
+        failure.assertThatCause(Matchers.containsString("Failed to transform artifact 'slf4j-api-1.7.25.jar (org.slf4j:slf4j-api:1.7.25)'"))
 
         assertTransformationsExecuted(
             simpleTransform('common.jar'),
@@ -594,17 +462,8 @@ project(':app') {
 
     def "transform does not execute when task from dependencies fails"() {
         given:
+        setupBuildWithTwoSteps()
         buildFile << """
-            project(':app') {
-                task resolve(type: Copy) {
-                    def artifacts = configurations.implementation.incoming.artifactView {
-                        attributes { it.attribute(artifactType, 'size') }
-                    }.artifacts
-                    from artifacts.artifactFiles
-                    into "\${buildDir}/libs"
-                }
-            }        
-            
             project(':common') {
                 producer.doLast {
                     throw new RuntimeException("broken")
@@ -613,7 +472,7 @@ project(':app') {
         """
 
         when:
-        fails "resolve"
+        fails ":app:resolveGreen"
 
         then:
         assertTransformationsExecuted()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 
 class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyResolutionTest implements ArtifactTransformTestFixture {
     /**
-     * Caller should add elements to the 'inputFiles' property to make them inputs to the transform
+     * Caller should add define an 'inputFiles' property to define the inputs to the transform
      */
     def setupBuildWithTransformFileInputs() {
         setupBuildWithColorTransform {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -69,6 +69,7 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
 
     private final Object parameterObject;
     private final Class<? extends FileNormalizer> fileNormalizer;
+    private final Class<? extends FileNormalizer> dependenciesNormalizer;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final IsolatableFactory isolatableFactory;
     private final ValueSnapshotter valueSnapshotter;
@@ -81,10 +82,11 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
 
     private IsolatableParameters isolatable;
 
-    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, Class<? extends FileNormalizer> fileNormalizer, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
+    public DefaultTransformer(Class<? extends ArtifactTransformAction> implementationClass, @Nullable Object parameterObject, ImmutableAttributes fromAttributes, Class<? extends FileNormalizer> inputArtifactNormalizer, Class<? extends FileNormalizer> dependenciesNormalizer, ClassLoaderHierarchyHasher classLoaderHierarchyHasher, IsolatableFactory isolatableFactory, ValueSnapshotter valueSnapshotter, PropertyWalker parameterPropertyWalker, DomainObjectProjectStateHandler projectStateHandler, InstantiationScheme actionInstantiationScheme) {
         super(implementationClass, fromAttributes);
         this.parameterObject = parameterObject;
-        this.fileNormalizer = fileNormalizer;
+        this.fileNormalizer = inputArtifactNormalizer;
+        this.dependenciesNormalizer = dependenciesNormalizer;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.isolatableFactory = isolatableFactory;
         this.valueSnapshotter = valueSnapshotter;
@@ -110,6 +112,11 @@ public class DefaultTransformer extends AbstractTransformer<ArtifactTransformAct
     @Override
     public Class<? extends FileNormalizer> getInputArtifactNormalizer() {
         return fileNormalizer;
+    }
+
+    @Override
+    public Class<? extends FileNormalizer> getInputArtifactDependenciesNormalizer() {
+        return dependenciesNormalizer;
     }
 
     public boolean requiresDependencies() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -44,7 +44,6 @@ import org.gradle.internal.execution.history.changes.ExecutionStateChanges;
 import org.gradle.internal.execution.history.changes.InputFileChanges;
 import org.gradle.internal.execution.impl.steps.UpToDateResult;
 import org.gradle.internal.file.TreeType;
-import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinter;
@@ -80,7 +79,6 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
     private final ArtifactTransformListener artifactTransformListener;
     private final CachingTransformationWorkspaceProvider immutableTransformationWorkspaceProvider;
     private final FileCollectionFingerprinterRegistry fileCollectionFingerprinterRegistry;
-    private final FileCollectionFingerprinter dependencyFingerprinter;
     private final FileCollectionFactory fileCollectionFactory;
     private final FileCollectionFingerprinter outputFingerprinter;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
@@ -105,13 +103,12 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.projectFinder = projectFinder;
         this.useTransformationWorkspaces = useTransformationWorkspaces;
-        // Assume absolute for now
-        dependencyFingerprinter = fileCollectionFingerprinterRegistry.getFingerprinter(AbsolutePathInputNormalizer.class);
         outputFingerprinter = fileCollectionFingerprinterRegistry.getFingerprinter(OutputNormalizer.class);
     }
 
     @Override
     public Try<ImmutableList<File>> invoke(Transformer transformer, File inputArtifact, ArtifactTransformDependencies dependencies, TransformationSubject subject) {
+        FileCollectionFingerprinter dependencyFingerprinter = fileCollectionFingerprinterRegistry.getFingerprinter(transformer.getInputArtifactDependenciesNormalizer());
         CurrentFileCollectionFingerprint dependenciesFingerprint = dependencies.fingerprint(dependencyFingerprinter);
         ProjectInternal producerProject = determineProducerProject(subject);
         CachingTransformationWorkspaceProvider workspaceProvider = determineWorkspaceProvider(producerProject);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -84,6 +84,11 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
     }
 
     @Override
+    public Class<? extends FileNormalizer> getInputArtifactDependenciesNormalizer() {
+        return AbsolutePathInputNormalizer.class;
+    }
+
+    @Override
     public void visitDependencies(TaskDependencyResolveContext context) {
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -53,4 +53,6 @@ public interface Transformer extends Describable, TaskDependencyContainer {
     void isolateParameters();
 
     Class<? extends FileNormalizer> getInputArtifactNormalizer();
+
+    Class<? extends FileNormalizer> getInputArtifactDependenciesNormalizer();
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -142,6 +142,11 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         }
 
         @Override
+        Class<? extends FileNormalizer> getInputArtifactDependenciesNormalizer() {
+            return AbsolutePathInputNormalizer
+        }
+
+        @Override
         void isolateParameters() {
         }
 


### PR DESCRIPTION
### Context

Plus a bit of test coverage.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
