### PR TITLE
Add configuration capabilities to core repositories

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -225,6 +225,32 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
     MavenArtifactRepository mavenLocal();
 
     /**
+     * Adds a repository which looks in the local Maven cache for dependencies. The name of the repository is
+     * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#DEFAULT_MAVEN_LOCAL_REPO_NAME}.
+     *
+     * <p>Examples:</p>
+     * <pre class='autoTested'>
+     * repositories {
+     *     mavenLocal()
+     * }
+     * </pre>
+     * <p>
+     * The location for the repository is determined as follows (in order of precedence):
+     * </p>
+     * <ol>
+     * <li>The value of system property 'maven.repo.local' if set;</li>
+     * <li>The value of element &lt;localRepository&gt; of <code>~/.m2/settings.xml</code> if this file exists and element is set;</li>
+     * <li>The value of element &lt;localRepository&gt; of <code>$M2_HOME/conf/settings.xml</code> (where <code>$M2_HOME</code> is the value of the environment variable with that name) if this file exists and element is set;</li>
+     * <li>The path <code>~/.m2/repository</code>.</li>
+     * </ol>
+     *
+     * @param action a configuration action
+     * @return the added resolver
+     * @since 5.3
+     */
+    MavenArtifactRepository mavenLocal(Action<? super MavenArtifactRepository> action);
+
+    /**
      * Adds a repository which looks in Google's Maven repository for dependencies.
      * <p>
      * The URL used to access this repository is {@literal "https://dl.google.com/dl/android/maven2/"}.

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -183,6 +183,24 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
     MavenArtifactRepository mavenCentral();
 
     /**
+     * Adds a repository which looks in the Maven central repository for dependencies. The URL used to access this repository is
+     * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#MAVEN_CENTRAL_URL}. The name of the repository is
+     * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#DEFAULT_MAVEN_CENTRAL_REPO_NAME}.
+     *
+     * <p>Examples:</p>
+     * <pre class='autoTested'>
+     * repositories {
+     *     mavenCentral()
+     * }
+     * </pre>
+     *
+     * @param action a configuration action
+     * @return the added resolver
+     * @since 5.3
+     */
+    MavenArtifactRepository mavenCentral(Action<? super MavenArtifactRepository> action);
+
+    /**
      * Adds a repository which looks in the local Maven cache for dependencies. The name of the repository is
      * {@value org.gradle.api.artifacts.ArtifactRepositoryContainer#DEFAULT_MAVEN_LOCAL_REPO_NAME}.
      *
@@ -222,6 +240,24 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      * @since 4.0
      */
     MavenArtifactRepository google();
