### PR TITLE
Introduce `TargetJvmVersion` attribute

### DIFF
--- a/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/org/gradle/gradlebuild/unittestandcompile/UnitTestAndCompilePlugin.kt
@@ -26,6 +26,7 @@ import org.gradle.api.Named
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.internal.tasks.testing.junit.result.TestResultSerializer
+import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.bundling.Jar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.CompileOptions
@@ -45,6 +46,7 @@ import java.lang.IllegalStateException
 import java.util.concurrent.Callable
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.jar.Attributes
+import kotlin.reflect.full.declaredFunctions
 
 
 enum class ModuleType(val compatibility: JavaVersion) {
@@ -307,6 +309,7 @@ open class UnitTestAndCompileExtension(val project: Project) {
             field = value!!
             project.java.targetCompatibility = value.compatibility
             project.java.sourceCompatibility = value.compatibility
+            project.java.disableAutoTargetJvmGradle53()
         }
 
     init {
@@ -315,5 +318,13 @@ open class UnitTestAndCompileExtension(val project: Project) {
                 throw InvalidUserDataException("gradlebuild.moduletype must be set for project $project")
             }
         }
+    }
+}
+
+
+fun JavaPluginConvention.disableAutoTargetJvmGradle53() {
+    val function = JavaPluginConvention::class.declaredFunctions.find { it.name == "disableAutoTargetJvm" }
+    function?.also {
+        it.call(this)
     }
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJavaPlatform.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJavaPlatform.java
@@ -30,5 +30,5 @@ public interface TargetJavaPlatform {
     /**
      * The minimal target platform for a Java library. Any consumer below this version would not be able to consume it.
      */
-    Attribute<Integer> MINIMAL_TARGET_PLATFORM_ATTRIBUTE = Attribute.of("org.gradle.java.min.platform", Integer.class);
+    Attribute<Integer> TARGET_PLATFORM_ATTRIBUTE = Attribute.of("org.gradle.jvm.platform", Integer.class);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJavaPlatform.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJavaPlatform.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.attributes.java;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.attributes.Attribute;
+
+/**
+ * Represents the target platform of a Java library or platform. The target level is expected to correspond
+ * to a Java platform version number (integer). For example, "5" for Java 5, "8" for Java 8, or "11" for Java 11.
+ *
+ * @since 5.3
+ */
+@Incubating
+public interface TargetJavaPlatform {
+
+    /**
+     * The minimal target platform for a Java library. Any consumer below this version would not be able to consume it.
+     */
+    Attribute<Integer> MINIMAL_TARGET_PLATFORM_ATTRIBUTE = Attribute.of("org.gradle.java.min.platform", Integer.class);
+}

--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJvmVersion.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/java/TargetJvmVersion.java
@@ -19,16 +19,16 @@ import org.gradle.api.Incubating;
 import org.gradle.api.attributes.Attribute;
 
 /**
- * Represents the target platform of a Java library or platform. The target level is expected to correspond
+ * Represents the target version of a Java library or platform. The target level is expected to correspond
  * to a Java platform version number (integer). For example, "5" for Java 5, "8" for Java 8, or "11" for Java 11.
  *
  * @since 5.3
  */
 @Incubating
-public interface TargetJavaPlatform {
+public interface TargetJvmVersion {
 
     /**
-     * The minimal target platform for a Java library. Any consumer below this version would not be able to consume it.
+     * The minimal target version for a Java library. Any consumer below this version would not be able to consume it.
      */
-    Attribute<Integer> TARGET_PLATFORM_ATTRIBUTE = Attribute.of("org.gradle.jvm.platform", Integer.class);
+    Attribute<Integer> TARGET_JVM_VERSION_ATTRIBUTE = Attribute.of("org.gradle.jvm.version", Integer.class);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -49,13 +49,13 @@ public abstract class JavaEcosystemSupport {
         String majorVersion = version.getMajorVersion();
         AttributeContainerInternal attributes = (AttributeContainerInternal) configuration.getAttributes();
         // If nobody said anything about this variant's target platform, use whatever the convention says
-        if (!attributes.contains(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)) {
-            attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
+        if (!attributes.contains(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)) {
+            attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
         }
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {
-        AttributeMatchingStrategy<Integer> targetPlatformSchema = attributesSchema.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE);
+        AttributeMatchingStrategy<Integer> targetPlatformSchema = attributesSchema.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE);
         targetPlatformSchema.getCompatibilityRules().ordered(Ordering.natural());
         targetPlatformSchema.getDisambiguationRules().pickLast(Ordering.<Integer>natural());
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -30,7 +30,7 @@ import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
-import org.gradle.api.attributes.java.TargetJavaPlatform;
+import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.internal.ReusableAction;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -49,13 +49,13 @@ public abstract class JavaEcosystemSupport {
         String majorVersion = version.getMajorVersion();
         AttributeContainerInternal attributes = (AttributeContainerInternal) configuration.getAttributes();
         // If nobody said anything about this variant's target platform, use whatever the convention says
-        if (!attributes.contains(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)) {
-            attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
+        if (!attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)) {
+            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(majorVersion));
         }
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {
-        AttributeMatchingStrategy<Integer> targetPlatformSchema = attributesSchema.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE);
+        AttributeMatchingStrategy<Integer> targetPlatformSchema = attributesSchema.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE);
         targetPlatformSchema.getCompatibilityRules().ordered(Ordering.natural());
         targetPlatformSchema.getDisambiguationRules().pickLast(Ordering.<Integer>natural());
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -20,16 +20,19 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
 import org.gradle.api.Action;
 import org.gradle.api.ActionConfiguration;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.attributes.AttributeCompatibilityRule;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.AttributesSchema;
 import org.gradle.api.attributes.CompatibilityCheckDetails;
+import org.gradle.api.attributes.HasAttributes;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.java.TargetJavaPlatform;
 import org.gradle.api.internal.ReusableAction;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.model.ObjectFactory;
 
 import javax.inject.Inject;
@@ -40,6 +43,15 @@ public abstract class JavaEcosystemSupport {
         configureUsage(attributesSchema, objectFactory);
         configureBundling(attributesSchema);
         configureTargetPlatform(attributesSchema);
+    }
+
+    public static void configureDefaultTargetPlatform(HasAttributes configuration, JavaVersion version) {
+        String majorVersion = version.getMajorVersion();
+        AttributeContainerInternal attributes = (AttributeContainerInternal) configuration.getAttributes();
+        // If nobody said anything about this variant's target platform, use whatever the convention says
+        if (!attributes.contains(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)) {
+            attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
+        }
     }
 
     private static void configureTargetPlatform(AttributesSchema attributesSchema) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJavaPlatform;
 import org.gradle.api.initialization.dsl.ScriptHandler;
@@ -114,9 +115,10 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
         }
         if (classpathConfiguration == null) {
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
-            classpathConfiguration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME));
-            classpathConfiguration.getAttributes().attribute(Bundling.BUNDLING_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Bundling.class, Bundling.EXTERNAL));
-            classpathConfiguration.getAttributes().attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
+            AttributeContainer attributes = classpathConfiguration.getAttributes();
+            attributes.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME));
+            attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Bundling.class, Bundling.EXTERNAL));
+            attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -24,7 +24,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
-import org.gradle.api.attributes.java.TargetJavaPlatform;
+import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
@@ -118,7 +118,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
             AttributeContainer attributes = classpathConfiguration.getAttributes();
             attributes.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME));
             attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Bundling.class, Bundling.EXTERNAL));
-            attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
+            attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
         }
     }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/DefaultScriptHandler.java
@@ -16,12 +16,14 @@
 package org.gradle.api.internal.initialization;
 
 import groovy.lang.Closure;
+import org.gradle.api.JavaVersion;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.attributes.java.TargetJavaPlatform;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.artifacts.DependencyResolutionServices;
@@ -114,6 +116,7 @@ public class DefaultScriptHandler implements ScriptHandler, ScriptHandlerInterna
             classpathConfiguration = configContainer.create(CLASSPATH_CONFIGURATION);
             classpathConfiguration.getAttributes().attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME));
             classpathConfiguration.getAttributes().attribute(Bundling.BUNDLING_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Bundling.class, Bundling.EXTERNAL));
