### PR TITLE
Clarify attribute compatibility rule contract

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeCompatibilityRule.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/AttributeCompatibilityRule.java
@@ -21,9 +21,16 @@ import org.gradle.api.Incubating;
 
 /**
  * A rule that determines whether a given attribute value is compatible some provided attribute value.
+ * <p>
+ * The provided {@link CompatibilityCheckDetails} will give access to consumer and producer values and allow implementation
+ * mark the producer value as compatible or not.
+ * <p>
+ * Note that the rule will never receive a {@code CompatibilityCheckDetails} that has {@code equal} consumer and producer
+ * values as this check is performed before invoking the rule and assumes compatiblity in that case.
  *
  * @since 4.0
  * @param <T> The attribute value type.
+ * @see CompatibilityCheckDetails
  */
 @Incubating
 public interface AttributeCompatibilityRule<T> extends Action<CompatibilityCheckDetails<T>> {

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/CompatibilityCheckDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/CompatibilityCheckDetails.java
@@ -20,6 +20,8 @@ import javax.annotation.Nullable;
 /**
  * Provides context about attribute compatibility checks, and allows the user to define
  * when an attribute is compatible with another.
+ * <p>
+ * A compatibility check will <em>never</em> be performed when the consumer and producer values are equal.
  *
  * @param <T> the concrete type of the attribute
  *
@@ -28,6 +30,9 @@ import javax.annotation.Nullable;
 public interface CompatibilityCheckDetails<T> {
     /**
      * The value of the attribute as found on the consumer side.
+     * <p>
+     * Never equal to the {@link #getProducerValue()}.
+     *
      * @return the value from the consumer
      */
     @Nullable
@@ -35,6 +40,9 @@ public interface CompatibilityCheckDetails<T> {
 
     /**
      * The value of the attribute as found on the producer side.
+     * <p>
+     * Never equal to the {@link #getConsumerValue()}.
+     *
      * @return the value from the producer
      */
     @Nullable

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/DependencyGraphBuilder.java
@@ -15,7 +15,6 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -72,6 +71,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -413,13 +413,13 @@ public class DependencyGraphBuilder {
     }
 
     private static boolean compatible(CompatibilityRule<Object> rule, Object v1, Object v2) {
+        if (Objects.equals(v1, v2)) {
+            // Equal values are compatible
+            return true;
+        }
         DefaultCompatibilityCheckResult<Object> result = new DefaultCompatibilityCheckResult<>(v1, v2);
         rule.execute(result);
-        if (!result.hasResult()) {
-            // the rule said nothing, so we use equality
-            return Objects.equal(v1, v2);
-        }
-        return result.isCompatible();
+        return result.hasResult() && result.isCompatible();
     }
 
     private void attachMultipleForceOnPlatformFailureToEdges(ModuleResolveState module) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultCompatibilityCheckResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/DefaultCompatibilityCheckResult.java
@@ -18,6 +18,8 @@ package org.gradle.internal.component.model;
 
 import org.gradle.api.internal.attributes.CompatibilityCheckResult;
 
+import java.util.Objects;
+
 public class DefaultCompatibilityCheckResult<T> implements CompatibilityCheckResult<T> {
     private final T consumerValue;
     private final T producerValue;
@@ -25,6 +27,8 @@ public class DefaultCompatibilityCheckResult<T> implements CompatibilityCheckRes
     private boolean done;
 
     public DefaultCompatibilityCheckResult(T consumerValue, T producerValue) {
+        assert producerValue != null : "Internal contract of the current implementation, can be changed with a motivation";
+        assert !Objects.equals(consumerValue, producerValue);
         this.consumerValue = consumerValue;
         this.producerValue = producerValue;
     }


### PR DESCRIPTION
The provided details will never have equal consumer and producer values
as that check is performed before invoking the rule.
This also means that equal values are determined to be always
compatible.