### PR TITLE
Disallow Nested on transform parameters

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -27,6 +27,7 @@ import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.LocalState
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
@@ -141,22 +142,9 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         settingsFile << """
             include 'a', 'b'
         """
-        buildFile << """
-            interface NestedType {
-                @InputFile
-                RegularFileProperty getInputFile()
-                @OutputDirectory
-                DirectoryProperty getOutputDirectory()
-            }
-                        
-            allprojects {
-                ext.nested = objects.newInstance(NestedType)
-            }
-        """
         setupBuildWithColorTransform {
             params("""
                 extension = 'green'
-                nested.set(project.ext.nested)
             """)
         }
         buildFile << """
@@ -198,8 +186,6 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
                     @PathSensitive(PathSensitivity.ABSOLUTE)
                     @InputFiles
                     ConfigurableFileCollection getAbsolutePathSensitivity()
-                    @Nested
-                    Property<NestedType> getNested()
                 }
             
                 void transform(TransformOutputs outputs) {
@@ -225,9 +211,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
             absolutePathSensitivity: 'is declared to be sensitive to absolute paths. This is not allowed for cacheable transforms',
             noPathSensitivity: 'is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity',
             noPathSensitivityDir: 'is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity',
-            noPathSensitivityFile: 'is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity',
-            'nested.outputDirectory': 'is annotated with unsupported annotation @OutputDirectory',
-            'nested.inputFile': 'is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity',
+            noPathSensitivityFile: 'is declared without path sensitivity. Properties of cacheable transforms must declare their path sensitivity'
         )
     }
 
@@ -342,7 +326,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         assertPropertyValidationErrors(bad: "is annotated with unsupported annotation @${annotation.simpleName}")
 
         where:
-        annotation << [OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues]
+        annotation << [OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues, Nested]
     }
 
     @Unroll
@@ -529,7 +513,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
         assertPropertyValidationErrors(bad: "is annotated with unsupported annotation @${annotation.simpleName}")
 
         where:
-        annotation << [Input, InputFile, InputDirectory, OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues, Console, Internal]
+        annotation << [Input, InputFile, InputDirectory, OutputFile, OutputFiles, OutputDirectory, OutputDirectories, Destroys, LocalState, OptionValues, Console, Internal, Nested]
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -114,6 +114,62 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         outputContains("result = [b.jar.green, c.jar.green]")
     }
 
+    def "transform can receive a file input from a nested bean on the parameter object"() {
+        settingsFile << """
+            include 'a', 'b'
+        """
+        setupBuildWithColorTransform {
+            params("""
+                nestedBean.set(provider { project.ext.nestedInputFiles })
+            """)
+        }
+        buildFile << """
+            interface NestedInputFiles {
+                @InputFiles
+                ConfigurableFileCollection getInputFiles()
+            }
+
+            allprojects {
+                task tool(type: FileProducer) {
+                    output = file("build/tool-\${project.name}.jar")
+                }
+                ext.nestedInputFiles = objects.newInstance(NestedInputFiles)
+                nestedInputFiles.inputFiles.from(tool.output)                
+            }
+
+            project(':a') {
+                dependencies {
+                    implementation project(':b')
+                }
+            }
+
+            abstract class MakeGreen implements TransformAction<Parameters> {
+                interface Parameters extends TransformParameters{
+                    @Nested
+                    Property<NestedInputFiles> getNestedBean()
+                }
+            
+                @InputArtifact
+                abstract File getInput()
+                
+                void transform(TransformOutputs outputs) {
+                    def inputFiles = parameters.nestedBean.get().inputFiles
+                    println "processing \${input.name} using \${inputFiles*.name}"
+                    def output = outputs.file(input.name + ".green")
+                    def paramContent = inputFiles.collect { it.file ? it.text : it.list().length }.join("")
+                    output.text = input.text + paramContent + ".green"
+                }
+            }
+        """
+
+        when:
+        run(":a:resolve")
+
+        then:
+        outputContains("processing b.jar using [tool-a.jar]")
+        outputContains("result = [b.jar.green]")
+    }
+
     def "transform can receive a file collection containing task outputs as parameter"() {
         settingsFile << """
                 include 'a', 'b', 'c'
@@ -133,7 +189,7 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                     implementation project(':c')
                 }
             }
-"""
+        """
 
         when:
         run(":a:resolve")

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DependencyManagementGlobalScopeServices.java
@@ -49,7 +49,6 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
-import org.gradle.api.tasks.Nested;
 import org.gradle.cache.internal.ProducerGuard;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -125,7 +124,7 @@ class DependencyManagementGlobalScopeServices {
     ArtifactTransformParameterScheme createArtifactTransformParameterScheme(InspectionSchemeFactory inspectionSchemeFactory, InstantiatorFactory instantiatorFactory) {
         // TODO - should decorate
         InstantiationScheme instantiationScheme = instantiatorFactory.injectScheme();
-        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, Classpath.class, CompileClasspath.class, Nested.class, Inject.class, Console.class, Internal.class));
+        InspectionScheme inspectionScheme = inspectionSchemeFactory.inspectionScheme(ImmutableSet.of(Input.class, InputFile.class, InputFiles.class, InputDirectory.class, Classpath.class, CompileClasspath.class, Inject.class, Console.class, Internal.class));
         return new ArtifactTransformParameterScheme(instantiationScheme, inspectionScheme);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -169,7 +169,10 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
             parameterPropertyWalker.visitProperties(parameterObject, ParameterValidationContext.NOOP, new PropertyVisitor.Adapter() {
                 @Override
                 public void visitInputFileProperty(String propertyName, boolean optional, boolean skipWhenEmpty, @Nullable Class<? extends FileNormalizer> fileNormalizer, PropertyValue value, InputFilePropertyType filePropertyType) {
-                    context.maybeAdd(value.call());
+                    Object actualValue = value.call();
+                    if (actualValue != null) {
+                        context.maybeAdd(actualValue);
+                    }
                 }
             });
         }


### PR DESCRIPTION
Currently, using `@Nested` for transform parameters is pretty complicated, since the managed type needs to be generated separately. We want to disallow `@Nested` on transform parameters for now and enable them again when the support is better.