### PR TITLE
Add ReplacedBy attribute to identify properties that are replaced by …

### DIFF
--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/ElementWarningsRenderer.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/ElementWarningsRenderer.java
@@ -48,5 +48,13 @@ public class ElementWarningsRenderer {
             link.appendChild(document.createTextNode("incubating"));
             para.appendChild(document.createTextNode(" and may change in a future version of Gradle."));
         }
+        if (elementDoc.isReplaced()) {
+            Document document = parent.getOwnerDocument();
+            Element caution = document.createElement("caution");
+            parent.appendChild(caution);
+            Element para = document.createElement("para");
+            caution.appendChild(para);
+            para.appendChild(document.createTextNode(String.format("Note: This %s has been replaced by %s.", type, elementDoc.getReplacement())));
+        }
     }
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/PropertyDetailRenderer.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/PropertyDetailRenderer.java
@@ -46,10 +46,13 @@ public class PropertyDetailRenderer {
         Element literal = document.createElement("literal");
         title.appendChild(literal);
         literal.appendChild(document.createTextNode(propertyDoc.getName()));
-        if (!propertyDoc.getMetaData().isWriteable()) {
-            title.appendChild(document.createTextNode(" (read-only)"));
-        } else if (!propertyDoc.getMetaData().isReadable()) {
-            title.appendChild(document.createTextNode(" (write-only)"));
+
+        if (!propertyDoc.getMetaData().isProviderApi()) {
+            if (!propertyDoc.getMetaData().isWriteable()) {
+                title.appendChild(document.createTextNode(" (read-only)"));
+            } else if (!propertyDoc.getMetaData().isReadable()) {
+                title.appendChild(document.createTextNode(" (write-only)"));
+            }
         }
 
         warningsRenderer.renderTo(propertyDoc, "property", section);

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/PropertyTableRenderer.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/PropertyTableRenderer.java
@@ -70,6 +70,11 @@ public class PropertyTableRenderer {
                 td.appendChild(caution);
                 caution.appendChild(document.createTextNode("Incubating"));
             }
+            if (propDoc.isReplaced()) {
+                Element caution = document.createElement("caution");
+                td.appendChild(caution);
+                caution.appendChild(document.createTextNode("Replaced"));
+            }
             td.appendChild(document.importNode(propDoc.getDescription(), true));
         }
     }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/BlockDoc.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/BlockDoc.groovy
@@ -67,6 +67,15 @@ class BlockDoc implements DslElementDoc {
         return blockProperty.incubating || blockMethod.incubating
     }
 
+    boolean isReplaced() {
+        return blockProperty.replaced
+    }
+
+    @Override
+    String getReplacement() {
+        return blockProperty.replacement
+    }
+
     PropertyDoc getBlockProperty() {
         return blockProperty
     }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/ClassDoc.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/ClassDoc.groovy
@@ -73,6 +73,15 @@ class ClassDoc implements DslElementDoc {
         return classMetaData.incubating
     }
 
