### PR TITLE
 Proper propagation of flag when modifying metadata

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MixedMavenAndIvyModulesIntegrationTest.groovy
@@ -206,12 +206,14 @@ dependencies {
         }
     }
 
-    def "selects correct configuration of ivy module when dependency from consuming maven module is substituted"() {
-        def notRequired = ivyRepo.module("org.test", "ignore-me", "1.0")
+    def "selects default configuration of ivy module when dependency from consuming maven module is substituted"() {
         def m1 = ivyRepo.module("org.test", "m1", "1.0")
             .configuration("compile")
             .publish()
         def m2 = ivyRepo.module("org.test", "m2", "1.0").publish()
+            .configuration("master")
+            .publish()
+        def m3 = ivyRepo.module("org.test", "m3", "1.0").publish()
             .configuration("master")
             .publish()
         ivyRepo.module("org.test", "ivy", "1.2")
@@ -222,10 +224,10 @@ dependencies {
             .configuration("default")
             .dependsOn(m1, conf: "compile")
             .dependsOn(m2, conf: "master")
-            .dependsOn(notRequired, conf: "*,!compile,!master->unknown")
+            .dependsOn(m3, conf: "*,!compile,!master")
             .artifact(name: "compile", conf: "compile")
             .artifact(name: "master", conf: "master")
-            .artifact(name: 'ignore-me', conf: "other,default,runtime")
+            .artifact(name: 'default', conf: "other,default,runtime")
             .publish()
         def ivyModule = ivyRepo.module("org.test", "ivy", "1.0")
         mavenRepo.module("org.test", "maven", "1.0")
@@ -246,10 +248,8 @@ configurations.conf.resolutionStrategy.force('org.test:ivy:1.2')
                     configuration = 'compile'
                     edge('org.test:ivy:1.0', 'org.test:ivy:1.2') {
                         forced()
-                        artifact(name: 'compile')
-                        artifact(name: 'master')
-                        module('org.test:m1:1.0')
-                        module('org.test:m2:1.0')
+                        artifact(name: 'default')
+                        module('org.test:m3:1.0')
                     }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -51,17 +51,22 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
 
     private boolean alwaysUseAttributeMatching;
 
-    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, String reason) {
+    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching, String reason) {
         this.configuration = configuration;
         this.componentId = componentId;
         this.dependencyDescriptor = dependencyDescriptor;
+        this.alwaysUseAttributeMatching = alwaysUseAttributeMatching;
         this.reason = reason;
         this.isTransitive = dependencyDescriptor.isTransitive();
         this.isConstraint = dependencyDescriptor.isConstraint();
     }
 
+    private ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor, boolean alwaysUseAttributeMatching) {
+        this(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, null);
+    }
+
     public ConfigurationBoundExternalDependencyMetadata(ConfigurationMetadata configuration, ModuleComponentIdentifier componentId, ExternalDependencyDescriptor dependencyDescriptor) {
-        this(configuration, componentId, dependencyDescriptor, null);
+        this(configuration, componentId, dependencyDescriptor, false, null);
     }
 
     public ConfigurationBoundExternalDependencyMetadata alwaysUseAttributeMatching() {
@@ -134,16 +139,16 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         if (Objects.equal(reason, this.getReason())) {
             return this;
         }
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, reason);
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, dependencyDescriptor, alwaysUseAttributeMatching, reason);
     }
 
     public ConfigurationBoundExternalDependencyMetadata withDescriptor(ExternalDependencyDescriptor descriptor) {
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, descriptor);
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, descriptor, alwaysUseAttributeMatching);
     }
 
     private ModuleDependencyMetadata withRequested(ModuleComponentSelector newSelector) {
         ExternalDependencyDescriptor newDelegate = dependencyDescriptor.withRequested(newSelector);
-        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, newDelegate);
+        return new ConfigurationBoundExternalDependencyMetadata(configuration, componentId, newDelegate, alwaysUseAttributeMatching);
     }
 
     @Override

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -38,7 +38,7 @@ Some plugins will break with this new version of Gradle, for example because the
 
 === Potential breaking changes
 
-==== Bugfixes in platform resolution
+==== Bug fixes in platform resolution
 
 There was a bug from Gradle 5.0 to 5.2.1 (included) where enforced platforms would potentially include dependencies instead of constraints.
 This would happen whenever a POM file defined both dependencies and "constraints" (via `<dependencyManagement>`) and that you used `enforcedPlatform`.
@@ -72,6 +72,13 @@ java {
    disableAutoTargetJvm()
 }
 ```
+
+==== Bug fix in Maven / Ivy interoperability with dependency substitution
+
+If you have a Maven dependency pointing to an Ivy dependency where the `default` configuration dependencies do not match the `compile` + `runtime` + `master` ones
+_and_ that Ivy dependency was substituted (using a `resolutionStrategy.force`, `resolutionStrategy.eachDependency` or `resolutionStrategy.dependencySubstitution`)
+then this fix will impact you.
+The legacy behaviour of Gradle, prior to 5.0, was still in place instead of being replaced by the changes introduced by improved pom support.
 
 [[changes_5.2]]
 == Upgrading from 5.1 and earlier


### PR DESCRIPTION
The `ConfigurationBoundExternalDependencyMetadata` was not properly
propagating the `alwaysUseAttributeMatching` state when the metadata was
modified.
This caused legacy Maven / Ivy interop to kick in, as happened before Maven
was fully moved to variant aware dependency management. One test needed
to be modified, which in reality should have been changed at the 5.0
release.