### PR TITLE
Implement classifier to variant mapping

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/alignment/ForcingPlatformAlignmentTest.groovy
@@ -1067,6 +1067,7 @@ include 'other'
                         members.each { member ->
                             constraint(member)
                         }
+                        noArtifacts = true
                     }
                     // this is used only in BOMs
                     members.each { member ->

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/ClassifierToVariantResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/ClassifierToVariantResolveIntegrationTest.groovy
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.maven
+
+import org.gradle.api.attributes.Usage
+import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+
+class ClassifierToVariantResolveIntegrationTest extends AbstractHttpDependencyResolutionTest {
+    ResolveTestFixture resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+
+    def setup() {
+        settingsFile << """
+            rootProject.name = 'test'
+        """
+        buildFile << """
+            apply plugin: 'java-library'
+            
+            repositories {
+                maven { url "${mavenHttpRepo.uri}" }
+            }
+            
+        """
+        resolve.expectDefaultConfiguration('compile')
+        resolve.prepare()
+    }
+
+    /**
+     * This simulates the case where a library is published with Gradle metadata, and
+     * that this library published additional variants, that use an artifact with a classifier.
+     * If a Maven consumer wants to use that artifact, it has no choice but using <classifier>,
+     * so if a Gradle consumer depends on that Maven published library, we want to make sure we
+     * can match this classified dependency to a proper variant.
+     */
+    def "reasonable behavior when a Maven library uses a classifier to select a Gradle variant"() {
+        def gradleLibrary = mavenHttpRepo.module("org", "lib", "1.0")
+                .adhocVariants()
+                .variant("apiElements", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'classic'])
+                .variant("runtimeElements", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'classic'])
+                .variant("apiElementsIndy", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'indy']) {
+            artifact("lib-1.0-indy.jar")
+        }
+        .variant("runtimeElementsIndy", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'indy']) {
+            artifact("lib-1.0-indy.jar")
+        }
+        .withGradleMetadataRedirection()
+                .withModuleMetadata()
+                .publish()
+        def mavenConsumer = mavenHttpRepo.module("org", "maven-consumer", "1.0")
+                .dependsOn("org", "lib", "1.0", "jar", "compile", "indy")
+                .publish()
+
+        buildFile << """
+            dependencies {
+                api 'org:maven-consumer:1.0'
+            }
+        """
+
+        when:
+        mavenConsumer.pom.expectGet()
+        mavenConsumer.artifact.expectGet()
+        gradleLibrary.pom.expectGet()
+        gradleLibrary.moduleMetadata.expectGet()
+        gradleLibrary.getArtifact(classifier: 'indy').expectGet()
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:maven-consumer:1.0') {
+                    module('org:lib:1.0') {
+                        variant('apiElementsIndy', [
+                                'org.gradle.usage': Usage.JAVA_API_JARS,
+                                'org.gradle.status': 'release',
+                                'groovy.runtime': 'indy'])
+                        artifact(name: 'lib', version: '1.0', classifier: 'indy')
+                    }
+                }
+            }
+        }
+
+    }
+
+    /**
+     * A Gradle consumer should _not_ do this, but use attributes instead. However,
+     * there's nothing which prevents this from being done, so we must make sure it is
+     * supported. The path is exactly the same as when a Maven consumer wants to depend
+     * on a library published with Gradle that uses variants published using different
+     * classified artifacts.
+     */
+    def "reasonable behavior when a Gradle consumer uses a classifier to select a Gradle variant"() {
+        def gradleLibrary = mavenHttpRepo.module("org", "lib", "1.0")
+                .adhocVariants()
+                .variant("apiElements", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'classic'])
+                .variant("runtimeElements", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'classic'])
+                .variant("apiElementsIndy", ['org.gradle.usage': Usage.JAVA_API_JARS, 'groovy.runtime': 'indy']) {
+            artifact("lib-1.0-indy.jar")
+        }
+        .variant("runtimeElementsIndy", ['org.gradle.usage': Usage.JAVA_RUNTIME_JARS, 'groovy.runtime': 'indy']) {
+            artifact("lib-1.0-indy.jar")
+        }
+        .withGradleMetadataRedirection()
+                .withModuleMetadata()
+                .publish()
+
+        buildFile << """
+            dependencies {
+                api 'org:lib:1.0:indy'
+            }
+        """
+
+        when:
+        gradleLibrary.pom.expectGet()
+        gradleLibrary.moduleMetadata.expectGet()
+        gradleLibrary.getArtifact(classifier: 'indy').expectGet()
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":test:") {
+                module('org:lib:1.0') {
+                    variant('apiElementsIndy', [
+                            'org.gradle.usage': Usage.JAVA_API_JARS,
+                            'org.gradle.status': 'release',
+                            'groovy.runtime': 'indy'])
+                    artifact(name: 'lib', version: '1.0', classifier: 'indy')
+                }
+            }
+        }
+
+    }
+
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/AbstractVariantBackedConfigurationMetadata.java
@@ -143,7 +143,7 @@ class AbstractVariantBackedConfigurationMetadata implements ConfigurationMetadat
 
     @Override
     public List<? extends ComponentArtifactMetadata> getArtifacts() {
-        return ImmutableList.of();
+        return variant.getArtifacts();
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ConfigurationBoundExternalDependencyMetadata.java
@@ -89,7 +89,7 @@ public class ConfigurationBoundExternalDependencyMetadata implements ModuleDepen
         // This is a slight different condition than that used for a dependency declared in a Gradle project,
         // which is (targetHasVariants || consumerHasAttributes), relying on the fallback to 'default' for consumer attributes without any variants.
         if (alwaysUseAttributeMatching || hasVariants(targetComponent)) {
-            return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema));
+            return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema, getArtifacts()));
         }
         return dependencyDescriptor.selectLegacyConfigurations(componentId, configuration, targetComponent);
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/GradleDependencyMetadata.java
@@ -96,7 +96,7 @@ public class GradleDependencyMetadata implements ModuleDependencyMetadata, Forci
      */
     @Override
     public List<ConfigurationMetadata> selectConfigurations(ImmutableAttributes consumerAttributes, ComponentResolveMetadata targetComponent, AttributesSchemaInternal consumerSchema, Collection<? extends Capability> explicitRequestedCapabilities) {
-        return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema));
+        return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema, getArtifacts()));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/LocalComponentDependencyMetadata.java
@@ -132,7 +132,7 @@ public class LocalComponentDependencyMetadata implements LocalOriginDependencyMe
         Optional<ImmutableList<? extends ConfigurationMetadata>> targetVariants = targetComponent.getVariantsForGraphTraversal();
         boolean useConfigurationAttributes = dependencyConfiguration == null && (consumerHasAttributes || targetVariants.isPresent());
         if (useConfigurationAttributes) {
-            return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema));
+            return ImmutableList.of(AttributeConfigurationSelector.selectConfigurationUsingAttributeMatching(consumerAttributes, explicitRequestedCapabilities, targetComponent, consumerSchema, getArtifacts()));
         }
 
         String targetConfiguration = GUtil.elvis(dependencyConfiguration, Dependency.DEFAULT_CONFIGURATION);

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/ModuleVersionSpec.groovy
@@ -297,6 +297,10 @@ class ModuleVersionSpec {
                     capabilities = variant.capabilities.collect {
                         new CapabilitySpec(group: it.group, name: it.name, version: it.version)
                     }
+                    if (variant.noArtifacts) {
+                        artifacts = []
+                        useDefaultArtifacts = false
+                    }
                 }
             }
         }

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/VariantSpec.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/integtests/fixtures/publish/VariantSpec.groovy
@@ -26,6 +26,7 @@ class VariantSpec {
     Map<String, String> attributes = [:]
     List<ArtifactSpec> artifacts = []
     List<CapabilitySpec> capabilities = []
+    boolean noArtifacts = false
 
     void dependsOn(coord) {
         dependsOn << coord


### PR DESCRIPTION
### Context

This commit implements a strategy to disambiguate
variants whenever the consumer uses a classifier
in the dependency descriptor. This can be the case
if a Maven library depends on a Gradle library published
with Gradle module metadata, or even if a Gradle
library depends on another Gradle library but makes
use of a classifier (when it should really be using an
attribute).
