### PR TITLE
Deprecate mapped outputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/project/taskfactory/TaskPropertyNamingIntegrationTest.groovy
@@ -100,6 +100,7 @@ class TaskPropertyNamingIntegrationTest extends AbstractIntegrationSpec {
             }
         """
         when:
+        executer.expectDeprecationWarnings(2)
         run "myTask"
         then:
         output.contains "Input: inputDirectory [inputs]"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CachedCustomTaskExecutionIntegrationTest.groovy
@@ -418,6 +418,9 @@ class CachedCustomTaskExecutionIntegrationTest extends AbstractIntegrationSpec i
                 ]
             }
         """
+        executer.beforeExecute {
+            expectDeprecationWarning()
+        }
 
         when:
         withBuildCache().run "customTask"

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskInputPropertiesIntegrationTest.groovy
@@ -211,7 +211,10 @@ class TaskInputPropertiesIntegrationTest extends AbstractIntegrationSpec {
         """
 
         expect:
+        executer.expectDeprecationWarnings(2)
         succeeds "test"
+        outputContains("Using output properties with type Map has been deprecated. This is scheduled to be removed in Gradle 6.0. Output property outputFiles of task ':test' is of type Map. Please use @Nested on a Map instead.")
+        outputContains("Using output properties with type Map has been deprecated. This is scheduled to be removed in Gradle 6.0. Output property outputDirs of task ':test' is of type Map. Please use @Nested on a Map instead.")
     }
 
     def "fails when input file calls are chained (properties(Map))"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/FileParameterUtils.java
@@ -36,6 +36,7 @@ import org.gradle.internal.fingerprint.IgnoredPathInputNormalizer;
 import org.gradle.internal.fingerprint.NameOnlyInputNormalizer;
 import org.gradle.internal.fingerprint.RelativePathInputNormalizer;
 import org.gradle.util.DeferredUtil;
+import org.gradle.util.DeprecationLogger;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -121,6 +122,7 @@ public class FileParameterUtils {
 
     private static void resolveCompositeOutputFilePropertySpecs(final String ownerDisplayName, final String propertyName, Object unpackedValue, final TreeType outputType, FileCollectionFactory fileCollectionFactory, Consumer<OutputFilePropertySpec> consumer) {
         if (unpackedValue instanceof Map) {
+            DeprecationLogger.nagUserWithDeprecatedIndirectUserCodeCause("Using output properties with type Map", "Please use @Nested on a Map instead.", String.format("Output property %s of %s is of type Map.", propertyName, ownerDisplayName));
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) unpackedValue).entrySet()) {
                 Object key = entry.getKey();
                 if (key == null) {

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -95,6 +95,8 @@ in the next major Gradle version (Gradle 6.0). See the User Manual section on th
 
 The following are the newly deprecated items in this Gradle release. If you have concerns about a deprecation, please raise it via the [Gradle Forums](https://discuss.gradle.org).
 
+* Using `@OutputFiles` or `@OutputDirectories` on a property of type `Map` has been deprecated. See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html#rel5.3:mapped_outputs) for more information.
+
 ### Incubating method `ProjectLayout.configurableFiles()` replaced by `ObjectFactory.fileCollection()`
 
 The method `ProjectLayout.configurableFiles()` is now deprecated, and will be removed in Gradle 6.0. You should use `ObjectFactory.fileCollection()` instead.

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -80,32 +80,38 @@ _and_ that Ivy dependency was substituted (using a `resolutionStrategy.force`, `
 then this fix will impact you.
 The legacy behaviour of Gradle, prior to 5.0, was still in place instead of being replaced by the changes introduced by improved pom support.
 
+[[deprecations_5.3]]
 === Deprecations
 
 [[rel5.3:mapped_outputs]]
- * You should not use mapped outputs
-+
-To support tasks producing multiple outputs we've Gradle has a notion using a `Map` so each output file or directory would have a name assigned to it. Like so:
-+
+==== Using mapped outputs has been deprecated.
+
+To support tasks producing multiple outputs Gradle has a notion using a `Map` so each output file or directory would have a name assigned to it. E.g. like this:
+
 [source,java]
 ----
-@OutputDirectories
-public Map<String, File> getEnabledDirectoryReportDestinations() {
-    // ...
+public class MyTask extends DefaultTask {
+    @OutputDirectories
+    public Map<String, File> getEnabledDirectoryReportDestinations() { /* ... */ }
 }
 ----
-+
-Gradle also introduced the option to handle collections of complex objects as parameters that could in turn declare outputs, so this more flexible approach is now an option:
-+
+
+This is now deprecated, since Gradle introduced the option to handle collections of complex objects as parameters that could in turn declare outputs. This more flexible approach should now be used:
+
 [source,java]
 ----
-class MyTask {
-    @Nested List<Item> getItems() { /* ... */ }
+public class MyTask extends DefaultTask {
+    @Nested
+    public Map<String, Report> getEnabledReports() { /* ... */ }
 }
 
-class Item {
-    @Input String getName() { /* ... */ }
-    @OutputFile File getFile() { /* ... */ }
+public interface Report {}
+
+public class DirectoryReport {
+    @Input
+    String getName() { /* ... */ }
+    @OutputDirectory
+    File getOutputDirectory() { /* ... */ }
 }
 ----
 

--- a/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
+++ b/subprojects/docs/src/docs/userguide/upgrading_version_5.adoc
@@ -80,6 +80,35 @@ _and_ that Ivy dependency was substituted (using a `resolutionStrategy.force`, `
 then this fix will impact you.
 The legacy behaviour of Gradle, prior to 5.0, was still in place instead of being replaced by the changes introduced by improved pom support.
 
+=== Deprecations
+
+[[rel5.3:mapped_outputs]]
+ * You should not use mapped outputs
++
+To support tasks producing multiple outputs we've Gradle has a notion using a `Map` so each output file or directory would have a name assigned to it. Like so:
++
+[source,java]
+----
+@OutputDirectories
+public Map<String, File> getEnabledDirectoryReportDestinations() {
+    // ...
+}
+----
++
+Gradle also introduced the option to handle collections of complex objects as parameters that could in turn declare outputs, so this more flexible approach is now an option:
++
+[source,java]
+----
+class MyTask {
+    @Nested List<Item> getItems() { /* ... */ }
+}
+
+class Item {
+    @Input String getName() { /* ... */ }
+    @OutputFile File getFile() { /* ... */ }
+}
+----
+
 [[changes_5.2]]
 == Upgrading from 5.1 and earlier
 

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -31,7 +31,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
         build("generateScriptPluginAdapters")
 
-        executer.expectDeprecationWarning()
+        executer.expectDeprecationWarnings(3)
         build("ktlintC")
     }
 


### PR DESCRIPTION
Instead of using
```groovy
@OutputFiles Map<String, File> reportOutputs
```
use
```groovy
@Nested Map<String, Report> reports
...

class Report {
    @OutputFile File reportLocation
}
```