### PR TITLE
Add santa tracker android performance test and fix regression

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
@@ -63,6 +63,11 @@ class ActionNode extends Node {
     }
 
     @Override
+    public boolean requiresMonitoring() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "work action " + action;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -106,7 +106,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
     private final Map<Pair<Node, Node>, Boolean> reachableCache = Maps.newHashMap();
     private final Set<Node> dependenciesCompleteCache = Sets.newHashSet();
     private final Set<Node> dependenciesWithChanges = Sets.newHashSet();
-    private final Set<Node> dependenciesWhichRequireMonitoring = Sets.newHashSet();
+    private final List<Node> dependenciesWhichRequireMonitoring = Lists.newArrayList();
     private final Set<Node> readyToExecute = Sets.newHashSet();
     private final WorkerLeaseService workerLeaseService;
     private final GradleInternal gradle;
@@ -262,6 +262,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             }
         }));
         int visitingSegmentCounter = nodeQueue.size();
+        Set<Node> dependenciesWhichRequireMonitoring = Sets.newHashSet();
 
         HashMultimap<Node, Integer> visitingNodes = HashMultimap.create();
         Deque<GraphEdge> walkedShouldRunAfterEdges = new ArrayDeque<GraphEdge>();
@@ -346,6 +347,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         executionQueue.clear();
         Iterables.addAll(executionQueue, nodeMapping);
         Iterables.addAll(dependenciesWithChanges, nodeMapping);