+    boolean isReplaced() {
+        return classMetaData.replaced
+    }
+
+    @Override
+    String getReplacement() {
+        return classMetaData.replacement
+    }
+
     Collection<PropertyDoc> getClassProperties() { return classProperties }
 
     void addClassProperty(PropertyDoc propertyDoc) {

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/DslElementDoc.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/DslElementDoc.java
@@ -30,4 +30,8 @@ public interface DslElementDoc {
     boolean isDeprecated();
 
     boolean isIncubating();
+
+    boolean isReplaced();
+
+    String getReplacement();
 }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/MethodDoc.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/MethodDoc.groovy
@@ -64,6 +64,15 @@ class MethodDoc implements DslElementDoc {
         return metaData.incubating || metaData.ownerClass.incubating
     }
 
+    boolean isReplaced() {
+        return metaData.replaced
+    }
+
+    @Override
+    String getReplacement() {
+        return metaData.replacement
+    }
+
     Element getDescription() {
         return comment.find { it.nodeName == 'para' }
     }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/PropertyDoc.groovy
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/docbook/model/PropertyDoc.groovy
@@ -75,6 +75,15 @@ class PropertyDoc implements DslElementDoc {
         return metaData.incubating || metaData.ownerClass.incubating
     }
 
+    boolean isReplaced() {
+        return metaData.replaced
+    }
+
+    @Override
+    String getReplacement() {
+        return metaData.replacement
+    }
+
     Element getDescription() {
         return comment.find { it.nodeName == 'para' }
     }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/SourceMetaDataVisitor.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/SourceMetaDataVisitor.java
@@ -28,6 +28,7 @@ import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
 import com.github.javaparser.ast.expr.Expression;
 import com.github.javaparser.ast.expr.LiteralStringValueExpr;
+import com.github.javaparser.ast.expr.SingleMemberAnnotationExpr;
 import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithExtends;
 import com.github.javaparser.ast.nodeTypes.NodeWithImplements;
@@ -35,11 +36,18 @@ import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
-import org.gradle.build.docs.dsl.source.model.*;
+import org.gradle.build.docs.dsl.source.model.AbstractLanguageElement;
+import org.gradle.build.docs.dsl.source.model.ClassMetaData;
 import org.gradle.build.docs.dsl.source.model.ClassMetaData.MetaType;
+import org.gradle.build.docs.dsl.source.model.MethodMetaData;
+import org.gradle.build.docs.dsl.source.model.PropertyMetaData;
+import org.gradle.build.docs.dsl.source.model.TypeMetaData;
 import org.gradle.build.docs.model.ClassMetaDataRepository;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -149,6 +157,7 @@ public class SourceMetaDataVisitor extends VoidVisitorAdapter<ClassMetaDataRepos
             String propName = name.substring(startName, startName + 1).toLowerCase() + name.substring(startName + 1);
             PropertyMetaData property = getCurrentClass().addReadableProperty(propName, returnType, rawCommentText, methodMetaData);
             methodMetaData.getAnnotationTypeNames().forEach(property::addAnnotationTypeName);
+            property.setReplacement(methodMetaData.getReplacement());
             return;
         }
 
