### PR TITLE
Fix class generation when declared service injection getter return type is a type variable

### DIFF
--- a/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
+++ b/subprojects/model-core/src/main/java/org/gradle/model/internal/asm/AsmClassGeneratorUtils.java
@@ -18,7 +18,12 @@ package org.gradle.model.internal.asm;
 
 import org.objectweb.asm.Type;
 
-import java.lang.reflect.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
 
 public class AsmClassGeneratorUtils {
 
@@ -31,6 +36,13 @@ public class AsmClassGeneratorUtils {
         visitParameters(builder, constructor.getGenericParameterTypes());
         builder.append("V");
         visitExceptions(builder, constructor.getGenericExceptionTypes());
+        return builder.toString();
+    }
+
+    public static String getterSignature(java.lang.reflect.Type returnType) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("()");
+        visitType(returnType, builder);
         return builder.toString();
     }
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
@@ -21,11 +21,13 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceLookup
 import org.gradle.internal.service.ServiceRegistry
+import org.gradle.util.ToBeImplemented
 
 import javax.inject.Inject
 import java.lang.annotation.Annotation
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
@@ -62,6 +64,23 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         obj.thing == 12
         obj.getThing() == 12
         obj.getProperty("thing") == 12
+    }
+
+    @ToBeImplemented("Resolving type parameters to implement the correct methods in the subclass does not work, yet")
+    def "can inject service using @Inject on a super interface with type parameters"() {
+        given:
+        def services = Mock(ServiceLookup)
+        _ * services.get(Number) >> 12
+
+        when:
+        def obj = create(AbstractClassWithConcreteTypeParameter, services)
+
+        then:
+        def e = thrown(InvocationTargetException)
+        e.cause.class == NullPointerException
+//        obj.thing == 12
+//        obj.getThing() == 12
+//        obj.getProperty("thing") == 12
     }
 
     def "can inject service using @Inject on an interface getter method"() {
@@ -310,6 +329,13 @@ interface InterfaceWithServices {
     @Inject
     Number getThing()
 }
+
+interface InterfaceWithTypeParameter<T> {
+    @Inject
+    T getThing()
+}
+
+abstract class AbstractClassWithConcreteTypeParameter implements InterfaceWithTypeParameter<Number> {}
 
 class BeanWithServices {
     @Inject

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorInjectDecoratedTest.groovy
@@ -21,16 +21,16 @@ import org.gradle.api.plugins.ExtensionContainer
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.internal.service.ServiceLookup
 import org.gradle.internal.service.ServiceRegistry
-import org.gradle.util.ToBeImplemented
 
 import javax.inject.Inject
 import java.lang.annotation.Annotation
 import java.lang.annotation.Retention
 import java.lang.annotation.RetentionPolicy
-import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
+import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.AbstractClassWithConcreteTypeParameter
+import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.AbstractClassWithParameterizedTypeParameter
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.FinalInjectBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.NonGetterInjectBean
 import static org.gradle.internal.instantiation.AsmBackedClassGeneratorTest.PrivateInjectBean
@@ -66,8 +66,7 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         obj.getProperty("thing") == 12
     }
 
-    @ToBeImplemented("Resolving type parameters to implement the correct methods in the subclass does not work, yet")
-    def "can inject service using @Inject on a super interface with type parameters"() {
+    def "can inject service using @Inject on a super interface with class type parameter"() {
         given:
         def services = Mock(ServiceLookup)
         _ * services.get(Number) >> 12
@@ -76,11 +75,40 @@ class AsmBackedClassGeneratorInjectDecoratedTest extends AbstractClassGeneratorS
         def obj = create(AbstractClassWithConcreteTypeParameter, services)
 
         then:
-        def e = thrown(InvocationTargetException)
-        e.cause.class == NullPointerException
-//        obj.thing == 12
-//        obj.getThing() == 12
-//        obj.getProperty("thing") == 12
+        obj.thing == 12
+        obj.getThing() == 12
+        obj.getProperty("thing") == 12
+        obj.doSomething()
+
+        def returnType = obj.getClass().getDeclaredMethod("getThing").genericReturnType
+        returnType == Number
+    }
+
+    def "can inject service using @Inject on a super interface with parameterized type parameter"() {
+        given:
+        def services = Mock(ServiceLookup)
+        _ * services.get(_) >> { Type type ->
+            assert type instanceof ParameterizedType
+            assert type.rawType == List.class
+            assert type.actualTypeArguments.length == 1
+            assert type.actualTypeArguments[0] == Number
+            return [12]
+        }
+
+        when:
+        def obj = create(AbstractClassWithParameterizedTypeParameter, services)
+
+        then:
+        obj.thing == [12]
+        obj.getThing() == [12]
+        obj.getProperty("thing") == [12]
+        obj.doSomething() == "[12]"
+
+        def returnType = obj.getClass().getDeclaredMethod("getThing").genericReturnType
+        returnType instanceof ParameterizedType
+        returnType.rawType == List
+        returnType.actualTypeArguments.length == 1
+        returnType.actualTypeArguments[0] == Number
     }
 
     def "can inject service using @Inject on an interface getter method"() {
@@ -329,13 +357,6 @@ interface InterfaceWithServices {
     @Inject
     Number getThing()
 }
-
-interface InterfaceWithTypeParameter<T> {
-    @Inject
-    T getThing()
-}
-
-abstract class AbstractClassWithConcreteTypeParameter implements InterfaceWithTypeParameter<Number> {}
 
 class BeanWithServices {
     @Inject

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/instantiation/AsmBackedClassGeneratorTest.java
@@ -1820,4 +1820,23 @@ public class AsmBackedClassGeneratorTest {
             setName("thing");
         }
     }
+
+    interface InterfaceWithTypeParameter<T> {
+        @Inject
+        T getThing();
+    }
+
+    public static abstract class AbstractClassWithConcreteTypeParameter implements InterfaceWithTypeParameter<Number> {
+        public String doSomething() {
+            Number thing = getThing();
+            return String.valueOf(thing);
+        }
+    }
+
+    public static abstract class AbstractClassWithParameterizedTypeParameter implements InterfaceWithTypeParameter<List<Number>> {
+        public String doSomething() {
+            List<Number> thing = getThing();
+            return thing.toString();
+        }
+    }
 }


### PR DESCRIPTION
### Context

This is a partial fix for the case where a service injection getter's return type is a type variable. This can happen when the getter is inherited from a parameterized super type. For example:

```
interface Thing<T> {
   @Inject
   T getThing()
}

abstract class ConcreteThing implements Thing<MyParams> {
    ...
}

project.extensions.create('thing', ConcreteThing.class)
```

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
