### PR TITLE
Fix Java usage disambiguation rules

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/artifacts/JavaEcosystemSupport.java
@@ -140,6 +140,10 @@ public abstract class JavaEcosystemSupport {
                     } else if (candidateValues.contains(javaApi)) {
                         // Prefer the API over the runtime when the API has been requested
                         details.closestMatch(javaApi);
+                    } else if (candidateValues.contains(javaRuntimeClasses)) {
+                        details.closestMatch(javaRuntimeClasses);
+                    } else if (candidateValues.contains(javaRuntimeJars)) {
+                        details.closestMatch(javaRuntimeJars);
                     }
                 } else if (runtimeVariants.contains(consumerValue)) {
                     // we're asking for a runtime variant, but no exact match was found


### PR DESCRIPTION
### Context

This commit makes sure that if for an API, we have 2 runtime
candidates, we select the most appropriate runtime. This
happened in a Kotlin test project.

