### PR TITLE
cpp-plugin: Add  '.c' and '.cxx' suffixes as new C++ source filter 

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppApplicationIntegrationTest.groovy
@@ -217,7 +217,6 @@ class CppApplicationIntegrationTest extends AbstractCppIntegrationTest implement
         given:
         app.writeToProject(testDirectory)
         file("src/main/cpp/ignore.swift") << 'broken!'
-        file("src/main/cpp/ignore.c") << 'broken!'
         file("src/main/cpp/ignore.m") << 'broken!'
         file("src/main/cpp/ignore.h") << 'broken!'
         file("src/main/cpp/ignore.java") << 'broken!'

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppComponent.java
@@ -54,7 +54,7 @@ public abstract class DefaultCppComponent extends DefaultNativeComponent impleme
         super(fileOperations);
         this.name = name;
         this.fileOperations = fileOperations;
-        cppSource = createSourceView("src/" + name + "/cpp", Arrays.asList("cpp", "c++", "cc"));
+        cppSource = createSourceView("src/" + name + "/cpp", Arrays.asList("cpp", "c++", "cc", "cxx", "c"));
         privateHeaders = fileOperations.configurableFiles();
         privateHeadersWithConvention = createDirView(privateHeaders, "src/" + name + "/headers");
         baseName = objectFactory.property(String.class);

--- a/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
+++ b/subprojects/language-native/src/test/groovy/org/gradle/language/cpp/internal/DefaultCppComponentTest.groovy
@@ -50,10 +50,12 @@ class DefaultCppComponentTest extends Specification {
         def f1 = tmpDir.createFile("a.cpp")
         def f2 = tmpDir.createFile("b.c++")
         def f3 = tmpDir.createFile("c.cc")
+        def f4 = tmpDir.createFile("d.cxx")
+        def f5 = tmpDir.createFile("e.c")
 
         expect:
-        component.source.from(f1, f2, f3)
-        component.cppSource.files == [f1, f2, f3] as Set
+        component.source.from(f1, f2, f3, f4, f5)
+        component.cppSource.files == [f1, f2, f3, f4, f5] as Set
     }
 
     def "can include source files from a directory"() {
@@ -61,12 +63,14 @@ class DefaultCppComponentTest extends Specification {
         def f1 = d.createFile("a.cpp")
         def f2 = d.createFile("nested/b.cpp")
         def f3 = d.createFile("c.cc")
+        def f4 = d.createFile("nested/d.c")
+        def f5 = d.createFile("nested/e.cxx")
         d.createFile("ignore.txt")
         d.createFile("other/ignore.txt")
 
         expect:
         component.source.from(d)
-        component.cppSource.files == [f1, f2, f3] as Set
+        component.cppSource.files == [f1, f2, f3, f4, f5] as Set
     }
 
     def "uses source layout convention when no other source files specified"() {
@@ -87,6 +91,7 @@ class DefaultCppComponentTest extends Specification {
     def "does not use the convention when specified directory is empty"() {
         tmpDir.createFile("src/main/cpp/a.cpp")
         tmpDir.createFile("src/main/cpp/nested/b.cpp")
+        tmpDir.createFile("src/main/cpp/nested/nested/c.c")
         def d = tmpDir.createDir("other")
 
         expect:

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/CppCompiler.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/CppCompiler.java
@@ -33,7 +33,7 @@ class CppCompiler extends VisualCppNativeCompiler<CppCompileSpec> {
     private static class CppCompilerArgsTransformer extends VisualCppCompilerArgsTransformer<CppCompileSpec> {
         @Override
         protected String getLanguageOption() {
-            return "/TP";
+            return null;
         }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -43,7 +43,9 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
     }
 
     protected void addToolSpecificArgs(T spec, List<String> args) {
-        args.add(getLanguageOption());
+        String languageOption = getLanguageOption();
+        if (languageOption != null)
+        	args.add(languageOption);
         args.add("/nologo");
         args.add("/c");
         if (spec.isDebuggable()) {
@@ -74,6 +76,6 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
      * @return compiler language option or empty string if the language does not require it
      */
     protected String getLanguageOption() {
-        return "";
+        return null;
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -73,7 +73,7 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
 
     /**
      * Returns compiler specific language option
-     * @return compiler language option or empty string if the language does not require it
+     * @return compiler language option or null if the language does not require it
      */
     protected String getLanguageOption() {
         return null;

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/toolchain/internal/msvcpp/VisualCppCompilerArgsTransformer.java
@@ -44,8 +44,9 @@ abstract class VisualCppCompilerArgsTransformer<T extends NativeCompileSpec> imp
 
     protected void addToolSpecificArgs(T spec, List<String> args) {
         String languageOption = getLanguageOption();
-        if (languageOption != null)
-        	args.add(languageOption);
+        if (languageOption != null) {
+            args.add(languageOption);
+        }
         args.add("/nologo");
         args.add("/c");
         if (spec.isDebuggable()) {


### PR DESCRIPTION
### Context
[Here the discussion about this PR ](https://github.com/gradle/gradle-native/issues/974#issuecomment-462886948)

### Contributor Checklist
- [x ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`
The above languageNative:check fails on
```
org.gradle.language.cpp.CppLanguageIncrementalCompileIntegrationTest > recompiles when replacement header file with different content is added to source directory [visual c++ 2017 (15.0.0)] FAILED
    org.spockframework.runtime.ConditionFailedWithExceptionError
        Caused by: org.codehaus.groovy.runtime.powerassert.PowerAssertionError

org.gradle.language.cpp.CppLanguageIncrementalCompileIntegrationTest > does not recompile when replacement header file with same content is added to source directory [visual c++ 2017 (15.0.0)] FAILED
    org.spockframework.runtime.ConditionFailedWithExceptionError
        Caused by: org.codehaus.groovy.runtime.powerassert.PowerAssertionError
```
but I do not understand how to them.



### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
