### PR TITLE
Don't show errors about Java 8 API usage in IntelliJ

### DIFF
--- a/.idea/inspectionProfiles/Gradle.xml
+++ b/.idea/inspectionProfiles/Gradle.xml
@@ -20,6 +20,9 @@
     <inspection_tool class="LambdaCanBeMethodCall" enabled="false" level="INFORMATION" enabled_by_default="false" />
     <inspection_tool class="SafeVarargsDetector" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="SimplifyForEach" enabled="false" level="INFORMATION" enabled_by_default="false" />
+    <inspection_tool class="Since15" enabled="true" level="ERROR" enabled_by_default="true">
+      <effectiveLL value="JDK_1_8" />
+    </inspection_tool>
     <inspection_tool class="StaticPseudoFunctionalStyleMethod" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TryFinallyCanBeTryWithResources" enabled="false" level="WARNING" enabled_by_default="false" />
     <inspection_tool class="TryWithIdenticalCatches" enabled="false" level="WARNING" enabled_by_default="false" />


### PR DESCRIPTION
Most of Gradle now requires JDK 8, but :core unfortunately requires Java 6, yet in many places it uses Java 8 APIs. To keep things in a workable state we only let IntelliJ warn about things not available in Java 8, and rely on runtime tests to prevent Java 7/8 APIs leaking into code that must still run on Java 6.
