### PR TITLE
Use latest httpcomponents release in docs

### DIFF
--- a/subprojects/docs/src/docs/userguide/java_library_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_library_plugin.adoc
@@ -97,11 +97,11 @@ The following class makes use of a couple of third-party libraries, one of which
 include::{samplesPath}/java-library/quickstart/groovy/src/main/java/org/gradle/HttpClientWrapper.java[tag=sample]
 ----
 
-The _public_ constructor of `HttpClientWrapper` uses `HttpClient` as a parameter, so it is exposed to consumers and therefore belongs to the API. Note that `GetMethod` is used in the signature of a _private_ method, and so it doesn't count towards making HttpClient an API dependency.
+The _public_ constructor of `HttpClientWrapper` uses `HttpClient` as a parameter, so it is exposed to consumers and therefore belongs to the API. Note that `HttpGet` and `HttpEntity` are used in the signature of a _private_ method, and so they don't count towards making HttpClient an API dependency.
 
 On the other hand, the `ExceptionUtils` type, coming from the `commons-lang` library, is only used in a method body (not in its signature), so it's an implementation dependency.
 
-Therefore, we can deduce that `commons-httpclient` is an API dependency, whereas `commons-lang` is an implementation dependency. This conclusion translates into the following declaration in the build script:
+Therefore, we can deduce that `httpclient` is an API dependency, whereas `commons-lang` is an implementation dependency. This conclusion translates into the following declaration in the build script:
 
 .Declaring API and implementation dependencies
 ====

--- a/subprojects/docs/src/samples/java-library/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/samples/java-library/quickstart/groovy/build.gradle
@@ -29,7 +29,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    api 'commons-httpclient:commons-httpclient:3.1'
+    api 'org.apache.httpcomponents:httpclient:4.5.7'
     implementation 'org.apache.commons:commons-lang3:3.5'
 }
 // end::dependencies[]

--- a/subprojects/docs/src/samples/java-library/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/java-library/quickstart/kotlin/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 
 // tag::dependencies[]
 dependencies {
-    api("commons-httpclient:commons-httpclient:3.1")
+    api("org.apache.httpcomponents:httpclient:4.5.7")
     implementation("org.apache.commons:commons-lang3:3.5")
 }
 // end::dependencies[]


### PR DESCRIPTION
The Apache Commons HttpComponents library has evolved to its own top
level project inside the Apache Software Foundation. The docs and
examples of the java-library plugin still reference the now deprecated
commons-httpclient release. Although the docs are about the java-library
plugin, this can still confuse users. For this reason, this updates the
docs and examples to use org.apache.httpcomponents:httpclient instead.
