### PR TITLE
Expose classpath of buildscript via `buildEnvironment`

### DIFF
--- a/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/BuildEnvironmentReportTask.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/tasks/diagnostics/BuildEnvironmentReportTask.java
@@ -17,11 +17,14 @@ package org.gradle.api.tasks.diagnostics;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Incubating;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.diagnostics.internal.DependencyReportRenderer;
 import org.gradle.api.tasks.diagnostics.internal.ProjectReportGenerator;
@@ -51,7 +54,10 @@ public class BuildEnvironmentReportTask extends DefaultTask {
 
     private DependencyReportRenderer renderer = new AsciiDependencyReportRenderer();
 
+    private final Configuration configuration;
+
     public BuildEnvironmentReportTask() {
+        configuration = getProject().getBuildscript().getConfigurations().getByName(ScriptHandler.CLASSPATH_CONFIGURATION);
         getOutputs().upToDateWhen(new Spec<Task>() {
             public boolean isSatisfiedBy(Task element) {
                 return false;
@@ -69,12 +75,22 @@ public class BuildEnvironmentReportTask extends DefaultTask {
         throw new UnsupportedOperationException();
     }
 
+    /**
+     * The classpath for the build environment for this project.
+     *
+     * @since 5.3
+     */
+    @Incubating
+    @Classpath
+    protected FileCollection getClasspath() {
+        return configuration;
+    }
+
     @TaskAction
     public void generate() {
         ProjectReportGenerator projectReportGenerator = new ProjectReportGenerator() {
             @Override
             public void generateReport(Project project) throws IOException {
-                Configuration configuration = getProject().getBuildscript().getConfigurations().getByName(ScriptHandler.CLASSPATH_CONFIGURATION);
                 renderer.startConfiguration(configuration);
                 renderer.render(configuration);
                 renderer.completeConfiguration(configuration);


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
