### PR TITLE
Fix handling of aborted containers with completed children

### DIFF
--- a/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
+++ b/subprojects/testing-junit-platform/src/main/java/org/gradle/api/internal/tasks/testing/junitplatform/JUnitPlatformTestExecutionListener.java
@@ -121,7 +121,9 @@ public class JUnitPlatformTestExecutionListener implements TestExecutionListener
     }
 
     private void reportSkipped(TestIdentifier testIdentifier) {
-        currentTestPlan.getChildren(testIdentifier).forEach(child -> executionSkipped(child));
+        currentTestPlan.getChildren(testIdentifier).stream()
+            .filter(child -> !wasStarted(child))
+            .forEach(child -> executionSkipped(child));
         if (testIdentifier.isTest()) {
             resultProcessor.completed(getId(testIdentifier), completeEvent(SKIPPED));
         } else if (isClass(testIdentifier)) {

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
@@ -25,8 +25,8 @@ import org.gradle.api.JavaVersion
  */
 class JUnitCoverage {
     final static String NEWEST = '4.12'
-    final static String LATEST_JUPITER_VERSION = '5.3.1'
-    final static String LATEST_VINTAGE_VERSION = '5.3.1'
+    final static String LATEST_JUPITER_VERSION = '5.4.0'
+    final static String LATEST_VINTAGE_VERSION = '5.4.0'
     final static String JUPITER = 'Jupiter:' + LATEST_JUPITER_VERSION
     final static String VINTAGE = 'Vintage:' + LATEST_VINTAGE_VERSION
     final static String[] LARGE_COVERAGE = ['4.0', '4.4', '4.8.2', NEWEST]

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.testing.junit
+
+import org.gradle.integtests.fixtures.DefaultTestExecutionResult
+import org.gradle.integtests.fixtures.TargetCoverage
+import org.gradle.integtests.fixtures.TestResources
+import org.gradle.testing.fixture.JUnitMultiVersionIntegrationSpec
+import org.junit.Rule
+
+import static org.gradle.testing.fixture.JUnitCoverage.JUNIT_VINTAGE
+
+@TargetCoverage({ JUNIT_VINTAGE })
+class JUnitAbortedTestClassIntegrationTest extends JUnitMultiVersionIntegrationSpec {
+
+    @Rule TestResources resources = new TestResources(temporaryFolder)
+
+    def supportsAssumptionsInRules() {
+        given:
+        executer.noExtraLogging()
+        buildFile << """
+dependencies {
+    testCompile '$dependencyNotation'
+}
+"""
+
+        when:
+        run('test')
+
+        then:
+        def result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted('org.gradle.SkippingRuleTests')
+        result.testClass('org.gradle.SkippingRuleTests')
+            .assertTestCount(3, 0, 0)
+            .assertTestsExecuted('a')
+            .assertTestsSkipped('b', 'c')
+    }
+
+}

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junitplatform/JUnitPlatformIntegrationTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.integtests.fixtures.DefaultTestExecutionResult
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
 import spock.lang.Issue
+import spock.lang.Timeout
 import spock.lang.Unroll
 
 import static org.gradle.testing.fixture.JUnitCoverage.LATEST_JUPITER_VERSION
@@ -366,6 +367,7 @@ public class StaticInnerTest {
         'excludeEngines' | '"junit-jupiter"'
     }
 
+    @Timeout(60)
     @Issue('https://github.com/gradle/gradle/issues/6453')
     def "can handle parallel test execution"() {
         given:
@@ -383,8 +385,11 @@ public class StaticInnerTest {
 
             import java.util.concurrent.*;
             import org.junit.jupiter.api.*;
+            import org.junit.jupiter.api.parallel.*;
             import static org.junit.jupiter.api.Assertions.*;
+            import static org.junit.jupiter.api.parallel.ExecutionMode.CONCURRENT;
 
+            @Execution(CONCURRENT)
             class Sync {
                 static CountDownLatch LATCH = new CountDownLatch($numTestClasses);
             }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest/supportsAssumptionsInRules/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest/supportsAssumptionsInRules/build.gradle
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2013 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+apply plugin: 'java'
+repositories { mavenCentral() }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest/supportsAssumptionsInRules/src/test/java/org/gradle/SkippingRuleTests.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitAbortedTestClassIntegrationTest/supportsAssumptionsInRules/src/test/java/org/gradle/SkippingRuleTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle;
+
+import org.junit.FixMethodOrder;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.MethodRule;
+
+import static org.junit.Assume.assumeFalse;
+import static org.junit.runners.MethodSorters.NAME_ASCENDING;
+
+@FixMethodOrder(NAME_ASCENDING)
+public class SkippingRuleTests {
+
+    @Rule
+    public MethodRule misbehavingSkippingRule = (statement, method, target) -> {
+        assumeFalse(method.getName().equals("b"));
+        return statement;
+    };
+
+    @Test
+    public void a() {
+    }
+
+    @Test
+    public void b() {
+    }
+
+    @Test
+    public void c() {
+    }
+
+}


### PR DESCRIPTION
When a container `TestIdentifier` was reported as finished, we reported
all of its children as skipped, regardless whether they already had been
completed previously. Now, we only report unstarted children as skipped.

Resolves #8685.