### PR TITLE
Improve performance of scheduler in the presence of many nodes

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/ActionNode.java
@@ -63,6 +63,11 @@ class ActionNode extends Node {
     }
 
     @Override
+    public boolean requiresMonitoring() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "work action " + action;
     }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -106,7 +106,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
     private final Map<Pair<Node, Node>, Boolean> reachableCache = Maps.newHashMap();
     private final Set<Node> dependenciesCompleteCache = Sets.newHashSet();
     private final Set<Node> dependenciesWithChanges = Sets.newHashSet();
-    private final Set<Node> dependenciesWhichRequireMonitoring = Sets.newHashSet();
+    private final List<Node> dependenciesWhichRequireMonitoring = Lists.newArrayList();
     private final Set<Node> readyToExecute = Sets.newHashSet();
     private final WorkerLeaseService workerLeaseService;
     private final GradleInternal gradle;
@@ -262,6 +262,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             }
         }));
         int visitingSegmentCounter = nodeQueue.size();
+        Set<Node> dependenciesWhichRequireMonitoring = Sets.newHashSet();
 
         HashMultimap<Node, Integer> visitingNodes = HashMultimap.create();
         Deque<GraphEdge> walkedShouldRunAfterEdges = new ArrayDeque<GraphEdge>();
@@ -346,6 +347,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         executionQueue.clear();
         Iterables.addAll(executionQueue, nodeMapping);
         Iterables.addAll(dependenciesWithChanges, nodeMapping);
+        this.dependenciesWhichRequireMonitoring.addAll(dependenciesWhichRequireMonitoring);
     }
 
     private MutationInfo getOrCreateMutationsOf(Node node) {
@@ -519,6 +521,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         dependenciesCompleteCache.clear();
         dependenciesWithChanges.clear();
         dependenciesWhichRequireMonitoring.clear();
+        readyToExecute.clear();
         runningNodes.clear();
     }
 

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/LocalTaskNode.java
@@ -88,11 +88,16 @@ public class LocalTaskNode extends TaskNode {
             processHardSuccessor.execute(targetNode);
         }
         for (Node targetNode : getMustRunAfter(dependencyResolver)) {
-            addMustSuccessor(targetNode);
+            addMustSuccessor((TaskNode) targetNode);
         }
         for (Node targetNode : getShouldRunAfter(dependencyResolver)) {
             addShouldSuccessor(targetNode);
         }
