### PR TITLE
Refine :kCE:patchKotlinCompilerEmbeddable task

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/PatchKotlinCompilerEmbeddable.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/PatchKotlinCompilerEmbeddable.kt
@@ -20,6 +20,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.file.RelativePath
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.specs.Spec
 import org.gradle.api.specs.Specs
 import org.gradle.api.tasks.CacheableTask
@@ -46,8 +47,8 @@ import org.gradle.kotlin.dsl.*
 @Suppress("unused")
 abstract class PatchKotlinCompilerEmbeddable : DefaultTask() {
 
-    @Input
-    val excludes = project.objects.listProperty<String>()
+    @get:Input
+    abstract val excludes: ListProperty<String>
 
     @get:Classpath
     abstract val originalFiles: ConfigurableFileCollection

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/PatchKotlinCompilerEmbeddable.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/build/PatchKotlinCompilerEmbeddable.kt
@@ -17,6 +17,8 @@
 package build
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.file.RelativePath
 import org.gradle.api.specs.Spec
 import org.gradle.api.specs.Specs
@@ -41,26 +43,27 @@ import org.gradle.kotlin.dsl.*
 
 
 @CacheableTask
-open class PatchKotlinCompilerEmbeddable : DefaultTask() {
+@Suppress("unused")
+abstract class PatchKotlinCompilerEmbeddable : DefaultTask() {
 
     @Input
     val excludes = project.objects.listProperty<String>()
 
-    @Classpath
-    val originalFiles = project.objects.fileCollection()
+    @get:Classpath
+    abstract val originalFiles: ConfigurableFileCollection
 
-    @Classpath
-    val dependencies = project.objects.fileCollection()
+    @get:Classpath
+    abstract val dependencies: ConfigurableFileCollection
 
     @Input
     val dependenciesIncludes = project.objects.mapProperty<String, List<String>>()
 
-    @InputFiles
-    @PathSensitive(PathSensitivity.NAME_ONLY)
-    val additionalRootFiles = project.objects.fileCollection()
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val additionalRootFiles: ConfigurableFileCollection
 
-    @OutputFile
-    val outputFile = project.objects.fileProperty()
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
 
     @TaskAction
     @Suppress("unused")

--- a/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
+++ b/subprojects/kotlin-compiler-embeddable/kotlin-compiler-embeddable.gradle.kts
@@ -55,7 +55,7 @@ tasks {
         dependenciesIncludes.set(mapOf(
             "jansi-" to listOf("META-INF/native/**", "org/fusesource/jansi/internal/CLibrary*.class")
         ))
-        additionalFiles = files(classpathManifest).asFileTree
+        additionalRootFiles.from(classpathManifest)
 
         outputFile.set(jar.get().archiveFile)
     }


### PR DESCRIPTION
by turning `additionalFiles` into a `FileCollection`
renamed to `additionalRootFiles` for clarity
using `@PathSensitive(PathSensitivity.NAME_ONLY)`
