### PR TITLE
Clarify plugin incompatibility

### DIFF
--- a/subprojects/docs/src/docs/userguide/java_platform_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/java_platform_plugin.adoc
@@ -30,6 +30,11 @@ it is only used to reference other libraries, so that they play well together du
 
 Platforms can be published as {maven-bom}[Maven BOMs] or with the experimental {metadata-file-spec}[Gradle metadata file] format.
 
+[NOTE]
+====
+The `java-platform` plugin cannot be used in combination with the `java` or `java-library` plugins in a given project.
+Conceptually a project is either a platform, with no binaries, _or_ produces binaries.
+====
 
 [[sec:java_platform_usage]]
 == Usage

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaIncompatiblePluginsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaIncompatiblePluginsIntegrationTest.groovy
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.java
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import spock.lang.Unroll
+
+class JavaIncompatiblePluginsIntegrationTest  extends AbstractIntegrationSpec {
+
+    @Unroll
+    def "nag users when applying both java-platform and #plugin"() {
+        when:
+        buildFile << """
+plugins {
+    id 'java-platform'
+    id '${plugin}'
+}
+"""
+        then:
+        executer.expectDeprecationWarning()
+        succeeds 'help'
+
+        where:
+        plugin << ['java', 'java-library']
+    }
+
+    @Unroll
+    def "cannot apply both #plugin and java-platform"() {
+        when:
+        buildFile << """
+plugins {
+    id '${plugin}'
+    id 'java-platform'
+}
+"""
+        then:
+        fails 'help'
+        failureHasCause("The \"java-platform\" plugin cannot be applied together with the \"java\" (or \"java-library\") plugin")
+
+        where:
+        plugin << ['java', 'java-library']
+    }
+}

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -93,11 +93,18 @@ public class JavaPlatformPlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        if (project.getPluginManager().hasPlugin("java")) {
+            // This already throws when creating `apiElements` so be eager to have a clear error message
+            throw new IllegalStateException("The \"java-platform\" plugin cannot be applied together with the \"java\" (or \"java-library\") plugin. " +
+                "A project is either a platform or a library but cannot be both at the same time.");
+        }
         project.getPluginManager().apply(BasePlugin.class);
         createConfigurations(project);
         configureExtension(project);
         addPlatformDisambiguationRule(project);
         JavaEcosystemSupport.configureSchema(project.getDependencies().getAttributesSchema(), project.getObjects());
+
+
     }
 
     private void addPlatformDisambiguationRule(Project project) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -55,6 +55,7 @@ import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.language.jvm.tasks.ProcessResources;
+import org.gradle.util.DeprecationLogger;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -274,6 +275,11 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         configureTest(project, javaConvention);
         configureArchivesAndComponent(project, javaConvention);
         configureBuild(project);
+
+        if (project.getPluginManager().hasPlugin("java-platform")) {
+            DeprecationLogger.nagUserOfDeprecatedBehaviour("The \"java\" (or \"java-library\") plugin cannot be used together with the \"java-platform\" plugin on a given project. " +
+                "A project is either a platform or a library but cannot be both at the same time.");
+        }
     }
 
     private void configureSourceSets(JavaPluginConvention pluginConvention, final BuildOutputCleanupRegistry buildOutputCleanupRegistry) {


### PR DESCRIPTION
Since applying the `java-platform` plugin after `java` or `java-library`
already throws, we will just improve the error message in that case.
In order to not break existing builds, applying `java` or `java-library`
after `java-platform` will cause a deprecation warning in 5.3+ and will
break in 6+.