### PR TITLE
Allow a 'Could not initialise system classpath' exception in TaskTimeoutIntegrationTest under certain conditions 

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -154,6 +154,7 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
         given:
         if (isolationMode == IsolationMode.PROCESS) {
             // worker starting threads can be interrupted during worker startup and cause a 'Could not initialise system classpath' exception.
+            // See: https://github.com/gradle/gradle/issues/8699
             executer.withStackTraceChecksDisabled()
         }
         buildFile << """

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/TaskTimeoutIntegrationTest.groovy
@@ -152,6 +152,10 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
     @Unroll
     def "timeout stops long running work items with #isolationMode isolation"() {
         given:
+        if (isolationMode == IsolationMode.PROCESS) {
+            // worker starting threads can be interrupted during worker startup and cause a 'Could not initialise system classpath' exception.
+            executer.withStackTraceChecksDisabled()
+        }
         buildFile << """
             import java.util.concurrent.CountDownLatch;
             import java.util.concurrent.TimeUnit;
@@ -193,6 +197,9 @@ class TaskTimeoutIntegrationTest extends AbstractIntegrationSpec {
         fails "block"
         failure.assertHasDescription("Execution failed for task ':block'.")
         failure.assertHasCause("Timeout has been exceeded")
+        if (isolationMode == IsolationMode.PROCESS && failure.output.contains("Caused by:")) {
+            assert failure.output.contains("Error occurred during initialization of VM")
+        }
 
         where:
         isolationMode << IsolationMode.values()


### PR DESCRIPTION
This is causing the test to be flaky if worker startup takes longer.