### PR TITLE
Update javadoc to remove deprecated configurations

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/Project.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Project.java
@@ -1551,7 +1551,7 @@ public interface Project extends Comparable<Project>, ExtensionAware, PluginAwar
      * copy the files. Example:
      * <pre>
      * copy {
-     *    from configurations.runtime
+     *    from configurations.runtimeClasspath
      *    into 'build/deploy/lib'
      * }
      * </pre>

--- a/subprojects/core-api/src/main/java/org/gradle/api/Script.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/Script.java
@@ -256,7 +256,7 @@ public interface Script {
      * is then used to copy the files. Example:
      * <pre>
      * copy {
-     *    from configurations.runtime
+     *    from configurations.runtimeClasspath
      *    into 'build/deploy/lib'
      * }
      * </pre>

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ConfigurationContainer.java
@@ -49,32 +49,36 @@ import org.gradle.internal.HasInternalProtocol;
  * An example showing how to refer to a given configuration by name
  * in order to get hold of all dependencies (e.g. jars, but only)
  * <pre class='autoTested'>
- *   apply plugin: 'java' //so that I can use 'compile' configuration
+ *   apply plugin: 'java' //so that I can use 'implementation', 'compileClasspath' configuration
  *
- *   //copying all dependencies attached to 'compile' into a specific folder
+ *   dependencies {
+ *       implementation 'org.slf4j:slf4j-api:1.7.26'
+ *   }
+ *
+ *   //copying all dependencies attached to 'compileClasspath' into a specific folder
  *   task copyAllDependencies(type: Copy) {
- *     //referring to the 'compile' configuration
- *     from configurations.compile
+ *     //referring to the 'compileClasspath' configuration
+ *     from configurations.compileClasspath
  *     into 'allLibs'
  *   }
  * </pre>
  *
  * An example showing how to declare and configure configurations
  * <pre class='autoTested'>
- * apply plugin: 'java' //so that I can use 'compile', 'testCompile' configurations
+ * apply plugin: 'java' //so that I can use 'implementation', 'testImplementation' configurations
  *
  * configurations {
  *   //adding a configuration:
  *   myConfiguration
  *
  *   //adding a configuration that extends existing configuration:
- *   //(testCompile was added by the java plugin)
- *   myIntegrationTestsCompile.extendsFrom(testCompile)
+ *   //(testImplementation was added by the java plugin)
+ *   myIntegrationTestsCompile.extendsFrom(testImplementation)
  *
  *   //configuring existing configurations not to put transitive dependencies on the compile classpath
  *   //this way you can avoid issues with implicit dependencies to transitive libraries
- *   compile.transitive = false
- *   testCompile.transitive = false
+ *   compileClasspath.transitive = false
+ *   testCompileClasspath.transitive = false
  * }
  * </pre>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ModuleDependency.java
@@ -54,10 +54,10 @@ public interface ModuleDependency extends Dependency, HasConfigurableAttributes<
      * then consider using forced versions' feature: {@link ResolutionStrategy#force(Object...)}.
      *
      * <pre class='autoTested'>
-     * apply plugin: 'java' //so that I can declare 'compile' dependencies
+     * apply plugin: 'java' //so that I can declare 'implementation' dependencies
      *
      * dependencies {
-     *   compile('org.hibernate:hibernate:3.1') {
+     *   implementation('org.hibernate:hibernate:3.1') {
      *     //excluding a particular transitive dependency:
      *     exclude module: 'cglib' //by artifact name
      *     exclude group: 'org.jmock' //by group

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/ResolutionStrategy.java
@@ -171,7 +171,7 @@ public interface ResolutionStrategy {
      * Example:
      * <pre class='autoTested'>
      * configurations {
-     *   compile.resolutionStrategy {
+     *   compileClasspath.resolutionStrategy {
      *     eachDependency { DependencyResolveDetails details -&gt;
      *       //specifying a fixed version for all libraries with 'org.gradle' group
      *       if (details.requested.group == 'org.gradle') {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -38,29 +38,29 @@ import java.util.Map;
  *
  * <pre>
  * dependencies {
- *     <i>configurationName</i> <i>dependencyNotation1</i>, <i>dependencyNotation2</i>, ...
+ *     <i>configurationName</i> <i>dependencyNotation</i>
  * }
  * </pre>
  *
  * <p>Example shows a basic way of declaring dependencies.
  * <pre class='autoTested'>
  * apply plugin: 'java'
- * //so that we can use 'compile', 'testCompile' for dependencies
+ * //so that we can use 'implementation', 'testImplementation' for dependencies
  *
  * dependencies {
  *   //for dependencies found in artifact repositories you can use
  *   //the group:name:version notation
- *   compile 'commons-lang:commons-lang:2.6'
- *   testCompile 'org.mockito:mockito:1.9.0-rc1'
+ *   implementation 'commons-lang:commons-lang:2.6'
+ *   testImplementation 'org.mockito:mockito:1.9.0-rc1'
  *
  *   //map-style notation:
- *   compile group: 'com.google.code.guice', name: 'guice', version: '1.0'
+ *   implementation group: 'com.google.code.guice', name: 'guice', version: '1.0'
  *
  *   //declaring arbitrary files as dependencies
- *   compile files('hibernate.jar', 'libs/spring.jar')
+ *   implementation files('hibernate.jar', 'libs/spring.jar')
  *
  *   //putting all jars from 'libs' onto compile classpath
- *   compile fileTree('libs')
+ *   implementation fileTree('libs')
  * }
  * </pre>
  *
@@ -86,10 +86,10 @@ import java.util.Map;
  * </ul>
  *
  * <pre class='autoTested'>
- * apply plugin: 'java' //so that I can declare 'compile' dependencies
+ * apply plugin: 'java' //so that I can declare 'implementation' dependencies
  *
  * dependencies {
- *   compile('org.hibernate:hibernate:3.1') {
+ *   implementation('org.hibernate:hibernate:3.1') {
  *     //in case of versions conflict '3.1' version of hibernate wins:
  *     force = true
  *
@@ -111,14 +111,14 @@ import java.util.Map;
  * </ul>
  *
  * <pre class='autoTested'>
- * apply plugin: 'java' //so that I can declare 'compile' dependencies
+ * apply plugin: 'java' //so that I can declare 'implementation' dependencies
  *
  * dependencies {
  *   //configuring dependency to specific configuration of the module
- *   compile configuration: 'someConf', group: 'org.someOrg', name: 'someModule', version: '1.0'
+ *   implementation configuration: 'someConf', group: 'org.someOrg', name: 'someModule', version: '1.0'
  *
  *   //configuring dependency on 'someLib' module
- *   compile(group: 'org.myorg', name: 'someLib', version:'1.0') {
+ *   implementation(group: 'org.myorg', name: 'someLib', version:'1.0') {
  *     //explicitly adding the dependency artifact:
  *     artifact {
  *       //useful when some artifact properties unconventional
@@ -161,16 +161,16 @@ import java.util.Map;
  *
  * <pre class='autoTested'>
  * apply plugin: 'java'
- * //so that we can use 'compile', 'testCompile' for dependencies
+ * //so that we can use 'implementation', 'testImplementation' for dependencies
  *
  * dependencies {
  *   //for dependencies found in artifact repositories you can use
  *   //the string notation, e.g. group:name:version
- *   compile 'commons-lang:commons-lang:2.6'
- *   testCompile 'org.mockito:mockito:1.9.0-rc1'
+ *   implementation 'commons-lang:commons-lang:2.6'
+ *   testImplementation 'org.mockito:mockito:1.9.0-rc1'
  *
  *   //map notation:
- *   compile group: 'com.google.code.guice', name: 'guice', version: '1.0'
+ *   implementation group: 'com.google.code.guice', name: 'guice', version: '1.0'
  * }
  * </pre>
  *
@@ -195,14 +195,14 @@ import java.util.Map;
  *
  * <pre class='autoTested'>
  * apply plugin: 'java'
- * //so that we can use 'compile', 'testCompile' for dependencies
+ * //so that we can use 'implementation', 'testImplementation' for dependencies
  *
  * dependencies {
  *   //declaring arbitrary files as dependencies
- *   compile files('hibernate.jar', 'libs/spring.jar')
+ *   implementation files('hibernate.jar', 'libs/spring.jar')
  *
  *   //putting all jars from 'libs' onto compile classpath
- *   compile fileTree('libs')
+ *   implementation fileTree('libs')
  * }
  * </pre>
  *
@@ -225,17 +225,17 @@ import java.util.Map;
  * <pre class='autoTested'>
  * //Our Gradle plugin is written in groovy
  * apply plugin: 'groovy'
- * //now we can use the 'compile' configuration for declaring dependencies
+ * //now we can use the 'implementation' configuration for declaring dependencies
  *
  * dependencies {
  *   //we will use the Groovy version that ships with Gradle:
- *   compile localGroovy()
+ *   implementation localGroovy()
  *
  *   //our plugin requires Gradle API interfaces and classes to compile:
- *   compile gradleApi()
+ *   implementation gradleApi()
  *
  *   //we will use the Gradle test-kit to test build logic:
- *   testCompile gradleTestKit()
+ *   testImplementation gradleTestKit()
  * }
  * </pre>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/query/ArtifactResolutionQuery.java
@@ -31,7 +31,7 @@ import java.util.Collection;
  *
  * task resolveCompileSources {
  *     doLast {
- *         def componentIds = configurations.compile.incoming.resolutionResult.allDependencies.collect { it.selected.id }
+ *         def componentIds = configurations.compileClasspath.incoming.resolutionResult.allDependencies.collect { it.selected.id }
  *
  *         def result = dependencies.createArtifactResolutionQuery()
  *                                  .forComponents(componentIds)


### PR DESCRIPTION
The javadoc of a number of core types were still using `compile` or
`runtime` configurations in their examples.
These have been moved to use `implementation`, `compileClasspath` or
similar based on the example.