### PR TITLE
Deduplication of serialized metadata

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/CacheLayout.java
@@ -53,7 +53,7 @@ public enum CacheLayout {
         .changedTo(63, "4.10-rc-1")
         .changedTo(68, "5.0-milestone-1")
         .changedTo(69, "5.0-rc-1")
-        .changedTo(70, "5.3-rc-1")
+        .changedTo(71, "5.3-rc-1")
     ),
 
     RESOURCES(ROOT, "resources", introducedIn("1.9-rc-1")),

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -27,6 +27,7 @@ import org.gradle.internal.component.external.model.AbstractLazyModuleComponentR
 import org.gradle.internal.component.external.model.AbstractRealisedModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier;
 import org.gradle.internal.component.external.model.DefaultVirtualModuleComponentIdentifier;
+import org.gradle.internal.component.external.model.ExternalDependencyDescriptor;
 import org.gradle.internal.component.external.model.ModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.MutableModuleComponentResolveMetadata;
 import org.gradle.internal.component.external.model.VirtualComponentIdentifier;
@@ -34,6 +35,7 @@ import org.gradle.internal.component.external.model.ivy.DefaultIvyModuleResolveM
 import org.gradle.internal.component.external.model.ivy.RealisedIvyModuleResolveMetadata;
 import org.gradle.internal.component.external.model.ivy.RealisedIvyModuleResolveMetadataSerializationHelper;
 import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
+import org.gradle.internal.component.external.model.maven.MavenDependencyDescriptor;
 import org.gradle.internal.component.external.model.maven.RealisedMavenModuleResolveMetadata;
 import org.gradle.internal.component.external.model.maven.RealisedMavenModuleResolveMetadataSerializationHelper;
 import org.gradle.internal.resolve.caching.DesugaringAttributeContainerSerializer;
