### PR TITLE
Improve `@CacheableTask` Javadoc

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/CacheableTask.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/CacheableTask.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Target;
  *
  * <p>Only tasks that produce reproducible and relocatable output should be marked with {@code CacheableTask}.</p>
  *
- * <p>Caching for individual task instances can be disabled via {@link TaskOutputs#cacheIf(String, Spec)} or {@link TaskOutputs#doNotCacheIf(String, Spec)}.</p>
+ * <p>Caching for individual task instances can be enabled and disabled via {@link TaskOutputs#cacheIf(String, Spec)} or disabled via {@link TaskOutputs#doNotCacheIf(String, Spec)}, even if the task type is not annotated with {@link CacheableTask}</p>
  *
  * @since 3.0
  */


### PR DESCRIPTION
It was not clear that caching can be enabled via `cacheIf`, even if the task is not annotated with `@CacheableTask`.