+
+    /**
+     * Adds a repository which looks in Google's Maven repository for dependencies.
+     * <p>
+     * The URL used to access this repository is {@literal "https://dl.google.com/dl/android/maven2/"}.
+     * <p>
+     * Examples:
+     * <pre class='autoTested'>
+     * repositories {
+     *     google()
+     * }
+     * </pre>
+     *
+     * @param action a configuration action
+     * @return the added resolver
+     * @since 5.3
+     */
+    MavenArtifactRepository google(Action<? super MavenArtifactRepository> action);
 
     /**
      * Adds and configures a Maven repository. Newly created instance of {@code MavenArtifactRepository} is passed as an argument to the closure.

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenLocalRepoResolveIntegrationTest.groovy
@@ -27,7 +27,11 @@ class MavenLocalRepoResolveIntegrationTest extends AbstractDependencyResolutionT
         using m2
         buildFile << """
                 repositories {
-                    mavenLocal()
+                    mavenLocal {
+                        content {
+                            excludeGroup 'unused'
+                        }
+                    }
                 }
                 configurations { compile }
                 dependencies {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -77,6 +77,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
         return addRepository(repositoryFactory.createMavenCentralRepository(), DEFAULT_MAVEN_CENTRAL_REPO_NAME);
     }
 
+    @Override
+    public MavenArtifactRepository mavenCentral(Action<? super MavenArtifactRepository> action) {
+        return addRepository(repositoryFactory.createMavenCentralRepository(), DEFAULT_MAVEN_CENTRAL_REPO_NAME, action);
+    }
+
     public MavenArtifactRepository jcenter() {
         return addRepository(repositoryFactory.createJCenterRepository(), DEFAULT_BINTRAY_JCENTER_REPO_NAME);
     }
@@ -96,6 +101,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
 
     public MavenArtifactRepository google() {
         return addRepository(repositoryFactory.createGoogleRepository(), GOOGLE_REPO_NAME);
+    }
+
+    @Override
+    public MavenArtifactRepository google(Action<? super MavenArtifactRepository> action) {
+        return addRepository(repositoryFactory.createGoogleRepository(), GOOGLE_REPO_NAME, action);
     }
 
     public MavenArtifactRepository maven(Action<? super MavenArtifactRepository> action) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -99,6 +99,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
         return addRepository(repositoryFactory.createMavenLocalRepository(), DEFAULT_MAVEN_LOCAL_REPO_NAME);
     }
 
+    @Override
+    public MavenArtifactRepository mavenLocal(Action<? super MavenArtifactRepository> action) {
+        return addRepository(repositoryFactory.createMavenLocalRepository(), DEFAULT_MAVEN_LOCAL_REPO_NAME, action);
+    }
+
     public MavenArtifactRepository google() {
         return addRepository(repositoryFactory.createGoogleRepository(), GOOGLE_REPO_NAME);
     }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -5,6 +5,22 @@
             "member": "Method org.gradle.api.tasks.testing.Test.getForkOptionsFactory()",
             "acceptation": "Added injection method",
             "changes": []
+        },
+        {
+            "type": "org.gradle.api.artifacts.dsl.RepositoryHandler",
+            "member": "Method org.gradle.api.artifacts.dsl.RepositoryHandler.google(org.gradle.api.Action)",
+            "acceptation": "Ability to configure repository",
+            "changes": [
+                "Method added to interface"
+            ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.dsl.RepositoryHandler",
+            "member": "Method org.gradle.api.artifacts.dsl.RepositoryHandler.mavenCentral(org.gradle.api.Action)",
+            "acceptation": "Ability to configure repository",
+            "changes": [
+                "Method added to interface"
+            ]
         }
     ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -21,6 +21,14 @@
             "changes": [
                 "Method added to interface"
             ]
+        },
+        {
+            "type": "org.gradle.api.artifacts.dsl.RepositoryHandler",
+            "member": "Method org.gradle.api.artifacts.dsl.RepositoryHandler.mavenLocal(org.gradle.api.Action)",
+            "acceptation": "Ability to configure repository",
+            "changes": [
+                "Method added to interface"
+            ]
         }
     ]
 }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/connectivity/MavenCentralDependencyResolveIntegrationTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/connectivity/MavenCentralDependencyResolveIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,16 +20,16 @@ import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 
 @Requires(TestPrecondition.ONLINE)
-class MavenJcenterDependencyResolveIntegrationTest extends AbstractIntegrationSpec {
-    def "resolves a minimal dependency from bintray's jcenter"() {
+class MavenCentralDependencyResolveIntegrationTest extends AbstractIntegrationSpec {
+    def "resolves a minimal dependency from Maven Central"() {
         given:
         buildFile << """
 repositories {
-    jcenter()
-    jcenter { // just test this syntax works.
-        name = "otherJcenter"
+    mavenCentral()
+    mavenCentral { // just test this syntax works.
+        name = "otherCentral"
         content {
-            includeGroup 'org.sample'
+            includeGroup 'org.test'
         }
     }
 }
@@ -74,6 +74,6 @@ task repoNames {
         succeeds "check", "repoNames"
 
         and:
-        output.contains(["BintrayJCenter", "otherJcenter"].toString())
+        output.contains(["MavenRepo", "otherCentral"].toString())
     }
 }

--- a/subprojects/soak/src/integTest/groovy/org/gradle/connectivity/MavenGoogleDependencyResolveIntegrationTest.groovy
+++ b/subprojects/soak/src/integTest/groovy/org/gradle/connectivity/MavenGoogleDependencyResolveIntegrationTest.groovy
@@ -27,6 +27,12 @@ class MavenGoogleDependencyResolveIntegrationTest extends AbstractDependencyReso
         buildFile << """
             repositories {
                 google()
+                google { // just test this syntax works.
+                    name = "otherGoogle"
+                    content {
+                        includeGroup 'org.sample'
+                    }
+                }
             }
         """
     }
@@ -36,7 +42,7 @@ class MavenGoogleDependencyResolveIntegrationTest extends AbstractDependencyReso
         buildFile << """
             task checkRepoName {
                 doLast {
-                    assert repositories*.name == ['Google']
+                    assert repositories*.name == ['Google', 'otherGoogle']
                 }
             }
         """


### PR DESCRIPTION
Some of the configuration capabilities were not available for core
repositories like `google` or `mavenCentral`.
This change adds the ability to configure such repositories, including
the content filtering aspect.