@@ -218,6 +227,9 @@ public class SourceMetaDataVisitor extends VoidVisitorAdapter<ClassMetaDataRepos
 
     private void findAnnotations(NodeWithAnnotations<?> node, AbstractLanguageElement currentElement) {
         for (AnnotationExpr child : node.getAnnotations()) {
+            if (child instanceof SingleMemberAnnotationExpr && child.getNameAsString().endsWith("ReplacedBy")) {
+                currentElement.setReplacement(((SingleMemberAnnotationExpr) child).getMemberValue().asLiteralStringValueExpr().getValue());
+            }
             currentElement.addAnnotationTypeName(child.getNameAsString());
         }
     }

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/AbstractLanguageElement.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/AbstractLanguageElement.java
@@ -60,7 +60,7 @@ public abstract class AbstractLanguageElement implements LanguageElement, Serial
     }
 
     public boolean isReplaced() {
-        return annotationNames.contains("org.gradle.api.tasks.ReplacedBy");
+        return annotationNames.contains("org.gradle.api.ReplacedBy");
     }
 
     public String getReplacement() {

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/AbstractLanguageElement.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/AbstractLanguageElement.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 public abstract class AbstractLanguageElement implements LanguageElement, Serializable {
     private String rawCommentText;
     private final List<String> annotationNames = new ArrayList<String>();
+    private String replacement;
 
     protected AbstractLanguageElement() {
     }
@@ -56,6 +57,18 @@ public abstract class AbstractLanguageElement implements LanguageElement, Serial
 
     public boolean isIncubating() {
         return annotationNames.contains("org.gradle.api.Incubating");
+    }
+
+    public boolean isReplaced() {
+        return annotationNames.contains("org.gradle.api.tasks.ReplacedBy");
+    }
+
+    public String getReplacement() {
+        return replacement;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
     }
 
     public void resolveTypes(Transformer<String, String> transformer) {

--- a/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/PropertyMetaData.java
+++ b/buildSrc/subprojects/build/src/main/groovy/org/gradle/build/docs/dsl/source/model/PropertyMetaData.java
@@ -59,6 +59,11 @@ public class PropertyMetaData extends AbstractLanguageElement implements Seriali
         return getter != null;
     }
 
+    public boolean isProviderApi() {
+        // TODO: Crude approximation
+        return setter == null && (getType().getName().contains("Provider") || getType().getName().contains("Property"));
+    }
+
     public ClassMetaData getOwnerClass() {
         return ownerClass;
     }

--- a/subprojects/core-api/src/main/java/org/gradle/api/ReplacedBy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ReplacedBy.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api.tasks;
+package org.gradle.api;
+
+import org.gradle.api.tasks.Internal;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
@@ -25,13 +27,13 @@ import java.lang.annotation.Target;
 /**
  * <p>Attached to a task property to indicate that the property has been replaced by another. Like {@link Internal}, the property is ignored during up-to-date checks.</p>
  *
- * <p>This annotation should be attached to the getter <b>and</b> setter method in Java or the property field in Groovy. You should also consider adding {@link Deprecated} to any replaced property.</p>
+ * <p>This annotation should be attached to the getter method in Java or the property field in Groovy. You should also consider adding {@link Deprecated} to any replaced property.</p>
  *
  * <p>This will cause the task <em>not</em> to be considered out-of-date when the property has changed.</p>
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.METHOD)
+@Target({ElementType.METHOD, ElementType.FIELD})
 public @interface ReplacedBy {
     /**
      * The Java Bean-style name of the replacement property.

--- a/subprojects/core-api/src/main/java/org/gradle/api/ReplacedBy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/ReplacedBy.java
@@ -30,10 +30,13 @@ import java.lang.annotation.Target;
  * <p>This annotation should be attached to the getter method in Java or the property field in Groovy. You should also consider adding {@link Deprecated} to any replaced property.</p>
  *
  * <p>This will cause the task <em>not</em> to be considered out-of-date when the property has changed.</p>
+ *
+ * @since 5.3
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
+@Incubating
 public @interface ReplacedBy {
     /**
      * The Java Bean-style name of the replacement property.

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/ReplacedBy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/ReplacedBy.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.tasks;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * <p>Attached to a task property to indicate that the property has been replaced by another. Like {@link Internal}, the property is ignored during up-to-date checks.</p>
+ *
+ * <p>This annotation should be attached to the getter <b>and</b> setter method in Java or the property field in Groovy. You should also consider adding {@link Deprecated} to any replaced property.</p>
+ *
+ * <p>This will cause the task <em>not</em> to be considered out-of-date when the property has changed.</p>
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ReplacedBy {
+    /**
+     * The Java Bean-style name of the replacement property.
+     * <p>
+     *     If the property has been replaced with a method named {@code getFooBar()}, then this should be {@code fooBar}.
+     * </p>
+     */
+    String value();
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
@@ -38,6 +38,7 @@ import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHa
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.ReplacedBy;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStore.java
@@ -38,7 +38,6 @@ import org.gradle.api.internal.tasks.properties.annotations.PropertyAnnotationHa
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.ReplacedBy;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.cache.internal.CrossBuildInMemoryCache;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
@@ -58,7 +57,7 @@ import java.util.Set;
 public class DefaultTypeMetadataStore implements TypeMetadataStore {
     // Avoid reflecting on classes we know we don't need to look at
     private static final ImmutableSet<Class<?>> IGNORED_SUPER_CLASSES = ImmutableSet.of(
-        ConventionTask.class, DefaultTask.class, AbstractTask.class, Task.class, Object.class, GroovyObject.class, IConventionAware.class, ExtensionAware.class, HasConvention.class, ScriptOrigin.class, DynamicObjectAware.class
+            ConventionTask.class, DefaultTask.class, AbstractTask.class, Task.class, Object.class, GroovyObject.class, IConventionAware.class, ExtensionAware.class, HasConvention.class, ScriptOrigin.class, DynamicObjectAware.class
     );
 
     private static final ImmutableSet<Class<?>> IGNORED_METHODS = ImmutableSet.of(Object.class, GroovyObject.class, ScriptOrigin.class);
@@ -115,11 +114,11 @@ public class DefaultTypeMetadataStore implements TypeMetadataStore {
 
     private static Set<Class<? extends Annotation>> collectRelevantAnnotationTypes(Set<Class<? extends Annotation>> propertyTypeAnnotations) {
         return ImmutableSet.<Class<? extends Annotation>>builder()
-            .addAll(propertyTypeAnnotations)
-            .add(Optional.class)
-            .add(SkipWhenEmpty.class)
-            .add(PathSensitive.class)
-            .build();
+                .addAll(propertyTypeAnnotations)
+                .add(Optional.class)
+                .add(SkipWhenEmpty.class)
+                .add(PathSensitive.class)
+                .build();
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.AbstractCopyTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ReplacedBy;
+import org.gradle.api.ReplacedBy;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.GUtil;
@@ -120,7 +120,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveFileName()}
      */
     @Deprecated
-    @ReplacedBy("archiveFileName")
     public void setArchiveName(String name) {
         archiveName.set(name);
     }
@@ -189,7 +188,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getDestinationDirectory()}
      */
     @Deprecated
-    @ReplacedBy("destinationDirectory")
     public void setDestinationDir(File destinationDir) {
         archiveDestinationDirectory.set(destinationDir);
     }
@@ -223,7 +221,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveBaseName()}
      */
     @Deprecated
-    @ReplacedBy("archiveBaseName")
     public void setBaseName(@Nullable String baseName) {
         this.archiveBaseName.set(baseName);
     }
@@ -258,7 +255,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveAppendix()}
      */
     @Deprecated
-    @ReplacedBy("archiveAppendix")
     public void setAppendix(@Nullable String appendix) {
         this.archiveAppendix.set(appendix);
     }
@@ -293,7 +289,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveVersion()}
      */
     @Deprecated
