### PR TITLE
Fix filtering parameterized tests by category

### DIFF
--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/fixture/JUnitCoverage.groovy
@@ -25,16 +25,17 @@ import org.gradle.api.JavaVersion
  */
 class JUnitCoverage {
     final static String NEWEST = '4.12'
+    final static String PREVIEW = '4.13-beta-2'
     final static String LATEST_JUPITER_VERSION = '5.4.0'
     final static String LATEST_VINTAGE_VERSION = '5.4.0'
     final static String JUPITER = 'Jupiter:' + LATEST_JUPITER_VERSION
     final static String VINTAGE = 'Vintage:' + LATEST_VINTAGE_VERSION
-    final static String[] LARGE_COVERAGE = ['4.0', '4.4', '4.8.2', NEWEST]
-    final static String[] IGNORE_ON_CLASS = ['4.4', '4.8.2', NEWEST]
-    final static String[] ASSUMPTIONS = ['4.5', NEWEST]
-    final static String[] CATEGORIES = ['4.8', NEWEST]
-    final static String[] FILTER_JUNIT3_TESTS = ['3.8.1', '4.6', NEWEST]
-    final static String[] JUNIT_4_LATEST = [NEWEST]
+    final static String[] LARGE_COVERAGE = ['4.0', '4.4', '4.8.2', NEWEST, PREVIEW]
+    final static String[] IGNORE_ON_CLASS = ['4.4', '4.8.2', NEWEST, PREVIEW]
+    final static String[] ASSUMPTIONS = ['4.5', NEWEST, PREVIEW]
+    final static String[] CATEGORIES = ['4.8', NEWEST, PREVIEW]
+    final static String[] FILTER_JUNIT3_TESTS = ['3.8.1', '4.6', NEWEST, PREVIEW]
+    final static String[] JUNIT_4_LATEST = [NEWEST, PREVIEW]
     final static String[] JUNIT_VINTAGE = emptyIfJava7(VINTAGE)
     final static String[] JUNIT_VINTAGE_JUPITER = emptyIfJava7(VINTAGE, JUPITER)
 

--- a/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
+++ b/subprojects/testing-jvm/src/integTest/groovy/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec.groovy
@@ -32,15 +32,10 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
 
     def setup() {
         executer.noExtraLogging()
-    }
-
-    def configureJUnit() {
         buildFile << "dependencies { testCompile '$dependencyNotation' }"
     }
 
     def canSpecifyIncludeAndExcludeCategories() {
-        configureJUnit()
-
         when:
         run('test')
 
@@ -59,8 +54,6 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
     }
 
     def canSpecifyExcludesOnly() {
-        configureJUnit()
-
         when:
         run('test')
 
@@ -76,8 +69,6 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
     }
 
     def canCombineCategoriesWithCustomRunner() {
-        configureJUnit()
-
         when:
         run('test')
 
@@ -86,5 +77,21 @@ class JUnitCategoriesCoverageIntegrationSpec extends JUnitMultiVersionIntegratio
         result.assertTestClassesExecuted('org.gradle.SomeLocaleTests')
         result.testClass("org.gradle.SomeLocaleTests").assertTestCount(3, 0, 0)
         result.testClass("org.gradle.SomeLocaleTests").assertTestsExecuted('ok1 [de]', 'ok1 [en]', 'ok1 [fr]')
+    }
+
+    def canRunParameterizedTestsWithCategories() {
+        when:
+        run('test')
+
+        then:
+        def expectedTestClasses = ['org.gradle.NestedTestsWithCategories$TagOnMethodNoParam', 'org.gradle.NestedTestsWithCategories$TagOnMethod']
+        if (isVintage() || !(version in ['4.10', '4.11', '4.12'])) {
+            expectedTestClasses << 'org.gradle.NestedTestsWithCategories$TagOnClass'
+        }
+        DefaultTestExecutionResult result = new DefaultTestExecutionResult(testDirectory)
+        result.assertTestClassesExecuted(expectedTestClasses as String[])
+        expectedTestClasses.each {
+            result.testClass(it).assertTestCount(1, 0, 0)
+        }
     }
 }

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithCategories/build.gradle
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithCategories/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: "java"
+
+repositories {
+    mavenCentral()
+}
+
+test {
+    useJUnit {
+        includeCategories 'org.gradle.SomeCategory'
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithCategories/src/test/java/org/gradle/NestedTestsWithCategories.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithCategories/src/test/java/org/gradle/NestedTestsWithCategories.java
@@ -1,0 +1,96 @@
+package org.gradle;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+
+import static org.junit.Assert.fail;
+
+public class NestedTestsWithCategories {
+
+    @Category(SomeCategory.class)
+    @RunWith(Parameterized.class)
+    public static class TagOnClass {
+        @Parameterized.Parameters
+        public static Iterable<Object[]> getParameters() {
+            ArrayList<Object[]> parameters = new ArrayList<>();
+            parameters.add(new Object[] { "tag on class" });
+            return parameters;
+        }
+
+        private final String param;
+
+        public TagOnClass(String param) {
+            this.param = param;
+        }
+
+        @Test
+        public void run() {
+            System.err.println("executed " + param);
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class TagOnMethod {
+        @Parameterized.Parameters
+        public static Iterable<Object[]> getParameters() {
+            ArrayList<Object[]> parameters = new ArrayList<>();
+            parameters.add(new Object[] { "tag on method" });
+            return parameters;
+        }
+
+        private final String param;
+
+        public TagOnMethod(String param) {
+            this.param = param;
+        }
+
+        @Test
+        @Category(SomeCategory.class)
+        public void run() {
+            System.err.println("executed " + param);
+        }
+
+        @Test
+        public void filteredOut() {
+            throw new AssertionError("should be filtered out");
+        }
+    }
+
+    public static class TagOnMethodNoParam {
+        @Test
+        @Category(SomeCategory.class)
+        public void run() {
+            System.err.println("executed tag on method (no param)");
+        }
+
+        @Test
+        public void filteredOut() {
+            throw new AssertionError("should be filtered out");
+        }
+    }
+
+    @RunWith(Parameterized.class)
+    public static class Untagged {
+        @Parameterized.Parameters
+        public static Iterable<Object[]> getParameters() {
+            ArrayList<Object[]> parameters = new ArrayList<>();
+            parameters.add(new Object[] { "untagged" });
+            return parameters;
+        }
+
+        private final String param;
+
+        public Untagged(String param) {
+            this.param = param;
+        }
+
+        @Test
+        public void run() {
+            System.err.println("executed " + param);
+        }
+    }
+}

--- a/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithCategories/src/test/java/org/gradle/SomeCategory.java
+++ b/subprojects/testing-jvm/src/integTest/resources/org/gradle/testing/junit/JUnitCategoriesCoverageIntegrationSpec/canRunParameterizedTestsWithCategories/src/test/java/org/gradle/SomeCategory.java
@@ -1,0 +1,4 @@
+package org.gradle;
+
+public interface SomeCategory {
+}

--- a/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/CategoryFilter.java
+++ b/subprojects/testing-jvm/src/main/java/org/gradle/api/internal/tasks/testing/junit/CategoryFilter.java
@@ -43,8 +43,8 @@ class CategoryFilter extends Filter {
     public boolean shouldRun(final Description description) {
         Class<?> testClass = description.getTestClass();
         verifyCategories(testClass);
-        Description desc = description.isSuite() || testClass == null ? null : Description.createSuiteDescription(testClass);
-        return shouldRun(description, desc);
+        Description parent = description.isSuite() || testClass == null ? null : Description.createSuiteDescription(testClass);
+        return shouldRun(description, parent);
     }
 
     private void verifyCategories(Class<?> testClass) {
@@ -60,6 +60,18 @@ class CategoryFilter extends Filter {
     }
 
     private boolean shouldRun(final Description description, final Description parent) {
+        if (hasCorrectCategoryAnnotation(description, parent)) {
+            return true;
+        }
+        for (Description each : description.getChildren()) {
+            if (shouldRun(each, description)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasCorrectCategoryAnnotation(Description description, Description parent) {
         final Set<Class<?>> categories = new HashSet<Class<?>>();
         Category annotation = description.getAnnotation(Category.class);
         if (annotation != null) {


### PR DESCRIPTION
Prior to this commit methods in parameterized test classes were not
checked for `@Category` annotations.

Resolves #8424.