### PR TITLE
Prevent samples from sharing generated API jars from other subprojects

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.3-20190218000054+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.3-20190220000051+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/subprojects/integ-test/integ-test.gradle.kts
+++ b/subprojects/integ-test/integ-test.gradle.kts
@@ -46,6 +46,8 @@ testFixtures {
 val integTestTasks: DomainObjectCollection<IntegrationTest> by extra
 integTestTasks.configureEach {
     libsRepository.required = true
+    outputs.upToDateWhen { false }
+    outputs.cacheIf { false }
 }
 
 testFilesCleanup {

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -75,6 +75,10 @@ val apiExtensionsOutputDir = file("src/generated/kotlin")
 val publishedKotlinDslPluginVersion = "1.2.2" // TODO:kotlin-dsl
 
 tasks {
+    withType(Test::class.java).configureEach { 
+       outputs.upToDateWhen { false }
+       outputs.cacheIf { false }
+    }
 
     val generateKotlinDependencyExtensions by registering(GenerateKotlinDependencyExtensions::class) {
         outputFile = apiExtensionsOutputDir.resolve("org/gradle/kotlin/dsl/KotlinDependencyExtensions.kt")


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
