### PR TITLE
Add link from `SourceSet` API doc to user manual

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/tasks/SourceSet.java
@@ -25,10 +25,13 @@ import org.gradle.api.plugins.ExtensionAware;
 import javax.annotation.Nullable;
 
 /**
- * A {@code SourceSet} represents a logical group of Java source and resources.
+ * A {@code SourceSet} represents a logical group of Java source and resource files. They
+ * are covered in more detail in the
+ * <a href="/userguide/building_java_projects.html#sec:java_source_sets">user manual</a>.
  * <p>
- * See the example below how {@link SourceSet} 'main' is accessed and how the {@link SourceDirectorySet} 'java'
- * is configured to exclude some package from compilation.
+ * The following example shows how you can configure the 'main' source set, which in this
+ * case involves excluding classes whose package begins 'some.unwatned.package' from
+ * compilation of the source files in the 'java' {@link SourceDirectorySet}:
  *
  * <pre class='autoTested'>
  * apply plugin: 'java'


### PR DESCRIPTION
A lot of users land on this API doc when they do a web search for "gradle
sourcesets". But it doesn't explain what source sets are. This change adds a
link to the user manual which _does_ explain what they are and how to use
them.

Implements #dotorg-docs/348.
