### PR TITLE
Make archives produced reproducible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -386,3 +386,13 @@ tasks.register<Zip>("allIncubationReportsZip") {
 }
 
 fun Project.collectAllIncubationReports() = subprojects.flatMap { it.tasks.withType(IncubatingApiReportTask::class) }
+
+// Ensure the archives produced are reproducible
+allprojects {
+    tasks.withType<AbstractArchiveTask>().configureEach {
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+        dirMode = Integer.parseInt("0755", 8)
+        fileMode = Integer.parseInt("0644", 8)
+    }
+}

--- a/subprojects/wrapper/wrapper.gradle
+++ b/subprojects/wrapper/wrapper.gradle
@@ -35,12 +35,7 @@ testFixtures {
 }
 
 tasks.register("executableJar", Jar) {
-    // gradle-wrapper.jar will be part of the plugins.jar - so it needs to be identical for now
-    reproducibleFileOrder = true
-    preserveFileTimestamps = false
     archiveName = 'gradle-wrapper.jar'
-    fileMode = 0644
-    dirMode = 0755
     manifest {
         attributes.remove(Attributes.Name.IMPLEMENTATION_VERSION.toString())
         attributes([(Attributes.Name.IMPLEMENTATION_TITLE.toString()): "Gradle Wrapper"])


### PR DESCRIPTION
This makes the JARs and ZIPs created by Gradle use the same file order and fixed timestamps and file/dir access modes. So if the same build timestamp is supplied, the resulting distribution should be the same every time it is built.

Superseds #8096:

> When running two builds of the same sources of Gradle, outputs were not binary equivalent, this was primarily due to zip files not being equivalent due to both file ordering and timestamps in the file metadata.
> 
> This changes makes it so that running two gradle builds with the same `buildTimestamp`
> (e.g. `-PbuildTimestamp="20181220000000-0800"`) produce the same output.
> 
> Having a reproducible build will make it easier to verify that the official distributions match the sources on github.
> 
> ### Context
> A chain of custody from source to binary is a great thing to have so people can verify for themselves that the distribution matches the sources.