### PR TITLE
Less build dependencies resolution 

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/DependencySubstitutionRulesIntegrationTest.groovy
@@ -1052,7 +1052,7 @@ class DependencySubstitutionRulesIntegrationTest extends AbstractIntegrationSpec
         fails "checkDeps"
 
         then:
-        failure.assertHasCause("Could not resolve all task dependencies for configuration ':conf'.")
+        failure.assertHasCause("Could not resolve all dependencies for configuration ':conf'.")
         failure.assertHasCause("Could not find org.utils:api:1.123.15")
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -290,7 +290,7 @@ class DefaultDependencySubstitutionsSpec extends Specification {
         from        | to                | result
         "org:test"  | ":foo"            | true
         ":bar"      | "org:test:1.0"    | true
-        "org:test"  | "org:foo:1.0"     | true
+        "org:test"  | "org:foo:1.0"     | false
     }
 
     ComponentSelector createComponent(String componentNotation) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/dependencysubstitution/DefaultDependencySubstitutionsSpec.groovy
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.ivyservice.dependencysubstitution
 import org.gradle.api.Action
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.artifacts.component.ComponentSelector
+import org.gradle.api.artifacts.component.ProjectComponentSelector
 import org.gradle.api.internal.artifacts.ComponentSelectorConverter
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
@@ -259,5 +260,44 @@ class DefaultDependencySubstitutionsSpec extends Specification {
 
         then:
         0 * validator.validateMutation(_)
+    }
+
+    def "registering an all rule toggles the hasRule flag"() {
+        given:
+        def action = Mock(Action)
+
+        when:
+        substitutions.all(action)
+
+        then:
+        substitutions.hasRules()
+    }
+
+    @Unroll
+    def "registering a substitute rule with (#from, #to) causes hasRule #result"() {
+        given:
+        componentIdentifierFactory.createProjectComponentSelector(_) >> Mock(ProjectComponentSelector)
+        def fromComponent = createComponent(from)
+        def toComponent = createComponent(to)
+
+        when:
+        substitutions.substitute(fromComponent).with(toComponent)
+
+        then:
+        substitutions.hasRules() == result
+
+        where:
+        from        | to                | result
+        "org:test"  | ":foo"            | true
+        ":bar"      | "org:test:1.0"    | true
+        "org:test"  | "org:foo:1.0"     | true
+    }
+
+    ComponentSelector createComponent(String componentNotation) {
+        if (componentNotation.startsWith(":")) {
+            return substitutions.project(componentNotation)
+        } else {
+            return substitutions.module(componentNotation)
+        }
     }
 }


### PR DESCRIPTION
When substitutions are used, projects dependencies can appear anywhere in
the dependency graph. This forces Gradle to resolve the configurations
during the build configuration phase.
With this commit, substitutions that do not involve a project no longer
cause this early resolution.