### PR TITLE
Rework category attribute

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/attributes/Category.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.attributes;
+
+import org.gradle.api.Incubating;
+import org.gradle.api.Named;
+
+/**
+ * This attribute describes the categories of variants for a given module.
+ * <p>
+ * Two values are found in published components:
+ * <ul>
+ *     <li>{@code library}: Indicates that the variant is a library, that usually means a binary and a set of dependencies</li>
+ *     <li>{@code platform}: indicates that the variant is a platform, that usually means a definition of dependency constraints</li>
+ * </ul>
+ * One value is used for derivation. A {@code platform} variant can be consumed as a {@code enforced-platform} which means all the dependency
+ * information it provides is applied as {@code forced}.
+ *
+ * @since 5.3
+ */
+@Incubating
+public interface Category extends Named {
+
+    Attribute<Category> CATEGORY_ATTRIBUTE = Attribute.of("org.gradle.category", Category.class);
+
+    /**
+     * The library category
+     */
+    String LIBRARY = "library";
+
+    /**
+     * The platform category
+     */
+    String REGULAR_PLATFORM = "platform";
+
+    /**
+     * The enforced platform, usually a synthetic variant derived from the {@code platform}
+     */
+    String ENFORCED_PLATFORM = "enforced-platform";
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/ProjectDependencyResolveIntegrationTest.groovy
@@ -187,7 +187,7 @@ project(":b") {
                     variant('runtime')
                     module('org.other:externalA:1.2') {
                         byReason('also check dependency reasons')
-                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.component.category':'library', 'org.gradle.usage':'java-runtime'])
+                        variant('runtime', ['org.gradle.status': 'release', 'org.gradle.category':'library', 'org.gradle.usage':'java-runtime'])
                     }
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -1063,7 +1063,7 @@ include 'other'
             module(platformName) {
                 version(platformVersion) {
                     variant("platform") {
-                        attribute('org.gradle.component.category', 'platform')
+                        attribute('org.gradle.category', 'platform')
                         members.each { member ->
                             constraint(member)
                         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/CrossProjectMultipleVariantSelectionIntegrationTest.groovy
@@ -81,7 +81,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
                 project(":lib", "test:lib:") {
@@ -103,6 +103,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
                     canBeConsumed = true
                     attributes {
                         attribute(Usage.USAGE_ATTRIBUTE, project.objects.named(Usage, 'java-api-jars'))
+                        attribute(Category.CATEGORY_ATTRIBUTE, project.objects.named(Category, Category.LIBRARY))
                         attribute(Bundling.BUNDLING_ATTRIBUTE, project.objects.named(Bundling, Bundling.EXTERNAL))
                         attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().majorVersion))
                     }
@@ -129,7 +130,7 @@ class CrossProjectMultipleVariantSelectionIntegrationTest extends AbstractDepend
         resolve.expectGraph {
             root(":", ":test:") {
                 project(":lib", "test:lib:") {
-                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
+                    variant "apiElements", ['org.gradle.usage':'java-api-jars', 'org.gradle.category':'library', 'org.gradle.dependency.bundling':'external', 'org.gradle.jvm.version': JavaVersion.current().majorVersion]
                     artifact group:'', module:'', version: '', type: '', name: 'main', noType: true
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenBomResolveIntegrationTest.groovy
@@ -169,12 +169,12 @@ class MavenBomResolveIntegrationTest extends AbstractHttpDependencyResolutionTes
         resolve.expectGraph {
             root(':', ':testproject:') {
                 module("group:bom:1.0") {
-                    variant("platform-runtime", ['org.gradle.component.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
+                    variant("platform-runtime", ['org.gradle.category':'platform', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
                     constraint("group:moduleA:2.0")
                     noArtifacts()
                 }
                 module("group:bom:1.0") {
-                    variant("runtime", ['org.gradle.component.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
+                    variant("runtime", ['org.gradle.category':'library', 'org.gradle.status':'release', 'org.gradle.usage':'java-runtime'])
                     module("group:moduleC:1.0")
                     noArtifacts()
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -16,8 +16,8 @@
 
 package org.gradle.integtests.resolve.platforms
 
+import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
@@ -219,9 +219,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         def platform = mavenHttpRepo.module("org", "platform", "1.0")
                 .withModuleMetadata()
                 .adhocVariants()
-                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (PlatformSupport.VARIANT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
+                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
                 .dependsOn("org", "foo", "1.0")
-                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (PlatformSupport.VARIANT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) {
+                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (Category.CATEGORY_ATTRIBUTE.name): Category.REGULAR_PLATFORM]) {
                     useDefaultArtifacts = false
                 }
                 .dependsOn("org", "foo", "1.0")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/JavaPlatformResolveIntegrationTest.groovy
@@ -70,7 +70,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.component.category': 'platform'])
+                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -114,7 +114,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.component.category': 'platform'])
+                    variant("runtimeElements", ['org.gradle.usage': 'java-runtime', 'org.gradle.category': 'platform'])
                     constraint("org:foo:1.1")
                     constraint("org:bar:1.2")
                     noArtifacts()
@@ -159,7 +159,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.component.category': 'platform'])
+                    variant("apiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'platform'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -200,7 +200,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         resolve.expectGraph {
             root(":", "org.test:test:1.9") {
                 project(":platform", "org.test:platform:1.9") {
-                    variant("enforcedApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.component.category': 'enforced-platform'])
+                    variant("enforcedApiElements", ['org.gradle.usage': 'java-api', 'org.gradle.category': 'enforced-platform'])
                     constraint("org:foo:1.1")
                     noArtifacts()
                 }
@@ -219,9 +219,9 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
         def platform = mavenHttpRepo.module("org", "platform", "1.0")
                 .withModuleMetadata()
                 .adhocVariants()
-                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (PlatformSupport.COMPONENT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
+                .variant("apiElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_API, (PlatformSupport.VARIANT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) { useDefaultArtifacts = false }
                 .dependsOn("org", "foo", "1.0")
-                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (PlatformSupport.COMPONENT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) {
+                .variant("runtimeElements", [(Usage.USAGE_ATTRIBUTE.name): Usage.JAVA_RUNTIME, (PlatformSupport.VARIANT_CATEGORY.name): PlatformSupport.REGULAR_PLATFORM]) {
                     useDefaultArtifacts = false
                 }
                 .dependsOn("org", "foo", "1.0")
@@ -254,7 +254,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                     configuration = "enforcedApiElements"
                     variant("enforcedApiElements", [
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.component.category': 'enforced-platform',
+                            'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
                     ])
                     module("org:foo:1.0")
@@ -294,7 +294,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                 edge("org:platform", "org:platform:1.0") {
                     variant("platform-compile", [
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.component.category': 'platform',
+                            'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
                     ])
                     byConstraint()
@@ -303,7 +303,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
                 constraint("org:platform:1.0", "org:platform:1.0") {
                     variant("platform-compile", [
                             'org.gradle.usage': 'java-api',
-                            'org.gradle.component.category': 'platform',
+                            'org.gradle.category': 'platform',
                             'org.gradle.status': 'release',
                     ])
                 }
@@ -335,7 +335,7 @@ class JavaPlatformResolveIntegrationTest extends AbstractHttpDependencyResolutio
             root(":", "org.test:test:1.9") {
                 module("org:top:1.0") {
                     variant("enforced-platform-compile", [
-                            'org.gradle.component.category': 'enforced-platform',
+                            'org.gradle.category': 'enforced-platform',
                             'org.gradle.status': 'release',
                             'org.gradle.usage': 'java-api'])
                     noArtifacts()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/ComponentReplacementIntegrationTest.groovy
@@ -429,9 +429,9 @@ class ComponentReplacementIntegrationTest extends AbstractIntegrationSpec {
         then:
         result.groupedOutput.task(':dependencyInsight').output.contains("""org:b:1
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : $expected

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/VariantAttributesRulesIntegrationTest.groovy
@@ -205,7 +205,7 @@ class VariantAttributesRulesIntegrationTest extends AbstractModuleDependencyReso
                                 // the format attribute is added by the rule
                                 expectedAttributes = [format: 'custom', 'org.gradle.status': GradleMetadataResolveRunner.useIvy() ? 'integration' : 'release']
                                 expectedAttributes['org.gradle.usage'] = 'java-api'
-                                expectedAttributes['org.gradle.component.category'] = 'library'
+                                expectedAttributes['org.gradle.category'] = 'library'
                             }
                         }
                         variant(expectedTargetVariant, expectedAttributes)

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -409,7 +409,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 resolutionQueryFactory,
                 attributesSchema,
                 artifactTransformRegistrations,
-                artifactTypeRegistry);
+                artifactTypeRegistry,
+                NamedObjectInstantiator.INSTANCE);
         }
 
         DependencyLockingHandler createDependencyLockingHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer) {
@@ -421,7 +422,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, ComponentMetadataHandler componentMetadataHandler) {
-            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, componentMetadataHandler);
+            return instantiator.newInstance(DefaultDependencyConstraintHandler.class, configurationContainer, dependencyFactory, NamedObjectInstantiator.INSTANCE);
         }
 
         DefaultComponentMetadataHandler createComponentMetadataHandler(Instantiator instantiator, ImmutableModuleIdentifierFactory moduleIdentifierFactory, SimpleMapInterner interner, ImmutableAttributesFactory attributesFactory, IsolatableFactory isolatableFactory, ComponentMetadataRuleExecutor componentMetadataRuleExecutor) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandler.java
@@ -33,9 +33,11 @@ import org.gradle.api.artifacts.transform.TransformSpec;
 import org.gradle.api.artifacts.transform.VariantTransform;
 import org.gradle.api.artifacts.type.ArtifactTypeContainer;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.internal.artifacts.VariantTransformRegistry;
 import org.gradle.api.internal.artifacts.query.ArtifactResolutionQueryFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.Factory;
 import org.gradle.internal.metaobject.MethodAccess;
 import org.gradle.internal.metaobject.MethodMixIn;
@@ -57,6 +59,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     private final AttributesSchema attributesSchema;
     private final VariantTransformRegistry transforms;
     private final Factory<ArtifactTypeContainer> artifactTypeContainer;
+    private final NamedObjectInstantiator namedObjectInstantiator;
     private final DynamicAddDependencyMethods dynamicMethods;
 
     public DefaultDependencyHandler(ConfigurationContainer configurationContainer,
@@ -68,7 +71,8 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
                                     ArtifactResolutionQueryFactory resolutionQueryFactory,
                                     AttributesSchema attributesSchema,
                                     VariantTransformRegistry transforms,
-                                    Factory<ArtifactTypeContainer> artifactTypeContainer) {
+                                    Factory<ArtifactTypeContainer> artifactTypeContainer,
+                                    NamedObjectInstantiator namedObjectInstantiator) {
         this.configurationContainer = configurationContainer;
         this.dependencyFactory = dependencyFactory;
         this.projectFinder = projectFinder;
@@ -79,6 +83,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         this.attributesSchema = attributesSchema;
         this.transforms = transforms;
         this.artifactTypeContainer = artifactTypeContainer;
+        this.namedObjectInstantiator = namedObjectInstantiator;
         configureSchema();
         dynamicMethods = new DynamicAddDependencyMethods(configurationContainer, new DirectDependencyAdder());
     }
@@ -223,7 +228,7 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
     public Dependency platform(Object notation) {
         Dependency dependency = create(notation);
         if (dependency instanceof HasConfigurableAttributes) {
-            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<Object>) dependency, PlatformSupport.REGULAR_PLATFORM);
+            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<Object>) dependency, toCategory(Category.REGULAR_PLATFORM));
         }
         return dependency;
     }
@@ -241,9 +246,9 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         if (platformDependency instanceof ExternalModuleDependency) {
             ExternalModuleDependency externalModuleDependency = (ExternalModuleDependency) platformDependency;
             externalModuleDependency.setForce(true);
-            PlatformSupport.addPlatformAttribute(externalModuleDependency, PlatformSupport.ENFORCED_PLATFORM);
+            PlatformSupport.addPlatformAttribute(externalModuleDependency, toCategory(Category.ENFORCED_PLATFORM));
         } else if (platformDependency instanceof HasConfigurableAttributes) {
-            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<?>) platformDependency, PlatformSupport.ENFORCED_PLATFORM);
+            PlatformSupport.addPlatformAttribute((HasConfigurableAttributes<?>) platformDependency, toCategory(Category.ENFORCED_PLATFORM));
         }
         return platformDependency;
     }
@@ -253,6 +258,10 @@ public class DefaultDependencyHandler implements DependencyHandler, MethodMixIn 
         Dependency dep = enforcedPlatform(notation);
         configureAction.execute(dep);
         return dep;
+    }
+
+    private Category toCategory(String category) {
+        return namedObjectInstantiator.named(Category.class, category);
     }
 
     private class DirectDependencyAdder implements DynamicAddDependencyMethods.DependencyAdder<Dependency> {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -18,68 +18,77 @@ package org.gradle.api.internal.artifacts.dsl.dependencies;
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Action;
-import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.AttributeDisambiguationRule;
 import org.gradle.api.attributes.AttributeMatchingStrategy;
 import org.gradle.api.attributes.AttributesSchema;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.HasConfigurableAttributes;
 import org.gradle.api.attributes.MultipleCandidatesDetails;
 import org.gradle.api.internal.ReusableAction;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.internal.component.external.model.ComponentVariant;
 
 import java.util.Set;
 
 public abstract class PlatformSupport {
-    public static final Attribute<String> VARIANT_CATEGORY = Attribute.of("org.gradle.category", String.class);
-    public static final String LIBRARY = "library";
-    public static final String REGULAR_PLATFORM = "platform";
-    public static final String ENFORCED_PLATFORM = "enforced-platform";
+
+    public static final Category REGULAR_PLATFORM = NamedObjectInstantiator.INSTANCE.named(Category.class, Category.REGULAR_PLATFORM);
+    public static final Category ENFORCED_PLATFORM = NamedObjectInstantiator.INSTANCE.named(Category.class, Category.ENFORCED_PLATFORM);
 
     public static boolean isTargettingPlatform(HasConfigurableAttributes<?> target) {
-        String category = target.getAttributes().getAttribute(VARIANT_CATEGORY);
+        Category category = target.getAttributes().getAttribute(Category.CATEGORY_ATTRIBUTE);
         return REGULAR_PLATFORM.equals(category) || ENFORCED_PLATFORM.equals(category);
     }
 
     public static void configureSchema(AttributesSchema attributesSchema) {
-        AttributeMatchingStrategy<String> componentTypeMatchingStrategy = attributesSchema.attribute(PlatformSupport.VARIANT_CATEGORY);
+        AttributeMatchingStrategy<Category> componentTypeMatchingStrategy = attributesSchema.attribute(Category.CATEGORY_ATTRIBUTE);
         componentTypeMatchingStrategy.getDisambiguationRules().add(PlatformSupport.ComponentCategoryDisambiguationRule.class);
     }
 
-    static <T> void addPlatformAttribute(HasConfigurableAttributes<T> dependency, final String type) {
+    static <T> void addPlatformAttribute(HasConfigurableAttributes<T> dependency, final Category category) {
         dependency.attributes(new Action<AttributeContainer>() {
             @Override
             public void execute(AttributeContainer attributeContainer) {
-                attributeContainer.attribute(VARIANT_CATEGORY, type);
+                attributeContainer.attribute(Category.CATEGORY_ATTRIBUTE, category);
             }
         });
     }
 
+    /**
+     * Checks if the variant is an {@code enforced-platform} one.
+     * <p>
+     * This method is designed to be called on parsed metadata and thus interacts with the {@code String} version of the attribute.
+     *
+     * @param variant the variant to test
+     * @return {@code true} if this represents an {@code enforced-platform}, {@code false} otherwise
+     */
     public static boolean hasForcedDependencies(ComponentVariant variant) {
-        return Objects.equal(variant.getAttributes().getAttribute(VARIANT_CATEGORY), ENFORCED_PLATFORM);
+        return Objects.equal(variant.getAttributes().getAttribute(MavenImmutableAttributesFactory.CATEGORY_ATTRIBUTE), Category.ENFORCED_PLATFORM);
     }
 
-    public static class ComponentCategoryDisambiguationRule implements AttributeDisambiguationRule<String>, ReusableAction {
+    public static class ComponentCategoryDisambiguationRule implements AttributeDisambiguationRule<Category>, ReusableAction {
         @Override
-        public void execute(MultipleCandidatesDetails<String> details) {
-            String consumerValue = details.getConsumerValue();
-            Set<String> candidateValues = details.getCandidateValues();
+        public void execute(MultipleCandidatesDetails<Category> details) {
+            Category consumerValue = details.getConsumerValue();
+            Set<Category> candidateValues = details.getCandidateValues();
             if (consumerValue == null) {
                 // consumer expressed no preference, defaults to library
-                if (candidateValues.contains(LIBRARY)) {
-                    details.closestMatch(LIBRARY);
-                    return;
-                }
+                candidateValues.stream()
+                    .filter(it -> it.getName().equals(Category.LIBRARY))
+                    .findFirst()
+                    .ifPresent(it -> details.closestMatch(it));
             }
         }
 
     }
 
-    public static class PreferRegularPlatform implements AttributeDisambiguationRule<String> {
-        private final static Set<String> PLATFORM_TYPES = ImmutableSet.of(REGULAR_PLATFORM, ENFORCED_PLATFORM);
+    public static class PreferRegularPlatform implements AttributeDisambiguationRule<Category> {
+        private final static Set<Category> PLATFORM_TYPES = ImmutableSet.of(REGULAR_PLATFORM, ENFORCED_PLATFORM);
 
         @Override
-        public void execute(MultipleCandidatesDetails<String> details) {
+        public void execute(MultipleCandidatesDetails<Category> details) {
             if (details.getCandidateValues().equals(PLATFORM_TYPES)) {
                 details.closestMatch(REGULAR_PLATFORM);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/dependencies/PlatformSupport.java
@@ -31,18 +31,18 @@ import org.gradle.internal.component.external.model.ComponentVariant;
 import java.util.Set;
 
 public abstract class PlatformSupport {
-    public static final Attribute<String> COMPONENT_CATEGORY = Attribute.of("org.gradle.component.category", String.class);
+    public static final Attribute<String> VARIANT_CATEGORY = Attribute.of("org.gradle.category", String.class);
     public static final String LIBRARY = "library";
     public static final String REGULAR_PLATFORM = "platform";
     public static final String ENFORCED_PLATFORM = "enforced-platform";
 
     public static boolean isTargettingPlatform(HasConfigurableAttributes<?> target) {
-        String category = target.getAttributes().getAttribute(COMPONENT_CATEGORY);
+        String category = target.getAttributes().getAttribute(VARIANT_CATEGORY);
         return REGULAR_PLATFORM.equals(category) || ENFORCED_PLATFORM.equals(category);
     }
 
     public static void configureSchema(AttributesSchema attributesSchema) {
-        AttributeMatchingStrategy<String> componentTypeMatchingStrategy = attributesSchema.attribute(PlatformSupport.COMPONENT_CATEGORY);
+        AttributeMatchingStrategy<String> componentTypeMatchingStrategy = attributesSchema.attribute(PlatformSupport.VARIANT_CATEGORY);
         componentTypeMatchingStrategy.getDisambiguationRules().add(PlatformSupport.ComponentCategoryDisambiguationRule.class);
     }
 
@@ -50,13 +50,13 @@ public abstract class PlatformSupport {
         dependency.attributes(new Action<AttributeContainer>() {
             @Override
             public void execute(AttributeContainer attributeContainer) {
-                attributeContainer.attribute(COMPONENT_CATEGORY, type);
+                attributeContainer.attribute(VARIANT_CATEGORY, type);
             }
         });
     }
 
     public static boolean hasForcedDependencies(ComponentVariant variant) {
-        return Objects.equal(variant.getAttributes().getAttribute(COMPONENT_CATEGORY), ENFORCED_PLATFORM);
+        return Objects.equal(variant.getAttributes().getAttribute(VARIANT_CATEGORY), ENFORCED_PLATFORM);
     }
 
     public static class ComponentCategoryDisambiguationRule implements AttributeDisambiguationRule<String>, ReusableAction {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
@@ -15,9 +15,10 @@
  */
 package org.gradle.api.internal.artifacts.ivyservice.ivyresolve;
 
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.ModuleExclusion;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -66,10 +67,10 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
         }
         if (configuration.getArtifacts().isEmpty()) {
             // checks if it's a derived platform
-            AttributeValue<String> componentTypeEntry = configuration.getAttributes().findEntry(PlatformSupport.VARIANT_CATEGORY);
+            AttributeValue<String> componentTypeEntry = configuration.getAttributes().findEntry(MavenImmutableAttributesFactory.CATEGORY_ATTRIBUTE);
             if (componentTypeEntry.isPresent()) {
                 String value = componentTypeEntry.get();
-                if (PlatformSupport.REGULAR_PLATFORM.equals(value) || PlatformSupport.ENFORCED_PLATFORM.equals(value)) {
+                if (Category.REGULAR_PLATFORM.equals(value) || Category.ENFORCED_PLATFORM.equals(value)) {
                     return NO_ARTIFACTS;
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/RepositoryChainArtifactResolver.java
@@ -66,7 +66,7 @@ class RepositoryChainArtifactResolver implements ArtifactResolver, OriginArtifac
         }
         if (configuration.getArtifacts().isEmpty()) {
             // checks if it's a derived platform
-            AttributeValue<String> componentTypeEntry = configuration.getAttributes().findEntry(PlatformSupport.COMPONENT_CATEGORY);
+            AttributeValue<String> componentTypeEntry = configuration.getAttributes().findEntry(PlatformSupport.VARIANT_CATEGORY);
             if (componentTypeEntry.isPresent()) {
                 String value = componentTypeEntry.get();
                 if (PlatformSupport.REGULAR_PLATFORM.equals(value) || PlatformSupport.ENFORCED_PLATFORM.equals(value)) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -174,10 +174,10 @@ public class GradleModuleMetadataParser {
         reader.endObject();
         MutableComponentVariant variant = metadata.addVariant(variantName, attributes);
         populateVariant(files, dependencies, dependencyConstraints, capabilities, variant);
-        AttributeValue<String> entry = attributes.findEntry(PlatformSupport.COMPONENT_CATEGORY);
+        AttributeValue<String> entry = attributes.findEntry(PlatformSupport.VARIANT_CATEGORY);
         if (entry.isPresent() && PlatformSupport.REGULAR_PLATFORM.equals(entry.get())) {
             // This generates a synthetic enforced platform variant with the same dependencies, similar to what the Maven variant derivation strategy does
-            ImmutableAttributes enforcedAttributes = attributesFactory.concat(attributes, attributesFactory.of(PlatformSupport.COMPONENT_CATEGORY, PlatformSupport.ENFORCED_PLATFORM));
+            ImmutableAttributes enforcedAttributes = attributesFactory.concat(attributes, attributesFactory.of(PlatformSupport.VARIANT_CATEGORY, PlatformSupport.ENFORCED_PLATFORM));
             MutableComponentVariant syntheticEnforcedVariant = metadata.addVariant("enforced" + capitalize(variantName), enforcedAttributes);
             populateVariant(files, dependencies, dependencyConstraints, capabilities, syntheticEnforcedVariant);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/parser/GradleModuleMetadataParser.java
@@ -23,13 +23,14 @@ import com.google.gson.stream.JsonToken;
 import org.gradle.api.Transformer;
 import org.gradle.api.artifacts.VersionConstraint;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.internal.artifacts.ImmutableModuleIdentifierFactory;
 import org.gradle.api.internal.artifacts.ImmutableVersionConstraint;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.DefaultExcludeRuleConverter;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.ExcludeRuleConverter;
+import org.gradle.api.internal.artifacts.repositories.metadata.MavenImmutableAttributesFactory;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -174,10 +175,10 @@ public class GradleModuleMetadataParser {
         reader.endObject();
         MutableComponentVariant variant = metadata.addVariant(variantName, attributes);
         populateVariant(files, dependencies, dependencyConstraints, capabilities, variant);
-        AttributeValue<String> entry = attributes.findEntry(PlatformSupport.VARIANT_CATEGORY);
-        if (entry.isPresent() && PlatformSupport.REGULAR_PLATFORM.equals(entry.get())) {
+        AttributeValue<String> entry = attributes.findEntry(MavenImmutableAttributesFactory.CATEGORY_ATTRIBUTE);
+        if (entry.isPresent() && Category.REGULAR_PLATFORM.equals(entry.get())) {
             // This generates a synthetic enforced platform variant with the same dependencies, similar to what the Maven variant derivation strategy does
-            ImmutableAttributes enforcedAttributes = attributesFactory.concat(attributes, attributesFactory.of(PlatformSupport.VARIANT_CATEGORY, PlatformSupport.ENFORCED_PLATFORM));
+            ImmutableAttributes enforcedAttributes = attributesFactory.concat(attributes, MavenImmutableAttributesFactory.CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.ENFORCED_PLATFORM, instantiator));
             MutableComponentVariant syntheticEnforcedVariant = metadata.addVariant("enforced" + capitalize(variantName), enforcedAttributes);
             populateVariant(files, dependencies, dependencyConstraints, capabilities, syntheticEnforcedVariant);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -80,7 +80,7 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
-            result = concat(result, PlatformSupport.COMPONENT_CATEGORY, PlatformSupport.LIBRARY);
+            result = concat(result, PlatformSupport.VARIANT_CATEGORY, PlatformSupport.LIBRARY);
             concatCache.put(entry, result);
         }
         return result;
@@ -93,7 +93,7 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
-            result = concat(result, PlatformSupport.COMPONENT_CATEGORY, componentType);
+            result = concat(result, PlatformSupport.VARIANT_CATEGORY, componentType);
             concatCache.put(entry, result);
         }
         return result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/DefaultMavenImmutableAttributesFactory.java
@@ -18,7 +18,7 @@ package org.gradle.api.internal.artifacts.repositories.metadata;
 import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributeMergingException;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
@@ -76,11 +76,11 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
 
     @Override
     public ImmutableAttributes libraryWithUsage(ImmutableAttributes original, String usage) {
-        ComponentTypeEntry entry = new ComponentTypeEntry(original, PlatformSupport.LIBRARY, usage);
+        ComponentTypeEntry entry = new ComponentTypeEntry(original, Category.LIBRARY, usage);
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
-            result = concat(result, PlatformSupport.VARIANT_CATEGORY, PlatformSupport.LIBRARY);
+            result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(Category.LIBRARY, objectInstantiator));
             concatCache.put(entry, result);
         }
         return result;
@@ -88,12 +88,12 @@ public class DefaultMavenImmutableAttributesFactory implements MavenImmutableAtt
 
     @Override
     public ImmutableAttributes platformWithUsage(ImmutableAttributes original, String usage, boolean enforced) {
-        String componentType = enforced ? PlatformSupport.ENFORCED_PLATFORM : PlatformSupport.REGULAR_PLATFORM;
+        String componentType = enforced ? Category.ENFORCED_PLATFORM : Category.REGULAR_PLATFORM;
         ComponentTypeEntry entry = new ComponentTypeEntry(original, componentType, usage);
         ImmutableAttributes result = concatCache.get(entry);
         if (result == null) {
             result = concat(original, USAGE_ATTRIBUTE, new CoercingStringValueSnapshot(usage, objectInstantiator));
-            result = concat(result, PlatformSupport.VARIANT_CATEGORY, componentType);
+            result = concat(result, CATEGORY_ATTRIBUTE, new CoercingStringValueSnapshot(componentType, objectInstantiator));
             concatCache.put(entry, result);
         }
         return result;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/metadata/MavenImmutableAttributesFactory.java
@@ -16,6 +16,7 @@
 package org.gradle.api.internal.artifacts.repositories.metadata;
 
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
@@ -29,6 +30,7 @@ import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 public interface MavenImmutableAttributesFactory extends ImmutableAttributesFactory {
     // We need to work with the 'String' version of the usage attribute, since this is expected for all providers by the `PreferJavaRuntimeVariant` schema
     Attribute<String> USAGE_ATTRIBUTE = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class);
+    Attribute<String> CATEGORY_ATTRIBUTE = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class);
 
     ImmutableAttributes libraryWithUsage(ImmutableAttributes original, String usage);
     ImmutableAttributes platformWithUsage(ImmutableAttributes original, String usage, boolean enforced);

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -30,10 +30,10 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.capabilities.CapabilitiesMetadata;
 import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal;
 import org.gradle.api.internal.artifacts.configurations.OutgoingVariant;
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
 import org.gradle.api.internal.attributes.AttributeValue;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
@@ -407,8 +407,8 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                     }
                 }
                 maybeAddGeneratedDependencies(result);
-                AttributeValue<String> attributeValue = this.getAttributes().findEntry(PlatformSupport.VARIANT_CATEGORY);
-                if (attributeValue.isPresent() && attributeValue.get().equals(PlatformSupport.ENFORCED_PLATFORM)) {
+                AttributeValue<Category> attributeValue = this.getAttributes().findEntry(Category.CATEGORY_ATTRIBUTE);
+                if (attributeValue.isPresent() && attributeValue.get().getName().equals(Category.ENFORCED_PLATFORM)) {
                     // need to wrap all dependencies to force them
                     ImmutableList<LocalOriginDependencyMetadata> rawDependencies = result.build();
                     result = ImmutableList.builder();

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -407,7 +407,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                     }
                 }
                 maybeAddGeneratedDependencies(result);
-                AttributeValue<String> attributeValue = this.getAttributes().findEntry(PlatformSupport.COMPONENT_CATEGORY);
+                AttributeValue<String> attributeValue = this.getAttributes().findEntry(PlatformSupport.VARIANT_CATEGORY);
                 if (attributeValue.isPresent() && attributeValue.get().equals(PlatformSupport.ENFORCED_PLATFORM)) {
                     // need to wrap all dependencies to force them
                     ImmutableList<LocalOriginDependencyMetadata> rawDependencies = result.build();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyConstraintHandlerTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.artifacts.DependencyConstraint
 import org.gradle.api.artifacts.DependencyConstraintSet
 import org.gradle.api.artifacts.VersionConstraint
-import org.gradle.api.artifacts.dsl.ComponentMetadataHandler
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
@@ -35,9 +34,8 @@ class DefaultDependencyConstraintHandlerTest extends Specification {
     private def dependencyFactory = Mock(DependencyFactory)
     private def configuration = Mock(Configuration)
     private def dependencyConstraintSet = Mock(DependencyConstraintSet)
-    private def componentMetadataHandler = Mock(ComponentMetadataHandler)
 
-    private DefaultDependencyConstraintHandler dependencyConstraintHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory, componentMetadataHandler)
+    private DefaultDependencyConstraintHandler dependencyConstraintHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultDependencyConstraintHandler, configurationContainer, dependencyFactory, TestUtil.objectInstantiator())
 
     void setup() {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/dsl/dependencies/DefaultDependencyHandlerTest.groovy
@@ -48,7 +48,7 @@ class DefaultDependencyHandlerTest extends Specification {
 
     private DefaultDependencyHandler dependencyHandler = TestUtil.instantiatorFactory().decorateLenient().newInstance(DefaultDependencyHandler,
         configurationContainer, dependencyFactory, projectFinder, Stub(DependencyConstraintHandler), Stub(ComponentMetadataHandler), Stub(ComponentModuleMetadataHandler), Stub(ArtifactResolutionQueryFactory),
-        Stub(AttributesSchema), Stub(VariantTransformRegistry), Stub(Factory))
+        Stub(AttributesSchema), Stub(VariantTransformRegistry), Stub(Factory), TestUtil.objectInstantiator())
 
     void setup() {
         _ * configurationContainer.findByName(TEST_CONF_NAME) >> configuration

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -21,11 +21,11 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
+import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
 import org.gradle.api.internal.artifacts.DefaultImmutableModuleIdentifierFactory
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier
 import org.gradle.api.internal.artifacts.dependencies.DefaultMutableVersionConstraint
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.repositories.metadata.DefaultMavenImmutableAttributesFactory
 import org.gradle.api.internal.artifacts.repositories.metadata.MavenMutableModuleMetadataFactory
 import org.gradle.api.internal.model.NamedObjectInstantiator
@@ -147,7 +147,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
     def "recognises java library for packaging=#packaging"() {
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
-        def componentTypeAttribute = PlatformSupport.VARIANT_CATEGORY
+        def componentTypeAttribute = Attribute.of(Category.CATEGORY_ATTRIBUTE.getName(), String.class)
         def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], new DefaultMavenImmutableAttributesFactory(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE), TestUtil.objectInstantiator())
         metadata.packaging = packaging
         metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/component/external/model/DefaultMavenModuleResolveMetadataTest.groovy
@@ -147,7 +147,7 @@ class DefaultMavenModuleResolveMetadataTest extends AbstractLazyModuleComponentR
     def "recognises java library for packaging=#packaging"() {
         given:
         def stringUsageAttribute = Attribute.of(Usage.USAGE_ATTRIBUTE.getName(), String.class)
-        def componentTypeAttribute = PlatformSupport.COMPONENT_CATEGORY
+        def componentTypeAttribute = PlatformSupport.VARIANT_CATEGORY
         def metadata = new DefaultMutableMavenModuleResolveMetadata(Mock(ModuleVersionIdentifier), id, [], new DefaultMavenImmutableAttributesFactory(AttributeTestUtil.attributesFactory(), NamedObjectInstantiator.INSTANCE), TestUtil.objectInstantiator())
         metadata.packaging = packaging
         metadata.variantMetadataRules.variantDerivationStrategy = new JavaEcosystemVariantDerivationStrategy()

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -147,9 +147,9 @@ No dependencies matching given input were found in configuration ':conf'
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -201,9 +201,9 @@ org:leaf2:1.0
 Task :dependencyInsight
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
@@ -257,9 +257,9 @@ org:leaf2:1.5 -> 2.5
         outputContains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -279,9 +279,9 @@ org:leaf:1.0
         outputContains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -335,9 +335,9 @@ org:leaf:1.0
 
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
@@ -408,9 +408,9 @@ org:leaf2:1.5 -> 2.5
 
 org:leaf2:2.5
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - By conflict resolution : between versions 1.5, 2.5 and 1.0
@@ -580,9 +580,9 @@ org:foo:1.+ FAILED
         outputContains """
 org:leaf:1.0 (forced)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -601,9 +601,9 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:1.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -644,9 +644,9 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:2
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Was requested : didn't match version 3 because testing stuff
@@ -756,9 +756,9 @@ org:leaf:latest.integration -> 1.0
         outputContains """
 org:bar:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Forced
@@ -819,9 +819,9 @@ org:foo:1.0 -> org:bar:2.0
         outputContains """
 org.test:bar:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : why not?
@@ -831,9 +831,9 @@ org:bar:1.0 -> org.test:bar:2.0
 
 org:baz:1.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:baz:1.0
@@ -841,9 +841,9 @@ org:baz:1.0
 
 org:foo:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : because I am in control
@@ -889,9 +889,9 @@ org:foo:1.0 -> 2.0
         outputContains """
 org:baz:2.0 (selected by rule)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:baz:1.1 -> 2.0
@@ -899,9 +899,9 @@ org:baz:1.1 -> 2.0
 
 org:bar:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : foo superseded by bar
@@ -946,9 +946,9 @@ org:foo:1.0 -> org:bar:1.0
         outputContains """
 org:new-leaf:77 (selected by rule)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0 -> org:new-leaf:77
@@ -995,9 +995,9 @@ org:leaf:2.0 -> org:new-leaf:77
         then:
         outputContains """org:bar:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : I am not sure I want to explain
@@ -1007,9 +1007,9 @@ org:bar:1.0 -> 2.0
 
 org:foo:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Selected by rule : I want to
@@ -1100,9 +1100,9 @@ org:leaf:latest.integration -> 1.6
         outputContains """
 org:leaf:2.0 (forced)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:2.0
@@ -1148,9 +1148,9 @@ org:leaf:1.0 -> 2.0
         outputContains """
 org:leaf:1.5 (forced)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0 -> 1.5
@@ -1197,9 +1197,9 @@ org:leaf:2.0 -> 1.5
         outputContains """
 org:leaf:1.0 (forced)
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -1245,9 +1245,9 @@ org:leaf:2.0 -> 1.0
         outputContains """
 org:leaf:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
    Selection reasons:
       - Forced
@@ -1658,9 +1658,9 @@ project :C FAILED
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -1752,9 +1752,9 @@ project :
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -1855,7 +1855,7 @@ org:leaf4:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -1893,7 +1893,7 @@ org:leaf1:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -1913,7 +1913,7 @@ org:leaf2:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2057,7 +2057,7 @@ org:leaf3:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2105,9 +2105,9 @@ org:leaf3:1.0
         then:
         result.groupedOutput.task(":dependencyInsight").output.contains("""foo:bar:2.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 foo:bar:2.0
@@ -2115,9 +2115,9 @@ foo:bar:2.0
 
 foo:foo:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 foo:foo:1.0
@@ -2161,7 +2161,7 @@ foo:foo:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2217,7 +2217,7 @@ org:foo -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2270,7 +2270,7 @@ org:foo -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2320,7 +2320,7 @@ org:foo:${displayVersion} -> $selected
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2376,7 +2376,7 @@ org:foo:[1.1,1.3] -> 1.3
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2392,7 +2392,7 @@ org:foo:1.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2452,7 +2452,7 @@ org:bar:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2469,7 +2469,7 @@ org:foo:1.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2514,7 +2514,7 @@ org:leaf:1.0 (by constraint)
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2567,7 +2567,7 @@ org.test:leaf:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2614,9 +2614,9 @@ org.test:leaf:1.0
         outputContains """
 org:leaf2:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf2:1.0
@@ -2749,7 +2749,7 @@ org:foo:1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2806,7 +2806,7 @@ org:foo:{require [1.0,); reject 1.1} -> 1.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2872,7 +2872,7 @@ org:foo:1.0
       color                          = blue
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2947,7 +2947,7 @@ planet:mercury:1.0.2
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -2978,7 +2978,7 @@ planet:venus:2.0.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -3009,7 +3009,7 @@ planet:pluto:1.0.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -1705,6 +1705,7 @@ project :
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
+      org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
@@ -1804,6 +1805,7 @@ project :impl
    variant "runtimeElements" [
       org.gradle.usage               = java-runtime-jars (not requested)
       org.gradle.dependency.bundling = external (not requested)
+      org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion} (not requested)
    ]
 
@@ -1974,6 +1976,7 @@ project :api
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
+      org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -1991,6 +1994,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
+      org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 
@@ -2007,6 +2011,7 @@ project :some:deeply:nested
    variant "apiElements" [
       org.gradle.usage               = java-api-jars (compatible with: java-api)
       org.gradle.dependency.bundling = external
+      org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -178,9 +178,9 @@ org:middle:1.0 FAILED
         output.contains """
 org:leaf:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:leaf:1.0
@@ -218,11 +218,11 @@ org:leaf:1.0
         then:
         output.contains """org:leaf:1.0
    variant "runtime" [
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
       Requested attributes not found in the selected variant:
-         usage                         = dummy
+         usage               = dummy
    ]
 
 org:leaf:1.0
@@ -280,10 +280,10 @@ org:leaf:1.0
         outputContains """
 org:testA:1.0
    variant "runtime" [
-      custom                        = dep_value
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      custom              = dep_value
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:testA:1.0
@@ -291,10 +291,10 @@ org:testA:1.0
 
 org:testB:1.0
    variant "runtime" [
-      custom                        = dep_value
-      org.gradle.status             = release (not requested)
-      org.gradle.usage              = java-runtime (not requested)
-      org.gradle.component.category = library (not requested)
+      custom              = dep_value
+      org.gradle.status   = release (not requested)
+      org.gradle.usage    = java-runtime (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 org:testB:+ -> 1.0

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportVariantDetailsIntegrationTest.groovy
@@ -57,6 +57,7 @@ class DependencyInsightReportVariantDetailsIntegrationTest extends AbstractInteg
    variant "$expectedVariant" [
       $expectedAttributes
       org.gradle.dependency.bundling = external
+      org.gradle.category            = library (not requested)
       org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
 

--- a/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
+++ b/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md
@@ -86,7 +86,7 @@ This value must contain an array of 0 or more capabilities. Each capability is a
 
 - `org.gradle.usage` indicates the purpose of the variant. See the `org.gradle.api.attributes.Usage` class for more details. Value must be a string.
 - `org.gradle.status` indicates the kind of release: one of `release` or `integration`.
-- `org.gradle.component.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library. Value must be a string.
+- `org.gradle.category` indicates the type of component (library or platform). This attribute is mostly used to disambiguate Maven POM files derived either as a platform or a library. Value must be a string.
 - `org.gradle.dependency.bundling` indicates how dependencies of the variant are bundled. Either externally, embedded or shadowed. See the `org.gradle.api.attributes.Bundling` for more details. Value must be a string.
 
 #### Java Ecosystem specific attributes

--- a/subprojects/docs/src/samples/java-feature-variant/incompatible-variants/kotlin/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/incompatible-variants/kotlin/runtimeClasspath.out
@@ -4,7 +4,7 @@ mysql:mysql-connector-java:8.0.14
    variant "runtime" [
       org.gradle.status             = release (not requested)
       org.gradle.usage              = java-runtime
-      org.gradle.component.category = library (not requested)
+      org.gradle.category = library (not requested)
    ]
 
 mysql:mysql-connector-java:8.0.14

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features-external/runtimeClasspath.out
@@ -4,7 +4,7 @@ org.mongodb:bson:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -22,7 +22,7 @@ org.mongodb:mongodb-driver-core:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external
@@ -38,7 +38,7 @@ org.mongodb:mongodb-driver-sync:3.9.1
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
+++ b/subprojects/docs/src/samples/java-feature-variant/requiring-features/runtimeClasspath.out
@@ -4,7 +4,7 @@ mysql:mysql-connector-java:8.0.14
    variant "runtime" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-runtime
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/inspectingDependencies/dependencyReason/dependencyReasonReport.out
@@ -2,7 +2,7 @@ org.ow2.asm:asm:6.0
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/declaringCapabilities/dependencyReport.out
@@ -21,7 +21,7 @@ org.slf4j:slf4j-log4j12:1.6.1
    variant "compile" [
       org.gradle.status              = release (not requested)
       org.gradle.usage               = java-api
-      org.gradle.component.category  = library (not requested)
+      org.gradle.category            = library (not requested)
 
       Requested attributes not found in the selected variant:
          org.gradle.dependency.bundling = external

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultWorkInProgressFormatterTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/DefaultWorkInProgressFormatterTest.groovy
@@ -28,9 +28,9 @@ class DefaultWorkInProgressFormatterTest extends Specification {
 
     def "formats operations"() {
         given:
-        def op1 = new ProgressOperation("STATUS_1", "CATEGORY", new OperationIdentifier(1), null)
+        def op1 = new ProgressOperation("STATUS_1", "VARIANT_CATEGORY", new OperationIdentifier(1), null)
         def op2 = new ProgressOperation(null,  null, new OperationIdentifier(2), op1)
-        def op3 = new ProgressOperation("STATUS_2", "CATEGORY", new OperationIdentifier(3), op2)
+        def op3 = new ProgressOperation("STATUS_2", "VARIANT_CATEGORY", new OperationIdentifier(3), op2)
 
         expect:
         statusBarFormatter.format(op3).first().text == "> STATUS_1 > STATUS_2"
@@ -40,7 +40,7 @@ class DefaultWorkInProgressFormatterTest extends Specification {
 
     def "trims output to one less than the max console width"() {
         given:
-        def operation = new ProgressOperation("these are more than 10 characters", "CATEGORY", new OperationIdentifier(1), null)
+        def operation = new ProgressOperation("these are more than 10 characters", "VARIANT_CATEGORY", new OperationIdentifier(1), null)
 
         when:
         _ * consoleMetaData.getCols() >> 10

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ProgressOperationTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/ProgressOperationTest.groovy
@@ -22,7 +22,7 @@ class ProgressOperationTest extends Specification {
 
     def "message prefers status"() {
         given:
-        ProgressOperation progressOperation = new ProgressOperation("STATUS", "CATEGORY", new OperationIdentifier(1), null)
+        ProgressOperation progressOperation = new ProgressOperation("STATUS", "VARIANT_CATEGORY", new OperationIdentifier(1), null)
 
         expect:
         progressOperation.getMessage() == "STATUS"
@@ -30,7 +30,7 @@ class ProgressOperationTest extends Specification {
 
     def "message is null if all inputs are null"() {
         given:
-        ProgressOperation progressOperation = new ProgressOperation(null, "CATEGORY", new OperationIdentifier(1), null)
+        ProgressOperation progressOperation = new ProgressOperation(null, "VARIANT_CATEGORY", new OperationIdentifier(1), null)
 
         expect:
         progressOperation.getMessage() == null
@@ -38,7 +38,7 @@ class ProgressOperationTest extends Specification {
 
     def "allows children to be managed"() {
         given:
-        ProgressOperation progressOperation = new ProgressOperation("STATUS", "CATEGORY", new OperationIdentifier(1), null)
+        ProgressOperation progressOperation = new ProgressOperation("STATUS", "VARIANT_CATEGORY", new OperationIdentifier(1), null)
         def mockOperation = Mock(ProgressOperation)
 
         when:

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.api.publish.maven
 
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
+import org.gradle.api.attributes.Category
 import org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication
 import org.gradle.integtests.fixtures.FeaturePreviewsFixture
 import org.gradle.integtests.fixtures.publish.maven.AbstractMavenPublishIntegTest
@@ -970,7 +970,7 @@ $append
             javaLibrary.parsedModuleMetadata.variant("apiElements") {
                 dependency('org.test:bar:').exists()
                 dependency('org.test:bom:1.0') {
-                    hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                    hasAttribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
                 }
                 noMoreDependencies()
             }
@@ -979,7 +979,7 @@ $append
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
             dependency('org.test:bar:').exists()
             dependency('org.test:bom:1.0') {
-                hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                hasAttribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
             }
             noMoreDependencies()
         }
@@ -1144,7 +1144,7 @@ include(':platform')
             javaLibrary.parsedModuleMetadata.variant("apiElements") {
                 dependency('org.test:bar:').exists()
                 dependency('org.gradle.test:platform:1.9') {
-                    hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                    hasAttribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
                 }
                 noMoreDependencies()
             }
@@ -1153,7 +1153,7 @@ include(':platform')
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
             dependency('org.test:bar:').exists()
             dependency('org.gradle.test:platform:1.9') {
-                hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                hasAttribute(Category.CATEGORY_ATTRIBUTE.name, Category.REGULAR_PLATFORM)
             }
             noMoreDependencies()
         }

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishJavaIntegTest.groovy
@@ -970,7 +970,7 @@ $append
             javaLibrary.parsedModuleMetadata.variant("apiElements") {
                 dependency('org.test:bar:').exists()
                 dependency('org.test:bom:1.0') {
-                    hasAttribute(PlatformSupport.COMPONENT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                    hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
                 }
                 noMoreDependencies()
             }
@@ -979,7 +979,7 @@ $append
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
             dependency('org.test:bar:').exists()
             dependency('org.test:bom:1.0') {
-                hasAttribute(PlatformSupport.COMPONENT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
             }
             noMoreDependencies()
         }
@@ -1144,7 +1144,7 @@ include(':platform')
             javaLibrary.parsedModuleMetadata.variant("apiElements") {
                 dependency('org.test:bar:').exists()
                 dependency('org.gradle.test:platform:1.9') {
-                    hasAttribute(PlatformSupport.COMPONENT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                    hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
                 }
                 noMoreDependencies()
             }
@@ -1153,7 +1153,7 @@ include(':platform')
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
             dependency('org.test:bar:').exists()
             dependency('org.gradle.test:platform:1.9') {
-                hasAttribute(PlatformSupport.COMPONENT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
+                hasAttribute(PlatformSupport.VARIANT_CATEGORY.name, PlatformSupport.REGULAR_PLATFORM)
             }
             noMoreDependencies()
         }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -24,12 +24,12 @@ import org.gradle.api.artifacts.ModuleDependency
 import org.gradle.api.artifacts.ModuleVersionIdentifier
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.PublishArtifact
+import org.gradle.api.attributes.Category
 import org.gradle.api.component.ComponentWithVariants
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.component.SoftwareComponentInternal
@@ -532,6 +532,6 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def platformAttribute() {
-        return AttributeTestUtil.attributes([(PlatformSupport.VARIANT_CATEGORY.name) : PlatformSupport.REGULAR_PLATFORM])
+        return AttributeTestUtil.attributesFactory().of(Category.CATEGORY_ATTRIBUTE, TestUtil.objectFactory().named(Category, Category.REGULAR_PLATFORM))
     }
 }

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publish/maven/internal/publication/DefaultMavenPublicationTest.groovy
@@ -532,6 +532,6 @@ class DefaultMavenPublicationTest extends Specification {
     }
 
     def platformAttribute() {
-        return AttributeTestUtil.attributes([(PlatformSupport.COMPONENT_CATEGORY.name) : PlatformSupport.REGULAR_PLATFORM])
+        return AttributeTestUtil.attributes([(PlatformSupport.VARIANT_CATEGORY.name) : PlatformSupport.REGULAR_PLATFORM])
     }
 }

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -132,7 +132,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
 
             dependencies {
                attributesSchema { 
-                getMatchingStrategy(PlatformSupport.VARIANT_CATEGORY)
+                getMatchingStrategy(Category.CATEGORY_ATTRIBUTE)
                    .disambiguationRules
                    .add(PlatformSupport.PreferRegularPlatform)
                }

--- a/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
+++ b/subprojects/maven/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/maven/AbstractMavenPublishIntegTest.groovy
@@ -132,7 +132,7 @@ abstract class AbstractMavenPublishIntegTest extends AbstractIntegrationSpec imp
 
             dependencies {
                attributesSchema { 
-                getMatchingStrategy(PlatformSupport.COMPONENT_CATEGORY)
+                getMatchingStrategy(PlatformSupport.VARIANT_CATEGORY)
                    .disambiguationRules
                    .add(PlatformSupport.PreferRegularPlatform)
                }

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaApplicationOutgoingVariantsIntegrationTest.groovy
@@ -79,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -97,8 +97,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -118,8 +118,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         when:
         buildFile << """
@@ -136,8 +136,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         where:
         usage                                          | _
@@ -161,8 +161,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -179,8 +179,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -202,8 +202,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -222,8 +222,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -240,8 +240,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -260,8 +260,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -278,8 +278,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
     }
     
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryCrossProjectTargetJvmVersionIntegrationTest.groovy
@@ -58,10 +58,12 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         then:
         failure.assertHasCause('''Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
+      - Found org.gradle.category 'library' but wasn't required.
       - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
+      - Found org.gradle.category 'library' but wasn't required.
       - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.''')
@@ -141,10 +143,12 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
         then:
         failure.assertHasCause("""Unable to find a matching variant of project :producer:
   - Variant 'apiElements' capability test:producer:unspecified:
+      - Found org.gradle.category 'library' but wasn't required.
       - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-api-jars'.
   - Variant 'runtimeElements' capability test:producer:unspecified:
+      - Found org.gradle.category 'library' but wasn't required.
       - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
       - Required org.gradle.jvm.version '6' and found incompatible value '7'.
       - Required org.gradle.usage 'java-api' and found compatible value 'java-runtime-jars'.""")
@@ -162,6 +166,7 @@ class JavaLibraryCrossProjectTargetJvmVersionIntegrationTest extends AbstractInt
             root(":", ":test:") {
                 project(':producer', 'test:producer:') {
                     variant("apiElements", [
+                            'org.gradle.category': 'library',
                             'org.gradle.dependency.bundling': 'external',
                             'org.gradle.jvm.version': '7',
                             'org.gradle.usage':'java-api-jars'

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaLibraryOutgoingVariantsIntegrationTest.groovy
@@ -81,8 +81,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -99,8 +99,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -119,8 +119,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
 
         when:
         buildFile << """
@@ -137,8 +137,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-classes}")
 
         where:
         usage                                          | _
@@ -162,8 +162,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -180,8 +180,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -203,8 +203,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, api-1.0.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -223,8 +223,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -241,8 +241,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -261,8 +261,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -279,8 +279,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, api-1.0.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
     }
 
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/JavaProjectOutgoingVariantsIntegrationTest.groovy
@@ -79,8 +79,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -97,8 +97,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     @Unroll
@@ -117,8 +117,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         when:
         buildFile << """
@@ -135,8 +135,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, runtime-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-api-jars}")
 
         where:
         usage                                          | _
@@ -161,8 +161,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         when:
         buildFile << """
@@ -179,8 +179,8 @@ project(':consumer') {
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
 
         where:
         usage                                           | _
@@ -202,8 +202,8 @@ project(':consumer') {
         result.assertTasksExecuted(":other-java:compileJava", ":other-java:processResources", ":other-java:classes", ":other-java:jar", ":java:compileJava", ":java:processResources", ":java:classes", ":java:jar", ":consumer:resolve")
         outputContains("files: [java.jar, file-dep.jar, compile-1.0.jar, other-java.jar, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
-        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
-        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("other-java.jar (project :other-java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
+        outputContains("java.jar (project :java) {artifactType=jar, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-jars}")
     }
 
     def "provides runtime classes variant"() {
@@ -221,8 +221,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
 
         when:
         buildFile << """
@@ -239,8 +239,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
-        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :other-java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
+        outputContains("main (project :java) {artifactType=java-classes-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-classes}")
     }
 
     def "provides runtime resources variant"() {
@@ -259,8 +259,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
 
         when:
         buildFile << """
@@ -277,8 +277,8 @@ project(':consumer') {
         outputContains("files: [main, file-dep.jar, compile-1.0.jar, main, implementation-1.0.jar, runtime-1.0.jar, runtime-only-1.0.jar]")
         outputContains("file-dep.jar {artifactType=jar, org.gradle.usage=java-runtime-jars}")
         outputContains("compile.jar (test:compile:1.0) {artifactType=jar, org.gradle.usage=java-runtime-jars}")
-        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
-        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :other-java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
+        outputContains("main (project :java) {artifactType=java-resources-directory, org.gradle.category=library, org.gradle.dependency.bundling=external, ${defaultTargetPlatform()}, org.gradle.usage=java-runtime-resources}")
     }
 
     static String defaultTargetPlatform() {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlatformPlugin.java
@@ -110,7 +110,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     private void addPlatformDisambiguationRule(Project project) {
         project.getDependencies()
                 .getAttributesSchema()
-                .getMatchingStrategy(PlatformSupport.COMPONENT_CATEGORY)
+                .getMatchingStrategy(PlatformSupport.VARIANT_CATEGORY)
                 .getDisambiguationRules()
                 .add(PlatformSupport.PreferRegularPlatform.class);
     }
@@ -158,7 +158,7 @@ public class JavaPlatformPlugin implements Plugin<Project> {
     }
 
     private void declareConfigurationCategory(Configuration configuration, String value) {
-        configuration.getAttributes().attribute(PlatformSupport.COMPONENT_CATEGORY, value);
+        configuration.getAttributes().attribute(PlatformSupport.VARIANT_CATEGORY, value);
     }
 
     private void declareConfigurationUsage(Project project, Configuration configuration, String usage) {

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java
@@ -29,6 +29,7 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.type.ArtifactTypeDefinition;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.component.AdhocComponentWithVariants;
@@ -66,6 +67,7 @@ import java.util.concurrent.Callable;
 import static org.gradle.api.attributes.Usage.USAGE_ATTRIBUTE;
 import static org.gradle.api.attributes.Bundling.EXTERNAL;
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
+import static org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE;
 
 /**
  * <p>A {@link Plugin} which compiles and tests Java source, and assembles it into a JAR file.</p>
@@ -459,6 +461,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         apiElementsConfiguration.setCanBeConsumed(true);
         apiElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_API_JARS));
         apiElementsConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
+        apiElementsConfiguration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         apiElementsConfiguration.extendsFrom(runtimeConfiguration);
 
         final Configuration runtimeElementsConfiguration = configurations.maybeCreate(RUNTIME_ELEMENTS_CONFIGURATION_NAME);
@@ -468,6 +471,7 @@ public class JavaPlugin implements Plugin<ProjectInternal> {
         runtimeElementsConfiguration.setDescription("Elements of runtime for main.");
         runtimeElementsConfiguration.getAttributes().attribute(USAGE_ATTRIBUTE, objectFactory.named(Usage.class, Usage.JAVA_RUNTIME_JARS));
         runtimeElementsConfiguration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
+        runtimeElementsConfiguration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, Category.LIBRARY));
         runtimeElementsConfiguration.extendsFrom(implementationConfiguration, runtimeOnlyConfiguration, runtimeConfiguration);
 
         defaultConfiguration.extendsFrom(runtimeElementsConfiguration);

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/internal/DefaultJavaFeatureSpec.java
@@ -22,6 +22,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.attributes.AttributeContainer;
+import org.gradle.api.attributes.Category;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.Bundling;
 import org.gradle.api.attributes.java.TargetJvmVersion;
@@ -51,6 +52,8 @@ import java.util.List;
 
 import static org.gradle.api.attributes.Bundling.EXTERNAL;
 import static org.gradle.api.attributes.Bundling.BUNDLING_ATTRIBUTE;
+import static org.gradle.api.attributes.Category.LIBRARY;
+import static org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE;
 import static org.gradle.api.plugins.internal.JavaPluginsHelper.registerClassesDirVariant;
 
 public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
@@ -136,6 +139,8 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
         configurePacking(runtimeElements);
         configureTargetPlatform(apiElements);
         configureTargetPlatform(runtimeElements);
+        configureCategory(apiElements);
+        configureCategory(runtimeElements);
         configureCapabilities(apiElements);
         configureCapabilities(runtimeElements);
         attachArtifactToConfiguration(apiElements);
@@ -179,6 +184,10 @@ public class DefaultJavaFeatureSpec implements FeatureSpecInternal {
 
     private void configurePacking(Configuration configuration) {
         configuration.getAttributes().attribute(BUNDLING_ATTRIBUTE, objectFactory.named(Bundling.class, EXTERNAL));
+    }
+
+    private void configureCategory(Configuration configuration) {
+        configuration.getAttributes().attribute(CATEGORY_ATTRIBUTE, objectFactory.named(Category.class, LIBRARY));
     }
 
     private void attachArtifactToConfiguration(Configuration configuration) {

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -18,8 +18,8 @@ package org.gradle.api.plugins
 
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.artifacts.ModuleDependency
+import org.gradle.api.attributes.Category
 import org.gradle.api.attributes.Usage
-import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import spock.lang.Unroll
@@ -120,17 +120,17 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         runtimeUsage.dependencyConstraints.size() == 2
         runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
-        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.VARIANT_CATEGORY] as Set
+        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
         runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
-        runtimeUsage.attributes.getAttribute(PlatformSupport.VARIANT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
+        runtimeUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
 
         apiUsage.dependencies.size() == 1
         apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         apiUsage.dependencyConstraints.size() == 1
         apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
-        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.VARIANT_CATEGORY] as Set
+        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, Category.CATEGORY_ATTRIBUTE] as Set
         apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
-        apiUsage.attributes.getAttribute(PlatformSupport.VARIANT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
+        apiUsage.attributes.getAttribute(Category.CATEGORY_ATTRIBUTE).name == Category.REGULAR_PLATFORM
     }
 
     @Unroll("cannot add a dependency to the #configuration configuration by default")

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/plugins/JavaPlatformPluginTest.groovy
@@ -120,17 +120,17 @@ class JavaPlatformPluginTest extends AbstractProjectBuilderSpec {
         runtimeUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         runtimeUsage.dependencyConstraints.size() == 2
         runtimeUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.RUNTIME_CONFIGURATION_NAME).allDependencyConstraints
-        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.COMPONENT_CATEGORY] as Set
+        runtimeUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.VARIANT_CATEGORY] as Set
         runtimeUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_RUNTIME
-        runtimeUsage.attributes.getAttribute(PlatformSupport.COMPONENT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
+        runtimeUsage.attributes.getAttribute(PlatformSupport.VARIANT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
 
         apiUsage.dependencies.size() == 1
         apiUsage.dependencies == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencies.withType(ModuleDependency)
         apiUsage.dependencyConstraints.size() == 1
         apiUsage.dependencyConstraints == project.configurations.getByName(JavaPlatformPlugin.API_CONFIGURATION_NAME).allDependencyConstraints
-        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.COMPONENT_CATEGORY] as Set
+        apiUsage.attributes.keySet() == [Usage.USAGE_ATTRIBUTE, PlatformSupport.VARIANT_CATEGORY] as Set
         apiUsage.attributes.getAttribute(Usage.USAGE_ATTRIBUTE).name == Usage.JAVA_API
-        apiUsage.attributes.getAttribute(PlatformSupport.COMPONENT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
+        apiUsage.attributes.getAttribute(PlatformSupport.VARIANT_CATEGORY) == PlatformSupport.REGULAR_PLATFORM
     }
 
     @Unroll("cannot add a dependency to the #configuration configuration by default")


### PR DESCRIPTION
Attribute is now `org.gradle.category` and typed `Category`
Adapt code to new typed attributes, dealing with coercible String values
when parsed from metadata and typed values when created inside a Gradle
build.