### PR TITLE
Fix start script to run in MingW shell properly

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -125,8 +125,8 @@ if \$darwin; then
     GRADLE_OPTS="\$GRADLE_OPTS \\"-Xdock:name=\$APP_NAME\\" \\"-Xdock:icon=\$APP_HOME/media/gradle.icns\\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if [ \$cygwin -o \$msys ] ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "\$cygwin" = "true" -o "\$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
     JAVACMD=`cygpath --unix "\$JAVACMD"`

--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -126,7 +126,7 @@ if \$darwin; then
 fi
 
 # For Cygwin, switch paths to Windows format before running java
-if \$cygwin ; then
+if [ \$cygwin -o \$msys ] ; then
     APP_HOME=`cygpath --path --mixed "\$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "\$CLASSPATH"`
     JAVACMD=`cygpath --unix "\$JAVACMD"`


### PR DESCRIPTION
This fix will allow classpath conversion from Unix to Windows under
CYGWIN or MINGW platform.

Hi, I have noticed when using MingW shell env, the generated unix startup script during "distZip" will not work if we have multiple entries in the "classpath". The reason it failed is that the classpath is not converted into Windows path properly. It works fine under Cygwin, but it seems to miss the check for "msys" platform. This PR fixes this issue.

To reproduce:
1. Add this to `build.gradle` then run `gradle distZip`.
```
startScripts {
    classpath = files("conf", "lib/*")
}
```
2. Open a MingW bash shell (eg: Use "Git For Windows" shell).
2. Build and then unpack the project zip dist and the run the unix startup script with "-h" option. Error will appear. Example:
```
ZDE@my-windows10 MINGW64 ~/src/zemian/gradle-starter/java-app (master)
$ uname -a
MINGW64_NT-10.0 my-windows10 2.11.2(0.329/5/3) 2018-11-10 14:38 x86_64 Msys

ZDE@my-windows10 MINGW64 ~/src/zemian/gradle-starter/java-app (master)
$ ./gradlew distZip
$ unzip -d build/distributions build/distributions/java-app.zip
$ build/distributions/java-project/bin/java-project -h
Error: Could not find or load main class zemian.gradlestarter.javaapp.App
```


