### PR TITLE
Fix for flaky tooling api test

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/AbstractFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/AbstractFailure.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.http;
+
+import com.sun.net.httpserver.HttpExchange;
+
+abstract class AbstractFailure implements ResponseProducer, Failure {
+    private final RuntimeException failure;
+
+    public AbstractFailure(RuntimeException failure) {
+        this.failure = failure;
+    }
+
+    @Override
+    public boolean isFailure() {
+        return true;
+    }
+
+    @Override
+    public RuntimeException getFailure() {
+        return failure;
+    }
+
+    @Override
+    public void writeTo(int requestId, HttpExchange exchange) {
+        throw new IllegalStateException();
+    }
+
+    protected static String withLeadingSlash(String path) {
+        if (path.startsWith("/")) {
+            return path;
+        } else {
+            return "/" + path;
+        }
+    }
+
+    protected static String contextSuffix(String context) {
+        if (context.isEmpty()) {
+            return context;
+        }
+        return ". " + context;
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierRequestHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/CyclicBarrierRequestHandler.java
@@ -17,6 +17,7 @@
 package org.gradle.test.fixtures.server.http;
 
 import com.sun.net.httpserver.HttpExchange;
+import org.gradle.internal.UncheckedException;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 
@@ -39,7 +40,7 @@ class CyclicBarrierRequestHandler implements TrackingHttpHandler, WaitPreconditi
     private final WaitPrecondition previous;
     private long mostRecentEvent;
     private boolean cancelled;
-    private AssertionError failure;
+    private final ExpectationState state = new ExpectationState();
 
     CyclicBarrierRequestHandler(Lock lock, int timeoutMs, WaitPrecondition previous, Collection<? extends ResourceExpectation> expectations) {
         this.lock = lock;
@@ -74,7 +75,7 @@ class CyclicBarrierRequestHandler implements TrackingHttpHandler, WaitPreconditi
     }
 
     @Override
-    public ResponseProducer selectResponseProducer(int id, HttpExchange httpExchange) throws Exception {
+    public ResponseProducer selectResponseProducer(int id, HttpExchange httpExchange) {
         ResourceHandler handler;
         lock.lock();
         try {
@@ -91,9 +92,9 @@ class CyclicBarrierRequestHandler implements TrackingHttpHandler, WaitPreconditi
             String path = httpExchange.getRequestURI().getPath().substring(1);
             handler = selectPending(pending, path);
             if (handler == null || !handler.getMethod().equals(httpExchange.getRequestMethod())) {
-                failure = new UnexpectedRequestException(String.format("Unexpected request %s /%s received. Waiting for %s, already received %s.", httpExchange.getRequestMethod(), path, format(pending), received));
+                ResponseProducer failure = state.unexpectedRequest(httpExchange.getRequestMethod(), path, describeCurrentState());
                 condition.signalAll();
-                throw failure;
+                return failure;
             }
 
             received.add(httpExchange.getRequestMethod() + " /" + path);
@@ -102,23 +103,34 @@ class CyclicBarrierRequestHandler implements TrackingHttpHandler, WaitPreconditi
                 condition.signalAll();
             }
 
-            while (!pending.isEmpty() && failure == null && !cancelled) {
+            if (state.isFailed()) {
+                // Failed in another thread
+                System.out.println(String.format("[%d] failure in another thread", id));
+                return state.alreadyFailed(httpExchange.getRequestMethod(), path, describeCurrentState());
+            }
+
+            while (!pending.isEmpty() && !state.isFailed() && !cancelled) {
                 long waitMs = mostRecentEvent + timeoutMs - timer.getElapsedMillis();
                 if (waitMs < 0) {
                     System.out.println(String.format("[%d] timeout waiting for other requests", id));
-                    failure = new AssertionError(String.format("Timeout waiting for expected requests to be received. Still waiting for %s, received %s.", format(pending), received));
+                    ResponseProducer failure = state.timeout(httpExchange.getRequestMethod(), path, "waiting for other requests", describeCurrentState());
                     condition.signalAll();
-                    throw failure;
+                    return failure;
                 }
                 System.out.println(String.format("[%d] waiting for other requests. Still waiting for %s", id, format(pending)));
-                condition.await(waitMs, TimeUnit.MILLISECONDS);
+                try {
+                    condition.await(waitMs, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    UncheckedException.throwAsUncheckedException(e);
+                }
             }
 
-            if (failure != null) {
+            if (state.isFailed()) {
                 // Failed in another thread
                 System.out.println(String.format("[%d] failure in another thread", id));
-                throw failure;
+                return state.failureWhileWaiting(httpExchange.getRequestMethod(), path, "waiting for other requests", describeCurrentState());
             }
+
             if (cancelled) {
                 return new ResponseProducer() {
                     @Override
@@ -137,6 +149,10 @@ class CyclicBarrierRequestHandler implements TrackingHttpHandler, WaitPreconditi
 
         // All requests completed, write response
         return handler;
+    }
+
+    private String describeCurrentState() {
+        return String.format("Waiting for %s, already received %s", format(pending), received);
     }
 
     @Override
@@ -179,12 +195,12 @@ class CyclicBarrierRequestHandler implements TrackingHttpHandler, WaitPreconditi
     public void assertComplete(Collection<Throwable> failures) throws AssertionError {
         lock.lock();
         try {
-            if (failure != null) {
+            if (state.isFailed()) {
                 // Already reported
                 return;
             }
             if (!pending.isEmpty()) {
-                failures.add(new AssertionError(String.format("Did not receive expected requests. Waiting for %s, received %s", format(pending), received)));
+                failures.add(new AssertionError(String.format("Did not receive expected requests. %s", describeCurrentState())));
             }
         } finally {
             lock.unlock();

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ExpectationState.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ExpectationState.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.test.fixtures.server.http;
+
+import static org.gradle.test.fixtures.server.http.AbstractFailure.contextSuffix;
+import static org.gradle.test.fixtures.server.http.AbstractFailure.withLeadingSlash;
+
+class ExpectationState {
+
+    private enum FailureType {
+        None, UnexpectedRequest, Timeout
+    }
+
+    private FailureType failure = FailureType.None;
+    private String unexpectedMethod;
+    private String unexpectedPath;
+
+    public boolean isFailed() {
+        return failure != FailureType.None;
+    }
+
+    /**
+     * Signals that an unexpected request was received.
+     *
+     * @return A response to return to the client
+     */
+    public ResponseProducer unexpectedRequest(String requestMethod, String path, String context) {
+        if (failure == FailureType.None) {
+            failure = FailureType.UnexpectedRequest;
+            unexpectedMethod = requestMethod;
+            unexpectedPath = path;
+        }
+        return new UnexpectedRequestFailure(requestMethod, path, context);
+    }
+
+    /**
+     * Signals that a timeout occurred waiting to handle the given request.
+     *
+     * @return A response to return to the client
+     */
+    public ResponseProducer timeout(String requestMethod, String path, String waitingFor, String context) {
+        if (failure == FailureType.None) {
+            failure = FailureType.Timeout;
+        }
+        return new RequestConditionFailure(requestMethod, path, String.format("Failed to handle %s %s due to a timeout %s%s", requestMethod, withLeadingSlash(path), waitingFor, contextSuffix(context)));
+    }
+
+    /**
+     * Signals that a timeout occurred waiting for test condition to become true.
+     */
+    public void timeout(String waitingFor, String context) {
+        if (failure == FailureType.None) {
+            failure = FailureType.Timeout;
+        }
+    }
+
+    /**
+     * Creates a response to return to the client for an expected request received after a failure.
+     */
+    public ResponseProducer alreadyFailed(String requestMethod, String path, String context) {
+        switch (failure) {
+            case UnexpectedRequest:
+                return new RequestConditionFailure(requestMethod, path, String.format("Failed to handle %s %s due to unexpected request %s %s%s", requestMethod, withLeadingSlash(path), unexpectedMethod, withLeadingSlash(unexpectedPath), contextSuffix(context)));
+            case Timeout:
+                return new RequestConditionFailure(requestMethod, path, String.format("Failed to handle %s %s due to a previous timeout%s", requestMethod, withLeadingSlash(path), contextSuffix(context)));
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * Creates a response to return to the client for a request that was waiting when a failure occurred.
+     */
+    public ResponseProducer failureWhileWaiting(String requestMethod, String path, String waitingFor, String context) {
+        switch (failure) {
+            case UnexpectedRequest:
+                return new RequestConditionFailure(requestMethod, path, String.format("Failed to handle %s %s due to unexpected request %s %s%s", requestMethod, withLeadingSlash(path), unexpectedMethod, withLeadingSlash(unexpectedPath), contextSuffix(context)));
+            case Timeout:
+                return new RequestConditionFailure(requestMethod, path, String.format("Failed to handle %s %s due to a timeout %s%s", requestMethod, withLeadingSlash(path), waitingFor, contextSuffix(context)));
+            default:
+                throw new IllegalStateException();
+        }
+    }
+
+    /**
+     * Creates an exception to throw to the test thread that is waiting for some condition
+     */
+    public RuntimeException getWaitFailure(String context) {
+        switch (failure) {
+            case UnexpectedRequest:
+                return new RuntimeException(String.format("Unexpected request %s %s received%s", unexpectedMethod, withLeadingSlash(unexpectedPath), contextSuffix(context)));
+            case Timeout:
+                return new RuntimeException(String.format("Timeout waiting for expected requests%s", contextSuffix(context)));
+            default:
+                throw new IllegalStateException();
+        }
+    }
+}

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/Failure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/Failure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,5 @@
 
 package org.gradle.test.fixtures.server.http;
 
-public class UnexpectedRequestException extends RuntimeException {
-    public UnexpectedRequestException(String message) {
-        super(message, null);
-    }
+interface Failure extends ResponseProducer {
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/RequestConditionFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/RequestConditionFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,8 @@
 
 package org.gradle.test.fixtures.server.http;
 
-public class UnexpectedRequestException extends RuntimeException {
-    public UnexpectedRequestException(String message) {
-        super(message, null);
+class RequestConditionFailure extends AbstractFailure {
+    public RequestConditionFailure(String method, String path, String message) {
+        super(new RuntimeException(message));
     }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ResponseProducer.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/ResponseProducer.java
@@ -21,8 +21,19 @@ import com.sun.net.httpserver.HttpExchange;
 import java.io.IOException;
 
 interface ResponseProducer {
+    default boolean isFailure() {
+        return false;
+    }
+
     /**
      * Called to handle a request. Is *not* called under lock.
      */
     void writeTo(int requestId, HttpExchange exchange) throws IOException;
+
+    /**
+     * Returns the failure, if any.
+     */
+    default RuntimeException getFailure() {
+        throw new IllegalStateException();
+    }
 }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/TrackingHttpHandler.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/TrackingHttpHandler.java
@@ -18,6 +18,7 @@ package org.gradle.test.fixtures.server.http;
 
 import com.sun.net.httpserver.HttpExchange;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 
 interface TrackingHttpHandler {
@@ -28,9 +29,10 @@ interface TrackingHttpHandler {
      *
      * This method may block until the request is ready to be handled, but must do so using a condition created from the state lock.
      *
-     * @throws Exception on failure to handle request. The handler is considered broken.
+     * @return null when this handler is not expecting any further requests.
      */
-    ResponseProducer selectResponseProducer(int id, HttpExchange exchange) throws Exception;
+    @Nullable
+    ResponseProducer selectResponseProducer(int id, HttpExchange exchange);
 
     /**
      * Returns a precondition that asserts that this handler is not expecting any further requests to be released by the test in order to complete.

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/UnexpectedRequestFailure.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/server/http/UnexpectedRequestFailure.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,12 @@
 
 package org.gradle.test.fixtures.server.http;
 
-public class UnexpectedRequestException extends RuntimeException {
-    public UnexpectedRequestException(String message) {
-        super(message, null);
+class UnexpectedRequestFailure extends AbstractFailure {
+    public UnexpectedRequestFailure(String method, String path) {
+        this(method, path, "");
+    }
+
+    public UnexpectedRequestFailure(String method, String path, String context) {
+        super(new UnexpectedRequestException(String.format("Unexpected request %s %s received%s", method, withLeadingSlash(path), contextSuffix(context))));
     }
 }

--- a/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
+++ b/subprojects/internal-integ-testing/src/test/groovy/org/gradle/test/fixtures/server/http/BlockingHttpServerTest.groovy
@@ -555,7 +555,7 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         then:
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
-        e.causes.message.sort() == ['Did not receive expected requests. Waiting for [GET /b], received []']
+        e.causes.message.sort() == ['Did not receive expected requests. Waiting for [GET /b], already received []']
     }
 
     def "fails when request is received after serial expectations met"() {
@@ -576,7 +576,7 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         then:
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
-        e.causes.message.sort() == ['Received unexpected request GET /a']
+        e.causes.message.sort() == ['Unexpected request GET /a received']
     }
 
     def "fails when request path does not match expected serial request"() {
@@ -585,7 +585,14 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         server.start()
 
         when:
-        server.uri("b").toURL().text
+        def connection = server.uri("b").toURL().openConnection()
+
+        then:
+        connection.responseCode == 400
+        connection.responseMessage == "Bad Request"
+
+        when:
+        connection.inputStream
 
         then:
         thrown(IOException)
@@ -597,9 +604,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /b'
+            'Unexpected request GET /b received. Waiting for [GET /a], already received []'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /b received. Waiting for [GET /a], already received [].'
     }
 
     def "fails when request method does not match expected serial GET request"() {
@@ -610,7 +616,13 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         when:
         def connection = server.uri("a").toURL().openConnection()
         connection.requestMethod = 'HEAD'
-        connection.inputStream.text
+
+        then:
+        connection.responseCode == 400
+        connection.responseMessage == "Bad Request"
+
+        when:
+        connection.inputStream
 
         then:
         thrown(IOException)
@@ -622,9 +634,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle HEAD /a'
+            'Unexpected request HEAD /a received. Waiting for [GET /a], already received []'
         ]
-        e.causes[0].cause.message == 'Unexpected request HEAD /a received. Waiting for [GET /a], already received [].'
     }
 
     def "fails when request method does not match expected serial PUT request"() {
@@ -645,9 +656,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a'
+            'Unexpected request GET /a received. Waiting for [PUT /a], already received []'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /a received. Waiting for [PUT /a], already received [].'
     }
 
     def "fails when request method does not match expected serial POST request"() {
@@ -668,9 +678,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message.sort() == [
-            'Failed to handle GET /a'
+            'Unexpected request GET /a received. Waiting for [POST /a], already received []'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /a received. Waiting for [POST /a], already received [].'
     }
 
     def "fails when some but not all expected parallel requests received"() {
@@ -691,9 +700,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message.sort() == [
-            'Failed to handle GET /a'
+            'Failed to handle GET /a due to a timeout waiting for other requests. Waiting for [GET /b], already received [GET /a]'
         ]
-        e.causes[0].cause.message == 'Timeout waiting for expected requests to be received. Still waiting for [GET /b], received [GET /a].'
     }
 
     def "fails when expected parallel request received after other request has failed"() {
@@ -720,12 +728,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a',
-            'Failed to handle GET /b',
+            'Failed to handle GET /a due to a timeout waiting for other requests. Waiting for [GET /b], already received [GET /a]',
+            'Failed to handle GET /b due to a previous timeout. Waiting for [], already received [GET /a, GET /b]'
         ]
-        e.causes[0].cause.message == 'Timeout waiting for expected requests to be received. Still waiting for [GET /b], received [GET /a].'
-        // TODO - message should say that expected request was received too late
-        e.causes[1].cause.message == 'Timeout waiting for expected requests to be received. Still waiting for [GET /b], received [GET /a].'
     }
 
     def "fails when some but not all expected parallel requests received when stop called"() {
@@ -747,7 +752,7 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Did not receive expected requests. Waiting for [GET /b], received [GET /a]'
+            'Did not receive expected requests. Waiting for [GET /b], already received [GET /a]'
         ]
     }
 
@@ -769,21 +774,34 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message.sort() == [
-            'Failed to handle GET /c'
+            'Unexpected request GET /c received. Waiting for [GET /a, GET /b], already received []'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /c received. Waiting for [GET /a, GET /b], already received [].'
     }
 
     def "fails when request path does not match expected blocking parallel request"() {
+        def requestFailure = null
+
         given:
-        server.expectConcurrentAndBlock("a", "b")
+        def handle = server.expectConcurrentAndBlock("a", "b")
         server.start()
 
         when:
-        server.uri("c").toURL().text
+        async {
+            start {
+                try {
+                    server.uri("c").toURL().text
+                } catch (IOException e) {
+                    requestFailure = e
+                }
+            }
+            handle.waitForAllPendingCalls()
+        }
 
         then:
-        thrown(IOException)
+        def waitException = thrown(RuntimeException)
+        waitException.message == 'Unexpected request GET /c received. Waiting for 2 further requests, received [], released [], not yet received [GET /a, GET /b]'
+
+        requestFailure instanceof IOException
 
         when:
         server.stop()
@@ -792,9 +810,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message.sort() == [
-            'Failed to handle GET /c'
+            'Unexpected request GET /c received. Waiting for 2 further requests, received [], released [], not yet received [GET /a, GET /b]'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /c received. Waiting for 2 further requests, already received [], released [], still expecting [GET /a, GET /b].'
     }
 
     def "fails when request method does not match expected parallel request"() {
@@ -847,14 +864,10 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle HEAD /a',
-            'Failed to handle GET /b',
-            'Failed to handle GET /c'
+            'Unexpected request HEAD /a received. Waiting for [GET /a, GET /b, PUT /c], already received []',
+            'Failed to handle GET /b due to unexpected request HEAD /a. Waiting for [GET /a, PUT /c], already received [GET /b]',
+            'Unexpected request GET /c received. Waiting for [GET /a, PUT /c], already received [GET /b]'
         ]
-        e.causes[0].cause.message == 'Unexpected request HEAD /a received. Waiting for [GET /a, GET /b, PUT /c], already received [].'
-        // TODO - message should indicate GET /b was received at the time the failure happened
-        e.causes[1].cause.message == 'Unexpected request HEAD /a received. Waiting for [GET /a, GET /b, PUT /c], already received [].'
-        e.causes[2].cause.message == 'Unexpected request GET /c received. Waiting for [GET /a, PUT /c], already received [GET /b].'
     }
 
     def "fails when request method does not match expected blocking parallel request"() {
@@ -863,7 +876,7 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def failure3 = null
 
         given:
-        server.expectConcurrentAndBlock(server.get("a"), server.get("b"), server.put("c"))
+        def handle = server.expectConcurrentAndBlock(server.get("a"), server.get("b"), server.put("c"))
         server.start()
 
         when:
@@ -893,9 +906,14 @@ class BlockingHttpServerTest extends ConcurrentSpec {
                     failure3 = t
                 }
             }
+            server.waitForRequests(3)
+            handle.waitForAllPendingCalls()
         }
 
         then:
+        def waitException = thrown(RuntimeException)
+        waitException.message == 'Unexpected request HEAD /a received. Waiting for 2 further requests, received [GET /b], released [], not yet received [GET /a, PUT /c]'
+
         failure1 instanceof IOException
         failure2 instanceof IOException
         failure3 instanceof IOException
@@ -907,15 +925,10 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle HEAD /a',
-            'Failed to handle GET /b',
-            'Failed to handle GET /c',
+            'Unexpected request HEAD /a received. Waiting for 3 further requests, received [], released [], not yet received [GET /a, GET /b, PUT /c]',
+            'Failed to handle GET /b due to unexpected request HEAD /a. Waiting for 2 further requests, received [GET /b], released [], not yet received [GET /a, PUT /c]',
+            'Unexpected request GET /c received. Waiting for 2 further requests, received [GET /b], released [], not yet received [GET /a, PUT /c]',
         ]
-        e.causes[0].cause.message == 'Unexpected request HEAD /a received. Waiting for 3 further requests, already received [], released [], still expecting [GET /a, GET /b, PUT /c].'
-        // TODO - message should indicate GET /b was received at the time the failure happened
-        e.causes[1].cause.message == 'Unexpected request HEAD /a received. Waiting for 3 further requests, already received [], released [], still expecting [GET /a, GET /b, PUT /c].'
-        // TODO - message should indicate GET /b was received at the time the failure happened
-        e.causes[2].cause.message == 'Unexpected request GET /c received. Waiting for 2 further requests, already received [GET /b], released [], still expecting [GET /a, PUT /c].'
     }
 
     def "fails when additional requests are made after parallel expectations are met"() {
@@ -939,8 +952,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         then:
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
-        e.cause.message == 'Received unexpected request GET /c'
-        e.causes.message.sort() == ['Received unexpected request GET /c']
+        e.cause.message == 'Unexpected request GET /c received'
+        e.causes.message.sort() == ['Unexpected request GET /c received']
     }
 
     def "fails when some but not all expected parallel requests received while waiting"() {
@@ -963,8 +976,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         }
 
         then:
-        def waitError = thrown(AssertionError)
-        waitError.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c].'
+        def waitError = thrown(RuntimeException)
+        waitError.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]'
 
         requestFailure instanceof IOException
 
@@ -975,9 +988,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a'
+            'Failed to handle GET /a due to a timeout waiting for other requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]'
         ]
-        e.causes[0].cause.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c].'
     }
 
     def "fails when expected parallel request received after waiting has failed"() {
@@ -1000,8 +1012,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         }
 
         then:
-        def waitError = thrown(AssertionError)
-        waitError.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c].'
+        def waitError = thrown(RuntimeException)
+        waitError.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]'
 
         requestFailure instanceof IOException
 
@@ -1018,12 +1030,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a',
-            'Failed to handle GET /b'
+            'Failed to handle GET /a due to a timeout waiting for other requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]',
+            'Failed to handle GET /b due to a previous timeout. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]'
         ]
-        e.causes[0].cause.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c].'
-        // TODO - message should indicate that request received after timeout
-        e.causes[1].cause.message == 'Timeout waiting for expected requests. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c].'
     }
 
     def "fails when unexpected request received while other request is waiting "() {
@@ -1058,11 +1067,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a',
-            'Failed to handle GET /c'
+            'Failed to handle GET /a due to unexpected request GET /c. Waiting for [GET /b], already received [GET /a]',
+            'Unexpected request GET /c received. Waiting for [GET /b], already received [GET /a]'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /c received. Waiting for [GET /b], already received [GET /a].'
-        e.causes[1].cause.message == 'Unexpected request GET /c received. Waiting for [GET /b], already received [GET /a].'
 
         failure1 instanceof IOException
         failure2 instanceof IOException
@@ -1097,8 +1104,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         }
 
         then:
-        def waitError = thrown(AssertionError)
-        waitError.message == "Unexpected request GET /d received. Waiting for 1 further requests, already received [GET /a], released [], still expecting [GET /b, GET /c]."
+        def waitError = thrown(RuntimeException)
+        waitError.message == "Unexpected request GET /d received. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]"
 
         failure1 instanceof IOException
         failure2 instanceof IOException
@@ -1110,11 +1117,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a',
-            'Failed to handle GET /d'
+            'Failed to handle GET /a due to unexpected request GET /d. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]',
+            'Unexpected request GET /d received. Waiting for 1 further requests, received [GET /a], released [], not yet received [GET /b, GET /c]'
         ]
-        e.causes[0].cause.message == 'Unexpected request GET /d received. Waiting for 1 further requests, already received [GET /a], released [], still expecting [GET /b, GET /c].'
-        e.causes[1].cause.message == 'Unexpected request GET /d received. Waiting for 1 further requests, already received [GET /a], released [], still expecting [GET /b, GET /c].'
     }
 
     def "fails when too many concurrent requests received while waiting"() {
@@ -1156,8 +1161,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         }
 
         then:
-        def waitError = thrown(AssertionError)
-        waitError.message == "Unexpected request GET /c received. Waiting for 0 further requests, already received [GET /a, GET /b], released [], still expecting [GET /c]."
+        def waitError = thrown(RuntimeException)
+        waitError.message == "Unexpected request GET /c received. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]"
 
         failure1 instanceof IOException
         failure2 instanceof IOException
@@ -1169,15 +1174,11 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         then:
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
+        // TODO - message should indicate that /c was expected but there were too many concurrent requests
         e.causes.message.sort() == [
-            'Failed to handle GET /a',
-            'Failed to handle GET /b',
-            'Failed to handle GET /c',
-        ]
-        e.causes.cause.message.sort() == [
-            "Unexpected request GET /c received. Waiting for 0 further requests, already received [GET /a, GET /b], released [], still expecting [GET /c].",
-            "Unexpected request GET /c received. Waiting for 0 further requests, already received [GET /a, GET /b], released [], still expecting [GET /c].",
-            "Unexpected request GET /c received. Waiting for 0 further requests, already received [GET /a, GET /b], released [], still expecting [GET /c]."
+            'Failed to handle GET /a due to unexpected request GET /c. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]',
+            'Failed to handle GET /b due to unexpected request GET /c. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]',
+            'Unexpected request GET /c received. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]',
         ]
     }
 
@@ -1216,9 +1217,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e4 = thrown(RuntimeException)
         e4.message == 'Failed to handle all HTTP requests.'
         e4.causes.message == [
-            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /a, GET /b].',
-            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /c, GET /d].',
-            'Did not receive expected requests. Waiting for [GET /e], received []'
+            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /a, GET /b]',
+            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /c, GET /d]',
+            'Did not receive expected requests. Waiting for [GET /e], already received []'
         ]
     }
 
@@ -1242,8 +1243,8 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e2 = thrown(RuntimeException)
         e2.message == 'Failed to handle all HTTP requests.'
         e2.causes.message == [
-            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /a, GET /b].',
-            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /c, GET /d].',
+            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /a, GET /b]',
+            'Did not handle all expected requests. Waiting for 2 further requests, received [], released [], not yet received [GET /c, GET /d]',
         ]
     }
 
@@ -1287,11 +1288,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e = thrown(RuntimeException)
         e.message == 'Failed to handle all HTTP requests.'
         e.causes.message == [
-            'Failed to handle GET /a',
-            'Failed to handle GET /b'
+            'Failed to handle GET /a due to a timeout waiting to be released. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]',
+            'Failed to handle GET /b due to a timeout waiting to be released. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c]'
         ]
-        e.causes[0].cause.message == 'Timeout waiting to be released. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c].'
-        e.causes[1].cause.message == 'Timeout waiting to be released. Waiting for 0 further requests, received [GET /a, GET /b], released [], not yet received [GET /c].'
     }
 
     def "fails when request is not released after sending partial response"() {
@@ -1356,9 +1355,9 @@ class BlockingHttpServerTest extends ConcurrentSpec {
         def e3 = thrown(RuntimeException)
         e3.message == 'Failed to handle all HTTP requests.'
         e3.causes.message == [
-            'Did not receive expected requests. Waiting for [GET /a], received []',
-            'Did not handle all expected requests. Waiting for 1 further requests, received [], released [], not yet received [GET /b].',
-            'Did not receive expected requests. Waiting for [GET /c], received []'
+            'Did not receive expected requests. Waiting for [GET /a], already received []',
+            'Did not handle all expected requests. Waiting for 1 further requests, received [], released [], not yet received [GET /b]',
+            'Did not receive expected requests. Waiting for [GET /c], already received []'
         ]
     }
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r51/ProjectConfigurationProgressEventCrossVersionSpec.groovy
@@ -217,6 +217,7 @@ class ProjectConfigurationProgressEventCrossVersionSpec extends ToolingApiSpecif
 
     def "reports plugin configuration results for remote script plugins"() {
         given:
+        toolingApi.requireIsolatedUserHome() // So that the script is not cached
         server.start()
         def scriptUri = server.uri("script.gradle")
         server.expect(server.get("script.gradle").send("""


### PR DESCRIPTION
### Context

This PR attempts to fix a flaky test. The PR also improves the diagnostics from `BlockingHttpServer` to give clearer error messages when something goes wrong, such when an unexpected request is received.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
