### PR TITLE
Rework daemon GC/memory expiration checks

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/Clock.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/Clock.java
@@ -23,7 +23,7 @@ package org.gradle.internal.time;
 public interface Clock {
 
     /**
-     * The current time.
+     * The current time in millis.
      */
     long getCurrentTime();
 

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -23,7 +23,7 @@ import org.gradle.internal.Pair;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.launcher.daemon.client.DaemonStartupMessage;
 import org.gradle.launcher.daemon.server.DaemonStateCoordinator;
-import org.gradle.launcher.daemon.server.health.LowTenuredSpaceDaemonExpirationStrategy;
+import org.gradle.launcher.daemon.server.health.LowHeapSpaceDaemonExpirationStrategy;
 import org.gradle.util.GUtil;
 import org.junit.ComparisonFailure;
 
@@ -131,7 +131,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
             } else if (line.contains(DaemonStateCoordinator.DAEMON_WILL_STOP_MESSAGE)) {
                 // Remove the "Daemon will be shut down" message
                 i++;
-            } else if (line.contains(LowTenuredSpaceDaemonExpirationStrategy.EXPIRE_DAEMON_MESSAGE)) {
+            } else if (line.contains(LowHeapSpaceDaemonExpirationStrategy.EXPIRE_DAEMON_MESSAGE)) {
                 // Remove the "Expiring Daemon" message
                 i++;
             } else if (line.contains(LoggingDeprecatedFeatureHandler.WARNING_SUMMARY)) {

--- a/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonExpirationIntegrationTest.groovy
+++ b/subprojects/launcher/src/integTest/groovy/org/gradle/launcher/daemon/DaemonExpirationIntegrationTest.groovy
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.launcher.daemon
+
+import org.gradle.integtests.fixtures.daemon.DaemonIntegrationSpec
+import org.gradle.launcher.daemon.server.health.gc.GarbageCollectorMonitoringStrategy
+
+class DaemonExpirationIntegrationTest extends DaemonIntegrationSpec {
+    def "daemon understands the GC used"() {
+        buildFile << """
+            import ${GarbageCollectorMonitoringStrategy.canonicalName}
+
+            def strategy = services.get(GarbageCollectorMonitoringStrategy)
+            assert strategy != GarbageCollectorMonitoringStrategy.UNKNOWN
+        """
+        expect:
+        run "help"
+    }
+}

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
@@ -105,8 +105,7 @@ public class DaemonServices extends DefaultServiceRegistry {
         return new File(get(DaemonDir.class).getVersionedDir(), fileName);
     }
 
-    protected DaemonMemoryStatus createDaemonMemoryStatus(DaemonHealthStats healthStats) {
-        GarbageCollectorMonitoringStrategy strategy = healthStats.getGcStrategy();
+    protected DaemonMemoryStatus createDaemonMemoryStatus(DaemonHealthStats healthStats, GarbageCollectorMonitoringStrategy strategy) {
         return new DaemonMemoryStatus(healthStats, strategy.getHeapUsageThreshold(), strategy.getGcRateThreshold(), strategy.getNonHeapUsageThreshold(), strategy.getThrashingThreshold());
     }
 
@@ -130,8 +129,12 @@ public class DaemonServices extends DefaultServiceRegistry {
         return new HealthExpirationStrategy(memoryStatus);
     }
 
-    protected DaemonHealthStats createDaemonHealthStats(DaemonRunningStats runningStats, ExecutorFactory executorFactory) {
-        return new DaemonHealthStats(runningStats, executorFactory);
+    protected DaemonHealthStats createDaemonHealthStats(DaemonRunningStats runningStats, GarbageCollectorMonitoringStrategy strategy, ExecutorFactory executorFactory) {
+        return new DaemonHealthStats(runningStats, strategy, executorFactory);
+    }
+
+    protected GarbageCollectorMonitoringStrategy createGarbageCollectorMonitoringStrategy() {
+        return GarbageCollectorMonitoringStrategy.determineGcStrategy();
     }
 
     protected ImmutableList<DaemonCommandAction> createDaemonCommandActions(DaemonContext daemonContext, ProcessEnvironment processEnvironment, DaemonHealthStats healthStats, DaemonHealthCheck healthCheck, BuildExecuter buildActionExecuter, DaemonRunningStats runningStats) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/DaemonServices.java
@@ -58,6 +58,7 @@ import org.gradle.launcher.daemon.server.health.DaemonHealthCheck;
 import org.gradle.launcher.daemon.server.health.DaemonHealthStats;
 import org.gradle.launcher.daemon.server.health.DaemonMemoryStatus;
 import org.gradle.launcher.daemon.server.health.HealthExpirationStrategy;
+import org.gradle.launcher.daemon.server.health.gc.GarbageCollectorMonitoringStrategy;
 import org.gradle.launcher.daemon.server.scaninfo.DaemonScanInfo;
 import org.gradle.launcher.daemon.server.scaninfo.DefaultDaemonScanInfo;
 import org.gradle.launcher.daemon.server.stats.DaemonRunningStats;
@@ -105,7 +106,8 @@ public class DaemonServices extends DefaultServiceRegistry {
     }
 
     protected DaemonMemoryStatus createDaemonMemoryStatus(DaemonHealthStats healthStats) {
-        return new DaemonMemoryStatus(healthStats);
+        GarbageCollectorMonitoringStrategy strategy = healthStats.getGcStrategy();
+        return new DaemonMemoryStatus(healthStats, strategy.getHeapUsageThreshold(), strategy.getGcRateThreshold(), strategy.getNonHeapUsageThreshold(), strategy.getThrashingThreshold());
     }
 
     protected DaemonHealthCheck createDaemonHealthCheck(ListenerManager listenerManager, HealthExpirationStrategy healthExpirationStrategy) {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/DaemonHealthStats.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/DaemonHealthStats.java
@@ -18,8 +18,8 @@ package org.gradle.launcher.daemon.server.health;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.internal.concurrent.ExecutorFactory;
-import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.concurrent.ManagedScheduledExecutor;
+import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.util.NumberUtil;
 import org.gradle.launcher.daemon.server.health.gc.GarbageCollectionInfo;
 import org.gradle.launcher.daemon.server.health.gc.GarbageCollectionMonitor;
@@ -58,8 +58,16 @@ public class DaemonHealthStats implements Stoppable {
         }
     }
 
-    GarbageCollectionMonitor getGcMonitor() {
-        return gcMonitor;
+    public GarbageCollectorMonitoringStrategy getGcStrategy() {
+        return gcMonitor.getGcStrategy();
+    }
+
+    public GarbageCollectionStats getHeapStats() {
+        return gcMonitor.getHeapStats();
+    }
+
+    public GarbageCollectionStats getNonHeapStats() {
+        return gcMonitor.getNonHeapStats();
     }
 
     /**
@@ -79,26 +87,23 @@ public class DaemonHealthStats implements Stoppable {
     }
 
     private String getBuildHealthInfo(int nextBuildNum) {
-        if (gcMonitor.getGcStrategy() != GarbageCollectorMonitoringStrategy.UNKNOWN) {
-            GarbageCollectionStats tenuredStats = gcMonitor.getTenuredStats();
-            GarbageCollectionStats permgenStats = gcMonitor.getPermGenStats();
-            String message = format("Starting %s build in daemon [uptime: %s, performance: %s%%",
-                NumberUtil.ordinal(nextBuildNum), runningStats.getPrettyUpTime(), getCurrentPerformance());
-            if (tenuredStats.getUsage() > 0) {
-                message += format(", GC rate: %.2f/s, tenured heap usage: %s%% of %s", tenuredStats.getRate(), tenuredStats.getUsage(), NumberUtil.formatBytes(tenuredStats.getMax()));
-                if (permgenStats.getUsage() > 0) {
-                    message += format(", perm gen usage: %s%% of %s",
-                        permgenStats.getUsage(), NumberUtil.formatBytes(permgenStats.getMax()));
-                }
-            } else {
-                message += ", no major garbage collections";
-            }
-            message += "]";
-            return message;
-        } else {
-            return format("Starting %s build in daemon [uptime: %s, performance: %s%%]",
-                NumberUtil.ordinal(nextBuildNum), runningStats.getPrettyUpTime(), getCurrentPerformance());
+
+        StringBuilder message = new StringBuilder(format("Starting %s build in daemon ", NumberUtil.ordinal(nextBuildNum)));
+        message.append(format("[uptime: %s, performance: %s%%", runningStats.getPrettyUpTime(), getCurrentPerformance()));
+
+        GarbageCollectionStats heapStats = gcMonitor.getHeapStats();
+        if (heapStats.isValid()) {
+            message.append(format(", GC rate: %.2f/s", heapStats.getGcRate()));
+            message.append(format(", heap usage: %s%% of %s", heapStats.getUsedPercent(), NumberUtil.formatBytes(heapStats.getMaxSizeInBytes())));
         }
+
+        GarbageCollectionStats nonHeapStats = gcMonitor.getNonHeapStats();
+        if (nonHeapStats.isValid()) {
+            message.append(format(", non-heap usage: %s%% of %s", nonHeapStats.getUsedPercent(), NumberUtil.formatBytes(nonHeapStats.getMaxSizeInBytes())));
+        }
+        message.append("]");
+
+        return message.toString();
     }
 
     /**

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/DaemonHealthStats.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/DaemonHealthStats.java
@@ -36,11 +36,11 @@ public class DaemonHealthStats implements Stoppable {
     private final GarbageCollectionInfo gcInfo;
     private final GarbageCollectionMonitor gcMonitor;
 
-    public DaemonHealthStats(DaemonRunningStats runningStats, ExecutorFactory executorFactory) {
+    public DaemonHealthStats(DaemonRunningStats runningStats, GarbageCollectorMonitoringStrategy strategy, ExecutorFactory executorFactory) {
         this.runningStats = runningStats;
         this.scheduler = executorFactory.createScheduled("Daemon health stats", 1);
         this.gcInfo = new GarbageCollectionInfo();
-        this.gcMonitor = new GarbageCollectionMonitor(scheduler);
+        this.gcMonitor = new GarbageCollectionMonitor(strategy, scheduler);
     }
 
     @VisibleForTesting
@@ -56,10 +56,6 @@ public class DaemonHealthStats implements Stoppable {
         if (scheduler != null) {
             scheduler.stop();
         }
-    }
-
-    public GarbageCollectorMonitoringStrategy getGcStrategy() {
-        return gcMonitor.getGcStrategy();
     }
 
     public GarbageCollectionStats getHeapStats() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/HealthExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/HealthExpirationStrategy.java
@@ -28,8 +28,8 @@ public class HealthExpirationStrategy implements DaemonExpirationStrategy {
     public HealthExpirationStrategy(DaemonMemoryStatus memoryStatus) {
         this.strategy = new AnyDaemonExpirationStrategy(ImmutableList.of(
             new GcThrashingDaemonExpirationStrategy(memoryStatus),
-            new LowTenuredSpaceDaemonExpirationStrategy(memoryStatus),
-            new LowPermGenDaemonExpirationStrategy(memoryStatus)
+            new LowHeapSpaceDaemonExpirationStrategy(memoryStatus),
+            new LowNonHeapDaemonExpirationStrategy(memoryStatus)
         ));
     }
 

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowHeapSpaceDaemonExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowHeapSpaceDaemonExpirationStrategy.java
@@ -23,20 +23,20 @@ import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStrategy;
 
 import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GRACEFUL_EXPIRE;
 
-public class LowTenuredSpaceDaemonExpirationStrategy implements DaemonExpirationStrategy {
+public class LowHeapSpaceDaemonExpirationStrategy implements DaemonExpirationStrategy {
     private final DaemonMemoryStatus status;
-    private static final Logger LOG = Logging.getLogger(LowTenuredSpaceDaemonExpirationStrategy.class);
+    private static final Logger LOG = Logging.getLogger(LowHeapSpaceDaemonExpirationStrategy.class);
 
     public static final String EXPIRATION_REASON = "after running out of JVM memory";
-    public static final String EXPIRE_DAEMON_MESSAGE = "Expiring Daemon because JVM Tenured space is exhausted";
+    public static final String EXPIRE_DAEMON_MESSAGE = "Expiring Daemon because JVM heap space is exhausted";
 
-    public LowTenuredSpaceDaemonExpirationStrategy(DaemonMemoryStatus status) {
+    public LowHeapSpaceDaemonExpirationStrategy(DaemonMemoryStatus status) {
         this.status = status;
     }
 
     @Override
     public DaemonExpirationResult checkExpiration() {
-        if (status.isTenuredSpaceExhausted()) {
+        if (status.isHeapSpaceExhausted()) {
             LOG.warn(EXPIRE_DAEMON_MESSAGE);
             return new DaemonExpirationResult(GRACEFUL_EXPIRE, EXPIRATION_REASON);
         } else {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowNonHeapDaemonExpirationStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/LowNonHeapDaemonExpirationStrategy.java
@@ -23,20 +23,20 @@ import org.gradle.launcher.daemon.server.expiry.DaemonExpirationStrategy;
 
 import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GRACEFUL_EXPIRE;
 
-public class LowPermGenDaemonExpirationStrategy implements DaemonExpirationStrategy {
+public class LowNonHeapDaemonExpirationStrategy implements DaemonExpirationStrategy {
     private final DaemonMemoryStatus status;
-    private static final Logger LOG = Logging.getLogger(LowPermGenDaemonExpirationStrategy.class);
+    private static final Logger LOG = Logging.getLogger(LowNonHeapDaemonExpirationStrategy.class);
 
     public static final String EXPIRATION_REASON = "after running out of JVM memory";
 
-    public LowPermGenDaemonExpirationStrategy(DaemonMemoryStatus status) {
+    public LowNonHeapDaemonExpirationStrategy(DaemonMemoryStatus status) {
         this.status = status;
     }
 
     @Override
     public DaemonExpirationResult checkExpiration() {
-        if (status.isPermGenSpaceExhausted()) {
-            LOG.info("Expiring Daemon due to JVM PermGen space being exhausted");
+        if (status.isNonHeapSpaceExhausted()) {
+            LOG.info("Expiring Daemon due to JVM Metaspace space being exhausted");
             return new DaemonExpirationResult(GRACEFUL_EXPIRE, EXPIRATION_REASON);
         } else {
             return DaemonExpirationResult.NOT_TRIGGERED;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/DefaultSlidingWindow.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/DefaultSlidingWindow.java
@@ -18,7 +18,7 @@ package org.gradle.launcher.daemon.server.health.gc;
 
 import com.google.common.collect.Sets;
 
-import java.util.Set;
+import java.util.Collection;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -43,10 +43,20 @@ public class DefaultSlidingWindow<T> implements SlidingWindow<T> {
     }
 
     @Override
-    public Set<T> snapshot() {
+    public Collection<T> snapshot() {
         lock.lock();
         try {
             return Sets.newLinkedHashSet(deque);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public T latest() {
+        lock.lock();
+        try {
+            return deque.peekLast();
         } finally {
             lock.unlock();
         }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionEvent.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionEvent.java
@@ -19,9 +19,9 @@ package org.gradle.launcher.daemon.server.health.gc;
 import java.lang.management.MemoryUsage;
 
 public class GarbageCollectionEvent {
-    final long timestamp;
-    final MemoryUsage usage;
-    final long count;
+    private final long timestamp;
+    private final MemoryUsage usage;
+    private final long count;
 
     public GarbageCollectionEvent(long timestamp, MemoryUsage usage, long count) {
         this.timestamp = timestamp;

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitor.java
@@ -16,17 +16,12 @@
 
 package org.gradle.launcher.daemon.server.health.gc;
 
-import org.gradle.api.Transformer;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.jvm.Jvm;
 import org.gradle.internal.time.Time;
 import org.gradle.util.CollectionUtils;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
-import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -34,16 +29,11 @@ public class GarbageCollectionMonitor {
     private static final int POLL_INTERVAL_SECONDS = 1;
     private static final int POLL_DELAY_SECONDS = 1;
     private static final int EVENT_WINDOW = 20;
-    private static final Logger LOGGER = Logging.getLogger(GarbageCollectionMonitor.class);
 
     private final SlidingWindow<GarbageCollectionEvent> heapEvents;
     private final SlidingWindow<GarbageCollectionEvent> nonHeapEvents;
     private final GarbageCollectorMonitoringStrategy gcStrategy;
     private final ScheduledExecutorService pollingExecutor;
-
-    public GarbageCollectionMonitor(ScheduledExecutorService pollingExecutor) {
-        this(determineGcStrategy(), pollingExecutor);
-    }
 
     public GarbageCollectionMonitor(GarbageCollectorMonitoringStrategy gcStrategy, ScheduledExecutorService pollingExecutor) {
         this.pollingExecutor = pollingExecutor;
@@ -52,29 +42,6 @@ public class GarbageCollectionMonitor {
         this.nonHeapEvents = new DefaultSlidingWindow<GarbageCollectionEvent>(EVENT_WINDOW);
         if (gcStrategy != GarbageCollectorMonitoringStrategy.UNKNOWN) {
             pollForValues();
-        }
-    }
-
-    private static GarbageCollectorMonitoringStrategy determineGcStrategy() {
-
-        final List<String> garbageCollectors = CollectionUtils.collect(ManagementFactory.getGarbageCollectorMXBeans(), new Transformer<String, GarbageCollectorMXBean>() {
-            @Override
-            public String transform(GarbageCollectorMXBean garbageCollectorMXBean) {
-                return garbageCollectorMXBean.getName();
-            }
-        });
-        GarbageCollectorMonitoringStrategy gcStrategy = CollectionUtils.findFirst(GarbageCollectorMonitoringStrategy.values(), new Spec<GarbageCollectorMonitoringStrategy>() {
-            @Override
-            public boolean isSatisfiedBy(GarbageCollectorMonitoringStrategy strategy) {
-                return garbageCollectors.contains(strategy.getGarbageCollectorName());
-            }
-        });
-
-        if (gcStrategy == null) {
-            LOGGER.info("Unable to determine a garbage collection monitoring strategy for " + Jvm.current().toString());
-            return GarbageCollectorMonitoringStrategy.UNKNOWN;
-        } else {
-            return gcStrategy;
         }
     }
 
@@ -94,9 +61,5 @@ public class GarbageCollectionMonitor {
 
     public GarbageCollectionStats getNonHeapStats() {
         return GarbageCollectionStats.forNonHeap(nonHeapEvents.snapshot());
-    }
-
-    public GarbageCollectorMonitoringStrategy getGcStrategy() {
-        return gcStrategy;
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitor.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitor.java
@@ -16,27 +16,28 @@
 
 package org.gradle.launcher.daemon.server.health.gc;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.gradle.api.Transformer;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
+import org.gradle.internal.jvm.Jvm;
+import org.gradle.internal.time.Time;
 import org.gradle.util.CollectionUtils;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class GarbageCollectionMonitor {
-    public static final int POLL_INTERVAL_SECONDS = 1;
+    private static final int POLL_INTERVAL_SECONDS = 1;
     private static final int POLL_DELAY_SECONDS = 1;
     private static final int EVENT_WINDOW = 20;
     private static final Logger LOGGER = Logging.getLogger(GarbageCollectionMonitor.class);
-    private final Map<String, SlidingWindow<GarbageCollectionEvent>> events;
+
+    private final SlidingWindow<GarbageCollectionEvent> heapEvents;
+    private final SlidingWindow<GarbageCollectionEvent> nonHeapEvents;
     private final GarbageCollectorMonitoringStrategy gcStrategy;
     private final ScheduledExecutorService pollingExecutor;
 
@@ -47,20 +48,14 @@ public class GarbageCollectionMonitor {
     public GarbageCollectionMonitor(GarbageCollectorMonitoringStrategy gcStrategy, ScheduledExecutorService pollingExecutor) {
         this.pollingExecutor = pollingExecutor;
         this.gcStrategy = gcStrategy;
-
+        this.heapEvents = new DefaultSlidingWindow<GarbageCollectionEvent>(EVENT_WINDOW);
+        this.nonHeapEvents = new DefaultSlidingWindow<GarbageCollectionEvent>(EVENT_WINDOW);
         if (gcStrategy != GarbageCollectorMonitoringStrategy.UNKNOWN) {
-            events = ImmutableMap.<String, SlidingWindow<GarbageCollectionEvent>>of(
-                gcStrategy.getTenuredPoolName(), new DefaultSlidingWindow<GarbageCollectionEvent>(EVENT_WINDOW),
-                gcStrategy.getPermGenPoolName(), new DefaultSlidingWindow<GarbageCollectionEvent>(EVENT_WINDOW)
-            );
-            pollForValues(gcStrategy.getGarbageCollectorName(), ImmutableList.copyOf(events.keySet()));
-        } else {
-            events = ImmutableMap.<String, SlidingWindow<GarbageCollectionEvent>>builder().build();
+            pollForValues();
         }
     }
 
     private static GarbageCollectorMonitoringStrategy determineGcStrategy() {
-        JVMStrategy jvmStrategy = JVMStrategy.current();
 
         final List<String> garbageCollectors = CollectionUtils.collect(ManagementFactory.getGarbageCollectorMXBeans(), new Transformer<String, GarbageCollectorMXBean>() {
             @Override
@@ -68,7 +63,7 @@ public class GarbageCollectionMonitor {
                 return garbageCollectorMXBean.getName();
             }
         });
-        GarbageCollectorMonitoringStrategy gcStrategy = CollectionUtils.findFirst(jvmStrategy.getGcStrategies(), new Spec<GarbageCollectorMonitoringStrategy>() {
+        GarbageCollectorMonitoringStrategy gcStrategy = CollectionUtils.findFirst(GarbageCollectorMonitoringStrategy.values(), new Spec<GarbageCollectorMonitoringStrategy>() {
             @Override
             public boolean isSatisfiedBy(GarbageCollectorMonitoringStrategy strategy) {
                 return garbageCollectors.contains(strategy.getGarbageCollectorName());
@@ -76,74 +71,32 @@ public class GarbageCollectionMonitor {
         });
 
         if (gcStrategy == null) {
-            LOGGER.info("Unable to determine a garbage collection monitoring strategy for " + jvmStrategy.toString());
+            LOGGER.info("Unable to determine a garbage collection monitoring strategy for " + Jvm.current().toString());
             return GarbageCollectorMonitoringStrategy.UNKNOWN;
         } else {
             return gcStrategy;
         }
     }
 
-    private void pollForValues(String garbageCollectorName, List<String> memoryPoolNames) {
-        pollingExecutor.scheduleAtFixedRate(new GarbageCollectionCheck(events, memoryPoolNames, garbageCollectorName), POLL_DELAY_SECONDS, POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    private void pollForValues() {
+        GarbageCollectorMXBean garbageCollectorMXBean = CollectionUtils.findFirst(ManagementFactory.getGarbageCollectorMXBeans(), new Spec<GarbageCollectorMXBean>() {
+            @Override
+            public boolean isSatisfiedBy(GarbageCollectorMXBean element) {
+                return element.getName().equals(gcStrategy.getGarbageCollectorName());
+            }
+        });
+        pollingExecutor.scheduleAtFixedRate(new GarbageCollectionCheck(Time.clock(), garbageCollectorMXBean, gcStrategy.getHeapPoolName(), heapEvents, gcStrategy.getNonHeapPoolName(), nonHeapEvents), POLL_DELAY_SECONDS, POLL_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
-    public GarbageCollectionStats getTenuredStats() {
-        return getGarbageCollectionStatsWithEmptyDefault(gcStrategy.getTenuredPoolName());
+    public GarbageCollectionStats getHeapStats() {
+        return GarbageCollectionStats.forHeap(heapEvents.snapshot());
     }
 
-    public GarbageCollectionStats getPermGenStats() {
-        return getGarbageCollectionStatsWithEmptyDefault(gcStrategy.getPermGenPoolName());
-    }
-
-    private GarbageCollectionStats getGarbageCollectionStatsWithEmptyDefault(final String memoryPoolName) {
-        SlidingWindow<GarbageCollectionEvent> slidingWindow;
-        if ((memoryPoolName == null) || events.get(memoryPoolName) == null) { // events has no entries on UNKNOWN
-            slidingWindow = new DefaultSlidingWindow<GarbageCollectionEvent>(EVENT_WINDOW);
-        } else {
-            slidingWindow = events.get(memoryPoolName);
-        }
-        return new GarbageCollectionStats(slidingWindow.snapshot());
+    public GarbageCollectionStats getNonHeapStats() {
+        return GarbageCollectionStats.forNonHeap(nonHeapEvents.snapshot());
     }
 
     public GarbageCollectorMonitoringStrategy getGcStrategy() {
         return gcStrategy;
-    }
-
-    public enum JVMStrategy {
-        IBM(GarbageCollectorMonitoringStrategy.IBM_ALL),
-        ORACLE_HOTSPOT(GarbageCollectorMonitoringStrategy.ORACLE_PARALLEL_CMS,
-                        GarbageCollectorMonitoringStrategy.ORACLE_SERIAL,
-                        GarbageCollectorMonitoringStrategy.ORACLE_6_CMS,
-                        GarbageCollectorMonitoringStrategy.ORACLE_G1),
-        UNSUPPORTED();
-
-        final GarbageCollectorMonitoringStrategy[] gcStrategies;
-
-        JVMStrategy(GarbageCollectorMonitoringStrategy... gcStrategies) {
-            this.gcStrategies = gcStrategies;
-        }
-
-        static JVMStrategy current() {
-            String vmname = System.getProperty("java.vm.name");
-
-            if (vmname.equals("IBM J9 VM")) {
-                return IBM;
-            }
-
-            if (vmname.startsWith("Java HotSpot(TM)")) {
-                return ORACLE_HOTSPOT;
-            }
-
-            return UNSUPPORTED;
-        }
-
-        public GarbageCollectorMonitoringStrategy[] getGcStrategies() {
-            return gcStrategies;
-        }
-
-        @Override
-        public String toString() {
-            return "JVMStrategy{" + System.getProperty("java.vendor") + " version " + System.getProperty("java.version") + "}";
-        }
     }
 }

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectorMonitoringStrategy.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/GarbageCollectorMonitoringStrategy.java
@@ -17,33 +17,33 @@
 package org.gradle.launcher.daemon.server.health.gc;
 
 public enum GarbageCollectorMonitoringStrategy {
-    ORACLE_PARALLEL_CMS("PS Old Gen", "PS Perm Gen", "PS MarkSweep", 1.2, 80, 80, 5.0),
-    ORACLE_6_CMS("CMS Old Gen", "CMS Perm Gen", "ConcurrentMarkSweep", 1.2, 80, 80, 5.0),
-    ORACLE_SERIAL("Tenured Gen", "Perm Gen", "MarkSweepCompact", 1.2, 80, 80, 5.0),
-    ORACLE_G1("G1 Old Gen", "G1 Perm Gen", "G1 Old Generation", 0.4, 75, 80, 2.0),
-    IBM_ALL("Java heap", "PermGen Not Used", "MarkSweepCompact", 0.8, 70, -1, 6.0),
+    ORACLE_PARALLEL_CMS("PS Old Gen", "Metaspace", "PS MarkSweep", 1.2, 80, 80, 5.0),
+    ORACLE_6_CMS("CMS Old Gen", "Metaspace", "ConcurrentMarkSweep", 1.2, 80, 80, 5.0),
+    ORACLE_SERIAL("Tenured Gen", "Metaspace", "MarkSweepCompact", 1.2, 80, 80, 5.0),
+    ORACLE_G1("G1 Old Gen", "Metaspace", "G1 Old Generation", 0.4, 75, 80, 2.0),
+    IBM_ALL("Java heap", "Not Used", "MarkSweepCompact", 0.8, 70, -1, 6.0),
     UNKNOWN(null, null, null, -1, -1, -1, -1);
 
-    private final String tenuredPoolName;
-    private final String permGenPoolName;
+    private final String heapPoolName;
+    private final String nonHeapPoolName;
     private final String garbageCollectorName;
     private final double gcRateThreshold;
-    private final int tenuredUsageThreshold;
-    private final int permGenUsageThreshold;
+    private final int heapUsageThreshold;
+    private final int nonHeapUsageThreshold;
     private final double thrashingThreshold;
 
-    GarbageCollectorMonitoringStrategy(String tenuredPoolName, String permGenPoolName, String garbageCollectorName, double gcRateThreshold, int tenuredUsageThreshold, int permGenUsageThreshold, double thrashingThreshold) {
-        this.tenuredPoolName = tenuredPoolName;
-        this.permGenPoolName = permGenPoolName;
+    GarbageCollectorMonitoringStrategy(String heapPoolName, String nonHeapPoolName, String garbageCollectorName, double gcRateThreshold, int heapUsageThreshold, int nonHeapUsageThreshold, double thrashingThreshold) {
+        this.heapPoolName = heapPoolName;
+        this.nonHeapPoolName = nonHeapPoolName;
         this.garbageCollectorName = garbageCollectorName;
         this.gcRateThreshold = gcRateThreshold;
-        this.tenuredUsageThreshold = tenuredUsageThreshold;
-        this.permGenUsageThreshold = permGenUsageThreshold;
+        this.heapUsageThreshold = heapUsageThreshold;
+        this.nonHeapUsageThreshold = nonHeapUsageThreshold;
         this.thrashingThreshold = thrashingThreshold;
     }
 
-    public String getTenuredPoolName() {
-        return tenuredPoolName;
+    public String getHeapPoolName() {
+        return heapPoolName;
     }
 
     public String getGarbageCollectorName() {
@@ -54,16 +54,16 @@ public enum GarbageCollectorMonitoringStrategy {
         return gcRateThreshold;
     }
 
-    public int getTenuredUsageThreshold() {
-        return tenuredUsageThreshold;
+    public int getHeapUsageThreshold() {
+        return heapUsageThreshold;
     }
 
-    public String getPermGenPoolName() {
-        return permGenPoolName;
+    public String getNonHeapPoolName() {
+        return nonHeapPoolName;
     }
 
-    public int getPermGenUsageThreshold() {
-        return permGenUsageThreshold;
+    public int getNonHeapUsageThreshold() {
+        return nonHeapUsageThreshold;
     }
 
     public double getThrashingThreshold() {

--- a/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/SlidingWindow.java
+++ b/subprojects/launcher/src/main/java/org/gradle/launcher/daemon/server/health/gc/SlidingWindow.java
@@ -16,7 +16,7 @@
 
 package org.gradle.launcher.daemon.server.health.gc;
 
-import java.util.Set;
+import java.util.Collection;
 
 public interface SlidingWindow<T> {
     /**
@@ -24,12 +24,17 @@ public interface SlidingWindow<T> {
      *
      * @param element The element to add
      */
-    public void slideAndInsert(T element);
+    void slideAndInsert(T element);
 
     /**
-     * Returns a snapshot of the elements in the window as a Set view.
+     * Returns a snapshot of the elements in the window.
      *
-     * @return Set view of the elements
+     * @return collection view of the elements
      */
-    public Set<T> snapshot();
+    Collection<T> snapshot();
+
+    /**
+     * @return the latest event in the window.
+     */
+    T latest();
 }

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/LowHeapSpaceDaemonExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/LowHeapSpaceDaemonExpirationStrategyTest.groovy
@@ -21,31 +21,31 @@ import spock.lang.Specification
 
 import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GRACEFUL_EXPIRE
 
-class LowTenuredSpaceDaemonExpirationStrategyTest extends Specification {
+class LowHeapSpaceDaemonExpirationStrategyTest extends Specification {
     private final DaemonMemoryStatus status = Mock(DaemonMemoryStatus)
 
     def "daemon is expired when tenured space is low" () {
-        LowTenuredSpaceDaemonExpirationStrategy strategy = new LowTenuredSpaceDaemonExpirationStrategy(status)
+        LowHeapSpaceDaemonExpirationStrategy strategy = new LowHeapSpaceDaemonExpirationStrategy(status)
 
         when:
         DaemonExpirationResult result = strategy.checkExpiration()
 
         then:
-        1 * status.isTenuredSpaceExhausted() >> true
+        1 * status.isHeapSpaceExhausted() >> true
 
         and:
         result.status == GRACEFUL_EXPIRE
-        result.reason == LowTenuredSpaceDaemonExpirationStrategy.EXPIRATION_REASON
+        result.reason == LowHeapSpaceDaemonExpirationStrategy.EXPIRATION_REASON
     }
 
     def "daemon is not expired when tenured space is fine" () {
-        LowTenuredSpaceDaemonExpirationStrategy strategy = new LowTenuredSpaceDaemonExpirationStrategy(status)
+        LowHeapSpaceDaemonExpirationStrategy strategy = new LowHeapSpaceDaemonExpirationStrategy(status)
 
         when:
         DaemonExpirationResult result = strategy.checkExpiration()
 
         then:
-        1 * status.isTenuredSpaceExhausted() >> false
+        1 * status.isHeapSpaceExhausted() >> false
 
         and:
         result == DaemonExpirationResult.NOT_TRIGGERED

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/LowNonHeapDaemonExpirationStrategyTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/LowNonHeapDaemonExpirationStrategyTest.groovy
@@ -21,31 +21,31 @@ import spock.lang.Specification
 
 import static org.gradle.launcher.daemon.server.expiry.DaemonExpirationStatus.GRACEFUL_EXPIRE
 
-class LowPermGenDaemonExpirationStrategyTest extends Specification {
+class LowNonHeapDaemonExpirationStrategyTest extends Specification {
     private final DaemonMemoryStatus status = Mock(DaemonMemoryStatus)
 
     def "daemon is expired when perm gen space is low" () {
-        LowPermGenDaemonExpirationStrategy strategy = new LowPermGenDaemonExpirationStrategy(status)
+        LowNonHeapDaemonExpirationStrategy strategy = new LowNonHeapDaemonExpirationStrategy(status)
 
         when:
         DaemonExpirationResult result = strategy.checkExpiration()
 
         then:
-        1 * status.isPermGenSpaceExhausted() >> true
+        1 * status.isNonHeapSpaceExhausted() >> true
 
         and:
         result.status == GRACEFUL_EXPIRE
-        result.reason == LowPermGenDaemonExpirationStrategy.EXPIRATION_REASON
+        result.reason == LowNonHeapDaemonExpirationStrategy.EXPIRATION_REASON
     }
 
     def "daemon is not expired when tenured space is fine" () {
-        LowPermGenDaemonExpirationStrategy strategy = new LowPermGenDaemonExpirationStrategy(status)
+        LowNonHeapDaemonExpirationStrategy strategy = new LowNonHeapDaemonExpirationStrategy(status)
 
         when:
         DaemonExpirationResult result = strategy.checkExpiration()
 
         then:
-        1 * status.isPermGenSpaceExhausted() >> false
+        1 * status.isNonHeapSpaceExhausted() >> false
 
         and:
         result == DaemonExpirationResult.NOT_TRIGGERED

--- a/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitorTest.groovy
+++ b/subprojects/launcher/src/test/groovy/org/gradle/launcher/daemon/server/health/gc/GarbageCollectionMonitorTest.groovy
@@ -17,30 +17,11 @@
 package org.gradle.launcher.daemon.server.health.gc
 
 import spock.lang.Specification
-import spock.lang.Unroll
 
 import java.util.concurrent.ScheduledExecutorService
 
 class GarbageCollectionMonitorTest extends Specification {
     ScheduledExecutorService scheduledExecutorService = Mock(ScheduledExecutorService)
-
-    @Unroll
-    def "schedules periodic garbage collection checks (#strategy)"() {
-        when:
-        new GarbageCollectionMonitor(strategy, scheduledExecutorService)
-
-        then:
-        1 * scheduledExecutorService.scheduleAtFixedRate(_, _, _, _) >> { args ->
-            GarbageCollectionCheck check = args[0] as GarbageCollectionCheck
-            assert check.garbageCollector == strategy.garbageCollectorName
-            assert check.memoryPools == [ strategy.tenuredPoolName, strategy.permGenPoolName ]
-            assert check.events.containsKey(strategy.tenuredPoolName)
-            assert check.events.containsKey(strategy.permGenPoolName)
-        }
-
-        where:
-        strategy << GarbageCollectorMonitoringStrategy.values() - GarbageCollectorMonitoringStrategy.UNKNOWN
-    }
 
     def "does not schedule garbage collection check when GC strategy is unknown" () {
         when:
@@ -50,23 +31,23 @@ class GarbageCollectionMonitorTest extends Specification {
         0 * scheduledExecutorService.scheduleAtFixedRate(_, _, _, _)
     }
 
-    def "tenured stats defaults to empty given unknown garbage collector"() {
+    def "heap stats defaults to empty given unknown garbage collector"() {
         given:
         def monitor = new GarbageCollectionMonitor(GarbageCollectorMonitoringStrategy.UNKNOWN, scheduledExecutorService)
 
         when:
-        monitor.getTenuredStats()
+        monitor.getHeapStats()
 
         then:
         noExceptionThrown()
     }
 
-    def "perm gen stats defaults to empty given unknown garbage collector"() {
+    def "non-heap stats defaults to empty given unknown garbage collector"() {
         given:
         def monitor = new GarbageCollectionMonitor(GarbageCollectorMonitoringStrategy.UNKNOWN, scheduledExecutorService)
 
         when:
-        monitor.getPermGenStats()
+        monitor.getNonHeapStats()
 
         then:
         noExceptionThrown()

--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
@@ -123,7 +123,7 @@ class DaemonPerformanceMonitoringSoakTest extends DaemonMultiJdkIntegrationTest 
     }
 
     def "when build leaks permgen space daemon is expired"() {
-        assumeTrue(version.vendor != JdkVendor.IBM && version.version == "1.7")
+        assumeTrue(version.vendor != JdkVendor.IBM)
 
         when:
         setupBuildScript = permGenLeak

--- a/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/launcher/daemon/DaemonPerformanceMonitoringSoakTest.groovy
@@ -28,6 +28,7 @@ import org.gradle.launcher.daemon.server.health.GcThrashingDaemonExpirationStrat
 import org.gradle.soak.categories.SoakTest
 import org.gradle.test.fixtures.ConcurrentTestUtil
 import org.junit.experimental.categories.Category
+import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.junit.Assume.assumeTrue
@@ -122,6 +123,7 @@ class DaemonPerformanceMonitoringSoakTest extends DaemonMultiJdkIntegrationTest 
         daemons.daemon.log.contains(DaemonStateCoordinator.DAEMON_WILL_STOP_MESSAGE)
     }
 
+    @Ignore
     def "when build leaks permgen space daemon is expired"() {
         assumeTrue(version.vendor != JdkVendor.IBM)
 


### PR DESCRIPTION
- Do not sniff for VM vendor to figure out which GC strategies may be used
- Rename permgen -> non-heap in most places, Java 8+ uses metaspace for this memory pool
- Rename tenured -> heap
- Only add GarbageCollectionEvents to the observation window when there's been a GC collection
   - This simplifies the calculation of GC rate
- Non-heap memory pools are not GC'd
- Re-enable daemon performance soak test

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
