### PR TITLE
Throw exception when using convention mapping with all new `Property` types

### DIFF
--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/CollectionPropertyIntegrationTest.groovy
@@ -424,7 +424,7 @@ task wrongPropertyElementTypeApi {
 
         expect:
         fails "convention"
-        failureHasCause("Using convention mapping with Property type is not supported. Use Property#set(...) instead.")
+        failureHasCause("You can't map property 'customProp' of Property type. Use Property#set(...) instead.")
     }
 
     def "throws exception when using convention mapping with SetProperty type"() {
@@ -447,6 +447,6 @@ task wrongPropertyElementTypeApi {
 
         expect:
         fails "convention"
-        failureHasCause("Using convention mapping with Property type is not supported. Use Property#set(...) instead.")
+        failureHasCause("You can't map property 'customProp' of Property type. Use Property#set(...) instead.")
     }
 }

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/MapPropertyIntegrationTest.groovy
@@ -579,6 +579,6 @@ task thing {
 
         expect:
         fails "convention"
-        failureHasCause("Using convention mapping with Property type is not supported. Use Property#set(...) instead.")
+        failureHasCause("You can't map property 'customProp' of Property type. Use Property#set(...) instead.")
     }
 }

--- a/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
+++ b/subprojects/model-core/src/integTest/groovy/org/gradle/api/provider/PropertyIntegrationTest.groovy
@@ -460,14 +460,14 @@ project.extensions.create("some", SomeExtension)
 
             task convention(type: ConventionTask) {
                 conventionMapping("customProp") {
-                    return project.objects.property(String).value("test")
+                    return project.objects.property(String).value("mapped value")
                 }
             }
         """
 
         expect:
         fails "convention"
-        failureHasCause("Using convention mapping with Property type is not supported. Use Property#set(...) instead.")
+        failureHasCause("You can't map property 'customProp' of Property type. Use Property#set(...) instead.")
     }
 
     def taskTypeWritesPropertyValueToFile() {

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -28,14 +28,12 @@ import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.internal.reflect.ClassInspector;
-import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -45,15 +43,13 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
     //prefix internal fields with _ so that they don't get into the way of propertyMissing()
     private final Convention _convention;
     private final IConventionAware _source;
-    private final Set<String> _propertyNames;
-    private final Map<String, Boolean> _propertyNamesAsProviderMapping;
+    private final Map<String, Boolean> _propertyNames;
     private final Map<String, MappedPropertyImpl> _mappings = new HashMap<String, MappedPropertyImpl>();
 
     public ConventionAwareHelper(IConventionAware source, Convention convention) {
         this._source = source;
         this._convention = convention;
-        this._propertyNamesAsProviderMapping = ClassInspector.inspect(source.getClass()).getProperties().stream().collect(Collectors.toMap(it -> it.getName(), it -> isProviderType(it.getGetters())));
-        this._propertyNames = JavaPropertyReflectionUtil.propertyNames(source);
+        this._propertyNames = ClassInspector.inspect(source.getClass()).getProperties().stream().collect(Collectors.toMap(it -> it.getName(), it -> isProviderType(it.getGetters())));
     }
 
     private static boolean isProviderType(List<Method> getters) {
@@ -65,10 +61,10 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
     }
 
     private MappedProperty map(String propertyName, MappedPropertyImpl mapping) {
-        if (_propertyNamesAsProviderMapping.getOrDefault(propertyName, false)) {
+        if (_propertyNames.getOrDefault(propertyName, false)) {
             throw new InvalidUserDataException("Using convention mapping with Property type is not supported. Use Property#set(...) instead.");
         }
-        if (!_propertyNames.contains(propertyName)) {
+        if (!_propertyNames.containsKey(propertyName)) {
             throw new InvalidUserDataException(
                 "You can't map a property that does not exist: propertyName=" + propertyName);
         }

--- a/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/extensibility/ConventionAwareHelper.java
@@ -23,13 +23,21 @@ import org.gradle.api.internal.ConventionMapping;
 import org.gradle.api.internal.HasConvention;
 import org.gradle.api.internal.IConventionAware;
 import org.gradle.api.plugins.Convention;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
+import org.gradle.internal.reflect.ClassInspector;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
 
+import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 import static org.gradle.util.GUtil.uncheckedCall;
 
@@ -38,15 +46,28 @@ public class ConventionAwareHelper implements ConventionMapping, HasConvention {
     private final Convention _convention;
     private final IConventionAware _source;
     private final Set<String> _propertyNames;
+    private final Map<String, Boolean> _propertyNamesAsProviderMapping;
     private final Map<String, MappedPropertyImpl> _mappings = new HashMap<String, MappedPropertyImpl>();
 
     public ConventionAwareHelper(IConventionAware source, Convention convention) {
         this._source = source;
         this._convention = convention;
+        this._propertyNamesAsProviderMapping = ClassInspector.inspect(source.getClass()).getProperties().stream().collect(Collectors.toMap(it -> it.getName(), it -> isProviderType(it.getGetters())));
         this._propertyNames = JavaPropertyReflectionUtil.propertyNames(source);
     }
 
+    private static boolean isProviderType(List<Method> getters) {
+        return getters.stream().anyMatch(ConventionAwareHelper::isProviderType);
+    }
+
+    private static boolean isProviderType(Method getter) {
+        return Property.class.isAssignableFrom(getter.getReturnType()) || ListProperty.class.isAssignableFrom(getter.getReturnType()) || SetProperty.class.isAssignableFrom(getter.getReturnType()) || MapProperty.class.isAssignableFrom(getter.getReturnType());
+    }
+
     private MappedProperty map(String propertyName, MappedPropertyImpl mapping) {
+        if (_propertyNamesAsProviderMapping.getOrDefault(propertyName, false)) {
+            throw new InvalidUserDataException("Using convention mapping with Property type is not supported. Use Property#set(...) instead.");
+        }
         if (!_propertyNames.contains(propertyName)) {
             throw new InvalidUserDataException(
                 "You can't map a property that does not exist: propertyName=" + propertyName);


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle/issues/8404

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fdeprecate-convention-mapping-for-provider)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
