### PR TITLE
Support the build cache for artifact transforms

### DIFF
--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadata.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/origin/OriginMetadata.java
@@ -24,16 +24,6 @@ public class OriginMetadata {
     private final UniqueId buildInvocationId;
     private final long executionTime;
 
-    @Deprecated
-    public static OriginMetadata fromCurrentBuild(UniqueId buildInvocationId, long executionTime) {
-        return new OriginMetadata(buildInvocationId, executionTime);
-    }
-
-    @Deprecated
-    public static OriginMetadata fromPreviousBuild(UniqueId buildInvocationId, long executionTime) {
-        return new OriginMetadata(buildInvocationId, executionTime);
-    }
-
     public OriginMetadata(UniqueId buildInvocationId, long executionTime) {
         this.buildInvocationId = Preconditions.checkNotNull(buildInvocationId, "buildInvocationId");
         this.executionTime = executionTime;

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/CacheableTransformAction.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/CacheableTransformAction.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.artifacts.transform;
+
+import org.gradle.api.Incubating;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Attached to an {@link TransformAction} type to indicate that the build cache should be used for artifact transforms of this type.</p>
+ *
+ * <p>Only an artifact transform that produces reproducible and relocatable outputs should be marked with {@code CacheableTransformAction}.</p>
+ *
+ * @since 5.3
+ */
+@Incubating
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface CacheableTransformAction {
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/PropertyAssociationTaskFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/PropertyAssociationTaskFactory.java
@@ -28,6 +28,8 @@ import org.gradle.api.internal.tasks.properties.PropertyWalker;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.reflect.Instantiator;
 
+import javax.annotation.Nullable;
+
 public class PropertyAssociationTaskFactory implements ITaskFactory {
     private final ITaskFactory delegate;
     private final PropertyWalker propertyWalker;
@@ -62,7 +64,7 @@ public class PropertyAssociationTaskFactory implements ITaskFactory {
         }
 
         @Override
-        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
             throw new UnsupportedOperationException();
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/DefaultTaskInputs.java
@@ -212,7 +212,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         public void visitContents(final FileCollectionResolveContext context) {
             TaskPropertyUtils.visitProperties(propertyWalker, task, new PropertyVisitor.Adapter() {
                 @Override
-                public void visitInputFileProperty(final String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+                public void visitInputFileProperty(final String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
                     if (!TaskInputUnionFileCollection.this.skipWhenEmptyOnly || skipWhenEmpty) {
                         FileCollection actualValue = FileParameterUtils.resolveInputFileValue(fileCollectionFactory, filePropertyType, value);
                         context.add(new PropertyFileCollection(task.toString(), propertyName, "input", actualValue));
@@ -230,7 +230,7 @@ public class DefaultTaskInputs implements TaskInputsInternal {
         }
 
         @Override
-        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
             hasInputs = true;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -71,13 +71,6 @@ public interface TaskExecutionContext {
      */
     long markExecutionTime();
 
-    /**
-     * The previously marked execution time.
-     *
-     * Throws if the execution time was not previously marked.
-     */
-    long getExecutionTime();
-
     @Nullable
     List<String> getUpToDateMessages();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -153,15 +153,6 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
     }
 
     @Override
-    public long getExecutionTime() {
-        if (this.executionTime == null) {
-            throw new IllegalStateException("execution time not yet set");
-        }
-
-        return executionTime;
-    }
-
-    @Override
     @Nullable
     public List<String> getUpToDateMessages() {
         return upToDateMessages;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -213,8 +213,7 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                     if (task.isHasCustomActions()) {
                         LOGGER.info("Custom actions are attached to {}.", task);
                     }
-                    if (buildCacheEnabled
-                            && context.isTaskCachingEnabled()
+                    if (context.isTaskCachingEnabled()
                             && context.getTaskExecutionMode().isAllowedToUseCachedResults()
                             && context.getBuildCacheKey().isValid()
                     ) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/CompositePropertyVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/CompositePropertyVisitor.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.tasks.FileNormalizer;
 
+import javax.annotation.Nullable;
+
 public class CompositePropertyVisitor implements PropertyVisitor {
     private final PropertyVisitor[] visitors;
 
@@ -36,7 +38,7 @@ public class CompositePropertyVisitor implements PropertyVisitor {
     }
 
     @Override
-    public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+    public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
         for (PropertyVisitor visitor : visitors) {
             visitor.visitInputFileProperty(propertyName, optional, skipWhenEmpty, fileNormalizer, value, filePropertyType);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.api.tasks.TaskExecutionException;
 import org.gradle.internal.Factory;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -248,7 +249,7 @@ public class DefaultTaskProperties implements TaskProperties {
         private final List<ValidatingProperty> taskPropertySpecs = new ArrayList<ValidatingProperty>();
 
         @Override
-        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
             taskPropertySpecs.add(new DefaultFinalizingValidatingProperty(propertyName, value, optional, filePropertyType.getValidationAction()));
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -37,6 +37,7 @@ import org.gradle.internal.fingerprint.NameOnlyInputNormalizer;
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer;
 import org.gradle.util.DeferredUtil;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
@@ -59,6 +60,12 @@ public class FileParameterUtils {
             default:
                 throw new IllegalArgumentException("Unknown path sensitivity: " + pathSensitivity);
         }
+    }
+
+    public static Class<? extends FileNormalizer> normalizerOrDefault(@Nullable Class<? extends FileNormalizer> fileNormalizer) {
+        // If this default is ever changed, ensure the documentation on PathSensitive is updated as well as this guide:
+        // https://guides.gradle.org/using-build-cache/#relocatability
+        return fileNormalizer == null ? AbsolutePathInputNormalizer.class : fileNormalizer;
     }
 
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputFilesVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/GetInputFilesVisitor.java
@@ -23,6 +23,7 @@ import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.tasks.PropertyFileCollection;
 import org.gradle.api.tasks.FileNormalizer;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 public class GetInputFilesVisitor extends PropertyVisitor.Adapter {
@@ -39,11 +40,11 @@ public class GetInputFilesVisitor extends PropertyVisitor.Adapter {
     }
 
     @Override
-    public void visitInputFileProperty(final String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+    public void visitInputFileProperty(final String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
         FileCollection actualValue = FileParameterUtils.resolveInputFileValue(fileCollectionFactory, filePropertyType, value);
         specs.add(new DefaultInputFilePropertySpec(
             propertyName,
-            fileNormalizer,
+            FileParameterUtils.normalizerOrDefault(fileNormalizer),
             new PropertyFileCollection(ownerDisplayName, propertyName, "input", actualValue),
             skipWhenEmpty));
         if (skipWhenEmpty) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyVisitor.java
@@ -18,6 +18,8 @@ package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.tasks.FileNormalizer;
 
+import javax.annotation.Nullable;
+
 /**
  * Visits properties of beans which are inputs, outputs, destroyables or local state.
  */
@@ -33,7 +35,7 @@ public interface PropertyVisitor {
      */
     boolean visitOutputFilePropertiesOnly();
 
-    void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType);
+    void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType);
 
     void visitInputProperty(String propertyName, PropertyValue value, boolean optional);
 
@@ -50,7 +52,7 @@ public interface PropertyVisitor {
         }
 
         @Override
-        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+        public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
         }
 
         @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/AbstractInputFilePropertyAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/AbstractInputFilePropertyAnnotationHandler.java
@@ -21,9 +21,9 @@ import org.gradle.api.internal.tasks.properties.FileParameterUtils;
 import org.gradle.api.internal.tasks.properties.InputFilePropertyType;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
+import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.internal.reflect.PropertyMetadata;
 
@@ -36,19 +36,12 @@ public abstract class AbstractInputFilePropertyAnnotationHandler implements Prop
     @Override
     public void visitPropertyValue(String propertyName, PropertyValue value, PropertyMetadata propertyMetadata, PropertyVisitor visitor, BeanPropertyContext context) {
         PathSensitive pathSensitive = propertyMetadata.getAnnotation(PathSensitive.class);
-        final PathSensitivity pathSensitivity;
-        if (pathSensitive == null) {
-            // If this default is ever changed, ensure the documentation on PathSensitive is updated as well as this guide:
-            // https://guides.gradle.org/using-build-cache/#relocatability
-            pathSensitivity = PathSensitivity.ABSOLUTE;
-        } else {
-            pathSensitivity = pathSensitive.value();
-        }
+        Class<? extends FileNormalizer> fileNormalizer = pathSensitive == null ? null : FileParameterUtils.determineNormalizerForPathSensitivity(pathSensitive.value());
         visitor.visitInputFileProperty(
             propertyName,
             propertyMetadata.isAnnotationPresent(Optional.class),
             propertyMetadata.isAnnotationPresent(SkipWhenEmpty.class),
-            FileParameterUtils.determineNormalizerForPathSensitivity(pathSensitivity),
+            fileNormalizer,
             value,
             getFilePropertyType()
         );

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -648,7 +648,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                     }
 
                     @Override
-                    public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+                    public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
                         mutations.hasFileInputs = true;
                     }
                 });

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -35,6 +35,7 @@ import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import javax.annotation.Nullable
 import java.util.concurrent.Callable
 
 class DefaultTaskInputsTest extends Specification {
@@ -297,7 +298,7 @@ class DefaultTaskInputsTest extends Specification {
         when:
         inputs.visitRegisteredProperties(new PropertyVisitor.Adapter() {
             @Override
-            void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+            void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
                 names += propertyName
             }
         })
@@ -326,7 +327,7 @@ class DefaultTaskInputsTest extends Specification {
         def inputFiles = [:]
         TaskPropertyUtils.visitProperties(walker, task, new PropertyVisitor.Adapter() {
             @Override
-            void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
+            void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
                 inputFiles[propertyName] = value.call()
             }
         })

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/SkipCachedTaskExecuterTest.groovy
@@ -77,7 +77,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * taskState.getFailure() >> null
 
         then:
-        1 * taskContext.getExecutionTime() >> 1
         1 * taskContext.getTaskExecutionMode() >> taskExecutionMode
         1 * buildCacheCommandFactory.createStore(cacheKey, task, outputFingerprints, 1) >> storeCommand
 
@@ -126,7 +125,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * taskState.getFailure() >> null
 
         then:
-        1 * taskContext.getExecutionTime() >> 1
         1 * taskContext.getTaskExecutionMode() >> taskExecutionMode
         1 * buildCacheCommandFactory.createStore(cacheKey, task, outputFingerprints, 1) >> storeCommand
 
@@ -187,7 +185,6 @@ class SkipCachedTaskExecuterTest extends Specification {
         1 * taskState.getFailure() >> null
 
         then:
-        1 * taskContext.getExecutionTime() >> 1
         1 * cacheKey.getDisplayName() >> "cache key"
         1 * taskContext.getTaskExecutionMode() >> taskExecutionMode
         1 * buildCacheCommandFactory.createStore(*_)

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformTestFixture.groovy
@@ -127,6 +127,8 @@ class JarProducer extends DefaultTask {
     final RegularFileProperty output = project.objects.fileProperty()
     @Input
     String content = "content"
+    @Input
+    long timestamp = 123L
 
     @TaskAction
     def go() {
@@ -134,7 +136,7 @@ class JarProducer extends DefaultTask {
         file.withOutputStream {
             def jarFile = new JarOutputStream(it)
             def entry = new ZipEntry("thing.class")
-            entry.time = 123L
+            entry.time = timestamp
             jarFile.putNextEntry(entry)
             jarFile << content
             jarFile.close()
@@ -251,6 +253,9 @@ allprojects { p ->
                     }
                     if (project.hasProperty("\${project.name}FileName")) {
                         output = layout.buildDir.file(project.property("\${project.name}FileName"))
+                    }
+                    if (project.hasProperty("\${project.name}Timestamp")) {
+                        timestamp = Long.parseLong(project.property("\${project.name}Timestamp"))
                     }
                 }
             """.stripIndent()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -122,7 +122,10 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 String getMissingInput()
                 void setMissingInput(String missing)
                 @InputFiles
-                ConfigurableFileCollection getInputFiles()
+                ConfigurableFileCollection getNoPathSensitivity()
+                @PathSensitive(PathSensitivity.ABSOLUTE)
+                @InputFiles
+                ConfigurableFileCollection getAbsolutePathSensitivity()
             }
             
             @CacheableTransformAction
@@ -145,7 +148,8 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasCause("Property 'extension' is not annotated with an input annotation.")
         failure.assertHasCause("Property 'outputDir' is annotated with unsupported annotation @OutputDirectory.")
         failure.assertHasCause("Property 'missingInput' does not have a value specified.")
-        failure.assertHasCause("Property 'inputFiles' must not have absolute path sensitivity declared. Use a different normalization for cacheable transform inputs.")
+        failure.assertHasCause("Property 'absolutePathSensitivity' is declared to be sensitive to absolute paths. This is not allowed for cacheable transforms.")
+        failure.assertHasCause("Property 'noPathSensitivity' is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity.")
     }
 
     @Unroll
@@ -283,8 +287,9 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 File notAnnotated 
 
                 @InputArtifact
-                abstract File getAbsolutePathSensitivity() 
+                abstract File getNoPathSensitivity() 
 
+                @PathSensitive(PathSensitivity.ABSOLUTE)
                 @InputArtifactDependencies
                 abstract File getAbsolutePathSensitivityDependencies() 
 
@@ -308,8 +313,8 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasCause("Property 'conflictingAnnotations' has conflicting property types declared: @InputArtifact, @InputArtifactDependencies.")
         failure.assertHasCause("Property 'inputFile' is annotated with unsupported annotation @InputFile.")
         failure.assertHasCause("Property 'notAnnotated' is not annotated with an input annotation.")
-        failure.assertHasCause("Property 'absolutePathSensitivity' must not have absolute path sensitivity declared. Use a different normalization for cacheable transform inputs.")
-        failure.assertHasCause("Property 'absolutePathSensitivityDependencies' must not have absolute path sensitivity declared. Use a different normalization for cacheable transform inputs.")
+        failure.assertHasCause("Property 'noPathSensitivity' is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity.")
+        failure.assertHasCause("Property 'absolutePathSensitivityDependencies' is declared to be sensitive to absolute paths. This is not allowed for cacheable transforms.")
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -121,8 +121,11 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 @Input
                 String getMissingInput()
                 void setMissingInput(String missing)
+                @InputFiles
+                ConfigurableFileCollection getInputFiles()
             }
             
+            @CacheableTransformAction
             abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
@@ -142,6 +145,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasCause("Property 'extension' is not annotated with an input annotation.")
         failure.assertHasCause("Property 'outputDir' is annotated with unsupported annotation @OutputDirectory.")
         failure.assertHasCause("Property 'missingInput' does not have a value specified.")
+        failure.assertHasCause("Property 'inputFiles' must not have absolute path sensitivity declared. Use a different normalization for cacheable transform inputs.")
     }
 
     @Unroll
@@ -268,6 +272,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 void setExtension(String value)
             }
             
+            @CacheableTransformAction
             abstract class MakeGreenAction implements TransformAction {
                 @TransformParameters
                 abstract MakeGreen getParameters()
@@ -277,6 +282,13 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                 
                 File notAnnotated 
 
+                @InputArtifact
+                abstract File getAbsolutePathSensitivity() 
+
+                @InputArtifactDependencies
+                abstract File getAbsolutePathSensitivityDependencies() 
+
+                @PathSensitive(PathSensitivity.NAME_ONLY)
                 @InputFile @InputArtifact @InputArtifactDependencies
                 File getConflictingAnnotations() { } 
                 
@@ -296,6 +308,8 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         failure.assertHasCause("Property 'conflictingAnnotations' has conflicting property types declared: @InputArtifact, @InputArtifactDependencies.")
         failure.assertHasCause("Property 'inputFile' is annotated with unsupported annotation @InputFile.")
         failure.assertHasCause("Property 'notAnnotated' is not annotated with an input annotation.")
+        failure.assertHasCause("Property 'absolutePathSensitivity' must not have absolute path sensitivity declared. Use a different normalization for cacheable transform inputs.")
+        failure.assertHasCause("Property 'absolutePathSensitivityDependencies' must not have absolute path sensitivity declared. Use a different normalization for cacheable transform inputs.")
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.reflect.TypeToken;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.transform.CacheableTransformAction;
 import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.InputArtifactDependencies;
 import org.gradle.api.artifacts.transform.TransformAction;
@@ -88,6 +89,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
     private final DomainObjectProjectStateHandler projectStateHandler;
     private final ProjectStateRegistry.SafeExclusiveLock isolationLock;
     private final WorkNodeAction isolateAction;
+    private final boolean cacheable;
 
     private IsolatableParameters isolatable;
 
@@ -118,6 +120,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
         this.parameterPropertyWalker = parameterPropertyWalker;
         this.instanceFactory = actionInstantiationScheme.forType(implementationClass);
         this.requiresDependencies = instanceFactory.serviceInjectionTriggeredByAnnotation(InputArtifactDependencies.class);
+        this.cacheable = implementationClass.isAnnotationPresent(CacheableTransformAction.class);
         this.projectStateHandler = projectStateHandler;
         this.isolationLock = projectStateHandler.newExclusiveOperationLock();
         this.isolateAction = parameterObject == null ? null : new WorkNodeAction() {
@@ -146,6 +149,11 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
 
     public boolean requiresDependencies() {
         return requiresDependencies;
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return cacheable;
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -53,6 +53,11 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
     }
 
     @Override
+    public boolean isCacheable() {
+        return false;
+    }
+
+    @Override
     public ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies) {
         ArtifactTransform transformer = newTransformer();
         transformer.setOutputDirectory(outputDir);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -41,6 +41,11 @@ public interface Transformer extends Describable, TaskDependencyContainer {
      */
     boolean requiresDependencies();
 
+    /**
+     * Whether the transformer is cacheable.
+     */
+    boolean isCacheable();
+
     ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies);
 
     /**

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -127,6 +127,11 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         }
 
         @Override
+        boolean isCacheable() {
+            return false
+        }
+
+        @Override
         ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies) {
             return ImmutableList.copyOf(transformationAction.apply(inputArtifact, outputDir))
         }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/steps/CacheStep.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/impl/steps/CacheStep.java
@@ -56,6 +56,9 @@ public class CacheStep<C extends CachingContext> implements Step<C, CurrentSnaps
 
     @Override
     public CurrentSnapshotResult execute(C context) {
+        if (!buildCache.isEnabled()) {
+            return executeWithoutCache(context);
+        }
         return context.getCacheHandler()
             .load(cacheKey -> load(context.getWork(), cacheKey))
             .map(loadResult -> (CurrentSnapshotResult) new CurrentSnapshotResult() {

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildCacheCommands.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/cache/BuildCacheCommands.kt
@@ -72,8 +72,8 @@ class LoadDirectory(
 
             override fun getMetadata() = metadata.run {
                 when (buildInvocationId) {
-                    currentBuildInvocationId -> OriginMetadata.fromCurrentBuild(buildInvocationId, executionTimeMillis)
-                    else -> OriginMetadata.fromPreviousBuild(buildInvocationId, executionTimeMillis)
+                    currentBuildInvocationId -> OriginMetadata(buildInvocationId, executionTimeMillis)
+                    else -> OriginMetadata(buildInvocationId, executionTimeMillis)
                 }
             }
 


### PR DESCRIPTION
This PR introduces the new `@CacheableTransformAction` annotation which allows making artifact transform to use the build cache.