### PR TITLE
Enable rerunner for more build types

### DIFF
--- a/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
+++ b/.teamcity/Gradle_Check/configurations/BuildDistributions.kt
@@ -10,7 +10,7 @@ class BuildDistributions(model: CIBuildModel, stage: Stage) : BaseGradleBuildTyp
     name = "Build Distributions"
     description = "Creation and verification of the distribution and documentation"
 
-    applyDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=${distributionTestJavaHome}")
+    applyTestDefaults(model, this, "packageBuild", extraParameters = buildScanTag("BuildDistributions") + " -PtestJavaHome=${distributionTestJavaHome}")
 
     artifactRules = """$artifactRules
         build/distributions/*.zip => distributions

--- a/.teamcity/Gradle_Check/configurations/Gradleception.kt
+++ b/.teamcity/Gradle_Check/configurations/Gradleception.kt
@@ -19,7 +19,7 @@ class Gradleception(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(mod
     val buildScanTagForType = buildScanTag("Gradleception")
     val defaultParameters = (gradleParameters() + listOf(buildScanTagForType)).joinToString(separator = " ")
 
-    applyDefaults(model, this, ":install", notQuick = true, extraParameters = "-Pgradle_installPath=dogfood-first $buildScanTagForType", extraSteps = {
+    applyTestDefaults(model, this, ":install", notQuick = true, extraParameters = "-Pgradle_installPath=dogfood-first $buildScanTagForType", extraSteps = {
         localGradle {
             name = "BUILD_WITH_BUILT_GRADLE"
             tasks = "clean :install"

--- a/.teamcity/Gradle_Check/configurations/SanityCheck.kt
+++ b/.teamcity/Gradle_Check/configurations/SanityCheck.kt
@@ -20,7 +20,7 @@ class SanityCheck(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model
         }
     }
 
-    applyDefaults(
+    applyTestDefaults(
             model,
             this,
             "sanityCheck",


### PR DESCRIPTION
### Context

Previously we only enabled rerunner for functional tests, however, some special build types (like sanityCheck) contain tests as well. We need enable rerunner for them to handle flaky tests, too: https://github.com/gradle/gradle-private/issues/1904
