### PR TITLE
 Mapping of feature variants for the Ivy world 

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
@@ -39,6 +39,16 @@ public interface ConfigurationVariantDetails {
     void skip();
 
     /**
+     * Provides information about the optional status of this added configuration variant.
+     *
+     * <ul>
+     *     <li>For the Maven world, this means that dependencies will be declared as {@code optional}.</li>
+     *     <li>For the Ivy world, this means that configuration marked optional will not be extended by the {@code default} configuration.</li>
+     * </ul>
+     */
+    void markOptional();
+
+    /**
      * Provides information about how to publish to a Maven POM file. If
      * nothing is said, Gradle will publish all dependencies from this
      * configuration to the <i>compile</i> scope. It is preferable to give
@@ -57,9 +67,8 @@ public interface ConfigurationVariantDetails {
      *
      * The mapping only applies to dependencies: dependency constraints will
      * systematically be published as import scope.
+     *  @param scope the Maven scope to use for dependencies found in this configuration variant
      *
-     * @param scope the Maven scope to use for dependencies found in this configuration variant
-     * @param optional true if the dependencies found in this configuration variant should be published as optional
      */
-    void mapToMavenScope(String scope, boolean optional);
+    void mapToMavenScope(String scope);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/component/ConfigurationVariantDetails.java
@@ -46,7 +46,7 @@ public interface ConfigurationVariantDetails {
      *     <li>For the Ivy world, this means that configuration marked optional will not be extended by the {@code default} configuration.</li>
      * </ul>
      */
-    void markOptional();
+    void mapToOptional();
 
     /**
      * Provides information about how to publish to a Maven POM file. If

--- a/subprojects/core/src/main/java/org/gradle/api/internal/component/IvyPublishingAwareContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/component/IvyPublishingAwareContext.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.component;
+
+public interface IvyPublishingAwareContext extends UsageContext {
+
+    boolean isOptional();
+}

--- a/subprojects/docs/src/docs/userguide/feature_variants.adoc
+++ b/subprojects/docs/src/docs/userguide/feature_variants.adoc
@@ -134,11 +134,11 @@ include::sample[dir="java-feature-variant/producer-separate-sourceset/kotlin",fi
 Depending on the metadata file format, publishing feature variants may be lossy:
 
 - using POM metadata (Maven), feature variants are published as **optional dependencies** and artifacts of feature variants are published with different _classifiers_
-- using Ivy metadata, feature variants are lost
+- using Ivy metadata, feature variants are published as extra configurations, which are _not_ extended by the `default` configuration
 - using {metadata-file-spec}[experimental Gradle metadata], everything is published and consumers will get the full benefit of feature variants
 ====
 
-Publishing feature variants is supported using the `maven-publish` plugin only.
+Publishing feature variants is supported using the `maven-publish` and `ivy-publish` plugins only.
 The Java Plugin (or Java Library Plugin) will take care of registering the additional variants for you, so there's no additional configuration required, only the regular publications:
 
 .Publishing a component with feature variants
@@ -153,10 +153,11 @@ include::sample[dir="java-feature-variant/producer/kotlin",files="build.gradle.k
 [WARNING]
 ====
 As mentioned earlier, feature variants can be lossy when published.
-As a consequence, a consumer can depend on a feature variant only in two cases:
+As a consequence, a consumer can depend on a feature variant only in these cases:
 
 - with a project dependency (in a multi-project build)
-- with Gradle metadata enabled (the publisher MUST have published using Gradle metadata)
+- with Gradle metadata available, that is the publisher MUST have published it
+- within the Ivy world, by declaring a dependency on the configuration matching the feature
 ====
 
 A consumer can specify that it needs a specific feature of a producer by declaring required capabilities.

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -1013,7 +1013,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
             }
 
             components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
-                if ($optional) it.markOptional()
+                if ($optional) it.mapToOptional()
             }
 
             publishing {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
@@ -44,7 +44,10 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 optionalFeatureImplementation 'org:optionaldep:1.0'
             }
             
-            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements, { it.mapToMavenScope('compile', true) })
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) { 
+                it.mapToMavenScope('compile')
+                it.markOptional()
+            }
         """
 
         when:
@@ -124,8 +127,14 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 optionalFeature2Implementation 'org:optionaldep2-g2:1.0'
             }
             
-            components.java.addVariantsFromConfiguration(configurations.optionalFeature1RuntimeElements, { it.mapToMavenScope('compile', true) })
-            components.java.addVariantsFromConfiguration(configurations.optionalFeature2RuntimeElements, { it.mapToMavenScope('compile', true) })
+            components.java.addVariantsFromConfiguration(configurations.optionalFeature1RuntimeElements) {
+                it.mapToMavenScope('compile')
+                it.markOptional()
+            }
+            components.java.addVariantsFromConfiguration(configurations.optionalFeature2RuntimeElements) {
+                it.mapToMavenScope('compile')
+                it.markOptional()
+            }
         """
 
         when:
@@ -185,7 +194,10 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 optionalFeatureImplementation 'org:optionaldep:1.0'
             }
             
-            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements, { it.mapToMavenScope('compile', true) })
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                it.mapToMavenScope('compile')
+                it.markOptional()
+            }
             
             artifacts {     
                 if ('$classifier' == 'null') {
@@ -285,7 +297,10 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 optionalFeatureImplementation 'org:optionaldep:1.0'
             }
             
-            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements, { it.mapToMavenScope('compile', true) })
+            components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
+                it.mapToMavenScope('compile')
+                it.markOptional()
+            }
             
             def alt = configurations.optionalFeatureRuntimeElements.outgoing.variants.create("alternate")
             alt.attributes {
@@ -366,7 +381,8 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                 if (it.configurationVariant.name != 'alternate') {
                     it.skip()
                 } else {
-                    it.mapToMavenScope('compile', true)
+                    it.mapToMavenScope('compile')
+                    it.markOptional()
                 } 
             }
             

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishFeaturesJavaIntegTest.groovy
@@ -46,7 +46,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             
             components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) { 
                 it.mapToMavenScope('compile')
-                it.markOptional()
+                it.mapToOptional()
             }
         """
 
@@ -129,11 +129,11 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             
             components.java.addVariantsFromConfiguration(configurations.optionalFeature1RuntimeElements) {
                 it.mapToMavenScope('compile')
-                it.markOptional()
+                it.mapToOptional()
             }
             components.java.addVariantsFromConfiguration(configurations.optionalFeature2RuntimeElements) {
                 it.mapToMavenScope('compile')
-                it.markOptional()
+                it.mapToOptional()
             }
         """
 
@@ -196,7 +196,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             
             components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
                 it.mapToMavenScope('compile')
-                it.markOptional()
+                it.mapToOptional()
             }
             
             artifacts {     
@@ -299,7 +299,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
             
             components.java.addVariantsFromConfiguration(configurations.optionalFeatureRuntimeElements) {
                 it.mapToMavenScope('compile')
-                it.markOptional()
+                it.mapToOptional()
             }
             
             def alt = configurations.optionalFeatureRuntimeElements.outgoing.variants.create("alternate")
@@ -382,7 +382,7 @@ class MavenPublishFeaturesJavaIntegTest extends AbstractMavenPublishFeaturesJava
                     it.skip()
                 } else {
                     it.mapToMavenScope('compile')
-                    it.markOptional()
+                    it.mapToOptional()
                 } 
             }
             

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublication.java
@@ -54,7 +54,6 @@ import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.java.JavaLibraryPlatform;
-import org.gradle.api.internal.java.usagecontext.FeatureConfigurationUsageContext;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -349,8 +348,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     private Set<MavenDependencyInternal> dependenciesFor(UsageContext usage) {
-        if (usage instanceof FeatureConfigurationUsageContext) {
-            MavenPublishingAwareContext.ScopeMapping mapping = ((FeatureConfigurationUsageContext) usage).getScopeMapping();
+        if (usage instanceof MavenPublishingAwareContext) {
+            MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usage).getScopeMapping();
             switch (mapping) {
                 case compile:
                     return apiDependencies;
@@ -371,8 +370,8 @@ public class DefaultMavenPublication implements MavenPublicationInternal {
     }
 
     private Set<MavenDependency> dependencyConstraintsFor(UsageContext usage) {
-        if (usage instanceof FeatureConfigurationUsageContext) {
-            MavenPublishingAwareContext.ScopeMapping mapping = ((FeatureConfigurationUsageContext) usage).getScopeMapping();
+        if (usage instanceof MavenPublishingAwareContext) {
+            MavenPublishingAwareContext.ScopeMapping mapping = ((MavenPublishingAwareContext) usage).getScopeMapping();
             switch (mapping) {
                 case compile:
                 case compile_optional:

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
@@ -135,7 +135,7 @@ public class ConfigurationVariantMapping {
         }
 
         @Override
-        public void markOptional() {
+        public void mapToOptional() {
             this.optional = true;
         }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/ConfigurationVariantMapping.java
@@ -135,9 +135,13 @@ public class ConfigurationVariantMapping {
         }
 
         @Override
-        public void mapToMavenScope(String scope, boolean optional) {
+        public void markOptional() {
+            this.optional = true;
+        }
+
+        @Override
+        public void mapToMavenScope(String scope) {
             this.mavenScope = assertValidScope(scope);
-            this.optional = optional;
         }
 
         private static String assertValidScope(String scope) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationUsageContext.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/java/usagecontext/FeatureConfigurationUsageContext.java
@@ -18,17 +18,20 @@ package org.gradle.api.internal.java.usagecontext;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
+import org.gradle.api.internal.component.IvyPublishingAwareContext;
 import org.gradle.api.internal.component.MavenPublishingAwareContext;
 import org.gradle.api.plugins.internal.AbstractConfigurationUsageContext;
 
-public class FeatureConfigurationUsageContext extends AbstractConfigurationUsageContext implements MavenPublishingAwareContext {
+public class FeatureConfigurationUsageContext extends AbstractConfigurationUsageContext implements MavenPublishingAwareContext, IvyPublishingAwareContext {
     private final Configuration configuration;
     private final ScopeMapping scopeMapping;
+    private final boolean optional;
 
     public FeatureConfigurationUsageContext(String name, Configuration configuration, ConfigurationVariant variant, String mavenScope, boolean optional) {
         super(name, ((AttributeContainerInternal)variant.getAttributes()).asImmutable(), variant.getArtifacts());
         this.configuration = configuration;
         this.scopeMapping = ScopeMapping.of(mavenScope, optional);
+        this.optional = optional;
     }
 
     @Override
@@ -39,5 +42,10 @@ public class FeatureConfigurationUsageContext extends AbstractConfigurationUsage
     @Override
     public ScopeMapping getScopeMapping() {
         return scopeMapping;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return optional;
     }
 }

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaConfigurationVariantMapping.java
@@ -39,7 +39,7 @@ public class JavaConfigurationVariantMapping implements Action<ConfigurationVari
         if (ArtifactTypeSpec.INSTANCE.isSatisfiedBy(variant)) {
             details.mapToMavenScope(scope);
             if (optional) {
-                details.markOptional();
+                details.mapToOptional();
             }
         } else {
             details.skip();

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaConfigurationVariantMapping.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/JavaConfigurationVariantMapping.java
@@ -37,7 +37,10 @@ public class JavaConfigurationVariantMapping implements Action<ConfigurationVari
     public void execute(ConfigurationVariantDetails details) {
         ConfigurationVariant variant = details.getConfigurationVariant();
         if (ArtifactTypeSpec.INSTANCE.isSatisfiedBy(variant)) {
-            details.mapToMavenScope(scope, optional);
+            details.mapToMavenScope(scope);
+            if (optional) {
+                details.markOptional();
+            }
         } else {
             details.skip();
         }


### PR DESCRIPTION
When using feature variants in the Ivy world, there was no special
handling. This mostly meant that any added configuration based on the
feature variant ended up being extended by the default Ivy
configuration.
Since the goal is to model optional features, such extension makes
little sense.
This change set improves the situation by decoupling the Maven scope
mapping from the optional status.
The optional status is now available to Ivy publication and is used to
control whether the `default` configuration should extend the created
configuration.