### PR TITLE
Support @Classpath and @CompileClasspath attached to input properties of an artifact transform action

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
@@ -104,7 +104,9 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
         ImmutableSetMultimap.Builder<Class<? extends Annotation>, Class<? extends Annotation>> builder = ImmutableSetMultimap.builder();
         for (PropertyAnnotationHandler handler : allAnnotationHandlers) {
             if (handler instanceof OverridingPropertyAnnotationHandler) {
-                builder.put(((OverridingPropertyAnnotationHandler) handler).getOverriddenAnnotationType(), handler.getAnnotationType());
+                for (Class<? extends Annotation> overriddenAnnotationType : ((OverridingPropertyAnnotationHandler) handler).getOverriddenAnnotationTypes()) {
+                    builder.put(overriddenAnnotationType, handler.getAnnotationType());
+                }
             }
         }
         return builder.build();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/ClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/ClasspathPropertyAnnotationHandler.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks.properties.annotations;
 
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.internal.tasks.properties.BeanPropertyContext;
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
@@ -36,8 +39,8 @@ public class ClasspathPropertyAnnotationHandler implements OverridingPropertyAnn
     }
 
     @Override
-    public Class<? extends Annotation> getOverriddenAnnotationType() {
-        return InputFiles.class;
+    public ImmutableList<Class<? extends Annotation>> getOverriddenAnnotationTypes() {
+        return ImmutableList.of(InputFiles.class, InputArtifact.class, InputArtifactDependencies.class);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/CompileClasspathPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/CompileClasspathPropertyAnnotationHandler.java
@@ -16,6 +16,9 @@
 
 package org.gradle.api.internal.tasks.properties.annotations;
 
+import com.google.common.collect.ImmutableList;
+import org.gradle.api.artifacts.transform.InputArtifact;
+import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.internal.tasks.properties.BeanPropertyContext;
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
@@ -36,8 +39,8 @@ public class CompileClasspathPropertyAnnotationHandler implements OverridingProp
     }
 
     @Override
-    public Class<? extends Annotation> getOverriddenAnnotationType() {
-        return InputFiles.class;
+    public ImmutableList<Class<? extends Annotation>> getOverriddenAnnotationTypes() {
+        return ImmutableList.of(InputFiles.class, InputArtifact.class, InputArtifactDependencies.class);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/OverridingPropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/OverridingPropertyAnnotationHandler.java
@@ -15,11 +15,13 @@
  */
 package org.gradle.api.internal.tasks.properties.annotations;
 
+import com.google.common.collect.ImmutableList;
+
 import java.lang.annotation.Annotation;
 
 public interface OverridingPropertyAnnotationHandler extends PropertyAnnotationHandler {
     /**
      * Returns the annotation type this annotation is allowed to override when declared on the same property.
      */
-    Class<? extends Annotation> getOverriddenAnnotationType();
+    ImmutableList<Class<? extends Annotation>> getOverriddenAnnotationTypes();
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -853,9 +853,11 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
     }
 
     @Unroll
-    def "can attach #annotation to input artifact property with project artifact file"() {
+    def "can attach @#annotation to input artifact property with project artifact file"() {
         settingsFile << "include 'a', 'b', 'c'"
-        setupBuildWithColorTransformAction()
+        setupBuildWithColorTransformAction {
+            produceJars()
+        }
         buildFile << """
             project(':a') {
                 dependencies {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -852,6 +852,94 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
         sensitivity << [PathSensitivity.RELATIVE, PathSensitivity.NAME_ONLY]
     }
 
+    @Unroll
+    def "can attach #annotation to input artifact property with project artifact file"() {
+        settingsFile << "include 'a', 'b', 'c'"
+        setupBuildWithColorTransformAction()
+        buildFile << """
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                    implementation project(':c')
+                }
+            }
+            
+            abstract class MakeGreen implements TransformAction {
+                @InputArtifact @${annotation}
+                abstract File getInput()
+                
+                void transform(TransformOutputs outputs) {
+                    println "processing \${input.name}"
+                    def output = outputs.file(input.name + ".green")
+                    output.text = input.text + ".green"
+                }
+            }
+        """
+
+        when:
+        succeeds(":a:resolve")
+
+        then:
+        result.assertTasksNotSkipped(":b:producer", ":c:producer", ":a:resolve")
+        transformed("b.jar", "c.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksNotSkipped(":a:resolve")
+        transformed()
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PbContent=new")
+        succeeds(":a:resolve")
+
+        then: // new content, should run
+        result.assertTasksNotSkipped(":b:producer", ":a:resolve")
+        transformed("b.jar")
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PbContent=new")
+        succeeds(":a:resolve")
+
+        then: // no change, should be up to date
+        result.assertTasksNotSkipped(":a:resolve")
+        transformed()
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PbContent=new", "-PbOutputDir=out")
+        succeeds(":a:resolve")
+
+        then: // path has changed, transforms up-to-date
+        result.assertTasksNotSkipped(":b:producer", ":a:resolve")
+        transformed()
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        executer.withArguments("-PbContent=new", "-PbOutputDir=out", "-PbFileName=b-blue.jar")
+        succeeds(":a:resolve")
+
+        then: // new file name, transforms up-to-date
+        result.assertTasksNotSkipped(":b:producer", ":a:resolve")
+        transformed()
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        when:
+        succeeds(":a:resolve")
+
+        then: // have already seen these artifacts before
+        result.assertTasksNotSkipped(":b:producer", ":a:resolve")
+        transformed()
+        outputContains("result = [b.jar.green, c.jar.green]")
+
+        where:
+        annotation << ["Classpath", "CompileClasspath"]
+    }
+
     void transformed(String... expected) {
         def actual = output.readLines().inject([]) { items, line ->
             def matcher = Pattern.compile("processing\\s+(.+)").matcher(line)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -139,7 +139,7 @@ class DependencyManagementGlobalScopeServices {
     ArtifactTransformActionScheme createArtifactTransformActionScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {
         InstantiationScheme instantiationScheme = instantiatorFactory.injectScheme(ImmutableSet.of(InputArtifact.class, InputArtifactDependencies.class, TransformParameters.class));
         InstantiationScheme legacyInstantiationScheme = instantiatorFactory.injectScheme();
-        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(InputArtifact.class, InputArtifactDependencies.class, TransformParameters.class, Inject.class));
+        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(InputArtifact.class, InputArtifactDependencies.class, TransformParameters.class, Inject.class, Classpath.class, CompileClasspath.class));
         return new ArtifactTransformActionScheme(instantiationScheme, inspectionScheme, legacyInstantiationScheme);
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -101,13 +101,13 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
         Class<? extends FileNormalizer> inputArtifactNormalizer = AbsolutePathInputNormalizer.class;
         Class<? extends FileNormalizer> dependenciesNormalizer = AbsolutePathInputNormalizer.class;
         for (PropertyMetadata propertyMetadata : actionMetadata.getPropertiesMetadata()) {
-            if (propertyMetadata.getPropertyType().equals(InputArtifact.class)) {
+            if (propertyMetadata.getAnnotation(InputArtifact.class) != null) {
                 // Should ask the annotation handler to figure this out instead
                 NormalizerCollectingVisitor visitor = new NormalizerCollectingVisitor();
                 actionMetadata.getAnnotationHandlerFor(propertyMetadata).visitPropertyValue(propertyMetadata.getPropertyName(), null, propertyMetadata, visitor, null);
                 inputArtifactNormalizer = visitor.normalizer;
             }
-            if (propertyMetadata.getPropertyType().equals(InputArtifactDependencies.class)) {
+            if (propertyMetadata.getAnnotation(InputArtifactDependencies.class) != null) {
                 NormalizerCollectingVisitor visitor = new NormalizerCollectingVisitor();
                 actionMetadata.getAnnotationHandlerFor(propertyMetadata).visitPropertyValue(propertyMetadata.getPropertyName(), null, propertyMetadata, visitor, null);
                 dependenciesNormalizer = visitor.normalizer;

--- a/subprojects/model-core/src/main/java/org/gradle/internal/reflect/PropertyExtractor.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/reflect/PropertyExtractor.java
@@ -110,7 +110,7 @@ public class PropertyExtractor {
                     // Discard overridden property type annotations when an overriding annotation is also present
                     Iterable<Annotation> overriddenAnnotations = filterOverridingAnnotations(declaredAnnotations, propertyTypeAnnotations);
 
-                    recordAnnotations(propertyMetadata, overriddenAnnotations, propertyTypeAnnotations);
+                    recordAnnotations(propertyMetadata, overriddenAnnotations, declaredAnnotations, propertyTypeAnnotations);
                 }
             }
         });
@@ -186,12 +186,16 @@ public class PropertyExtractor {
         });
     }
 
-    private void recordAnnotations(PropertyMetadataBuilder property, Iterable<Annotation> annotations, Set<Class<? extends Annotation>> propertyTypeAnnotations) {
+    private void recordAnnotations(PropertyMetadataBuilder property, Iterable<Annotation> overriddenAnnotations, Iterable<Annotation> annotations, Set<Class<? extends Annotation>> propertyTypeAnnotations) {
         Set<Class<? extends Annotation>> declaredPropertyTypes = Sets.newLinkedHashSet();
-        for (Annotation annotation : annotations) {
+        for (Annotation annotation : overriddenAnnotations) {
             if (propertyTypeAnnotations.contains(annotation.annotationType())) {
                 declaredPropertyTypes.add(annotation.annotationType());
+                property.addAnnotation(annotation);
             }
+        }
+
+        for (Annotation annotation : annotations) {
             property.addAnnotation(annotation);
         }
 


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