@@ -43,7 +45,8 @@ import org.gradle.internal.serialize.Encoder;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Serializer for {@link ModuleComponentResolveMetadata}.
@@ -68,14 +71,15 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
     @Override
     public ModuleComponentResolveMetadata read(Decoder decoder) throws EOFException, Exception {
 
-        MutableModuleComponentResolveMetadata mutable = delegate.read(decoder, moduleIdentifierFactory);
+        Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache = Maps.newHashMap();
+        MutableModuleComponentResolveMetadata mutable = delegate.read(decoder, moduleIdentifierFactory, deduplicationDependencyCache);
         readPlatformOwners(decoder, mutable);
         AbstractLazyModuleComponentResolveMetadata resolveMetadata = (AbstractLazyModuleComponentResolveMetadata) mutable.asImmutable();
 
         if (resolveMetadata instanceof DefaultIvyModuleResolveMetadata) {
             return ivySerializationHelper.readMetadata(decoder, (DefaultIvyModuleResolveMetadata) resolveMetadata);
         } else if (resolveMetadata instanceof DefaultMavenModuleResolveMetadata) {
-            return mavenSerializationHelper.readMetadata(decoder, (DefaultMavenModuleResolveMetadata) resolveMetadata);
+            return mavenSerializationHelper.readMetadata(decoder, (DefaultMavenModuleResolveMetadata) resolveMetadata, deduplicationDependencyCache);
         } else {
             throw new IllegalStateException("Unknown resolved metadata type: " + resolveMetadata.getClass());
         }
@@ -103,14 +107,15 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
     @Override
     public void write(Encoder encoder, ModuleComponentResolveMetadata value) throws Exception {
         AbstractRealisedModuleComponentResolveMetadata transformed = assertRealized(value);
-        delegate.write(encoder, transformed);
+        HashMap<ExternalDependencyDescriptor, Integer> deduplicationDependencyCache = Maps.newHashMap();
+        delegate.write(encoder, transformed, deduplicationDependencyCache);
         writeOwners(encoder, value.getPlatformOwners());
         if (transformed instanceof RealisedIvyModuleResolveMetadata) {
             ivySerializationHelper.writeRealisedVariantsData(encoder, transformed);
-            ivySerializationHelper.writeRealisedConfigurationsData(encoder, transformed, Collections.emptyMap());
+            ivySerializationHelper.writeRealisedConfigurationsData(encoder, transformed, deduplicationDependencyCache);
         } else if (transformed instanceof RealisedMavenModuleResolveMetadata) {
             mavenSerializationHelper.writeRealisedVariantsData(encoder, transformed);
-            mavenSerializationHelper.writeRealisedConfigurationsData(encoder, transformed, Maps.newHashMap());
+            mavenSerializationHelper.writeRealisedConfigurationsData(encoder, transformed, deduplicationDependencyCache);
         } else {
             throw new IllegalStateException("Unexpected realised module component resolve metadata type: " + transformed.getClass());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleComponentResolveMetadataSerializer.java
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
@@ -42,6 +43,7 @@ import org.gradle.internal.serialize.Encoder;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.util.Collections;
 
 /**
  * Serializer for {@link ModuleComponentResolveMetadata}.
@@ -105,10 +107,10 @@ public class ModuleComponentResolveMetadataSerializer extends AbstractSerializer
         writeOwners(encoder, value.getPlatformOwners());
         if (transformed instanceof RealisedIvyModuleResolveMetadata) {
             ivySerializationHelper.writeRealisedVariantsData(encoder, transformed);
-            ivySerializationHelper.writeRealisedConfigurationsData(encoder, transformed);
+            ivySerializationHelper.writeRealisedConfigurationsData(encoder, transformed, Collections.emptyMap());
         } else if (transformed instanceof RealisedMavenModuleResolveMetadata) {
             mavenSerializationHelper.writeRealisedVariantsData(encoder, transformed);
-            mavenSerializationHelper.writeRealisedConfigurationsData(encoder, transformed);
+            mavenSerializationHelper.writeRealisedConfigurationsData(encoder, transformed, Maps.newHashMap());
         } else {
             throw new IllegalStateException("Unexpected realised module component resolve metadata type: " + transformed.getClass());
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStore.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStore.java
@@ -17,6 +17,7 @@ package org.gradle.api.internal.artifacts.ivyservice.modulecache;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Interner;
+import com.google.common.collect.Maps;
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
@@ -54,7 +55,7 @@ public class ModuleMetadataStore {
             try {
                 StringDeduplicatingDecoder decoder = new StringDeduplicatingDecoder(new KryoBackedDecoder(new FileInputStream(resource.getFile())), stringInterner);
                 try {
-                    return moduleMetadataSerializer.read(decoder, moduleIdentifierFactory);
+                    return moduleMetadataSerializer.read(decoder, moduleIdentifierFactory, Maps.newHashMap());
                 } finally {
                     decoder.close();
                 }
@@ -72,7 +73,7 @@ public class ModuleMetadataStore {
                 try {
                     KryoBackedEncoder encoder = new KryoBackedEncoder(new FileOutputStream(moduleDescriptorFile));
                     try {
-                        moduleMetadataSerializer.write(encoder, metadata);
+                        moduleMetadataSerializer.write(encoder, metadata, Maps.newHashMap());
                     } finally {
                         encoder.close();
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractRealisedModuleResolveMetadataSerializationHelper.java
@@ -82,12 +82,12 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         }
     }
 
-    public void writeRealisedConfigurationsData(Encoder encoder, AbstractRealisedModuleComponentResolveMetadata transformed) throws IOException {
+    public void writeRealisedConfigurationsData(Encoder encoder, AbstractRealisedModuleComponentResolveMetadata transformed, Map<ExternalDependencyDescriptor, Integer> deduplicationDependencyCache) throws IOException {
         encoder.writeSmallInt(transformed.getConfigurationNames().size());
         for (String configurationName: transformed.getConfigurationNames()) {
             ConfigurationMetadata configuration = transformed.getConfiguration(configurationName);
             writeConfiguration(encoder, configuration);
-            writeDependencies(encoder, configuration);
+            writeDependencies(encoder, configuration, deduplicationDependencyCache);
         }
     }
 
@@ -147,7 +147,7 @@ public abstract class AbstractRealisedModuleResolveMetadataSerializationHelper {
         return ImmutableCapabilities.of(rawCapabilities);
     }
 
-    protected abstract void writeDependencies(Encoder encoder, ConfigurationMetadata configuration) throws IOException;
+    protected abstract void writeDependencies(Encoder encoder, ConfigurationMetadata configuration, Map<ExternalDependencyDescriptor, Integer> deduplicationDependencyCache) throws IOException;
 
     private void writeCapabilities(Encoder encoder, List<? extends Capability> capabilities) throws IOException {
         encoder.writeSmallInt(capabilities.size());

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/RealisedIvyModuleResolveMetadataSerializationHelper.java
@@ -73,7 +73,7 @@ public class RealisedIvyModuleResolveMetadataSerializationHelper extends Abstrac
         return new RealisedIvyModuleResolveMetadata(resolveMetadata, realisedVariants, readIvyConfigurations(decoder, resolveMetadata));
     }
 
-    protected void writeDependencies(Encoder encoder, ConfigurationMetadata configuration) throws IOException {
+    protected void writeDependencies(Encoder encoder, ConfigurationMetadata configuration, Map<ExternalDependencyDescriptor, Integer> deduplicationDependencyCache) throws IOException {
         List<? extends DependencyMetadata> dependencies = configuration.getDependencies();
         encoder.writeSmallInt(dependencies.size());
         for (DependencyMetadata dependency: dependencies) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/CacheLayoutTest.groovy
@@ -62,7 +62,7 @@ class CacheLayoutTest extends Specification {
         cacheLayout.versionMapping.getVersionUsedBy(GradleVersion.version("1.9-rc-2")).get() == CacheVersion.of(2, 1)
 
         where:
-        expectedVersion = 70
+        expectedVersion = 71
     }
 
     def "use transforms layout"() {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataSerializerTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.modulecache
 
+import com.google.common.collect.Maps
 import org.apache.commons.io.output.ByteArrayOutputStream
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
@@ -95,12 +96,12 @@ class ModuleMetadataSerializerTest extends Specification {
     }
 
     private MutableModuleComponentResolveMetadata deserialize(byte[] serializedForm) {
-        serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(serializedForm)), moduleIdentifierFactory)
+        serializer.read(new InputStreamBackedDecoder(new ByteArrayInputStream(serializedForm)), moduleIdentifierFactory, Maps.newHashMap())
     }
 
     private byte[] serialize(MutableModuleComponentResolveMetadata metadata) {
         ByteArrayOutputStream baos = new ByteArrayOutputStream()
-        serializer.write(new OutputStreamBackedEncoder(baos), metadata.asImmutable())
+        serializer.write(new OutputStreamBackedEncoder(baos), metadata.asImmutable(), Maps.newHashMap())
         baos.toByteArray()
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/modulecache/ModuleMetadataStoreTest.groovy
@@ -69,6 +69,6 @@ class ModuleMetadataStoreTest extends Specification {
         1 * pathKeyFileStore.add("org.test/testArtifact/1.0/repositoryId/descriptor.bin", _) >> { path, action ->
             action.execute(descriptorFile); fileStoreEntry
         };
-        1 * serializer.write(_, descriptor)
+        1 * serializer.write(_, descriptor, _)
     }
 }


### PR DESCRIPTION
When writing realised Maven metadata, when a cacheable
ComponentMetadataRule is used, a lot of duplication happened around
MavenDependencyDescriptor.
This was caused by the amount of derived variants computed in for Maven
dependencies, which effectively have a very common set of dependencies.

This change set fixes that by de-duplicating `MavenDependencyDescriptor` serialization.