+    }
+
+    @Override
+    public boolean requiresMonitoring() {
+        return false;
     }
 
     private void addFinalizerNode(TaskNode finalizerNode) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -31,6 +31,10 @@ import java.util.Set;
  */
 public abstract class Node implements Comparable<Node> {
 
+    protected Iterable<Node> getAllPredecessors() {
+        return getDependencyPredecessors();
+    }
+
     @VisibleForTesting
     enum ExecutionState {
         UNKNOWN, NOT_REQUIRED, SHOULD_RUN, MUST_RUN, MUST_NOT_RUN, EXECUTING, EXECUTED, SKIPPED
@@ -60,7 +64,7 @@ public abstract class Node implements Comparable<Node> {
     }
 
     public boolean isIncludeInGraph() {
-        return state == ExecutionState.NOT_REQUIRED || state == ExecutionState.UNKNOWN;
+        return state != ExecutionState.NOT_REQUIRED && state != ExecutionState.UNKNOWN;
     }
 
     public boolean isReady() {
@@ -220,6 +224,13 @@ public abstract class Node implements Comparable<Node> {
     public abstract Set<Node> getFinalizers();
 
     public abstract boolean isPublicNode();
+
+    /**
+     * Whether the task needs to be queried if it is completed.
+     *
+     * Everything where the value of {@link #isComplete()} depends on some other state, like another task in an included build.
+     */
+    public abstract boolean requiresMonitoring();
 
     /**
      * Returns the project which the node requires access to, if any.

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -31,10 +31,6 @@ import java.util.Set;
  */
 public abstract class Node implements Comparable<Node> {
 
-    protected Iterable<Node> getAllPredecessors() {
-        return getDependencyPredecessors();
-    }
-
     @VisibleForTesting
     enum ExecutionState {
         UNKNOWN, NOT_REQUIRED, SHOULD_RUN, MUST_RUN, MUST_NOT_RUN, EXECUTING, EXECUTED, SKIPPED
@@ -209,6 +205,11 @@ public abstract class Node implements Comparable<Node> {
             }
         }
         return true;
+    }
+
+    @OverridingMethodsMustInvokeSuper
+    protected Iterable<Node> getAllPredecessors() {
+        return getDependencyPredecessors();
     }
 
     public abstract void prepareForExecution();

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -42,6 +42,7 @@ public abstract class Node implements Comparable<Node> {
 
     private ExecutionState state;
     private boolean dependenciesProcessed;
+    private boolean allDependenciesComplete;
     private Throwable executionFailure;
     private final NavigableSet<Node> dependencySuccessors = Sets.newTreeSet();
     private final NavigableSet<Node> dependencyPredecessors = Sets.newTreeSet();
@@ -172,7 +173,7 @@ public abstract class Node implements Comparable<Node> {
     }
 
     @OverridingMethodsMustInvokeSuper
-    public boolean allDependenciesComplete() {
+    protected boolean doCheckDependenciesComplete() {
         for (Node dependency : dependencySuccessors) {
             if (!dependency.isComplete()) {
                 return false;
@@ -180,6 +181,25 @@ public abstract class Node implements Comparable<Node> {
         }
 
         return true;
+    }
+
+    /**
+     * Returns if all dependencies completed, but have not been completed in the last check.
+     */
+    public boolean updateAllDependenciesComplete() {
+        if (!allDependenciesComplete) {
+            forceAllDependenciesCompleteUpdate();
+            return allDependenciesComplete;
+        }
+        return false;
+    }
+
+    public void forceAllDependenciesCompleteUpdate() {
+        allDependenciesComplete = doCheckDependenciesComplete();
+    }
+
+    public boolean allDependenciesComplete() {
+        return allDependenciesComplete;
     }
 
     public boolean allDependenciesSuccessful() {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -28,6 +28,7 @@ import java.util.Set;
 public abstract class TaskNode extends Node {
 
     private final NavigableSet<Node> mustSuccessors = Sets.newTreeSet();
+    private final Set<Node> mustPredecessors = Sets.newHashSet();
     private final NavigableSet<Node> shouldSuccessors = Sets.newTreeSet();
     private final NavigableSet<Node> finalizers = Sets.newTreeSet();
     private final NavigableSet<Node> finalizingSuccessors = Sets.newTreeSet();
@@ -68,8 +69,9 @@ public abstract class TaskNode extends Node {
         return shouldSuccessors;
     }
 
-    protected void addMustSuccessor(Node toNode) {
+    protected void addMustSuccessor(TaskNode toNode) {
         mustSuccessors.add(toNode);
+        toNode.mustPredecessors.add(this);
     }
 
     protected void addFinalizingSuccessor(TaskNode finalized) {
@@ -101,6 +103,11 @@ public abstract class TaskNode extends Node {
             finalizingSuccessors.descendingSet(),
             shouldSuccessors.descendingSet()
         );
+    }
+
+    @Override
+    public Iterable<Node> getAllPredecessors() {
+        return Iterables.concat(mustPredecessors, super.getAllPredecessors());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNode.java
@@ -34,8 +34,8 @@ public abstract class TaskNode extends Node {
     private final NavigableSet<Node> finalizingSuccessors = Sets.newTreeSet();
 
     @Override
-    public boolean allDependenciesComplete() {
-        if (!super.allDependenciesComplete()) {
+    public boolean doCheckDependenciesComplete() {
+        if (!super.doCheckDependenciesComplete()) {
             return false;
         }
         for (Node dependency : mustSuccessors) {
@@ -107,7 +107,7 @@ public abstract class TaskNode extends Node {
 
     @Override
     public Iterable<Node> getAllPredecessors() {
-        return Iterables.concat(mustPredecessors, super.getAllPredecessors());
+        return Iterables.concat(mustPredecessors, finalizers, super.getAllPredecessors());
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/TaskNodeFactory.java
@@ -128,6 +128,11 @@ public class TaskNodeFactory {
         }
 
         @Override
+        public boolean requiresMonitoring() {
+            return true;
+        }
+
+        @Override
         public void require() {
             // Ignore
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNode.java
@@ -66,6 +66,11 @@ public abstract class TransformationNode extends Node {
     }
 
     @Override
+    public boolean requiresMonitoring() {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return transformationStep.getDisplayName();
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformationNodeSpec.groovy
@@ -119,6 +119,11 @@ class TransformationNodeSpec extends Specification {
         }
 
         @Override
+        boolean requiresMonitoring() {
+            return false
+        }
+
+        @Override
         String toString() {
             return null
         }


### PR DESCRIPTION
Instead of checking every time a new node to execute is queried if all the nodes are completed, we keep track of the nodes which have changed dependencies and only re-check those.

This mitigates part of the performance regression in `santa-tracker` with AGP 3.5 (another 3%) and fixes the performance regression between current `master` and Gradle 5.1.1. See #8713, for adding the santa tracker performance test and fixing another part of the regression.

The performance regression is now there, since Gradle adds more elements for transforms to the execution graph (one per transform registration, instead of one per transformation class configuration) since 5.2 and the AGP 3.5 is using more transforms when the jetifier is enabled.

Here is a flame graph which shows the expensive searching for nodes to execute:
![image](https://user-images.githubusercontent.com/423186/53751655-0ffcc980-3ead-11e9-97bb-624e833c7c88.png)