-    @ReplacedBy("archiveVersion")
     public void setVersion(@Nullable String version) {
         this.archiveVersion.set(version);
     }
@@ -326,7 +321,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveExtension()}
      */
     @Deprecated
-    @ReplacedBy("archiveExtension")
     public void setExtension(@Nullable String extension) {
         this.archiveExtension.set(extension);
     }
@@ -359,7 +353,6 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveClassifier()}
      */
     @Deprecated
-    @ReplacedBy("archiveClassifier")
     public void setClassifier(@Nullable String classifier) {
         this.archiveClassifier.set(classifier);
     }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -29,6 +29,7 @@ import org.gradle.api.tasks.AbstractCopyTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.ReplacedBy;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.GUtil;
@@ -107,7 +108,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveFileName()}
      */
     @Deprecated
-    @Internal("Represented as part of archiveFile")
+    @ReplacedBy("archiveFileName")
     public String getArchiveName() {
         return archiveName.get();
     }
@@ -119,6 +120,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveFileName()}
      */
     @Deprecated
+    @ReplacedBy("archiveFileName")
     public void setArchiveName(String name) {
         archiveName.set(name);
     }
@@ -142,7 +144,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveFile()}
      */
     @Deprecated
-    @Internal("Represented as a part of the archiveFile")
+    @ReplacedBy("archiveFile")
     public File getArchivePath() {
         return getArchiveFile().get().getAsFile();
     }
@@ -175,8 +177,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @return the directory
      * @deprecated Use {@link #getDestinationDirectory()}
      */
-    @Internal("Represented as part of archiveFile")
     @Deprecated
+    @ReplacedBy("destinationDirectory")
     public File getDestinationDir() {
         return archiveDestinationDirectory.getAsFile().get();
     }
@@ -187,6 +189,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getDestinationDirectory()}
      */
     @Deprecated
+    @ReplacedBy("destinationDirectory")
     public void setDestinationDir(File destinationDir) {
         archiveDestinationDirectory.set(destinationDir);
     }
