### PR TITLE
Ensure that input files specified by artifact transform parameters have been built before the transform is run

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -567,6 +567,7 @@ abstract class NoneTransformAction implements TransformAction {
         then:
         assertTransformationsExecuted()
         failure.assertResolutionFailure(":app:implementation")
+        failure.assertHasFailures(1)
         failure.assertThatCause(Matchers.containsString("Could not find unknown:not-found:4.3"))
     }
 
@@ -590,6 +591,7 @@ abstract class NoneTransformAction implements TransformAction {
 
         then:
         failure.assertResolutionFailure(":app:implementation")
+        failure.assertHasFailures(1)
         failure.assertThatCause(Matchers.containsString("Could not download cant-be-downloaded-4.3.jar (test:cant-be-downloaded:4.3)"))
 
         assertTransformationsExecuted(
@@ -613,6 +615,7 @@ abstract class NoneTransformAction implements TransformAction {
 
         then:
         failure.assertResolutionFailure(":app:implementation")
+        failure.assertHasFailures(1)
         failure.assertThatCause(Matchers.containsString("Failed to transform artifact 'slf4j-api-1.7.25.jar (org.slf4j:slf4j-api:1.7.25)'"))
 
         assertTransformationsExecuted(
@@ -628,7 +631,7 @@ abstract class NoneTransformAction implements TransformAction {
         )
     }
 
-    def "transform does not execute when task from dependencies fails"() {
+    def "transform does not execute when dependencies cannot be built"() {
         given:
         setupBuildWithTwoSteps()
         buildFile << """
@@ -645,6 +648,7 @@ abstract class NoneTransformAction implements TransformAction {
         then:
         assertTransformationsExecuted()
         failure.assertHasDescription("Execution failed for task ':common:producer'")
+        failure.assertHasFailures(1)
         failure.assertHasCause("broken")
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -140,8 +140,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         run(":a:resolve")
 
         then:
-        // TODO - should run the producer task
-//        result.assertTasksExecuted("a:tool", "b:producer", "c:producer", "a:resolve")
+        result.assertTasksExecuted(":a:tool", ":b:producer", ":c:producer", ":a:resolve")
         outputContains("processing b.jar using [tool-a.jar]")
         outputContains("processing c.jar using [tool-a.jar]")
         outputContains("result = [b.jar.green, c.jar.green]")
@@ -196,9 +195,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         run(":a:resolve")
 
         then:
-        // TODO wolfs: Build dependencies of transforms required by the parameters are not discovered
-        // result.assertTasksExecuted(":b:producer", ":c:producer", , ":d:producer", ":e:producer", ":a:resolve")
-        result.assertTasksExecuted(":b:producer", ":c:producer", ":a:resolve")
+        result.assertTasksExecuted(":b:producer", ":c:producer", ":d:producer", ":e:producer", ":a:resolve")
         outputContains("processing b.jar using [d.jar.red, e.jar.red]")
         outputContains("processing c.jar using [d.jar.red, e.jar.red]")
         outputContains("result = [b.jar.green, c.jar.green]")
@@ -254,8 +251,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         run(":a:resolve")
 
         then:
-        // TODO - should run the producer tasks
-//        result.assertTasksExecuted(":tools:tool-a:producer", ":tools:tool-b:producer", ":b:producer", "c:producer", ":a:resolve")
+        result.assertTasksExecuted(":tools:tool-a:producer", ":tools:tool-b:producer", ":b:producer", ":c:producer", ":a:resolve")
         outputContains("processing b.jar using [tool-a.jar, tool-b.jar]")
         outputContains("processing c.jar using [tool-a.jar, tool-b.jar]")
         outputContains("result = [b.jar.green, c.jar.green]")


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
