### PR TITLE
Use notimestamp for JavaDoc and notimestamp+noversionstamp for GroovyDoc

### DIFF
--- a/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/tasks/javadoc/Groovydoc.java
@@ -71,9 +71,9 @@ public class Groovydoc extends SourceTask {
 
     private boolean use;
 
-    private boolean noTimestamp;
+    private boolean noTimestamp = true;
 
-    private boolean noVersionStamp;
+    private boolean noVersionStamp = true;
 
     private String windowTitle;
 

--- a/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
+++ b/subprojects/language-java/src/main/java/org/gradle/external/javadoc/StandardJavadocDocletOptions.java
@@ -116,7 +116,7 @@ public class StandardJavadocDocletOptions extends CoreJavadocOptions implements 
         docFilesSubDirs = addBooleanOption("docfilessubdirs");
         excludeDocFilesSubDir = addStringsOption("excludedocfilessubdir", ":");
         noQualifiers = addStringsOption("noqualifier", ":");
-        noTimestamp = addBooleanOption("notimestamp");
+        noTimestamp = addBooleanOption("notimestamp", true);
         noComment = addBooleanOption("nocomment");
     }
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
+++ b/subprojects/language-java/src/test/groovy/org/gradle/external/javadoc/StandardJavadocDocletOptionsTest.java
@@ -89,7 +89,7 @@ public class StandardJavadocDocletOptionsTest {
         assertFalse(options.isDocFilesSubDirs());
         assertEmpty(options.getExcludeDocFilesSubDir());
         assertEmpty(options.getNoQualifiers());
-        assertFalse(options.isNoTimestamp());
+        assertTrue(options.isNoTimestamp());
         assertFalse(options.isNoComment());
     }
 


### PR DESCRIPTION
Timestamps in the generated documentation have very limited practical use,
however they mark all the files as "modified" even in case of a small changes.

Having notimestamp by default enables repeatable documentation build, and
it simplifies storage of the documentation (e.g. it reduces git traffic when javadocs are published to a git "site" repository, and so on)


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
