### PR TITLE
Documentat that upToDateWhen { false } disables caching

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/TaskOutputs.java
@@ -30,24 +30,35 @@ import org.gradle.internal.HasInternalProtocol;
 @HasInternalProtocol
 public interface TaskOutputs {
     /**
-     * <p>Adds a predicate to determine whether the outputs of this task are up-to-date. The given closure is executed
-     * at task execution time. The closure is passed the task as a parameter. If the closure returns false, the task
-     * outputs are considered out-of-date and the task will be executed.</p>
+     * <p>
+     *     Adds a predicate to determine whether previous outputs of this task can be reused.
+     *     The given closure is executed at task execution time.
+     *     The closure is passed the task as a parameter.
+     *     If the closure returns false, previous outputs of this task cannot be reused and the task will be executed.
+     *     That means the task is out-of-date and no outputs will be loaded from the build cache.
+     * </p>
      *
-     * <p>You can add multiple such predicates. The task outputs are considered out-of-date when any predicate returns
-     * false.<p>
+     * <p>
+     *     You can add multiple such predicates.
+     *     The task outputs cannot be reused when any predicate returns false.
+     * </p>
      *
      * @param upToDateClosure The closure to use to determine whether the task outputs are up-to-date.
      */
     void upToDateWhen(Closure upToDateClosure);
 
     /**
-     * <p>Adds a predicate to determine whether the outputs of this task are up-to-date. The given spec is evaluated at
-     * task execution time. If the spec returns false, the task outputs are considered out-of-date and the task will be
-     * executed.</p>
+     * <p>
+     *     Adds a predicate to determine whether previous outputs of this task can be reused.
+     *     The given spec is evaluated at task execution time.
+     *     If the spec returns false, previous outputs of this task cannot be reused and the task will be executed.
+     *     That means the task is out-of-date and no outputs will be loaded from the build cache.
+     * </p>
      *
-     * <p>You can add multiple such predicates. The task outputs are considered out-of-date when any predicate returns
-     * false.<p>
+     * <p>
+     *     You can add multiple such predicates.
+     *     The task outputs cannot be reused when any predicate returns false.
+     * </p>
      *
      * @param upToDateSpec The spec to use to determine whether the task outputs are up-to-date.
      */


### PR DESCRIPTION
The Javadocs of `outputs.upToDateWhen` didn't make it clear that loading from the cache is disabled when the spec returns false, just like `--rerun-tasks` does.

We also add a test for the behaviour.