### PR TITLE
Transform disambiguation with schema disambiguation

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -1029,6 +1029,7 @@ Found the following transforms:
                         }
                         variant3 {
                             attributes.attribute(buildType, 'debug')
+                            attributes.attribute(flavor, 'free')
                             artifact jar1
                         }
                     }
@@ -1109,11 +1110,13 @@ Found the following transforms:
       - With source attributes:
           - artifactType 'jar'
           - buildType 'debug'
+          - flavor 'free'
           - usage 'api'
       - Candidate transform(s):
           - Transform 'BrokenTransform' producing attributes:
               - artifactType 'transformed'
               - buildType 'debug'
+              - flavor 'free'
               - usage 'api'"""
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -173,7 +173,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         List<AttributeContainerInternal> matches = matcher.matches(candidateAttributes, componentRequested);
         if (matches.size() == 1) {
             AttributeContainerInternal singleMatch = matches.get(0);
-            return candidates.stream().filter(pair -> pair.getRight().attributes == singleMatch).collect(Collectors.toList());
+            return candidates.stream().filter(pair -> pair.getRight().attributes.equals(singleMatch)).collect(Collectors.toList());
         } else if (matches.size() > 0 && matches.size() < candidates.size()) {
             // We know all are compatibles, so this is only possible if some disambiguation happens but not getting us to 1 candidate
             return candidates.stream().filter(pair -> matches.contains(pair.getRight().attributes)).collect(Collectors.toList());

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -189,6 +189,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform2, 3)
         }
+        1 * attributeMatcher.matches(_, _) >> { args -> args[0] }
     }
 
     def 'can disambiguate 2 equivalent chains by picking shortest'() {
@@ -240,6 +241,58 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform2, 3)
         }
+        1 * attributeMatcher.matches(_, _) >> { args -> args[0] }
+    }
+
+    def 'can leverage schema disambiguation'() {
+        given:
+        def otherVariant = Mock(ResolvedVariant) {
+            getAttributes() >> otherVariantAttributes
+            asDescribable() >> Describables.of("mock other resolved variant")
+        }
+        def multiVariantSet = Mock(ResolvedVariantSet) {
+            asDescribable() >> Describables.of("mock multi producer")
+            getVariants() >> [variant, otherVariant]
+        }
+        def transform1 = Mock(Transformation)
+        def transform2 = Mock(Transformation)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, requestedAttributes, false, dependenciesResolverFactory)
+
+        when:
+        def result = selector.select(multiVariantSet)
+
+
+        then:
+        result.visitDependencies(new TaskDependencyResolveContext() {
+            @Override
+            void add(Object dependency) {
+                assert dependency instanceof DefaultTransformationDependency
+                assert dependency.transformation == transform1
+            }
+
+            @Override
+            void maybeAdd(Object dependency) {
+
+            }
+
+            @Override
+            void visitFailure(Throwable failure) {
+                throw failure
+            }
+
+            @Override
+            Task getTask() {
+                return null
+            }
+        })
+        1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(requestedAttributes, transform1, 2)
+        }
+        1 * consumerProvidedVariantFinder.collectConsumerVariants(otherVariantAttributes, requestedAttributes, _) >> { args ->
+            args[2].matched(variantAttributes, transform2, 3)
+        }
+        1 * attributeMatcher.matches(_, _) >> { args -> [args[0].get(0)] }
     }
 
     def 'can disambiguate between three chains when one subset of both others'() {
@@ -300,6 +353,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         1 * consumerProvidedVariantFinder.collectConsumerVariants(yetAnotherVariantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform3, 2)
         }
+        1 * attributeMatcher.matches(_, _) >> { args -> args[0] }
     }
 
     def 'can disambiguate 3 equivalent chains by picking shortest'() {
@@ -350,7 +404,6 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
             }
         })
         1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
-        2 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >> true
         1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform1, 3)
         }
@@ -360,6 +413,8 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         1 * consumerProvidedVariantFinder.collectConsumerVariants(yetAnotherVariantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform3, 3)
         }
+        2 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >> true
+        1 * attributeMatcher.matches(_, _) >> { args -> args[0] }
     }
 
     def 'cannot disambiguate 3 chains when 2 different'() {
@@ -409,7 +464,6 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
             }
         })
         1 * attributeMatcher.matches(_, _) >> Collections.emptyList()
-        3 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >>> [false, false, true]
         1 * consumerProvidedVariantFinder.collectConsumerVariants(variantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform1, 3)
         }
@@ -419,5 +473,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         1 * consumerProvidedVariantFinder.collectConsumerVariants(yetAnotherVariantAttributes, requestedAttributes, _) >> { args ->
             args[2].matched(requestedAttributes, transform3, 3)
         }
+        1 * attributeMatcher.matches(_, _) >> { args -> args[0] }
+        3 * attributeMatcher.isMatching(requestedAttributes, requestedAttributes) >>> [false, false, true]
     }
 }


### PR DESCRIPTION
With this change, transform disambiguation now first leverages the
schema disambiguation rule.
Size based disambiguation only happens in a second phase if still
required.