+            classpathConfiguration.getAttributes().attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
         }
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJavaPlatformRulesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJavaPlatformRulesTest.groovy
@@ -36,8 +36,8 @@ class TargetJavaPlatformRulesTest extends Specification {
     def setup() {
         AttributesSchema schema = new DefaultAttributesSchema(Stub(ComponentAttributeMatcher), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
-        compatibilityRules = schema.compatibilityRules(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)
-        disambiguationRules = schema.disambiguationRules(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)
+        compatibilityRules = schema.compatibilityRules(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)
+        disambiguationRules = schema.disambiguationRules(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)
     }
 
     @Unroll("compatibility consumer=#consumer producer=#producer compatible=#compatible")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJavaPlatformRulesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJavaPlatformRulesTest.groovy
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts
+
+import org.gradle.api.attributes.CompatibilityCheckDetails
+import org.gradle.api.attributes.MultipleCandidatesDetails
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class TargetJavaPlatformRulesTest extends Specification {
+    private JavaEcosystemSupport.TargetPlatformCompatibilityRules compatibilityRules = new JavaEcosystemSupport.TargetPlatformCompatibilityRules()
+    private JavaEcosystemSupport.TargetPlatformDisambiguationRules disambiguationRules = new JavaEcosystemSupport.TargetPlatformDisambiguationRules(8)
+
+    @Unroll("compatibility consumer=#consumer producer=#producer compatible=#compatible")
+    def "check compatibility rules"() {
+        CompatibilityCheckDetails details = Mock(CompatibilityCheckDetails)
+
+        when:
+        compatibilityRules.execute(details)
+
+        then:
+        1 * details.getConsumerValue() >> consumer
+        1 * details.getProducerValue() >> producer
+
+        if (compatible) {
+            1 * details.compatible()
+        } else {
+            1 * details.incompatible()
+        }
+
+        where:
+        consumer | producer | compatible
+        null     | 5        | true
+        null     | 6        | true
+        null     | 11       | true
+
+        8        | 6        | true
+        8        | 7        | true
+        8        | 8        | true
+        8        | 9        | false
+        8        | 10       | false
+        8        | 11       | false
+    }
+
+    @Unroll("disamgiguates when consumer=#consumer and candidates=#candidates chooses=#expected")
+    def "check disambiguation rules"() {
+        MultipleCandidatesDetails details = Mock(MultipleCandidatesDetails)
+
+        when:
+        disambiguationRules.execute(details)
+
+        then:
+        1 * details.getConsumerValue() >> consumer
+        1 * details.getCandidateValues() >> candidates
+        1 * details.closestMatch(expected)
+
+        where:
+        consumer | candidates | expected
+        null     | [4, 8, 11] | 8
+        null     | [11, 8]    | 8
+
+        6        | [6]        | 6
+        7        | [6, 7]     | 7
+        8        | [6, 7]     | 7
+        9        | [6, 7, 9]  | 9
+        10       | [6, 7, 9]  | 9
+        11       | [6, 7, 9]  | 9
+
+    }
+}

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/artifacts/TargetJvmVersionRulesTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts
 
 import org.gradle.api.attributes.AttributesSchema
-import org.gradle.api.attributes.java.TargetJavaPlatform
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.attributes.CompatibilityCheckResult
 import org.gradle.api.internal.attributes.CompatibilityRule
 import org.gradle.api.internal.attributes.DefaultAttributesSchema
@@ -29,15 +29,15 @@ import org.gradle.util.TestUtil
 import spock.lang.Specification
 import spock.lang.Unroll
 
-class TargetJavaPlatformRulesTest extends Specification {
+class TargetJvmVersionRulesTest extends Specification {
     private CompatibilityRule<Object> compatibilityRules
     private DisambiguationRule<Object> disambiguationRules
 
     def setup() {
         AttributesSchema schema = new DefaultAttributesSchema(Stub(ComponentAttributeMatcher), TestUtil.instantiatorFactory(), SnapshotTestUtil.valueSnapshotter())
         JavaEcosystemSupport.configureSchema(schema, TestUtil.objectFactory())
-        compatibilityRules = schema.compatibilityRules(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)
-        disambiguationRules = schema.disambiguationRules(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)
+        compatibilityRules = schema.compatibilityRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
+        disambiguationRules = schema.disambiguationRules(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)
     }
 
     @Unroll("compatibility consumer=#consumer producer=#producer compatible=#compatible")

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Usage
+import org.gradle.api.attributes.java.TargetJavaPlatform
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.groovy.scripts.ScriptSource
@@ -54,9 +55,10 @@ class DefaultScriptHandlerTest extends Specification {
         then:
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
-        2 * configuration.attributes >> attributes
+        1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
+        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
         0 * configurationContainer._
         0 * depMgmtServices._
     }
@@ -69,9 +71,10 @@ class DefaultScriptHandlerTest extends Specification {
         then:
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
-        2 * configuration.attributes >> attributes
+        1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
+        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         0 * configurationContainer._
         0 * depMgmtServices._
@@ -102,8 +105,9 @@ class DefaultScriptHandlerTest extends Specification {
         and:
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
-        2 * configuration.attributes >> attributes
+        1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
+        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
         1 * classpathResolver.resolveClassPath(configuration) >> classpath
     }
@@ -132,8 +136,9 @@ class DefaultScriptHandlerTest extends Specification {
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         1 * depMgmtServices.configurationContainer >> configurationContainer
         1 * configurationContainer.create('classpath') >> configuration
-        2 * configuration.attributes >> attributes
+        1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
+        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
         1 * dependencyHandler.add('config', 'dep')
     }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/initialization/DefaultScriptHandlerTest.groovy
@@ -22,7 +22,7 @@ import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.Usage
-import org.gradle.api.attributes.java.TargetJavaPlatform
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.api.internal.artifacts.DependencyResolutionServices
 import org.gradle.api.internal.attributes.AttributeContainerInternal
 import org.gradle.groovy.scripts.ScriptSource
@@ -58,7 +58,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
-        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
+        1 * attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, _)
         0 * configurationContainer._
         0 * depMgmtServices._
     }
@@ -74,7 +74,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
-        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
+        1 * attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, _)
         1 * depMgmtServices.dependencyHandler >> dependencyHandler
         0 * configurationContainer._
         0 * depMgmtServices._
@@ -107,7 +107,7 @@ class DefaultScriptHandlerTest extends Specification {
         1 * configurationContainer.create('classpath') >> configuration
         1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
-        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
+        1 * attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, _)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
         1 * classpathResolver.resolveClassPath(configuration) >> classpath
     }
@@ -138,8 +138,8 @@ class DefaultScriptHandlerTest extends Specification {
         1 * configurationContainer.create('classpath') >> configuration
         1 * configuration.attributes >> attributes
         1 * attributes.attribute(Usage.USAGE_ATTRIBUTE, _ as Usage)
-        1 * attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, _)
         1 * attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, _ as Bundling)
+        1 * attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, _)
         1 * dependencyHandler.add('config', 'dep')
     }
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -49,7 +49,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                        attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
+                        attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('org:lib-fixtures:1.0')
                 }
@@ -81,11 +81,11 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.java.min.platform': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.platform': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.java.min.platform': JavaVersion.current().majorVersion]
+                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.platform': JavaVersion.current().majorVersion]
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }
@@ -104,7 +104,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                        attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
+                        attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('test:lib:1.0')
                     outgoing.capability('test:lib-fixtures:1.0')
@@ -129,7 +129,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.java.min.platform': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.platform': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.integtests.resolve.attributes
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractDependencyResolutionTest
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 
@@ -48,6 +49,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('org:lib-fixtures:1.0')
                 }
@@ -79,11 +81,11 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external']
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.java.min.platform': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external']
+                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.java.min.platform': JavaVersion.current().majorVersion]
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }
@@ -102,6 +104,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
+                        attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('test:lib:1.0')
                     outgoing.capability('test:lib-fixtures:1.0')
@@ -126,7 +129,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external']
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.java.min.platform': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -49,7 +49,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                        attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
+                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('org:lib-fixtures:1.0')
                 }
@@ -81,11 +81,11 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.platform': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
-                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.platform': JavaVersion.current().majorVersion]
+                    variant "testFixtures", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'test', module:'lib', version:'unspecified', classifier: 'test-fixtures'
                 }
             }
@@ -104,7 +104,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
-                        attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
+                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
                     outgoing.capability('test:lib:1.0')
                     outgoing.capability('test:lib-fixtures:1.0')
@@ -129,7 +129,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.platform': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/ConfigurationInternal.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.artifacts.configurations;
 
+import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.internal.artifacts.ResolveContext;
@@ -58,6 +59,11 @@ public interface ConfigurationInternal extends ResolveContext, Configuration, De
      * Converts this configuration to an {@link OutgoingVariant} view. The view may not necessarily be immutable.
      */
     OutgoingVariant convertToOutgoingVariant();
+
+    /**
+     * Registers an action to execute before locking for further mutation.
+     */
+    void beforeLocking(Action<? super ConfigurationInternal> action);
 
     void preventFromFurtherMutation();
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/ModuleMetadataParser.java
@@ -51,6 +51,7 @@ import java.util.List;
 import static com.google.gson.stream.JsonToken.BOOLEAN;
 import static com.google.gson.stream.JsonToken.END_ARRAY;
 import static com.google.gson.stream.JsonToken.END_OBJECT;
+import static com.google.gson.stream.JsonToken.NUMBER;
 import static org.apache.commons.lang.StringUtils.capitalize;
 
 public class ModuleMetadataParser {
@@ -390,6 +391,9 @@ public class ModuleMetadataParser {
             if (reader.peek() == BOOLEAN) {
                 boolean attrValue = reader.nextBoolean();
                 attributes = attributesFactory.concat(attributes, Attribute.of(attrName, Boolean.class), attrValue);
+            } else if (reader.peek() == NUMBER) {
+                Integer attrValue = reader.nextInt();
+                attributes = attributesFactory.concat(attributes, Attribute.of(attrName, Integer.class), attrValue);
             } else {
                 String attrValue = reader.nextString();
                 attributes = attributesFactory.concat(attributes, Attribute.of(attrName, String.class), new CoercingStringValueSnapshot(attrValue, instantiator));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultOrderedDisambiguationRule.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/attributes/DefaultOrderedDisambiguationRule.java
@@ -18,8 +18,8 @@ package org.gradle.api.internal.attributes;
 import org.gradle.api.Action;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 
-import java.util.Collection;
 import java.util.Comparator;
+import java.util.Set;
 
 public class DefaultOrderedDisambiguationRule<T> implements Action<MultipleCandidatesDetails<T>> {
     private final Comparator<? super T> comparator;
@@ -32,22 +32,20 @@ public class DefaultOrderedDisambiguationRule<T> implements Action<MultipleCandi
 
     @Override
     public void execute(MultipleCandidatesDetails<T> details) {
-        Collection<T> values = details.getCandidateValues();
+        Set<T> candidateValues = details.getCandidateValues();
         T min = null;
         T max = null;
-        for (T value : values) {
-
+        for (T value : candidateValues) {
             if (min == null || comparator.compare(value, min) < 0) {
                 min = value;
             }
             if (max == null || comparator.compare(value, max) > 0) {
                 max = value;
             }
-
         }
         T cmp = pickFirst ? min : max;
         if (cmp != null) {
-            for (T value : details.getCandidateValues()) {
+            for (T value : candidateValues) {
                 if (value.equals(cmp)) {
                     details.closestMatch(value);
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractConfigurationMetadata.java
@@ -176,5 +176,4 @@ public abstract class AbstractConfigurationMetadata implements ConfigurationMeta
         return componentId;
     }
 
-    protected abstract ConfigurationMetadata withAttributes(ImmutableAttributes attributes);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/JavaEcosystemVariantDerivationStrategy.java
@@ -18,12 +18,14 @@ package org.gradle.internal.component.external.model;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.attributes.Usage;
+import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.internal.component.external.model.maven.DefaultMavenModuleResolveMetadata;
 import org.gradle.internal.component.model.ConfigurationMetadata;
 
 import java.util.Collections;
+import java.util.List;
 
 public class JavaEcosystemVariantDerivationStrategy implements VariantDerivationStrategy {
     @Override
@@ -39,6 +41,8 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
             MavenImmutableAttributesFactory attributesFactory = (MavenImmutableAttributesFactory) md.getAttributesFactory();
             DefaultConfigurationMetadata compileConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("compile");
             DefaultConfigurationMetadata runtimeConfiguration = (DefaultConfigurationMetadata) md.getConfiguration("runtime");
+            ModuleComponentIdentifier componentId = md.getId();
+            List<Capability> shadowedPlatformCapability = buildShadowPlatformCapability(componentId);
             return ImmutableList.of(
                     // When deriving variants for the Java ecosystem, we actually have 2 components "mixed together": the library and the platform
                     // and there's no way to figure out what was the intent when it was published. So we derive variants, but we also need
@@ -48,12 +52,22 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
                     // component we cannot mix precise usages with more generic ones)
                 libraryWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API),
                 libraryWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME),
-                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false),
-                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false),
-                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true),
-                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true));
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, false, shadowedPlatformCapability),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, false, shadowedPlatformCapability),
+                platformWithUsageAttribute(compileConfiguration, attributes, attributesFactory, Usage.JAVA_API, true, shadowedPlatformCapability),
+                platformWithUsageAttribute(runtimeConfiguration, attributes, attributesFactory, Usage.JAVA_RUNTIME, true, shadowedPlatformCapability));
         }
         return null;
