### PR TITLE
Move ReplacedBy to org.gradle.api.work

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/work/ReplacedBy.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/ReplacedBy.java
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package org.gradle.api;
+package org.gradle.work;
 
+import org.gradle.api.Incubating;
 import org.gradle.api.tasks.Internal;
 
 import java.lang.annotation.Documented;

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/bundling/AbstractArchiveTask.java
@@ -29,10 +29,10 @@ import org.gradle.api.tasks.AbstractCopyTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.ReplacedBy;
 import org.gradle.internal.nativeplatform.filesystem.FileSystem;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.util.GUtil;
+import org.gradle.work.ReplacedBy;
 
 import javax.annotation.Nullable;
 import java.io.File;

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -16,7 +16,6 @@
 package org.gradle.internal.service.scopes;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.api.ReplacedBy;
 import org.gradle.api.internal.project.taskfactory.DefaultTaskClassInfoStore;
 import org.gradle.api.internal.project.taskfactory.TaskClassInfoStore;
 import org.gradle.api.internal.tasks.properties.InspectionScheme;
@@ -57,6 +56,7 @@ import org.gradle.api.tasks.options.OptionValues;
 import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
 import org.gradle.internal.instantiation.InstantiationScheme;
 import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.work.ReplacedBy;
 
 import java.util.List;
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.properties
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.ReplacedBy
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.AbstractTask
@@ -48,6 +47,7 @@ import org.gradle.internal.reflect.PropertyMetadata
 import org.gradle.internal.scripts.ScriptOrigin
 import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.ExecutionGlobalServices
+import org.gradle.work.ReplacedBy
 import spock.lang.Issue
 import spock.lang.Shared
 import spock.lang.Specification

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -16,8 +16,6 @@
 
 package org.gradle.plugin.devel.tasks
 
-
-import org.gradle.api.ReplacedBy
 import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.InputArtifactDependencies
 import org.gradle.api.file.FileCollection
@@ -39,6 +37,7 @@ import org.gradle.api.tasks.options.OptionValues
 import org.gradle.integtests.fixtures.AbstractIntegrationSpec
 import org.gradle.util.Requires
 import org.gradle.util.TestPrecondition
+import org.gradle.work.ReplacedBy
 import spock.lang.Unroll
 
 import javax.inject.Inject

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -54,6 +54,7 @@ import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.util.DeprecationLogger;
+import org.gradle.work.ReplacedBy;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.Opcodes;
@@ -99,7 +100,7 @@ import java.util.Map;
  *             <li>{@literal @}{@link javax.inject.Inject} marks a Gradle service used by the task.</li>
  *             <li>{@literal @}{@link org.gradle.api.tasks.Console Console} marks a property that only influences the console output of the task.</li>
  *             <li>{@literal @}{@link org.gradle.api.tasks.Internal Internal} mark an internal property of the task.</li>
- *             <li>{@literal @}{@link org.gradle.api.ReplacedBy ReplacedBy} mark a property as replaced by another (similar to {@code Internal}).</li>
+ *             <li>{@literal @}{@link ReplacedBy ReplacedBy} mark a property as replaced by another (similar to {@code Internal}).</li>
  *         </ul>
  *     </li>
  * </ul>


### PR DESCRIPTION
So other `work` related annotations and types can be next to it.