@@ -208,8 +211,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveBaseName()}
      */
     @Nullable
-    @Internal("Represented as part of archiveFile")
     @Deprecated
+    @ReplacedBy("archiveBaseName")
     public String getBaseName() {
         return archiveBaseName.getOrNull();
     }
@@ -220,6 +223,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveBaseName()}
      */
     @Deprecated
+    @ReplacedBy("archiveBaseName")
     public void setBaseName(@Nullable String baseName) {
         this.archiveBaseName.set(baseName);
     }
@@ -242,8 +246,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveAppendix()}
      */
     @Nullable
-    @Internal("Represented as part of archiveFile")
     @Deprecated
+    @ReplacedBy("archiveAppendix")
     public String getAppendix() {
         return archiveAppendix.getOrNull();
     }
@@ -254,6 +258,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveAppendix()}
      */
     @Deprecated
+    @ReplacedBy("archiveAppendix")
     public void setAppendix(@Nullable String appendix) {
         this.archiveAppendix.set(appendix);
     }
@@ -276,8 +281,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveVersion()}
      */
     @Nullable
-    @Internal("Represented as part of archiveFile")
     @Deprecated
+    @ReplacedBy("archiveVersion")
     public String getVersion() {
         return archiveVersion.getOrNull();
     }
@@ -288,6 +293,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveVersion()}
      */
     @Deprecated
+    @ReplacedBy("archiveVersion")
     public void setVersion(@Nullable String version) {
         this.archiveVersion.set(version);
     }
@@ -308,8 +314,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveExtension()}
      */
     @Nullable
-    @Internal("Represented as part of archiveFile")
     @Deprecated
+    @ReplacedBy("archiveExtension")
     public String getExtension() {
         return archiveExtension.getOrNull();
     }
@@ -320,6 +326,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveExtension()}
      */
     @Deprecated
+    @ReplacedBy("archiveExtension")
     public void setExtension(@Nullable String extension) {
         this.archiveExtension.set(extension);
     }
@@ -340,8 +347,8 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveClassifier()}
      */
     @Nullable
-    @Internal("Represented as part of archiveFile")
     @Deprecated
+    @ReplacedBy("archiveClassifier")
     public String getClassifier() {
         return archiveClassifier.getOrNull();
     }
