### PR TITLE
Restore JavaExecHandlerBuilder.setClasspath behavior

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
+++ b/subprojects/core/src/main/java/org/gradle/process/internal/JavaExecHandleBuilder.java
@@ -207,7 +207,9 @@ public class JavaExecHandleBuilder extends AbstractExecHandleBuilder implements 
     }
 
     public JavaExecHandleBuilder setClasspath(FileCollection classpath) {
-        doGetClasspath().setFrom(classpath);
+        ConfigurableFileCollection newClasspath = fileCollectionFactory.configurableFiles("classpath");
+        newClasspath.setFrom(classpath);
+        this.classpath = newClasspath;
         return this;
     }
 

--- a/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/process/internal/JavaExecHandleBuilderTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.initialization.DefaultBuildCancellationToken
 import org.gradle.internal.jvm.Jvm
+import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -102,6 +103,22 @@ class JavaExecHandleBuilderTest extends Specification {
         then:
         !builder.classpath.contains(jar1)
         builder.classpath.contains(jar2)
+    }
+
+    @Issue("gradle/gradle#8748")
+    def "can prepend to classpath"() {
+        given:
+        File jar1 = new File("file1.jar").canonicalFile
+        File jar2 = new File("file2.jar").canonicalFile
+
+        builder.classpath(jar1)
+
+        when:
+        builder.setClasspath(fileCollectionFactory.resolving(jar2, builder.getClasspath()))
+
+        then:
+        builder.commandLine.contains("$jar2$File.pathSeparator$jar1".toString())
+
     }
 
     def "detects null entries early"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringDependenciesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesDeclaringDependenciesIntegrationTest.groovy
@@ -22,7 +22,6 @@ import org.gradle.integtests.fixtures.UsesSample
 import org.gradle.test.fixtures.file.TestFile
 import org.gradle.util.Requires
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 import static org.gradle.util.TestPrecondition.KOTLIN_SCRIPT
@@ -83,7 +82,6 @@ class SamplesDeclaringDependenciesIntegrationTest extends AbstractSampleIntegrat
         dsl << ['groovy', 'kotlin']
     }
 
-    @Ignore("Spring repo down and not mirrored")
     @Unroll
     @UsesSample("userguide/dependencyManagement/declaringDependencies/changingVersion")
     def "can use declare and resolve dependency with changing version with #dsl dsl"() {

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesTroubleshootingDependencyResolutionIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/dependencymanagement/SamplesTroubleshootingDependencyResolutionIntegrationTest.groovy
@@ -20,7 +20,6 @@ import org.gradle.integtests.fixtures.AbstractSampleIntegrationTest
 import org.gradle.integtests.fixtures.Sample
 import org.gradle.integtests.fixtures.UsesSample
 import org.junit.Rule
-import spock.lang.Ignore
 import spock.lang.Unroll
 
 class SamplesTroubleshootingDependencyResolutionIntegrationTest extends AbstractSampleIntegrationTest {
@@ -30,7 +29,6 @@ class SamplesTroubleshootingDependencyResolutionIntegrationTest extends Abstract
     @Rule
     Sample sample = new Sample(testDirectoryProvider)
 
-    @Ignore("Spring repo down and not mirrored")
     @Unroll
     @UsesSample("userguide/dependencyManagement/troubleshooting/cache/changing")
     def "can declare custom TTL for dependency with changing version"() {


### PR DESCRIPTION
Setting the classpath actually changes the field reference again to restore 5.2 and prior behavior.