+    }
+
+    private List<Capability> buildShadowPlatformCapability(ModuleComponentIdentifier componentId) {
+        return Collections.singletonList(
+                new DefaultShadowedCapability(new ImmutableCapability(
+                        componentId.getGroup(),
+                        componentId.getModule(),
+                        componentId.getVersion()
+                ), "-derived-platform")
+        );
     }
 
     private static ConfigurationMetadata libraryWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage) {
@@ -64,21 +78,14 @@ public class JavaEcosystemVariantDerivationStrategy implements VariantDerivation
                 .build();
     }
 
-    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, boolean enforcedPlatform) {
+    private static ConfigurationMetadata platformWithUsageAttribute(DefaultConfigurationMetadata conf, ImmutableAttributes originAttributes, MavenImmutableAttributesFactory attributesFactory, String usage, boolean enforcedPlatform, List<Capability> shadowedPlatformCapability) {
         ImmutableAttributes attributes = attributesFactory.platformWithUsage(originAttributes, usage, enforcedPlatform);
-        ModuleComponentIdentifier componentId = conf.getComponentId();
         String prefix = enforcedPlatform ? "enforced-platform-" : "platform-";
-        ImmutableCapability shadowed = new ImmutableCapability(
-                componentId.getGroup(),
-                componentId.getModule(),
-                componentId.getVersion()
-        );
         DefaultConfigurationMetadata.Builder builder = conf.mutate()
                 .withName(prefix + conf.getName())
                 .withAttributes(attributes)
                 .withConstraintsOnly()
-                .withCapabilities(Collections.singletonList(new DefaultShadowedCapability(shadowed, "-derived-platform")));
-
+                .withCapabilities(shadowedPlatformCapability);
         if (enforcedPlatform) {
             builder = builder.withForcedDependencies();
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/RealisedConfigurationMetadata.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
-import org.gradle.internal.component.model.ConfigurationMetadata;
 import org.gradle.internal.component.model.DependencyMetadata;
 import org.gradle.internal.component.model.ExcludeMetadata;
 
@@ -52,13 +51,6 @@ public class RealisedConfigurationMetadata extends AbstractConfigurationMetadata
     @Override
     public List<? extends DependencyMetadata> getDependencies() {
         return getConfigDependencies();
-    }
-
-    @Override
-    public ConfigurationMetadata withAttributes(ImmutableAttributes attributes) {
-        return new RealisedConfigurationMetadata(getComponentId(), getName(), isTransitive(), isVisible(),
-            getHierarchy(), ImmutableList.copyOf(getArtifacts()), getExcludes(), attributes,
-            ImmutableCapabilities.of(getCapabilities().getCapabilities()), getConfigDependencies());
     }
 
     public RealisedConfigurationMetadata withDependencies(ImmutableList<ModuleDependencyMetadata> dependencies) {

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1705,7 +1705,7 @@ project :
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
-      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.jvm.version         = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :
@@ -1804,7 +1804,7 @@ project :impl
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
-      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.jvm.version         = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :impl
@@ -1859,7 +1859,7 @@ org:leaf4:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf4:1.0
@@ -1897,7 +1897,7 @@ org:leaf1:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf1:1.0
@@ -1917,7 +1917,7 @@ org:leaf2:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf2:1.0
@@ -1974,7 +1974,7 @@ project :api
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 project :api
@@ -1991,7 +1991,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 project :some:deeply:nested
@@ -2006,8 +2006,8 @@ project :some:deeply:nested
 project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
-      org.gradle.dependency.bundling = external
-      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+      org.gradle.dependency.bundling = external (not requested)
+      org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 project :some:deeply:nested
@@ -2061,7 +2061,7 @@ org:leaf3:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf3:1.0
@@ -2165,7 +2165,7 @@ foo:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : $rejected
@@ -2221,7 +2221,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : ${rejected}${reason}
@@ -2274,7 +2274,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : ${rejected}${reason}
@@ -2324,7 +2324,7 @@ org:foo:${displayVersion} -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : didn't match versions 2.0, 1.5, 1.4
@@ -2380,7 +2380,7 @@ org:foo:[1.1,1.3] -> 1.3
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2396,7 +2396,7 @@ org:foo:1.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2456,7 +2456,7 @@ org:bar:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Rejection : 1.2 by rule because version 1.2 is bad
@@ -2473,7 +2473,7 @@ org:foo:1.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2518,7 +2518,7 @@ org:leaf:1.0 (by constraint)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf:1.0
@@ -2571,7 +2571,7 @@ org.test:leaf:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2753,7 +2753,7 @@ org:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2810,7 +2810,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2876,18 +2876,18 @@ org:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
-          - Attribute 'org.gradle.jvm.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
+          - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
-          - Attribute 'org.gradle.jvm.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
+          - Attribute 'org.gradle.jvm.version' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
 
 org:foo:[1.0,) -> 1.0
@@ -2951,7 +2951,7 @@ planet:mercury:1.0.2
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.0.2 and 1.0.1
@@ -2982,7 +2982,7 @@ planet:venus:2.0.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.0.0, 2.0.1 and 1.0
@@ -3013,7 +3013,7 @@ planet:pluto:1.0.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 planet:pluto:1.0.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -2006,7 +2006,7 @@ project :some:deeply:nested
 project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
-      org.gradle.dependency.bundling = external (not requested)
+      org.gradle.dependency.bundling = external
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -2221,7 +2221,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.version        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : ${rejected}${reason}

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1859,6 +1859,7 @@ org:leaf4:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf4:1.0
@@ -1896,6 +1897,7 @@ org:leaf1:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf1:1.0
@@ -1915,6 +1917,7 @@ org:leaf2:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf2:1.0
@@ -1971,7 +1974,7 @@ project :api
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 project :api
@@ -1988,7 +1991,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 project :some:deeply:nested
@@ -2004,7 +2007,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion}
    ]
 
 project :some:deeply:nested
@@ -2058,6 +2061,7 @@ org:leaf3:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf3:1.0
@@ -2161,6 +2165,7 @@ foo:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : $rejected
@@ -2216,6 +2221,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : ${rejected}${reason}
@@ -2268,6 +2274,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : ${rejected}${reason}
@@ -2317,6 +2324,7 @@ org:foo:${displayVersion} -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : didn't match versions 2.0, 1.5, 1.4
@@ -2372,6 +2380,7 @@ org:foo:[1.1,1.3] -> 1.3
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}         
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2387,6 +2396,7 @@ org:foo:1.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2446,6 +2456,7 @@ org:bar:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Rejection : 1.2 by rule because version 1.2 is bad
@@ -2462,6 +2473,7 @@ org:foo:1.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2506,6 +2518,7 @@ org:leaf:1.0 (by constraint)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf:1.0
@@ -2558,6 +2571,7 @@ org.test:leaf:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2739,6 +2753,7 @@ org:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2795,6 +2810,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2860,15 +2876,18 @@ org:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
+          - Attribute 'org.gradle.java.min.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
+          - Attribute 'org.gradle.java.min.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
 
 org:foo:[1.0,) -> 1.0
@@ -2932,6 +2951,7 @@ planet:mercury:1.0.2
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.0.2 and 1.0.1
@@ -2962,6 +2982,7 @@ planet:venus:2.0.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.0.0, 2.0.1 and 1.0
@@ -2992,6 +3013,7 @@ planet:pluto:1.0.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
    ]
 
 planet:pluto:1.0.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.tasks.diagnostics
 
 import groovy.transform.CompileStatic
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -1704,6 +1705,7 @@ project :
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :
@@ -1802,6 +1804,7 @@ project :impl
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :impl
@@ -1968,6 +1971,7 @@ project :api
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :api
@@ -1984,6 +1988,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :some:deeply:nested
@@ -1999,6 +2004,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :some:deeply:nested

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1705,7 +1705,7 @@ project :
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :
@@ -1804,7 +1804,7 @@ project :impl
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :impl
@@ -1859,7 +1859,7 @@ org:leaf4:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf4:1.0
@@ -1897,7 +1897,7 @@ org:leaf1:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf1:1.0
@@ -1917,7 +1917,7 @@ org:leaf2:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf2:1.0
@@ -1974,7 +1974,7 @@ project :api
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 project :api
@@ -1991,7 +1991,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 project :some:deeply:nested
@@ -2007,7 +2007,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 project :some:deeply:nested
@@ -2061,7 +2061,7 @@ org:leaf3:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf3:1.0
@@ -2165,7 +2165,7 @@ foo:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : $rejected
@@ -2221,7 +2221,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By constraint : ${rejected}${reason}
@@ -2274,7 +2274,7 @@ org:foo -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : ${rejected}${reason}
@@ -2324,7 +2324,7 @@ org:foo:${displayVersion} -> $selected
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : didn't match versions 2.0, 1.5, 1.4
@@ -2380,7 +2380,7 @@ org:foo:[1.1,1.3] -> 1.3
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}         
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2396,7 +2396,7 @@ org:foo:1.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2456,7 +2456,7 @@ org:bar:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Rejection : 1.2 by rule because version 1.2 is bad
@@ -2473,7 +2473,7 @@ org:foo:1.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected version 1.2
@@ -2518,7 +2518,7 @@ org:leaf:1.0 (by constraint)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 org:leaf:1.0
@@ -2571,7 +2571,7 @@ org.test:leaf:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2753,7 +2753,7 @@ org:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : rejected versions 1.2, 1.1
@@ -2810,7 +2810,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Was requested : first reason
@@ -2876,18 +2876,18 @@ org:foo:1.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - Rejection : version 1.2:
           - Attribute 'color' didn't match. Requested 'blue', was: 'red'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
-          - Attribute 'org.gradle.java.min.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
+          - Attribute 'org.gradle.jvm.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
       - Rejection : version 1.1:
           - Attribute 'color' didn't match. Requested 'blue', was: 'green'
           - Attribute 'org.gradle.dependency.bundling' didn't match. Requested 'external', was: not found
-          - Attribute 'org.gradle.java.min.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
+          - Attribute 'org.gradle.jvm.platform' didn't match. Requested '${JavaVersion.current().majorVersion}', was: not found
           - Attribute 'org.gradle.usage' didn't match. Requested 'java-api', was: not found
 
 org:foo:[1.0,) -> 1.0
@@ -2951,7 +2951,7 @@ planet:mercury:1.0.2
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.0.2 and 1.0.1
@@ -2982,7 +2982,7 @@ planet:venus:2.0.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
       - By conflict resolution : between versions 2.0.0, 2.0.1 and 1.0