@@ -352,6 +359,7 @@ public abstract class AbstractArchiveTask extends AbstractCopyTask {
      * @deprecated Use {@link #getArchiveClassifier()}
      */
     @Deprecated
+    @ReplacedBy("archiveClassifier")
     public void setClassifier(@Nullable String classifier) {
         this.archiveClassifier.set(classifier);
     }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -50,6 +50,7 @@ import org.gradle.api.tasks.OutputDirectories;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.OutputFiles;
+import org.gradle.api.tasks.ReplacedBy;
 import org.gradle.api.tasks.options.OptionValues;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.instantiation.InstantiationScheme;
@@ -87,6 +88,10 @@ public class ExecutionGlobalServices {
 
     PropertyAnnotationHandler createInternalAnnotationHandler() {
         return new NoOpPropertyAnnotationHandler(Internal.class);
+    }
+
+    PropertyAnnotationHandler createReplacedByAnnotationHandler() {
+        return new NoOpPropertyAnnotationHandler(ReplacedBy.class);
     }
 
     PropertyAnnotationHandler createOptionValuesAnnotationHandler() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -16,6 +16,7 @@
 package org.gradle.internal.service.scopes;
 
 import com.google.common.collect.ImmutableSet;
+import org.gradle.api.ReplacedBy;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
@@ -50,7 +51,6 @@ import org.gradle.api.tasks.OutputDirectories;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.OutputFiles;
-import org.gradle.api.tasks.ReplacedBy;
 import org.gradle.api.tasks.options.OptionValues;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.instantiation.InstantiationScheme;
@@ -66,7 +66,7 @@ public class ExecutionGlobalServices {
 
     TaskScheme createTaskScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {
         InstantiationScheme instantiationScheme = instantiatorFactory.decorateScheme();
-        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, OutputFile.class, OutputFiles.class, OutputDirectory.class, OutputDirectories.class, Classpath.class, CompileClasspath.class, Destroys.class, LocalState.class, Nested.class, Inject.class, Console.class, Internal.class, OptionValues.class));
+        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, OutputFile.class, OutputFiles.class, OutputDirectory.class, OutputDirectories.class, Classpath.class, CompileClasspath.class, Destroys.class, LocalState.class, Nested.class, Inject.class, Console.class, ReplacedBy.class, Internal.class, OptionValues.class));
         return new TaskScheme(instantiationScheme, inspectionScheme);
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.api.internal.tasks.properties
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.ReplacedBy
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.AbstractTask
@@ -58,7 +59,7 @@ class DefaultTypeMetadataStoreTest extends Specification {
     ]
 
     private static final List<Class<? extends Annotation>> UNPROCESSED_PROPERTY_TYPE_ANNOTATIONS = [
-        Console, Internal, Inject
+        Console, Internal, Inject, ReplacedBy
     ]
 
     @Shared GroovyClassLoader groovyClassLoader
@@ -241,6 +242,7 @@ class DefaultTypeMetadataStoreTest extends Specification {
         @OutputDirectories Set<File> outputDirectories
         @Inject Object injectedService
         @Internal Object internal
+        @ReplacedBy("inputString") String oldProperty
         @Console boolean console
     }
 

--- a/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.xml
@@ -26,11 +26,11 @@
             </tr>
             <tr>
                 <td>archiveAppendix</td>
-                <td><literal>null</literal></td>
+                <td><literal>""</literal></td>
             </tr>
             <tr>
                 <td>appendix</td>
-                <td><literal>null</literal></td>
+                <td><literal>""</literal></td>
             </tr>
             <tr>
                 <td>baseName</td>
@@ -58,11 +58,11 @@
             </tr>
             <tr>
                 <td>archiveClassifier</td>
-                <td><literal>null</literal></td>
+                <td><literal>""</literal></td>
             </tr>
             <tr>
                 <td>classifier</td>
-                <td><literal>null</literal></td>
+                <td><literal>""</literal></td>
             </tr>
             <tr>
                 <td>destinationDir</td>

--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -643,6 +643,10 @@ Using a file tree turns <<build_cache.adoc#sec:task_output_caching, caching>> of
 | Any type
 | Indicates that the property is used internally but is neither an input nor an output.
 
+| `@link:{javadocPath}/org/gradle/api/tasks/ReplacedBy.html[ReplacedBy]`
+| Any type
+| Indicates that the property has been replaced by another and should be ignored as an input or output.
+
 | [#skip-when-empty]`@link:{javadocPath}/org/gradle/api/tasks/SkipWhenEmpty.html[SkipWhenEmpty]`
 | `File`+++*+++
 | Used with `@InputFiles` or `@InputDirectory` to tell Gradle to skip the task if the corresponding files or directory are empty, along with all other input files declared with this annotation. Tasks that have been skipped due to all of their input files that were declared with this annotation being empty will result in a distinct “no source” outcome. For example, `NO-SOURCE` will be emitted in the console output.

--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -643,7 +643,7 @@ Using a file tree turns <<build_cache.adoc#sec:task_output_caching, caching>> of
 | Any type
 | Indicates that the property is used internally but is neither an input nor an output.
 
-| `@link:{javadocPath}/org/gradle/api/tasks/ReplacedBy.html[ReplacedBy]`
+| `@link:{javadocPath}/org/gradle/api/ReplacedBy.html[ReplacedBy]`
 | Any type
 | Indicates that the property has been replaced by another and should be ignored as an input or output.
 

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.plugin.devel.tasks
 
+import org.gradle.api.ReplacedBy
 import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.InputArtifactDependencies
 import org.gradle.api.artifacts.transform.TransformParameters
@@ -170,6 +171,7 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         Inject            | Inject.name                   | ObjectFactory
         OptionValues      | "${OptionValues.name}(\"a\")" | List
         Internal          | 'Internal'                    | String
+        ReplacedBy        | 'ReplacedBy'                  | String
         Console           | 'Console'                     | Boolean
         Destroys          | 'Destroys'                    | FileCollection
         LocalState        | 'LocalState'                  | FileCollection
@@ -589,5 +591,40 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         property    | value
         'classes'   | 'output.classesDirs'
         'classpath' | ' compileClasspath '
+    }
+
+    def "reports conflicting types when property is replaced but keeps old annotations"() {
+        file("src/main/java/MyTask.java") << """
+            import org.gradle.api.*;
+            import org.gradle.api.tasks.*;
+            import org.gradle.api.provider.*;
+            
+            public class MyTask extends DefaultTask {
+                private final Property<String> newProperty = getProject().getObjects().property(String.class);
+    
+                @Input
+                @ReplacedBy("newProperty")
+                public String getOldProperty() {
+                    return newProperty.get();
+                }
+    
+                public void setOldProperty(String oldProperty) {
+                    newProperty.set(oldProperty);
+                }
+    
+                @Input
+                public Property<String> getNewProperty() {
+                    return newProperty;
+                }
+            }
+        """
+
+        when:
+        fails "validateTaskProperties"
+
+        then:
+        file("build/reports/task-properties/report.txt").text == """
+            Warning: Task type 'MyTask': property 'oldProperty' has conflicting property types declared: @Input, @ReplacedBy
+        """.stripIndent().trim()
     }
 }

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -171,7 +171,7 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
         Inject            | Inject.name                   | ObjectFactory
         OptionValues      | "${OptionValues.name}(\"a\")" | List
         Internal          | 'Internal'                    | String
