### PR TITLE
Make patchKotlinCompilerEmbeddable depend on classpathManifest

### DIFF
--- a/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
+++ b/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
@@ -55,9 +55,8 @@ tasks {
         dependenciesIncludes.set(mapOf(
             "jansi-" to listOf("META-INF/native/**", "org/fusesource/jansi/internal/CLibrary*.class")
         ))
-        additionalFiles = fileTree(classpathManifest.get().manifestFile.parentFile) {
-            include(classpathManifest.get().manifestFile.name)
-        }
+        additionalFiles = files(classpathManifest).asFileTree
+
         outputFile.set(jar.get().archiveFile)
     }
 


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/1930

Previously, `:kotlinCompilerEmbeddable:patchKotlinCompilerEmbeddable` doesn't depends
on `:kotlinCompilerEmbeddable:classpathManifest`, which may result in the patched kotlin jar
not including classpath property files. This commit fixes this issue by making implicit dependencies.