@@ -3013,7 +3013,7 @@ planet:pluto:1.0.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform  = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 planet:pluto:1.0.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -57,7 +57,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
       org.gradle.dependency.bundling = external (not requested)
-      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 project :$expectedProject
@@ -110,7 +110,7 @@ project :$expectedProject
       Requested attributes not found in the selected variant:
          org.gradle.blah                = something
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
 org.test:leaf:1.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -56,7 +56,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         outputContains """project :$expectedProject
    variant "$expectedVariant" [
       $expectedAttributes
-      org.gradle.dependency.bundling = external (not requested)
+      org.gradle.dependency.bundling = external
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -108,8 +108,8 @@ project :$expectedProject
       org.gradle.status              = release (not requested)
 
       Requested attributes not found in the selected variant:
-         org.gradle.blah                = something
          org.gradle.dependency.bundling = external
+         org.gradle.blah                = something
          org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -57,7 +57,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
       org.gradle.dependency.bundling = external (not requested)
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion}
+      org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 project :$expectedProject
@@ -108,8 +108,9 @@ project :$expectedProject
       org.gradle.status              = release (not requested)
 
       Requested attributes not found in the selected variant:
+         org.gradle.blah                = something
          org.gradle.dependency.bundling = external
-         org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion}
+         org.gradle.jvm.platform        = ${JavaVersion.current().majorVersion}
    ]
 
 org.test:leaf:1.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -56,8 +56,8 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
         outputContains """project :$expectedProject
    variant "$expectedVariant" [
       $expectedAttributes
-      org.gradle.dependency.bundling = external
-      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
+      org.gradle.dependency.bundling = external (not requested)
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion}
    ]
 
 project :$expectedProject
@@ -101,7 +101,7 @@ project :$expectedProject
         run "dependencyInsight", "--dependency", "leaf"
 
         then:
-        output.contains """org.test:leaf:1.0
+        outputContains """org.test:leaf:1.0
    variant "api" [
       org.gradle.usage               = java-api
       org.gradle.test                = published attribute (not requested)
@@ -109,7 +109,7 @@ project :$expectedProject
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.blah                = something
+         org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion}
    ]
 
 org.test:leaf:1.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.tasks.diagnostics
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -56,6 +57,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
       org.gradle.dependency.bundling = external
+      org.gradle.java.min.platform   = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
 project :$expectedProject

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -100,13 +100,6 @@ The method `ProjectLayout.configurableFiles()` is now deprecated, and will be re
 
 ### Breaking changes
 
-#### Bugfixes in platform resolution
-
-There was a bug from Gradle 5.0 to 5.2.1 (included) where enforced platforms would potentially include dependencies instead of constraints.
-This would happen whenever a POM file defined both dependencies and "constraints" (via `<dependencyManagement>`) and that you used `enforcedPlatform`.
-Gradle 5.3 fixes this bug, meaning that you might have differences in the resolution result if you relied on this broken behavior.
-Similarly, Gradle 5.3 will no longer try to download jars for `platform` and `enforcedPlatform` dependencies (as they should only bring in constraints).
-
 <!-- summary and links -->
 
 See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html#changes_5.3) to learn about breaking changes and considerations when upgrading to Gradle 5.3.

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -33,6 +33,46 @@ Some plugins will break with this new version of Gradle, for example because the
 . Run `gradle wrapper --gradle-version {gradleVersion}` to update the project to {gradleVersion}.
 . Try to run the project and debug any errors using the <<troubleshooting.adoc#troubleshooting, Troubleshooting Guide>>.
 
+[[changes_5.3]]
+== Upgrading from 5.2 and earlier
+
+=== Potential breaking changes
+
+==== Bugfixes in platform resolution
+
+There was a bug from Gradle 5.0 to 5.2.1 (included) where enforced platforms would potentially include dependencies instead of constraints.
+This would happen whenever a POM file defined both dependencies and "constraints" (via `<dependencyManagement>`) and that you used `enforcedPlatform`.
+Gradle 5.3 fixes this bug, meaning that you might have differences in the resolution result if you relied on this broken behavior.
+Similarly, Gradle 5.3 will no longer try to download jars for `platform` and `enforcedPlatform` dependencies (as they should only bring in constraints).
+
+==== Automatic target JVM version
+
+If you apply any of the Java plugins, Gradle will now do its best to select dependencies which match the target compatibility of the module being compiled.
+What it means, in practice, is that if you have module A built for Java 8, and module B built for Java 8, then there's no change.
+However if B is built for Java 9+, then it's not binary compatible anymore, and Gradle would complain with an error message like the following:
+
+```
+Unable to find a matching variant of project :producer:
+  - Variant 'apiElements' capability test:producer:unspecified:
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+      - Required org.gradle.jvm.version '8' and found incompatible value '9'.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+  - Variant 'runtimeElements' capability test:producer:unspecified:
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+      - Required org.gradle.jvm.version '8' and found incompatible value '9'.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.
+```
+
+In general, this is a sign that your project is misconfigured and that your dependencies are not compatible.
+However, there are cases where you still may want to do this, for example when only a _subset_ of classes of your module actually need the Java 9 dependencies, and are not intended to be used on earlier releases.
+Java in general doesn't encourage you to do this (you should split your module instead), but if you face this problem, you can workaround by disabling this new behavior on the consumer side:
+
+```
+java {
+   disableAutoTargetJvm()
+}
+```
+
 [[changes_5.2]]
 == Upgrading from 5.1 and earlier
 

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
@@ -8,6 +8,7 @@ org.mongodb:bson:3.9.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.jvm.platform = 11
    ]
 
 org.mongodb:bson:3.9.1
@@ -25,6 +26,7 @@ org.mongodb:mongodb-driver-core:3.9.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.jvm.platform = 11
    ]
 
 org.mongodb:mongodb-driver-core:3.9.1
@@ -40,6 +42,7 @@ org.mongodb:mongodb-driver-sync:3.9.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.jvm.platform = 11
    ]
 
 org.mongodb:mongodb-driver-sync:3.9.1

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
@@ -8,7 +8,7 @@ org.mongodb:bson:3.9.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform = 11
+         org.gradle.jvm.version = 11
    ]
 
 org.mongodb:bson:3.9.1
@@ -26,7 +26,7 @@ org.mongodb:mongodb-driver-core:3.9.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform = 11
+         org.gradle.jvm.version = 11
    ]
 
 org.mongodb:mongodb-driver-core:3.9.1
@@ -42,7 +42,7 @@ org.mongodb:mongodb-driver-sync:3.9.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform = 11
+         org.gradle.jvm.version = 11
    ]
 
 org.mongodb:mongodb-driver-sync:3.9.1

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -2,9 +2,9 @@
 > Task :consumer:dependencyInsight
 mysql:mysql-connector-java:8.0.14
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime
-      org.gradle.component.category = library (not requested)
+      org.gradle.status              = release (not requested)
+      org.gradle.usage               = java-runtime
+      org.gradle.component.category  = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -7,8 +7,8 @@ mysql:mysql-connector-java:8.0.14
       org.gradle.component.category = library (not requested)
 
       Requested attributes not found in the selected variant:
-         org.gradle.jvm.platform = 11
          org.gradle.dependency.bundling = external