-        ReplacedBy        | 'ReplacedBy'                  | String
+        ReplacedBy        | 'ReplacedBy("")'              | String
         Console           | 'Console'                     | Boolean
         Destroys          | 'Destroys'                    | FileCollection
         LocalState        | 'LocalState'                  | FileCollection
@@ -624,7 +624,7 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
         then:
         file("build/reports/task-properties/report.txt").text == """
-            Warning: Task type 'MyTask': property 'oldProperty' has conflicting property types declared: @Input, @ReplacedBy
+            Warning: Task type 'MyTask': property 'oldProperty' has conflicting property types declared: @Input, @ReplacedBy.
         """.stripIndent().trim()
     }
 }

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -102,7 +102,7 @@ import java.util.Map;
  *             <li>{@literal @}{@link javax.inject.Inject} marks a Gradle service used by the task.</li>
  *             <li>{@literal @}{@link org.gradle.api.tasks.Console Console} marks a property that only influences the console output of the task.</li>
  *             <li>{@literal @}{@link org.gradle.api.tasks.Internal Internal} mark an internal property of the task.</li>
- *             <li>{@literal @}{@link org.gradle.api.tasks.ReplacedBy ReplacedBy} mark a property as replaced by another (similar to {@code Internal}).</li>
+ *             <li>{@literal @}{@link org.gradle.api.ReplacedBy ReplacedBy} mark a property as replaced by another (similar to {@code Internal}).</li>
  *         </ul>
  *     </li>
  * </ul>

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -102,6 +102,7 @@ import java.util.Map;
  *             <li>{@literal @}{@link javax.inject.Inject} marks a Gradle service used by the task.</li>
  *             <li>{@literal @}{@link org.gradle.api.tasks.Console Console} marks a property that only influences the console output of the task.</li>
  *             <li>{@literal @}{@link org.gradle.api.tasks.Internal Internal} mark an internal property of the task.</li>
+ *             <li>{@literal @}{@link org.gradle.api.tasks.ReplacedBy ReplacedBy} mark a property as replaced by another (similar to {@code Internal}).</li>
  *         </ul>
  *     </li>
  * </ul>


### PR DESCRIPTION
…other properties

This is informational only for now. @ReplacedBy is treated like @Internal.

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
