### PR TITLE
Fix performance regression introduced by using TypeToken to resolve type variables

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/reflect/JavaReflectionUtil.java
@@ -17,8 +17,16 @@
 package org.gradle.internal.reflect;
 
 import org.gradle.internal.UncheckedException;
+import org.gradle.util.CollectionUtils;
 
 import java.lang.reflect.Constructor;
+import java.lang.reflect.GenericArrayType;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.ArrayDeque;
+import java.util.Queue;
 
 public class JavaReflectionUtil {
 
@@ -54,5 +62,100 @@ public class JavaReflectionUtil {
         } catch (Throwable e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
+    }
+
+    /**
+     * Checks if a type has a type variable which may require resolving.
+     */
+    public static boolean hasTypeVariable(Type type) {
+        // do some checks up-front, so we avoid creating the queue in most cases
+        // Cases we want to handle:
+        // - List<String>
+        // - Class<?>
+        // - List<Class<?>>
+        // - Integer[]
+        // - ? extends BaseType
+        // - Class<?>[]
+        if (doesNotHaveTypeVariable(type)) {
+            return false;
+        }
+        if (type instanceof TypeVariable) {
+            return true;
+        }
+        if (type instanceof ParameterizedType) {
+            ParameterizedType parameterizedType = (ParameterizedType) type;
+            boolean noTypeVariables = true;
+            for (Type actualTypeArgument : parameterizedType.getActualTypeArguments()) {
+                if (actualTypeArgument instanceof TypeVariable) {
+                    return true;
+                }
+                noTypeVariables &= doesNotHaveTypeVariable(actualTypeArgument);
+            }
+            if (noTypeVariables) {
+                return false;
+            }
+        }
+        if (type instanceof GenericArrayType) {
+            GenericArrayType genericArrayType = (GenericArrayType) type;
+            if (genericArrayType.getGenericComponentType() instanceof TypeVariable) {
+                return true;
+            }
+        }
+
+        // Type is more complicated, need to check everything.
+        Queue<Type> typesToInspect = new ArrayDeque<Type>();
+        typesToInspect.add(type);
+        while (!typesToInspect.isEmpty()) {
+            Type typeToInspect = typesToInspect.remove();
+            if (typeToInspect instanceof Class) {
+                continue;
+            }
+            if (typeToInspect instanceof TypeVariable) {
+                return true;
+            }
+            if (typeToInspect instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = (ParameterizedType) typeToInspect;
+                CollectionUtils.addAll(typesToInspect, parameterizedType.getActualTypeArguments());
+            } else if (typeToInspect instanceof GenericArrayType) {
+                GenericArrayType arrayType = (GenericArrayType) typeToInspect;
+                typesToInspect.add(arrayType.getGenericComponentType());
+            } else if (typeToInspect instanceof WildcardType) {
+                WildcardType wildcardType = (WildcardType) typeToInspect;
+                CollectionUtils.addAll(typesToInspect, wildcardType.getLowerBounds());
+                CollectionUtils.addAll(typesToInspect, wildcardType.getUpperBounds());
+            } else {
+                // We don't know what the type is - let Guava take care of it.
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Quick check if a type does not have any type variables.
+     *
+     * Handled cases:
+     * - raw Class
+     * - Wildcard type with Class bounds, e.g. ? extends BaseType
+     */
+    private static boolean doesNotHaveTypeVariable(Type type) {
+        if (type instanceof Class) {
+            return true;
+        }
+        if (type instanceof WildcardType) {
+            WildcardType wildcardType = (WildcardType) type;
+            for (Type lowerBound : wildcardType.getLowerBounds()) {
+                if (!(lowerBound instanceof Class)) {
+                    return false;
+                }
+            }
+            for (Type upperBound : wildcardType.getUpperBounds()) {
+                if (!(upperBound instanceof Class)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect
+
+import com.google.common.reflect.TypeToken
+import org.gradle.testing.internal.util.Specification
+import spock.lang.Unroll
+
+import java.util.function.BiConsumer
+
+class JavaReflectionUtilTest extends Specification {
+
+    @Unroll
+    def "#type has type variable: #hasTypeVariable"() {
+        expect:
+        JavaReflectionUtil.hasTypeVariable(type.getType()) == hasTypeVariable
+
+        where:
+        type                                                              | hasTypeVariable
+        new TypeToken<Class<?>>() {}                                      | false
+        new TypeToken<Class<String>>() {}                                 | false
+        new TypeToken<Class<String>[]>() {}                               | false
+        TypeToken.of(String.class)                                        | false
+        TypeToken.of(String[].class)                                      | false
+        new TypeToken<List<BiConsumer<String, Collection<Integer>>>>() {} | false
+        new TypeToken<List<? extends Collection<String>>>() {}            | false
+        new TypeToken<List<? super List<String>>>() {}                    | false
+        new TypeToken<BiConsumer<List<String>, List<String>>>() {}        | false
+        genericReturnType("simpleGenericReturnType")                      | true
+        genericReturnType("encapsulatedTypeVariable")                     | true
+        genericReturnType("arrayTypeWithTypeVariable")                    | true
+        genericReturnType("complexTypeWithTypeVariable")                  | true
+        genericReturnType("anotherComplexTypeWithTypeVariable")           | true
+        genericReturnType("complexTypeWithArrayTypeVariable")             | true
+    }
+
+    private static TypeToken genericReturnType(String methodName) {
+        return TypeToken.of(JavaReflectionUtilTestMethods.getDeclaredMethod(methodName).genericReturnType)
+    }
+}

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTestMethods.java
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTestMethods.java
@@ -20,15 +20,16 @@ import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-public class JavaReflectionUtilTestMethods {
-    private <T> T simpleGenericReturnType() { return null; }
+public interface JavaReflectionUtilTestMethods {
+    <T> T simpleGenericReturnType();
 
-    private <T> List<T> encapsulatedTypeVariable() { return null; }
+    <T> List<T> encapsulatedTypeVariable();
 
-    private <T> T[] arrayTypeWithTypeVariable() { return null; }
+    <T> T[] arrayTypeWithTypeVariable();
 
-    private <T> List<Collection<? extends List<? super T>>[]> complexTypeWithTypeVariable() { return null; }
+    <T> List<Collection<? extends List<? super T>>[]> complexTypeWithTypeVariable();
 
-    private <T> List<BiConsumer<Collection<? super Class<Integer>>, ? extends List<? extends T>>[]> anotherComplexTypeWithTypeVariable() { return null; }
-    private <T> List<BiConsumer<Collection<? super Class<Integer>>, ? extends List<T[]>>> complexTypeWithArrayTypeVariable() { return null; }
+    <T> List<BiConsumer<Collection<? super Class<Integer>>, ? extends List<? extends T>>[]> anotherComplexTypeWithTypeVariable();
+
+    <T> List<BiConsumer<Collection<? super Class<Integer>>, ? extends List<T[]>>> complexTypeWithArrayTypeVariable();
 }

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTestMethods.java
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/reflect/JavaReflectionUtilTestMethods.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+
+public class JavaReflectionUtilTestMethods {
+    private <T> T simpleGenericReturnType() { return null; }
+
+    private <T> List<T> encapsulatedTypeVariable() { return null; }
+
+    private <T> T[] arrayTypeWithTypeVariable() { return null; }
+
+    private <T> List<Collection<? extends List<? super T>>[]> complexTypeWithTypeVariable() { return null; }
+
+    private <T> List<BiConsumer<Collection<? super Class<Integer>>, ? extends List<? extends T>>[]> anotherComplexTypeWithTypeVariable() { return null; }
+    private <T> List<BiConsumer<Collection<? super Class<Integer>>, ? extends List<T[]>>> complexTypeWithArrayTypeVariable() { return null; }
+}

--- a/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
+++ b/subprojects/model-core/src/main/java/org/gradle/internal/instantiation/AbstractClassGenerator.java
@@ -43,6 +43,7 @@ import org.gradle.internal.reflect.ClassDetails;
 import org.gradle.internal.reflect.ClassInspector;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.reflect.JavaPropertyReflectionUtil;
+import org.gradle.internal.reflect.JavaReflectionUtil;
 import org.gradle.internal.reflect.MethodSet;
 import org.gradle.internal.reflect.PropertyAccessorType;
 import org.gradle.internal.reflect.PropertyDetails;
@@ -453,7 +454,7 @@ abstract class AbstractClassGenerator implements ClassGenerator {
          */
         public MethodMetadata resolveTypeVariables(Method method) {
             Type returnType = method.getGenericReturnType();
-            Type resolvedReturnType = returnType instanceof Class ? returnType : TypeToken.of(type).method(method).getReturnType().getType();
+            Type resolvedReturnType = JavaReflectionUtil.hasTypeVariable(returnType) ? TypeToken.of(type).method(method).getReturnType().getType() : returnType;
             return new MethodMetadata(method, resolvedReturnType);
         }
 


### PR DESCRIPTION
We now determine if there are some type variables to resolve and only resolve them in that case since using TypeToken.resolveTypeVariable seems to be very expensive.