+         org.gradle.jvm.version = 11
    ]
 
 mysql:mysql-connector-java:8.0.14

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -2,11 +2,12 @@
 > Task :consumer:dependencyInsight
 mysql:mysql-connector-java:8.0.14
    variant "runtime" [
-      org.gradle.status              = release (not requested)
-      org.gradle.usage               = java-runtime
-      org.gradle.component.category  = library (not requested)
+      org.gradle.status             = release (not requested)
+      org.gradle.usage              = java-runtime
+      org.gradle.component.category = library (not requested)
 
       Requested attributes not found in the selected variant:
+         org.gradle.jvm.platform = 11
          org.gradle.dependency.bundling = external
    ]
 

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -6,7 +6,7 @@ org.ow2.asm:asm:6.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform = 11
+         org.gradle.jvm.version = 11
    ]
    Selection reasons:
       - Was requested : we require a JDK 9 compatible bytecode generator

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -6,6 +6,7 @@ org.ow2.asm:asm:6.0
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.jvm.platform = 11
    ]
    Selection reasons:
       - Was requested : we require a JDK 9 compatible bytecode generator

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -25,6 +25,7 @@ org.slf4j:slf4j-log4j12:1.6.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
+         org.gradle.jvm.platform = 11
    ]
 
 org.slf4j:slf4j-log4j12:1.6.1

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -25,7 +25,7 @@ org.slf4j:slf4j-log4j12:1.6.1
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
-         org.gradle.jvm.platform = 11
+         org.gradle.jvm.version = 11
    ]
 
 org.slf4j:slf4j-log4j12:1.6.1

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/common/build.gradle
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/common/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.6
 
 configurations {
     provided

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonJdt.properties
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonJdt.properties
@@ -1,11 +1,11 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
 org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.compliance=1.6
 org.eclipse.jdt.core.compiler.debug.lineNumber=generate
 org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.6

--- a/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonWtpFacet.xml
+++ b/subprojects/ide/src/integTest/resources/org/gradle/plugins/ide/eclipse/EclipseIntegrationTest/canCreateAndDeleteMetaData/expectedFiles/commonWtpFacet.xml
@@ -1,5 +1,5 @@
 <faceted-project>
 	<fixed facet="jst.java"/>
-	<installed facet="jst.java" version="1.7"/>
+	<installed facet="jst.java" version="6.0"/>
 	<installed facet="jst.utility" version="1.0"/>
 </faceted-project>

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.cache.internal.DefaultGeneratedGradleJarCache
 import org.gradle.integtests.fixtures.executer.IntegrationTestBuildContext
 import org.gradle.integtests.fixtures.executer.MoreMemorySampleModifier
 import org.gradle.integtests.fixtures.logging.ArtifactResolutionOmittingOutputNormalizer
+import org.gradle.integtests.fixtures.logging.DependencyInsightOutputNormalizer
 import org.gradle.integtests.fixtures.logging.NativeComponentReportOutputNormalizer
 import org.gradle.integtests.fixtures.logging.PlayComponentReportOutputNormalizer
 import org.gradle.integtests.fixtures.logging.SampleOutputNormalizer
@@ -39,12 +40,13 @@ import org.junit.runner.RunWith
 @Requires(TestPrecondition.JDK8_OR_LATER)
 @RunWith(GradleSamplesRunner.class)
 @SamplesOutputNormalizers([
-    JavaObjectSerializationOutputNormalizer.class,
-    SampleOutputNormalizer.class,
-    FileSeparatorOutputNormalizer.class,
-    ArtifactResolutionOmittingOutputNormalizer.class,
-    NativeComponentReportOutputNormalizer.class,
-    PlayComponentReportOutputNormalizer.class
+        JavaObjectSerializationOutputNormalizer,
+        SampleOutputNormalizer,
+        FileSeparatorOutputNormalizer,
+        ArtifactResolutionOmittingOutputNormalizer,
+        NativeComponentReportOutputNormalizer,
+        PlayComponentReportOutputNormalizer,
+        DependencyInsightOutputNormalizer
 ])
 @SampleModifiers([SetMirrorsSampleModifier, MoreMemorySampleModifier])
 class UserGuideSamplesIntegrationTest {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ArtifactResolutionOmittingOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/ArtifactResolutionOmittingOutputNormalizer.groovy
@@ -15,13 +15,14 @@
  */
 package org.gradle.integtests.fixtures.logging
 
+import groovy.transform.CompileStatic
 import org.gradle.internal.jvm.Jvm
-import org.gradle.samples.test.normalizer.OutputNormalizer
 import org.gradle.samples.executor.ExecutionMetadata
+import org.gradle.samples.test.normalizer.OutputNormalizer
 
 import javax.annotation.Nullable
 
-
+@CompileStatic
 class ArtifactResolutionOmittingOutputNormalizer implements OutputNormalizer {
     @Override
     String normalize(String commandOutput, @Nullable ExecutionMetadata executionMetadata) {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/DependencyInsightOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/DependencyInsightOutputNormalizer.groovy
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.fixtures.logging
+
+import groovy.transform.CompileStatic
+import org.gradle.samples.executor.ExecutionMetadata
+import org.gradle.samples.test.normalizer.OutputNormalizer
+
+@CompileStatic
+class DependencyInsightOutputNormalizer implements OutputNormalizer {
+
+    @Override
+    String normalize(String output, ExecutionMetadata executionMetadata) {
+        output.replaceAll("org\\.gradle\\.jvm\\.platform[ ]+= [0-9]+", "org.gradle.jvm.platform = 11")
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/DependencyInsightOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/DependencyInsightOutputNormalizer.groovy
@@ -25,6 +25,6 @@ class DependencyInsightOutputNormalizer implements OutputNormalizer {
 
     @Override
     String normalize(String output, ExecutionMetadata executionMetadata) {
-        output.replaceAll("org\\.gradle\\.jvm\\.platform[ ]+= [0-9]+", "org.gradle.jvm.platform = 11")
+        output.replaceAll("org\\.gradle\\.jvm\\.version[ ]+= [0-9]+", "org.gradle.jvm.version = 11")
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/SampleOutputNormalizer.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/logging/SampleOutputNormalizer.groovy
@@ -15,6 +15,7 @@
  */
 package org.gradle.integtests.fixtures.logging
 
+import groovy.transform.CompileStatic
 import org.gradle.integtests.fixtures.executer.OutputScrapingExecutionResult
 import org.gradle.internal.logging.ConsoleRenderer
 import org.gradle.samples.executor.ExecutionMetadata
@@ -22,6 +23,7 @@ import org.gradle.samples.test.normalizer.OutputNormalizer
 
 import java.util.regex.Pattern
 
+@CompileStatic
 class SampleOutputNormalizer implements OutputNormalizer {
     private static final String NORMALIZED_SAMPLES_PATH = "/home/user/gradle/samples"
     private static final String NORMALIZED_SAMPLES_FILE_URL = "file:///home/user/gradle/samples/"

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/GradleModuleMetadata.groovy
@@ -155,6 +155,10 @@ class GradleModuleMetadata {
             return ref == null ? null : new ModuleReference(ref.group, ref.module, ref.version, ref.url)
         }
 
+        Map<String, String> getAttributes() {
+            values.attributes
+        }
+
         List<Dependency> getDependencies() {
             if (dependencies == null) {
                 dependencies = (values.dependencies ?: []).collect {

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/gradle/VariantMetadataSpec.groovy
@@ -64,4 +64,8 @@ class VariantMetadataSpec {
     void constraint(String group, String module, String version, String reason = null, Map<String, ?> attributes=[:]) {
         dependencyConstraints << new DependencyConstraintSpec(group, module, version, null, null, null, reason, attributes)
     }
+
+    void artifact(String name) {
+        artifacts << new FileSpec(name)
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
@@ -30,7 +30,7 @@ class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements Publis
     IvyJavaModule(IvyFileModule backingModule) {
         super(backingModule)
         this.backingModule = backingModule
-        this.backingModule.attributes[TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
+        this.backingModule.attributes[TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
@@ -16,7 +16,8 @@
 
 package org.gradle.test.fixtures.ivy
 
-
+import org.gradle.api.JavaVersion
+import org.gradle.api.attributes.java.TargetJavaPlatform
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.PublishedJavaModule
 import org.gradle.test.fixtures.file.TestFile
@@ -29,6 +30,7 @@ class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements Publis
     IvyJavaModule(IvyFileModule backingModule) {
         super(backingModule)
         this.backingModule = backingModule
+        this.backingModule.attributes[TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyJavaModule.groovy
@@ -17,7 +17,7 @@
 package org.gradle.test.fixtures.ivy
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.attributes.java.TargetJavaPlatform
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.test.fixtures.ModuleArtifact
 import org.gradle.test.fixtures.PublishedJavaModule
 import org.gradle.test.fixtures.file.TestFile
@@ -30,7 +30,7 @@ class IvyJavaModule extends DelegatingIvyModule<IvyFileModule> implements Publis
     IvyJavaModule(IvyFileModule backingModule) {
         super(backingModule)
         this.backingModule = backingModule
-        this.backingModule.attributes[TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
+        this.backingModule.attributes[TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name] = JavaVersion.current().majorVersion
     }
 
     @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -16,6 +16,9 @@
 
 package org.gradle.test.fixtures.maven
 
+import org.gradle.api.JavaVersion
+import org.gradle.api.attributes.java.Bundling
+import org.gradle.api.attributes.java.TargetJavaPlatform
 import org.gradle.test.fixtures.PublishedJavaModule
 import org.gradle.util.GUtil
 
@@ -26,6 +29,7 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
     MavenJavaModule(MavenFileModule mavenModule) {
         super(mavenModule)
         this.mavenModule = mavenModule
+        this.mavenModule.attributes[TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
     }
 
     @Override
@@ -49,8 +53,17 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
 
         // Verify Gradle metadata particulars
         assert mavenModule.parsedModuleMetadata.variants*.name as Set == ['apiElements', 'runtimeElements'] as Set
-        assert mavenModule.parsedModuleMetadata.variant('apiElements').files*.name == [artifact('jar')]
-        assert mavenModule.parsedModuleMetadata.variant('runtimeElements').files*.name == [artifact('jar')]
+        def apiElements = mavenModule.parsedModuleMetadata.variant('apiElements')
+        def runtimeElements = mavenModule.parsedModuleMetadata.variant('runtimeElements')
+
+        assert apiElements.files*.name == [artifact('jar')]
+        assert runtimeElements.files*.name == [artifact('jar')]
+
+        // Verify it contains some expected attributes
+        assert apiElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
+        assert apiElements.attributes.containsKey(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name)
+        assert runtimeElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
+        assert runtimeElements.attributes.containsKey(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name)
 
         // Verify POM particulars
         assert mavenModule.parsedPom.packaging == null

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -29,7 +29,7 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
     MavenJavaModule(MavenFileModule mavenModule) {
         super(mavenModule)
         this.mavenModule = mavenModule
-        this.mavenModule.attributes[TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
+        this.mavenModule.attributes[TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
     }
 
     @Override
@@ -61,9 +61,9 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
 
         // Verify it contains some expected attributes
         assert apiElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
-        assert apiElements.attributes.containsKey(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name)
+        assert apiElements.attributes.containsKey(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name)
         assert runtimeElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
-        assert runtimeElements.attributes.containsKey(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE.name)
+        assert runtimeElements.attributes.containsKey(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name)
 
         // Verify POM particulars
         assert mavenModule.parsedPom.packaging == null

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -17,7 +17,7 @@
 package org.gradle.test.fixtures.maven
 
 import org.gradle.api.JavaVersion
-import org.gradle.api.attributes.java.Bundling
+import org.gradle.api.attributes.Bundling
 import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.test.fixtures.PublishedJavaModule
 import org.gradle.util.GUtil

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/maven/MavenJavaModule.groovy
@@ -18,7 +18,7 @@ package org.gradle.test.fixtures.maven
 
 import org.gradle.api.JavaVersion
 import org.gradle.api.attributes.java.Bundling
-import org.gradle.api.attributes.java.TargetJavaPlatform
+import org.gradle.api.attributes.java.TargetJvmVersion
 import org.gradle.test.fixtures.PublishedJavaModule
 import org.gradle.util.GUtil
 
@@ -29,7 +29,7 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
     MavenJavaModule(MavenFileModule mavenModule) {
         super(mavenModule)
         this.mavenModule = mavenModule
-        this.mavenModule.attributes[TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name] = JavaVersion.current().majorVersion
+        this.mavenModule.attributes[TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name] = JavaVersion.current().majorVersion
     }
 
     @Override
@@ -61,9 +61,9 @@ class MavenJavaModule extends DelegatingMavenModule<MavenFileModule> implements 
 
         // Verify it contains some expected attributes
         assert apiElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
-        assert apiElements.attributes.containsKey(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name)
+        assert apiElements.attributes.containsKey(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name)
         assert runtimeElements.attributes.containsKey(Bundling.BUNDLING_ATTRIBUTE.name)
-        assert runtimeElements.attributes.containsKey(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE.name)
+        assert runtimeElements.attributes.containsKey(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE.name)
 
         // Verify POM particulars
         assert mavenModule.parsedPom.packaging == null

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -283,6 +283,6 @@ project(':consumer') {
     }
     
     static String defaultTargetPlatform() {
-        "org.gradle.java.min.platform=${JavaVersion.current().majorVersion}"
+        "org.gradle.jvm.platform=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.java
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
@@ -78,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -96,8 +97,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -117,8 +118,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         when:
         buildFile << """
@@ -135,8 +136,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         where:
         usage                                          | _
@@ -160,8 +161,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -178,8 +179,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -201,8 +202,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -221,8 +222,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -239,8 +240,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -259,8 +260,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -277,7 +278,11 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+    }
+    
+    static String defaultTargetPlatform() {
+        "org.gradle.java.min.platform=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -283,6 +283,6 @@ project(':consumer') {
     }
     
     static String defaultTargetPlatform() {
-        "org.gradle.jvm.platform=${JavaVersion.current().majorVersion}"
+        "org.gradle.jvm.version=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -20,7 +20,7 @@ import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import spock.lang.Unroll
 
-class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractIntegrationSpec {
+class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractIntegrationSpec {
     ResolveTestFixture resolve
 
     def setup() {
@@ -58,11 +58,11 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
         then:
         failure.assertHasCause('''Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
     }
@@ -140,11 +140,11 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
         then:
         failure.assertHasCause("""Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.""")
 

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -72,6 +72,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         file('producer/build.gradle') << """
             // avoid test noise so that typically version 8 is not selected when running on JDK 8
             configurations.apiElements.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 1000)
+            configurations.runtimeElements.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 1000)
             
             [6, 7, 9].each { v ->
                 configurations {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetPlatformIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetPlatformIntegrationTest.groovy
@@ -49,7 +49,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
             }
         """
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, 6)
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, 6)
         """
 
         when:
@@ -59,11 +59,11 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
         failure.assertHasCause('''Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.java.min.platform '6' and found incompatible value '7'.
+      - Required org.gradle.jvm.platform '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.java.min.platform '6' and found incompatible value '7'.
+      - Required org.gradle.jvm.platform '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
     }
 
@@ -71,7 +71,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
     def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
         file('producer/build.gradle') << """
             // avoid test noise so that typically version 8 is not selected when running on JDK 8
-            configurations.apiElements.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, 1000)
+            configurations.apiElements.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, 1000)
             
             [6, 7, 9].each { v ->
                 configurations {
@@ -81,7 +81,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
                         attributes {
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-api-jars'))
                             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
-                            attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, v)
+                            attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, v)
                         }
                     }
                 }
@@ -91,7 +91,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
             }
         """
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, $requested)
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, $requested)
         """
 
         when:
@@ -103,7 +103,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
                 project(':producer', 'test:producer:') {
                     variant(expected, [
                             'org.gradle.dependency.bundling': 'external',
-                            'org.gradle.java.min.platform': selected,
+                            'org.gradle.jvm.platform': selected,
                             'org.gradle.usage':'java-api-jars'
                     ])
                     artifact(classifier: "jdk${selected}")

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetPlatformIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetPlatformIntegrationTest.groovy
@@ -49,7 +49,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
             }
         """
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, 6)
+            configurations.compileClasspath.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 6)
         """
 
         when:
@@ -59,11 +59,11 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
         failure.assertHasCause('''Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '6' and found incompatible value '7'.
+      - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '6' and found incompatible value '7'.
+      - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
     }
 
@@ -71,7 +71,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
     def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
         file('producer/build.gradle') << """
             // avoid test noise so that typically version 8 is not selected when running on JDK 8
-            configurations.apiElements.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, 1000)
+            configurations.apiElements.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 1000)
             
             [6, 7, 9].each { v ->
                 configurations {
@@ -81,7 +81,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
                         attributes {
                             attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-api-jars'))
                             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
-                            attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, v)
+                            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, v)
                         }
                     }
                 }
@@ -91,7 +91,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
             }
         """
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, $requested)
+            configurations.compileClasspath.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, $requested)
         """
 
         when:
@@ -103,7 +103,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
                 project(':producer', 'test:producer:') {
                     variant(expected, [
                             'org.gradle.dependency.bundling': 'external',
-                            'org.gradle.jvm.platform': selected,
+                            'org.gradle.jvm.version': selected,
                             'org.gradle.usage':'java-api-jars'
                     ])
                     artifact(classifier: "jdk${selected}")
@@ -141,11 +141,11 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
         failure.assertHasCause("""Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '6' and found incompatible value '7'.
+      - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '6' and found incompatible value '7'.
+      - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.""")
 
         when:
@@ -162,7 +162,7 @@ class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractInteg
                 project(':producer', 'test:producer:') {
                     variant("apiElements", [
                             'org.gradle.dependency.bundling': 'external',
-                            'org.gradle.jvm.platform': '7',
+                            'org.gradle.jvm.version': '7',
                             'org.gradle.usage':'java-api-jars'
                     ])
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetPlatformIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetPlatformIntegrationTest.groovy
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import spock.lang.Unroll
+
+class JavaLibraryCrossProjectTargetPlatformIntegrationTest extends AbstractIntegrationSpec {
+    ResolveTestFixture resolve
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+            include 'producer'
+        """
+        buildFile << """
+            allprojects {
+                apply plugin: 'java-library'
+            }
+            
+            dependencies {
+                api project(':producer')
+            }
+        """
+        resolve = new ResolveTestFixture(buildFile, 'compileClasspath')
+        resolve.prepare()
+    }
+
+    def "can fail resolution if producer doesn't have appropriate target version"() {
+        file('producer/build.gradle') << """
+            java {
+                sourceCompatibility = JavaVersion.VERSION_1_7
+                targetCompatibility = JavaVersion.VERSION_1_7
+            }
+        """
+        buildFile << """
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, 6)
+        """
+
+        when:
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause('''Unable to find a matching variant of project :producer:
+  - Variant 'apiElements' capability test:producer:unspecified:
+      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.java.min.platform '6' and found incompatible value '7'.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+  - Variant 'runtimeElements' capability test:producer:unspecified:
+      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.java.min.platform '6' and found incompatible value '7'.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
+    }
+
+    @Unroll
+    def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
+        file('producer/build.gradle') << """
+            // avoid test noise so that typically version 8 is not selected when running on JDK 8
+            configurations.apiElements.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, 1000)
+            
+            [6, 7, 9].each { v ->
+                configurations {
+                    "apiElementsJdk\${v}" {
+                        canBeConsumed = true
+                        canBeResolved = false
+                        attributes {
+                            attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, 'java-api-jars'))
+                            attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, 'external'))
+                            attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, v)
+                        }
+                    }
+                }
+                artifacts {
+                    "apiElementsJdk\${v}" file("producer-jdk\${v}.jar")
+                }
+            }
+        """
+        buildFile << """
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, $requested)
+        """
+
+        when:
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                project(':producer', 'test:producer:') {
+                    variant(expected, [
+                            'org.gradle.dependency.bundling': 'external',
+                            'org.gradle.java.min.platform': selected,
+                            'org.gradle.usage':'java-api-jars'
+                    ])
+                    artifact(classifier: "jdk${selected}")
+                }
+            }
+        }
+
+        where:
+        requested | selected
+        6         | 6
+        7         | 7
+        8         | 7
+        9         | 9
+        10        | 9
+
+        expected = "apiElementsJdk$selected"
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -284,6 +284,6 @@ project(':consumer') {
     }
 
     static String defaultTargetPlatform() {
-        "org.gradle.java.min.platform=${JavaVersion.current().majorVersion}"
+        "org.gradle.jvm.platform=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -284,6 +284,6 @@ project(':consumer') {
     }
 
     static String defaultTargetPlatform() {
-        "org.gradle.jvm.platform=${JavaVersion.current().majorVersion}"
+        "org.gradle.jvm.version=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.java
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
@@ -80,8 +81,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -98,8 +99,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -118,8 +119,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
 
         when:
         buildFile << """
@@ -136,8 +137,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
 
         where:
         usage                                          | _
@@ -161,8 +162,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -179,8 +180,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -202,8 +203,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -222,8 +223,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -240,8 +241,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -260,8 +261,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -278,7 +279,11 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+    }
+
+    static String defaultTargetPlatform() {
+        "org.gradle.java.min.platform=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetJvmVersionIntegrationTest.groovy
@@ -21,7 +21,7 @@ import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.test.fixtures.server.http.MavenHttpModule
 import spock.lang.Unroll
 
-class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDependencyResolutionTest {
+class JavaLibraryPublishedTargetJvmVersionIntegrationTest extends AbstractHttpDependencyResolutionTest {
     ResolveTestFixture resolve
     MavenHttpModule module
 
@@ -90,20 +90,35 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
         then:
         failure.assertHasCause('''Unable to find a matching variant of org:producer:1.0:
   - Variant 'apiElementsJdk6' capability org:producer:1.0:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'apiElementsJdk7' capability org:producer:1.0:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'apiElementsJdk9' capability org:producer:1.0:
-      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Found org.gradle.status 'release' but wasn't required.
-      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.''')
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+  - Variant 'runtimeElementsJdk6' capability org:producer:1.0:
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+      - Required org.gradle.jvm.version '5' and found incompatible value '6'.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.
+  - Variant 'runtimeElementsJdk7' capability org:producer:1.0:
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+      - Required org.gradle.jvm.version '5' and found incompatible value '7'.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.
+  - Variant 'runtimeElementsJdk9' capability org:producer:1.0:
+      - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
+      - Required org.gradle.jvm.version '5' and found incompatible value '9'.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
     }
 
     @Unroll

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetPlatformIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetPlatformIntegrationTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java
+
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.test.fixtures.server.http.MavenHttpModule
+import spock.lang.Unroll
+
+class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    ResolveTestFixture resolve
+    MavenHttpModule module
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            repositories {
+                maven { url '${mavenHttpRepo.uri}' }
+            }
+            
+            dependencies {
+                api 'org:producer:1.0'
+            }
+        """
+
+        resolve = new ResolveTestFixture(buildFile, 'compileClasspath')
+        resolve.prepare()
+
+        module = mavenHttpRepo.module('org', 'producer', '1.0')
+                .withModuleMetadata()
+                .withGradleMetadataRedirection()
+                .adhocVariants()
+                .variant("apiElementsJdk6", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.java.min.platform': '6',
+                'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk6.jar') })
+                .variant("apiElementsJdk7", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.java.min.platform': '7',
+                'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk7.jar') })
+                .variant("apiElementsJdk9", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.java.min.platform': '9',
+                'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk9.jar') })
+                .variant("runtimeElementsJdk6", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.java.min.platform': '6',
+                'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk6.jar') })
+                .variant("runtimeElementsJdk7", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.java.min.platform': '7',
+                'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk7.jar') })
+                .variant("runtimeElementsJdk9", [
+                'org.gradle.dependency.bundling': 'external',
+                'org.gradle.java.min.platform': '9',
+                'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk9.jar') })
+                .publish()
+
+    }
+
+    def "can fail resolution if producer doesn't have appropriate target version"() {
+        buildFile << """
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, 5)
+        """
+
+        when:
+        module.pom.expectGet()
+        module.moduleMetadata.expectGet()
+
+        fails ':checkDeps'
+
+        then:
+        failure.assertHasCause('''Unable to find a matching variant of org:producer:1.0:
+  - Variant 'apiElementsJdk6' capability org:producer:1.0:
+      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.java.min.platform '5' and found incompatible value '6'.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+  - Variant 'apiElementsJdk7' capability org:producer:1.0:
+      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.java.min.platform '5' and found incompatible value '7'.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
+  - Variant 'apiElementsJdk9' capability org:producer:1.0:
+      - Found org.gradle.dependency.bundling 'external' but wasn't required.
+      - Required org.gradle.java.min.platform '5' and found incompatible value '9'.
+      - Found org.gradle.status 'release' but wasn't required.
+      - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.''')
+    }
+
+    @Unroll
+    def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
+        buildFile << """
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, $requested)
+        """
+
+        when:
+        module.pom.expectGet()
+        module.moduleMetadata.expectGet()
+        module.getArtifact(classifier: "jdk${selected}").expectGet()
+
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:producer:1.0') {
+                    variant(expected, [
+                            'org.gradle.dependency.bundling': 'external',
+                            'org.gradle.java.min.platform': selected,
+                            'org.gradle.usage': 'java-api-jars',
+                            'org.gradle.status': 'release'
+                    ])
+                    artifact(classifier: "jdk${selected}")
+                }
+            }
+        }
+
+        where:
+        requested | selected
+        6         | 6
+        7         | 7
+        8         | 7
+        9         | 9
+        10        | 9
+
+        expected = "apiElementsJdk$selected"
+    }
+}

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetPlatformIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetPlatformIntegrationTest.groovy
@@ -50,27 +50,27 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
                 .adhocVariants()
                 .variant("apiElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.java.min.platform': '6',
+                'org.gradle.jvm.platform': '6',
                 'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("apiElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.java.min.platform': '7',
+                'org.gradle.jvm.platform': '7',
                 'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("apiElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.java.min.platform': '9',
+                'org.gradle.jvm.platform': '9',
                 'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk9.jar') })
                 .variant("runtimeElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.java.min.platform': '6',
+                'org.gradle.jvm.platform': '6',
                 'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("runtimeElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.java.min.platform': '7',
+                'org.gradle.jvm.platform': '7',
                 'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("runtimeElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.java.min.platform': '9',
+                'org.gradle.jvm.platform': '9',
                 'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk9.jar') })
                 .publish()
 
@@ -78,7 +78,7 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
 
     def "can fail resolution if producer doesn't have appropriate target version"() {
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, 5)
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, 5)
         """
 
         when:
@@ -91,17 +91,17 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
         failure.assertHasCause('''Unable to find a matching variant of org:producer:1.0:
   - Variant 'apiElementsJdk6' capability org:producer:1.0:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.java.min.platform '5' and found incompatible value '6'.
+      - Required org.gradle.jvm.platform '5' and found incompatible value '6'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'apiElementsJdk7' capability org:producer:1.0:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.java.min.platform '5' and found incompatible value '7'.
+      - Required org.gradle.jvm.platform '5' and found incompatible value '7'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'apiElementsJdk9' capability org:producer:1.0:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.java.min.platform '5' and found incompatible value '9'.
+      - Required org.gradle.jvm.platform '5' and found incompatible value '9'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.''')
     }
@@ -109,7 +109,7 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
     @Unroll
     def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, $requested)
+            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, $requested)
         """
 
         when:
@@ -125,7 +125,7 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
                 module('org:producer:1.0') {
                     variant(expected, [
                             'org.gradle.dependency.bundling': 'external',
-                            'org.gradle.java.min.platform': selected,
+                            'org.gradle.jvm.platform': selected,
                             'org.gradle.usage': 'java-api-jars',
                             'org.gradle.status': 'release'
                     ])

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetPlatformIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryPublishedTargetPlatformIntegrationTest.groovy
@@ -50,27 +50,27 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
                 .adhocVariants()
                 .variant("apiElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.platform': '6',
+                'org.gradle.jvm.version': '6',
                 'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("apiElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.platform': '7',
+                'org.gradle.jvm.version': '7',
                 'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("apiElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.platform': '9',
+                'org.gradle.jvm.version': '9',
                 'org.gradle.usage': 'java-api-jars'], { artifact('producer-1.0-jdk9.jar') })
                 .variant("runtimeElementsJdk6", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.platform': '6',
+                'org.gradle.jvm.version': '6',
                 'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk6.jar') })
                 .variant("runtimeElementsJdk7", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.platform': '7',
+                'org.gradle.jvm.version': '7',
                 'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk7.jar') })
                 .variant("runtimeElementsJdk9", [
                 'org.gradle.dependency.bundling': 'external',
-                'org.gradle.jvm.platform': '9',
+                'org.gradle.jvm.version': '9',
                 'org.gradle.usage': 'java-runtime-jars'], { artifact('producer-1.0-jdk9.jar') })
                 .publish()
 
@@ -78,7 +78,7 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
 
     def "can fail resolution if producer doesn't have appropriate target version"() {
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, 5)
+            configurations.compileClasspath.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 5)
         """
 
         when:
@@ -91,17 +91,17 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
         failure.assertHasCause('''Unable to find a matching variant of org:producer:1.0:
   - Variant 'apiElementsJdk6' capability org:producer:1.0:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '5' and found incompatible value '6'.
+      - Required org.gradle.jvm.version '5' and found incompatible value '6'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'apiElementsJdk7' capability org:producer:1.0:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '5' and found incompatible value '7'.
+      - Required org.gradle.jvm.version '5' and found incompatible value '7'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'apiElementsJdk9' capability org:producer:1.0:
       - Found org.gradle.dependency.bundling 'external' but wasn't required.
-      - Required org.gradle.jvm.platform '5' and found incompatible value '9'.
+      - Required org.gradle.jvm.version '5' and found incompatible value '9'.
       - Found org.gradle.status 'release' but wasn't required.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.''')
     }
@@ -109,7 +109,7 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
     @Unroll
     def "can select the most appropriate producer variant (#expected) based on target compatibility (#requested)"() {
         buildFile << """
-            configurations.compileClasspath.attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, $requested)
+            configurations.compileClasspath.attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, $requested)
         """
 
         when:
@@ -125,7 +125,7 @@ class JavaLibraryPublishedTargetPlatformIntegrationTest extends AbstractHttpDepe
                 module('org:producer:1.0') {
                     variant(expected, [
                             'org.gradle.dependency.bundling': 'external',
-                            'org.gradle.jvm.platform': selected,
+                            'org.gradle.jvm.version': selected,
                             'org.gradle.usage': 'java-api-jars',
                             'org.gradle.status': 'release'
                     ])

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.java
 
+import org.gradle.api.JavaVersion
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import spock.lang.Unroll
 
@@ -78,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -96,8 +97,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -116,8 +117,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         when:
         buildFile << """
@@ -134,8 +135,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-api-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         where:
         usage                                          | _
@@ -160,8 +161,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -178,8 +179,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -201,8 +202,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -220,8 +221,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -238,8 +239,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -258,8 +259,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -276,7 +277,11 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+    }
+
+    static String defaultTargetPlatform() {
+        "org.gradle.java.min.platform=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -282,6 +282,6 @@ project(':consumer') {
     }
 
     static String defaultTargetPlatform() {
-        "org.gradle.java.min.platform=${JavaVersion.current().majorVersion}"
+        "org.gradle.jvm.platform=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -282,6 +282,6 @@ project(':consumer') {
     }
 
     static String defaultTargetPlatform() {
-        "org.gradle.jvm.platform=${JavaVersion.current().majorVersion}"
+        "org.gradle.jvm.version=${JavaVersion.current().majorVersion}"
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
@@ -23,22 +23,22 @@ import org.gradle.api.InvalidUserCodeException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
-import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.ConfigurationVariantDetails;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.component.UsageContext;
 
 import java.util.Collection;
 import java.util.Set;
 
 public class ConfigurationVariantMapping {
-    private final Configuration outgoingConfiguration;
+    private final ConfigurationInternal outgoingConfiguration;
     private final Action<? super ConfigurationVariantDetails> action;
 
-    public ConfigurationVariantMapping(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> action) {
+    public ConfigurationVariantMapping(ConfigurationInternal outgoingConfiguration, Action<? super ConfigurationVariantDetails> action) {
         this.outgoingConfiguration = outgoingConfiguration;
         this.action = action;
     }
@@ -109,6 +109,7 @@ public class ConfigurationVariantMapping {
 
         @Override
         public AttributeContainer getAttributes() {
+            outgoingConfiguration.preventFromFurtherMutation();
             return outgoingConfiguration.getAttributes();
         }
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -305,7 +305,9 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         return new Action<ConfigurationInternal>() {
             @Override
             public void execute(ConfigurationInternal conf) {
-                JavaEcosystemSupport.configureDefaultTargetPlatform(conf, convention.getTargetCompatibility());
+                if (!convention.isAutoTargetJvmDisabled()) {
+                    JavaEcosystemSupport.configureDefaultTargetPlatform(conf, convention.getTargetCompatibility());
+                }
             }
         };
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -305,7 +305,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         return new Action<ConfigurationInternal>() {
             @Override
             public void execute(ConfigurationInternal conf) {
-                if (!convention.isAutoTargetJvmDisabled()) {
+                if (!convention.getAutoTargetJvmDisabled()) {
                     JavaEcosystemSupport.configureDefaultTargetPlatform(conf, convention.getTargetCompatibility());
                 }
             }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePlugin.java
@@ -32,8 +32,9 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.IConventionAware;
-import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
+import org.gradle.api.internal.artifacts.dsl.ComponentMetadataHandlerInternal;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.model.ObjectFactory;
@@ -150,7 +151,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
 
                 ConfigurationContainer configurations = project.getConfigurations();
 
-                defineConfigurationsForSourceSet(sourceSet, configurations);
+                defineConfigurationsForSourceSet(sourceSet, configurations, pluginConvention);
                 definePathsForSourceSet(sourceSet, outputConventionMapping, project);
 
                 createProcessResourcesTask(sourceSet, sourceSet.getResources(), project);
@@ -231,7 +232,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         sourceSet.getResources().srcDir("src/" + sourceSet.getName() + "/resources");
     }
 
-    private void defineConfigurationsForSourceSet(SourceSet sourceSet, ConfigurationContainer configurations) {
+    private void defineConfigurationsForSourceSet(SourceSet sourceSet, ConfigurationContainer configurations, final JavaPluginConvention convention) {
         String compileConfigurationName = sourceSet.getCompileConfigurationName();
         String implementationConfigurationName = sourceSet.getImplementationConfigurationName();
         String runtimeConfigurationName = sourceSet.getRuntimeConfigurationName();
@@ -241,6 +242,8 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         String annotationProcessorConfigurationName = sourceSet.getAnnotationProcessorConfigurationName();
         String runtimeClasspathConfigurationName = sourceSet.getRuntimeClasspathConfigurationName();
         String sourceSetName = sourceSet.toString();
+        Action<ConfigurationInternal> configureDefaultTargetPlatform = configureDefaultTargetPlatform(convention);
+
 
         Configuration compileConfiguration = configurations.maybeCreate(compileConfigurationName);
         compileConfiguration.setVisible(false);
@@ -269,6 +272,7 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         compileClasspathConfiguration.setCanBeConsumed(false);
         compileClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API));
         compileClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
+        ((ConfigurationInternal)compileClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 
         Configuration annotationProcessorConfiguration = configurations.maybeCreate(annotationProcessorConfigurationName);
         annotationProcessorConfiguration.setVisible(false);
@@ -290,10 +294,20 @@ public class JavaBasePlugin implements Plugin<ProjectInternal> {
         runtimeClasspathConfiguration.extendsFrom(runtimeOnlyConfiguration, runtimeConfiguration, implementationConfiguration);
         runtimeClasspathConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME));
         runtimeClasspathConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, Bundling.EXTERNAL));
+        ((ConfigurationInternal)runtimeClasspathConfiguration).beforeLocking(configureDefaultTargetPlatform);
 
         sourceSet.setCompileClasspath(compileClasspathConfiguration);
         sourceSet.setRuntimeClasspath(sourceSet.getOutput().plus(runtimeClasspathConfiguration));
         sourceSet.setAnnotationProcessorPath(annotationProcessorConfiguration);
+    }
+
+    private Action<ConfigurationInternal> configureDefaultTargetPlatform(final JavaPluginConvention convention) {
+        return new Action<ConfigurationInternal>() {
+            @Override
+            public void execute(ConfigurationInternal conf) {
+                JavaEcosystemSupport.configureDefaultTargetPlatform(conf, convention.getTargetCompatibility());
+            }
+        };
     }
 
     private void configureCompileDefaults(final Project project, final JavaPluginConvention javaConvention) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -31,14 +31,13 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
-import org.gradle.api.attributes.java.TargetJavaPlatform;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponentFactory;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
+import org.gradle.api.internal.artifacts.JavaEcosystemSupport;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
-import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.component.BuildableJavaComponent;
 import org.gradle.api.internal.component.ComponentRegistry;
 import org.gradle.api.internal.java.JavaLibraryPlatform;
@@ -479,12 +478,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         ((ConfigurationInternal)outgoing).beforeLocking(new Action<ConfigurationInternal>() {
             @Override
             public void execute(ConfigurationInternal configuration) {
-                String majorVersion = convention.getTargetCompatibility().getMajorVersion();
-                AttributeContainerInternal attributes = configuration.getAttributes();
-                // If nobody said anything about this variant's target platform, use whatever the convention says
-                if (!attributes.contains(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)) {
-                    attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
-                }
+                JavaEcosystemSupport.configureDefaultTargetPlatform(configuration, convention.getTargetCompatibility());
             }
         });
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
@@ -18,6 +18,7 @@ package org.gradle.api.plugins;
 
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.java.archives.Manifest;
@@ -157,4 +158,27 @@ public abstract class JavaPluginConvention {
     public abstract SourceSetContainer getSourceSets();
 
     public abstract ProjectInternal getProject();
+
+    /**
+     * If this method is called, Gradle will not automatically try to fetch
+     * dependencies which have a JVM version compatible with this module.
+     * This should be used whenever the default behavior is not
+     * applicable, in particular when for some reason it's not possible to split
+     * a module and that this module only has some classes which require dependencies
+     * on higher versions.
+     *
+     * @since 5.3
+     */
+    @Incubating
+    public abstract void disableAutoTargetJvm();
+
+    /**
+     * Tells if automatic JVM targetting is enabled. When disabled, Gradle
+     * will not automatically try to get dependencies corresponding to the
+     * same (or compatible) level as the target compatibility of this module.
+     *
+     * @since 5.3
+     */
+    @Incubating
+    public abstract boolean isAutoTargetJvmDisabled();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginConvention.java
@@ -180,5 +180,5 @@ public abstract class JavaPluginConvention {
      * @since 5.3
      */
     @Incubating
-    public abstract boolean isAutoTargetJvmDisabled();
+    public abstract boolean getAutoTargetJvmDisabled();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPluginExtension.java
@@ -59,4 +59,17 @@ public interface JavaPluginExtension {
      * @since 5.3
      */
     void registerFeature(String name, Action<? super FeatureSpec> configureAction);
+
+    /**
+     * If this method is called, Gradle will not automatically try to fetch
+     * dependencies which have a JVM version compatible with the target compatibility
+     * of this module. This should be used whenever the default behavior is not
+     * applicable, in particular when for some reason it's not possible to split
+     * a module and that this module only has some classes which require dependencies
+     * on higher versions.
+     *
+     * @since 5.3
+     */
+    @Incubating
+    void disableAutoTargetJvm();
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultAdhocSoftwareComponent.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.ConfigurationVariantDetails;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.java.usagecontext.ConfigurationVariantMapping;
@@ -43,7 +44,7 @@ public class DefaultAdhocSoftwareComponent implements AdhocComponentWithVariants
 
     @Override
     public void addVariantsFromConfiguration(Configuration outgoingConfiguration, Action<? super ConfigurationVariantDetails> spec) {
-        variants.add(new ConfigurationVariantMapping(outgoingConfiguration, spec));
+        variants.add(new ConfigurationVariantMapping((ConfigurationInternal) outgoingConfiguration, spec));
     }
 
     @Override

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -166,8 +166,8 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
                 String majorVersion = javaPluginConvention.getTargetCompatibility().getMajorVersion();
                 AttributeContainerInternal attributes = configuration.getAttributes();
                 // If nobody said anything about this variant's target platform, use whatever the convention says
-                if (!attributes.contains(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)) {
-                    attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
+                if (!attributes.contains(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)) {
+                    attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
                 }
             }
         });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -23,11 +23,14 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.java.TargetJavaPlatform;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.component.SoftwareComponentContainer;
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.dsl.LazyPublishArtifact;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.BasePlugin;
@@ -127,6 +130,8 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
         configureUsage(runtimeElements, Usage.JAVA_RUNTIME_JARS);
         configurePacking(apiElements);
         configurePacking(runtimeElements);
+        configureTargetPlatform(apiElements);
+        configureTargetPlatform(runtimeElements);
         configureCapabilities(apiElements);
         configureCapabilities(runtimeElements);
         attachArtifactToConfiguration(apiElements);
@@ -149,6 +154,20 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
                 if (component != null) {
                     component.addVariantsFromConfiguration(apiElements, new JavaConfigurationVariantMapping("compile", true));
                     component.addVariantsFromConfiguration(runtimeElements, new JavaConfigurationVariantMapping("runtime", true));
+                }
+            }
+        });
+    }
+
+    private void configureTargetPlatform(Configuration configuration) {
+        ((ConfigurationInternal)configuration).beforeLocking(new Action<ConfigurationInternal>() {
+            @Override
+            public void execute(ConfigurationInternal configuration) {
+                String majorVersion = javaPluginConvention.getTargetCompatibility().getMajorVersion();
+                AttributeContainerInternal attributes = configuration.getAttributes();
+                // If nobody said anything about this variant's target platform, use whatever the convention says
+                if (!attributes.contains(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE)) {
+                    attributes.attribute(TargetJavaPlatform.MINIMAL_TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
                 }
             }
         });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -23,7 +23,7 @@ import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
-import org.gradle.api.attributes.java.TargetJavaPlatform;
+import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.component.AdhocComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
@@ -166,8 +166,8 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
                 String majorVersion = javaPluginConvention.getTargetCompatibility().getMajorVersion();
                 AttributeContainerInternal attributes = configuration.getAttributes();
                 // If nobody said anything about this variant's target platform, use whatever the convention says
-                if (!attributes.contains(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE)) {
-                    attributes.attribute(TargetJavaPlatform.TARGET_PLATFORM_ATTRIBUTE, Integer.valueOf(majorVersion));
+                if (!attributes.contains(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE)) {
+                    attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(majorVersion));
                 }
             }
         });

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -52,6 +52,8 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
     private JavaVersion srcCompat;
     private JavaVersion targetCompat;
 
+    private boolean autoTargetJvm = true;
+
     public DefaultJavaPluginConvention(ProjectInternal project, ObjectFactory objectFactory) {
         this.project = project;
         sourceSets = objectFactory.newInstance(DefaultSourceSetContainer.class);
@@ -178,5 +180,15 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
     @Override
     public ProjectInternal getProject() {
         return project;
+    }
+
+    @Override
+    public void disableAutoTargetJvm() {
+        this.autoTargetJvm = false;
+    }
+
+    @Override
+    public boolean isAutoTargetJvmDisabled() {
+        return !autoTargetJvm;
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginConvention.java
@@ -188,7 +188,7 @@ public class DefaultJavaPluginConvention extends JavaPluginConvention implements
     }
 
     @Override
-    public boolean isAutoTargetJvmDisabled() {
+    public boolean getAutoTargetJvmDisabled() {
         return !autoTargetJvm;
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaPluginExtension.java
@@ -89,6 +89,11 @@ public class DefaultJavaPluginExtension implements JavaPluginExtension {
         spec.create();
     }
 
+    @Override
+    public void disableAutoTargetJvm() {
+        convention.disableAutoTargetJvm();
+    }
+
     private static String validateFeatureName(String name) {
         if (!VALID_FEATURE_NAME.matcher(name).matches()) {
             throw new InvalidUserDataException("Invalid feature name '" + name + "'. Must match " + VALID_FEATURE_NAME.pattern());

--- a/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
+++ b/subprojects/publish/src/main/java/org/gradle/api/publish/internal/ModuleMetadataFileGenerator.java
@@ -328,6 +328,9 @@ public class ModuleMetadataFileGenerator {
             if (value instanceof Boolean) {
                 Boolean b = (Boolean) value;
                 jsonWriter.value(b);
+            } else if (value instanceof Integer) {
+                Integer i = (Integer) value;
+                jsonWriter.value(i);
             } else if (value instanceof String) {
                 String s = (String) value;
                 jsonWriter.value(s);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/CoercingStringValueSnapshot.java
@@ -41,6 +41,9 @@ public class CoercingStringValueSnapshot extends StringValueSnapshot {
         if (Named.class.isAssignableFrom(type)) {
             return type.cast(instantiator.named(type.asSubclass(Named.class), getValue()));
         }
+        if (Integer.class.equals(type)) {
+            return type.cast(Integer.valueOf(getValue()));
+        }
         return null;
     }
 }


### PR DESCRIPTION
### Context

This PR adds a new Java ecosystem attribute, corresponding
to the minimal target platform a producer supports. It's often
the case that Java libraries are published with different
classifiers for different target platforms. However, a classifier
is not enough. With this attribute, we now have a proper model
of the producer and consumer side.

By default, the producer will not ask for a specific target
platform, but will only accept those which are lower than or
equal to the current Gradle runtime version. However, if the
consumer says something, it will then select the most appropriate
variant based on the producer attributes.

In the Java world, a consumer can use Java libraries produced
for older versions of Java, but not newer versions. This rule
is baked in as the default compatibility rule. Disambiguation
will then chose the closest version.

This pull request does **not** try to add a standard way to _produce_ multiple variants having different target platforms. However, it does show that it can handle both producing and consuming such variants if they are found either in a multi-project setup, or published in Gradle metadata.