+        this.dependenciesWhichRequireMonitoring.addAll(dependenciesWhichRequireMonitoring);
     }
 
     private MutationInfo getOrCreateMutationsOf(Node node) {
@@ -519,6 +521,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         dependenciesCompleteCache.clear();
         dependenciesWithChanges.clear();
         dependenciesWhichRequireMonitoring.clear();
+        readyToExecute.clear();
         runningNodes.clear();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -88,11 +88,16 @@ public class LocalTaskNode extends TaskNode {
             processHardSuccessor.execute(targetNode);
         }
         for (Node targetNode : getMustRunAfter(dependencyResolver)) {
-            addMustSuccessor(targetNode);
+            addMustSuccessor((TaskNode) targetNode);
         }
         for (Node targetNode : getShouldRunAfter(dependencyResolver)) {
             addShouldSuccessor(targetNode);
         }
+    }
+
+    @Override
+    public boolean requiresMonitoring() {
+        return false;
     }
 
     private void addFinalizerNode(TaskNode finalizerNode) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -31,6 +31,10 @@ import java.util.Set;
  */
 public abstract class Node implements Comparable<Node> {
 
+    protected Iterable<Node> getAllPredecessors() {
+        return getDependencyPredecessors();
+    }
+
     @VisibleForTesting
     enum ExecutionState {
         UNKNOWN, NOT_REQUIRED, SHOULD_RUN, MUST_RUN, MUST_NOT_RUN, EXECUTING, EXECUTED, SKIPPED
@@ -60,7 +64,7 @@ public abstract class Node implements Comparable<Node> {
     }
 
     public boolean isIncludeInGraph() {
-        return state == ExecutionState.NOT_REQUIRED || state == ExecutionState.UNKNOWN;
+        return state != ExecutionState.NOT_REQUIRED && state != ExecutionState.UNKNOWN;
     }
 
     public boolean isReady() {
@@ -220,6 +224,13 @@ public abstract class Node implements Comparable<Node> {
     public abstract Set<Node> getFinalizers();
 
     public abstract boolean isPublicNode();
+
+    /**
+     * Whether the task needs to be queried if it is completed.
+     *
+     * Everything where the value of {@link #isComplete()} depends on some other state, like another task in an included build.
+     */
+    public abstract boolean requiresMonitoring();
 
     /**
      * Returns the project which the node requires access to, if any.

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public abstract class TaskNode extends Node {
 
     private final NavigableSet<Node> mustSuccessors = Sets.newTreeSet();
+    private final Set<Node> mustPredecessors = Sets.newHashSet();
     private final NavigableSet<Node> shouldSuccessors = Sets.newTreeSet();
     private final NavigableSet<Node> finalizers = Sets.newTreeSet();
     private final NavigableSet<Node> finalizingSuccessors = Sets.newTreeSet();
@@ -68,8 +69,9 @@ public abstract class TaskNode extends Node {
         return shouldSuccessors;
     }
 
-    protected void addMustSuccessor(Node toNode) {
+    protected void addMustSuccessor(TaskNode toNode) {
         mustSuccessors.add(toNode);
+        toNode.mustPredecessors.add(this);
     }
 
     protected void addFinalizingSuccessor(TaskNode finalized) {
@@ -101,6 +103,11 @@ public abstract class TaskNode extends Node {
             finalizingSuccessors.descendingSet(),
             shouldSuccessors.descendingSet()
         );
+    }
+
+    @Override
+    public Iterable<Node> getAllPredecessors() {
+        return Iterables.concat(mustPredecessors, super.getAllPredecessors());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -128,6 +128,11 @@ public class TaskNodeFactory {
         }
 
         @Override
+        public boolean requiresMonitoring() {
+            return true;
+        }
+
+        @Override
         public void require() {
             // Ignore
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts;
 import org.gradle.StartParameter;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.ConfigurablePublishArtifact;
+import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.artifacts.dsl.ArtifactHandler;
 import org.gradle.api.artifacts.dsl.ComponentMetadataHandler;
 import org.gradle.api.artifacts.dsl.ComponentModuleMetadataHandler;
@@ -58,6 +59,7 @@ import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.GradleModu
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionSelectorScheme;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalComponentMetadataBuilder;
 import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.dependencies.LocalConfigurationMetadataBuilder;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.result.AttributeContainerSerializer;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.store.ResolutionResultsStoreFactory;
 import org.gradle.api.internal.artifacts.mvnsettings.LocalMavenRepositoryLocator;
@@ -76,10 +78,15 @@ import org.gradle.api.internal.artifacts.transform.DefaultTransformationRegistra
 import org.gradle.api.internal.artifacts.transform.DefaultTransformerInvoker;
 import org.gradle.api.internal.artifacts.transform.DefaultVariantTransformRegistry;
 import org.gradle.api.internal.artifacts.transform.DomainObjectProjectStateHandler;
+import org.gradle.api.internal.artifacts.transform.ExecutionGraphDependenciesResolver;
 import org.gradle.api.internal.artifacts.transform.ImmutableCachingTransformationWorkspaceProvider;
 import org.gradle.api.internal.artifacts.transform.MutableCachingTransformationWorkspaceProvider;
 import org.gradle.api.internal.artifacts.transform.MutableTransformationWorkspaceProvider;
+import org.gradle.api.internal.artifacts.transform.Transformation;
+import org.gradle.api.internal.artifacts.transform.TransformationNode;
+import org.gradle.api.internal.artifacts.transform.TransformationNodeFactory;
 import org.gradle.api.internal.artifacts.transform.TransformationRegistrationFactory;
+import org.gradle.api.internal.artifacts.transform.TransformationSubject;
 import org.gradle.api.internal.artifacts.transform.TransformerInvoker;
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
@@ -97,6 +104,7 @@ import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
 import org.gradle.initialization.ProjectAccessListener;
+import org.gradle.internal.Try;
 import org.gradle.internal.authentication.AuthenticationSchemeRegistry;
 import org.gradle.internal.build.BuildState;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
@@ -150,6 +158,7 @@ import org.gradle.vcs.internal.VcsMappingsStore;
 
 import javax.annotation.Nullable;
 import java.io.File;
+import java.util.Collection;
 import java.util.List;
 
 public class DefaultDependencyManagementServices implements DependencyManagementServices {
@@ -191,6 +200,21 @@ public class DefaultDependencyManagementServices implements DependencyManagement
 
         OutputFileCollectionFingerprinter createOutputFingerprinter(FileSystemSnapshotter fileSystemSnapshotter) {
             return new OutputFileCollectionFingerprinter(fileSystemSnapshotter);
+        }
+
+        TransformationNodeFactory createTransformationNodeFactory() {
+            return new TransformationNodeFactory() {
+                @Override
+                public Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ExecutionGraphDependenciesResolver dependenciesResolver) {
+                    throw new UnsupportedOperationException("Cannot schedule transforms for build script dependencies");
+                }
+
+                @Nullable
+                @Override
+                public Try<TransformationSubject> getResultIfCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+                    return null;
+                }
+            };
         }
 
         /**
@@ -456,7 +480,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                        ArtifactTypeRegistry artifactTypeRegistry,
                                                        ComponentSelectorConverter componentSelectorConverter,
                                                        AttributeContainerSerializer attributeContainerSerializer,
-                                                       BuildState currentBuild) {
+                                                       BuildState currentBuild,
+                                                       TransformationNodeFactory transformationNodeFactory) {
             return new ErrorHandlingConfigurationResolver(
                     new ShortCircuitEmptyConfigurationResolver(
                         new DefaultConfigurationResolver(
@@ -472,7 +497,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                     attributesSchema,
                                     attributesFactory),
                                 attributesSchema,
-                                attributesFactory
+                                attributesFactory,
+                                transformationNodeFactory
                             ),
                             moduleIdentifierFactory,
                             buildOperationExecutor,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -41,6 +41,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
     private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
+    private final TransformationNodeFactory transformationNodeFactory;
     private final ImmutableAttributes requested;
     private final boolean ignoreWhenNoMatches;
     private final ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver;
@@ -49,6 +50,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
         AttributesSchemaInternal schema,
         ImmutableAttributesFactory attributesFactory,
+        TransformationNodeFactory transformationNodeFactory,
         AttributeContainerInternal requested,
         boolean ignoreWhenNoMatches,
         ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver
@@ -56,6 +58,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
         this.schema = schema;
         this.attributesFactory = attributesFactory;
+        this.transformationNodeFactory = transformationNodeFactory;
         this.requested = requested.asImmutable();
         this.ignoreWhenNoMatches = ignoreWhenNoMatches;
         this.dependenciesResolver = dependenciesResolver;
@@ -105,7 +108,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             ResolvedArtifactSet artifacts = result.getLeft().getArtifacts();
             AttributeContainerInternal attributes = result.getRight().attributes;
             Transformation transformation = result.getRight().transformation;
-            return new ConsumerProvidedResolvedVariant(producer.getComponentId(), artifacts, attributes, transformation, dependenciesResolver);
+            return new ConsumerProvidedResolvedVariant(producer.getComponentId(), artifacts, attributes, transformation, dependenciesResolver, transformationNodeFactory);
         }
 
         if (!candidates.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/ConsumerProvidedResolvedVariant.java
@@ -37,20 +37,29 @@ public class ConsumerProvidedResolvedVariant implements ResolvedArtifactSet {
     private final AttributeContainerInternal attributes;
     private final Transformation transformation;
     private final ExtraExecutionGraphDependenciesResolverFactory resolverFactory;
+    private final TransformationNodeFactory transformationNodeFactory;
 
-    public ConsumerProvidedResolvedVariant(ComponentIdentifier componentIdentifier, ResolvedArtifactSet delegate, AttributeContainerInternal target, Transformation transformation, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory) {
+    public ConsumerProvidedResolvedVariant(
+        ComponentIdentifier componentIdentifier,
+        ResolvedArtifactSet delegate,
+        AttributeContainerInternal target,
+        Transformation transformation,
+        ExtraExecutionGraphDependenciesResolverFactory dependenciesResolverFactory,
+        TransformationNodeFactory transformationNodeFactory
+    ) {
         this.componentIdentifier = componentIdentifier;
         this.delegate = delegate;
         this.attributes = target;
         this.transformation = transformation;
         this.resolverFactory = dependenciesResolverFactory;
+        this.transformationNodeFactory = transformationNodeFactory;
     }
 
     @Override
     public Completion startVisit(BuildOperationQueue<RunnableBuildOperation> actions, AsyncArtifactListener listener) {
-        Map<ComponentArtifactIdentifier, TransformationOperation> artifactResults = Maps.newConcurrentMap();
-        Map<File, TransformationOperation> fileResults = Maps.newConcurrentMap();
-        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, listener, actions, artifactResults, fileResults, getDependenciesResolver()));
+        Map<ComponentArtifactIdentifier, TransformationResult> artifactResults = Maps.newConcurrentMap();
+        Map<File, TransformationResult> fileResults = Maps.newConcurrentMap();
+        Completion result = delegate.startVisit(actions, new TransformingAsyncArtifactListener(transformation, listener, actions, artifactResults, fileResults, getDependenciesResolver(), transformationNodeFactory));
         return new TransformCompletion(result, attributes, artifactResults, fileResults);
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
@@ -24,20 +24,23 @@ public class DefaultArtifactTransforms implements ArtifactTransforms {
     private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
+    private final TransformationNodeFactory transformationNodeFactory;
 
     public DefaultArtifactTransforms(
         ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
         AttributesSchemaInternal schema,
-        ImmutableAttributesFactory attributesFactory
+        ImmutableAttributesFactory attributesFactory,
+        TransformationNodeFactory transformationNodeFactory
     ) {
         this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
         this.schema = schema;
         this.attributesFactory = attributesFactory;
+        this.transformationNodeFactory = transformationNodeFactory;
     }
 
     @Override
     public VariantSelector variantSelector(AttributeContainerInternal consumerAttributes, boolean allowNoMatchingVariants, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver) {
-        return new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, schema, attributesFactory, consumerAttributes.asImmutable(), allowNoMatchingVariants, dependenciesResolver);
+        return new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, schema, attributesFactory, transformationNodeFactory, consumerAttributes.asImmutable(), allowNoMatchingVariants, dependenciesResolver);
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeFactory.java
@@ -23,7 +23,9 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.internal.Try;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,18 @@ public class DefaultTransformationNodeFactory implements TransformationNodeFacto
         };
         collectTransformNodes(artifactSet, builder, nodeCreator);
         return builder.build();
+    }
+
+    @Override
+    @Nullable
+    public Try<TransformationSubject> getResultIfCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+        List<Equivalence.Wrapper<TransformationStep>> transformationChain = unpackTransformation(transformation);
+        ArtifactTransformKey transformKey = new ArtifactTransformKey(artifactId, transformationChain);
+        TransformationNode node = transformations.get(transformKey);
+        if (node != null && node.isComplete()) {
+            return node.getTransformedSubject();
+        }
+        return null;
     }
 
     private void collectTransformNodes(ResolvedArtifactSet artifactSet, ImmutableList.Builder<TransformationNode> builder, Function<ResolvableArtifact, TransformationNode> nodeCreator) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/PrecomputedTransformationResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/PrecomputedTransformationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,17 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.internal.Try;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
+public class PrecomputedTransformationResult implements TransformationResult {
+    private final Try<TransformationSubject> result;
 
-public interface TransformationNodeFactory {
-    Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ExecutionGraphDependenciesResolver dependenciesResolver);
+    public PrecomputedTransformationResult(Try<TransformationSubject> result) {
+        this.result = result;
+    }
 
-    @Nullable
-    Try<TransformationSubject> getResultIfCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation);
+    @Override
+    public Try<TransformationSubject> getResult() {
+        return result;
+    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformCompletion.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformCompletion.java
@@ -27,10 +27,10 @@ import java.util.Map;
 public class TransformCompletion implements ResolvedArtifactSet.Completion {
     private final AttributeContainerInternal attributes;
     private final ResolvedArtifactSet.Completion delegate;
-    private final Map<ComponentArtifactIdentifier, TransformationOperation> artifactResults;
-    private final Map<File, TransformationOperation> fileResults;
+    private final Map<ComponentArtifactIdentifier, TransformationResult> artifactResults;
+    private final Map<File, TransformationResult> fileResults;
 
-    public TransformCompletion(ResolvedArtifactSet.Completion delegate, AttributeContainerInternal attributes, Map<ComponentArtifactIdentifier, TransformationOperation> artifactResults, Map<File, TransformationOperation> fileResults) {
+    public TransformCompletion(ResolvedArtifactSet.Completion delegate, AttributeContainerInternal attributes, Map<ComponentArtifactIdentifier, TransformationResult> artifactResults, Map<File, TransformationResult> fileResults) {
         this.delegate = delegate;
         this.attributes = attributes;
         this.artifactResults = artifactResults;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -66,6 +66,11 @@ public abstract class TransformationNode extends Node {
     }
 
     @Override
+    public boolean requiresMonitoring() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return transformationStep.getDisplayName();
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -75,7 +75,7 @@ public abstract class TransformationNode extends Node {
         return transformationStep.getDisplayName();
     }
 
-    private Try<TransformationSubject> getTransformedSubject() {
+    public Try<TransformationSubject> getTransformedSubject() {
         if (transformedSubject == null) {
             throw new IllegalStateException(String.format("Transformation %s has been scheduled and is now required, but did not execute, yet.", transformationStep.getDisplayName()));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationOperation.java
@@ -24,7 +24,7 @@ import org.gradle.internal.operations.RunnableBuildOperation;
 
 import javax.annotation.Nullable;
 
-class TransformationOperation implements RunnableBuildOperation {
+class TransformationOperation implements TransformationResult, RunnableBuildOperation {
     private final Transformation transformation;
     private final TransformationSubject subject;
     private final ExecutionGraphDependenciesResolver dependenciesResolver;
@@ -49,6 +49,7 @@ class TransformationOperation implements RunnableBuildOperation {
             .operationType(BuildOperationCategory.UNCATEGORIZED);
     }
 
+    @Override
     public Try<TransformationSubject> getResult() {
         return result;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationResult.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,8 @@
 
 package org.gradle.api.internal.artifacts.transform;
 
-import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
-import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
 import org.gradle.internal.Try;
 
-import javax.annotation.Nullable;
-import java.util.Collection;
-
-public interface TransformationNodeFactory {
-    Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ExecutionGraphDependenciesResolver dependenciesResolver);
-
-    @Nullable
-    Try<TransformationSubject> getResultIfCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation);
+public interface TransformationResult {
+    Try<TransformationSubject> getResult();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingArtifactVisitor.java
@@ -35,10 +35,10 @@ import java.util.Map;
 class TransformingArtifactVisitor implements ArtifactVisitor {
     private final ArtifactVisitor visitor;
     private final AttributeContainerInternal target;
-    private final Map<ComponentArtifactIdentifier, TransformationOperation> artifactResults;
-    private final Map<File, TransformationOperation> fileResults;
+    private final Map<ComponentArtifactIdentifier, TransformationResult> artifactResults;
+    private final Map<File, TransformationResult> fileResults;
 
-    TransformingArtifactVisitor(ArtifactVisitor visitor, AttributeContainerInternal target, Map<ComponentArtifactIdentifier, TransformationOperation> artifactResults, Map<File, TransformationOperation> fileResults) {
+    TransformingArtifactVisitor(ArtifactVisitor visitor, AttributeContainerInternal target, Map<ComponentArtifactIdentifier, TransformationResult> artifactResults, Map<File, TransformationResult> fileResults) {
         this.visitor = visitor;
         this.target = target;
         this.artifactResults = artifactResults;
@@ -47,7 +47,7 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
 
     @Override
     public void visitArtifact(DisplayName variantName, AttributeContainer variantAttributes, ResolvableArtifact artifact) {
-        TransformationOperation operation = artifactResults.get(artifact.getId());
+        TransformationResult operation = artifactResults.get(artifact.getId());
         operation.getResult().ifSuccessfulOrElse(
             transformedSubject -> {
                 ResolvedArtifact sourceArtifact = artifact.toPublicView();
@@ -79,7 +79,7 @@ class TransformingArtifactVisitor implements ArtifactVisitor {
 
     @Override
     public void visitFile(ComponentArtifactIdentifier artifactIdentifier, DisplayName variantName, AttributeContainer variantAttributes, File file) {
-        TransformationOperation operation = fileResults.get(file);
+        TransformationResult operation = fileResults.get(file);
         operation.getResult().ifSuccessfulOrElse(
             transformedSubject -> {
                 for (File outputFile : transformedSubject.getFiles()) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -32,6 +32,7 @@ import spock.lang.Specification
 class AttributeMatchingVariantSelectorSpec extends Specification {
 
     def consumerProvidedVariantFinder = Mock(ConsumerProvidedVariantFinder)
+    def transformationNodeFactory = Mock(TransformationNodeFactory)
     def attributeMatcher = Mock(AttributeMatcher)
     def attributesSchema = Mock(AttributesSchemaInternal) {
         withProducer(_) >> attributeMatcher
@@ -55,7 +56,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
     def 'direct match on variant means no finder interaction'() {
         given:
         def resolvedArtifactSet = Mock(ResolvedArtifactSet)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(variantSet)
@@ -73,7 +74,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
             asDescribable() >> Describables.of('other mocked variant')
             getAttributes() >> otherVariantAttributes
         }
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(variantSet)
@@ -106,7 +107,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
 
     def 'selecting a transform results in added DefaultTransformationDependency'() {
         given:
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(variantSet)
@@ -152,7 +153,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         }
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -203,7 +204,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         }
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -260,7 +261,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
         def transform3 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -320,7 +321,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
         def transform3 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -380,7 +381,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
         def transform3 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeFactory, requestedAttributes, false, dependenciesResolverFactory)
 
         when:
         def result = selector.select(multiVariantSet)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -50,7 +50,18 @@ class DefaultArtifactTransformsTest extends Specification {
     def consumerSchema = Mock(AttributesSchemaInternal)
     def attributeMatcher = Mock(AttributeMatcher)
     def dependenciesResolver = Stub(ExtraExecutionGraphDependenciesResolverFactory)
-    def transforms = new DefaultArtifactTransforms(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory())
+    def transformationNodeFactory = new TransformationNodeFactory() {
+        @Override
+        Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ExecutionGraphDependenciesResolver dependenciesResolver) {
+            throw new UnsupportedOperationException()
+        }
+
+        @Override
+        Try<TransformationSubject> getResultIfCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+            return null
+        }
+    }
+    def transforms = new DefaultArtifactTransforms(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformationNodeFactory)
 
     def "selects producer variant with requested attributes"() {
         def variant1 = resolvedVariant()

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -119,6 +119,11 @@ class TransformationNodeSpec extends Specification {
         }
 
         @Override
+        boolean requiresMonitoring() {
+            return false
+        }
+
+        @Override
         String toString() {
             return null
         }

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/android/RealLifeAndroidBuildPerformanceTest.groovy
@@ -40,11 +40,12 @@ class RealLifeAndroidBuildPerformanceTest extends AbstractAndroidPerformanceTest
 
         where:
         testProject         | memory | parallel | warmUpRuns | runs | tasks
-        'k9AndroidBuild'    | '1g'   | false    | null       | null | 'help'
-        'k9AndroidBuild'    | '1g'   | false    | null       | null | 'assembleDebug'
+        'k9AndroidBuild'           | '1g' | false | null | null | 'help'
+        'k9AndroidBuild'           | '1g' | false | null | null | 'assembleDebug'
 //        'k9AndroidBuild'    | '1g'   | false    | null       | null | 'clean k9mail:assembleDebug'
-        'largeAndroidBuild' | '5g'   | true     | null       | null | 'help'
-        'largeAndroidBuild' | '5g'   | true     | null       | null | 'assembleDebug'
-        'largeAndroidBuild' | '5g'   | true     | 2          | 8    | 'clean phthalic:assembleDebug'
+        'largeAndroidBuild'        | '5g' | true  | null | null | 'help'
+        'largeAndroidBuild'        | '5g' | true  | null | null | 'assembleDebug'
+        'largeAndroidBuild'        | '5g' | true  | 2    | 8    | 'clean phthalic:assembleDebug'
+        'santaTrackerAndroidBuild' | '1g' | true  | null | null | 'assembleDebug'
     }
 }

--- a/subprojects/performance/templates.gradle
+++ b/subprojects/performance/templates.gradle
@@ -354,6 +354,88 @@ tasks.register("largeAndroidBuild", RemoteProject) {
     branch = 'android-34'
 }
 
+tasks.register("santaTrackerAndroidBuild", RemoteProject) {
+    remoteUri = 'https://github.com/gradle/santa-tracker-android.git'
+    branch = 'agp-3.5.0'
+    doLast {
+        new File(outputDirectory, 'santa-tracker/google-services.json') << """
+{
+  "project_info": {
+    "project_number": "012345678912",
+    "firebase_url": "https://example.com",
+    "project_id": "example",
+    "storage_bucket": "example.example.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678912:android:0123456789abcdef",
+        "android_client_info": {
+          "package_name": "com.google.android.apps.santatracker.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "foo.example.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "012345678901234567890123456789012345678"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:012345678912:android:0123456789abcdef",
+        "android_client_info": {
+          "package_name": "com.google.android.apps.santatracker.debug"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "foo.example.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "012345678901234567890123456789012345678"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}
+"""
+    }
+}
+
 tasks.register("excludeRuleMergingBuild", RemoteProject) {
     remoteUri = 'https://github.com/gradle/performance-comparisons.git'
     branch = 'master'


### PR DESCRIPTION
Santa tracker seem to be a good test project with complicated enough sources to yield some meaningful results. Moreover, it is updated by Google on a regular basis.

We got a report about a performance regression between 5.1 and 5.2 for the santa-tracker fully up-to-date build. It seems because we now schedule every transform registration instance instead of de-duplicating the transforms by implementation/parameters. This adds more stress on our scheduling infrastructure.

This PR fixes the problems by improving two things:
- Keep track of nodes with changed dependencies in the task graph, so we don't need to re-check every node whenever we try to schedule something.
- Directly query the scheduled transform for the result instead of going through the workspace when running the immediate transform.