### PR TITLE
Make incremental compiler handle transitive changes

### DIFF
--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/AbstractCrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -44,6 +44,8 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
 
     protected abstract String getProjectDependencyBlock()
 
+    protected abstract void addDependency(String from, String to)
+
     private File java(Map projectToClassBodies) {
         File out
         projectToClassBodies.each { project, bodies ->
@@ -75,11 +77,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
         settingsFile << """
             include 'app'
         """
-        buildFile << """
-            project(':app') {
-                dependencies { compile project(path:':impl', configuration: 'classesDir') }
-            }
-        """
+        addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         java api: ["class A {}"]
         java impl: ["class B extends A {}"]
@@ -98,11 +96,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
         settingsFile << """
             include 'app'
         """
-        buildFile << """
-            project(':app') {
-                dependencies { compile project(path:':impl', configuration: 'classesDir') }
-            }
-        """
+        addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         java api: ["class A {}"]
         java impl: ["class B { public A a;}"]
@@ -121,11 +115,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
         settingsFile << """
             include 'app'
         """
-        buildFile << """
-            project(':app') {
-                dependencies { compile project(path:':impl', configuration: 'classesDir') }
-            }
-        """
+        addDependency("app", "impl")
         def app = new CompilationOutputsFixture(file("app/build/classes"))
         java api: ["class A {}"]
         java impl: ["class B { public A a;}"]
@@ -138,7 +128,7 @@ abstract class AbstractCrossTaskIncrementalJavaCompilationIntegrationTest extend
 
         when:
         file("api/src/main/java/A.java").delete()
-        fails "app:compileJava", "-X", "impl:compileJava"
+        run "app:compileJava", "-x", "impl:compileJava"
 
         then:
         impl.noneRecompiled()

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationIntegrationTest.groovy
@@ -27,4 +27,13 @@ class CrossTaskIncrementalJavaCompilationIntegrationTest extends AbstractCrossTa
             }
         '''
     }
+
+    @Override
+    protected void addDependency(String from, String to) {
+        buildFile << """
+            project(':$from') {
+                dependencies { compile project(':$to') }
+            }
+        """
+    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationUsingClassDirectoryIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationUsingClassDirectoryIntegrationTest.groovy
@@ -37,4 +37,13 @@ class CrossTaskIncrementalJavaCompilationUsingClassDirectoryIntegrationTest exte
             }
         '''
     }
+
+    @Override
+    protected void addDependency(String from, String to) {
+        buildFile << """
+            project(':$from') {
+                dependencies { compile project(path:':$to', configuration: 'classesDir') }
+            }
+        """
+    }
 }

--- a/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationUsingClassDirectoryIntegrationTest.groovy
+++ b/subprojects/language-java/src/integTest/groovy/org/gradle/java/compile/incremental/CrossTaskIncrementalJavaCompilationUsingClassDirectoryIntegrationTest.groovy
@@ -22,9 +22,11 @@ class CrossTaskIncrementalJavaCompilationUsingClassDirectoryIntegrationTest exte
     @Override
     protected String getProjectDependencyBlock() {
         '''
-            project(':api') {
+            subprojects {
                 configurations {
-                   classesDir
+                    classesDir {
+                        extendsFrom(compile)
+                    }
                 }
                 artifacts {
                     classesDir file: compileJava.destinationDir, builtBy:compileJava

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisSerializer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/analyzer/ClassAnalysisSerializer.java
@@ -44,8 +44,7 @@ public class ClassAnalysisSerializer extends AbstractSerializer<ClassAnalysis> {
         boolean relatedToAll = decoder.readBoolean();
         Set<String> classes = stringSetSerializer.read(decoder);
         IntSet constants = IntSetSerializer.INSTANCE.read(decoder);
-        Set<String> superTypes = stringSetSerializer.read(decoder);
-        return new ClassAnalysis(className, classes, relatedToAll, constants, superTypes);
+        return new ClassAnalysis(className, classes, relatedToAll, constants);
     }
 
     @Override
@@ -54,7 +53,6 @@ public class ClassAnalysisSerializer extends AbstractSerializer<ClassAnalysis> {
         encoder.writeBoolean(value.isDependencyToAll());
         stringSetSerializer.write(encoder, value.getClassDependencies());
         IntSetSerializer.INSTANCE.write(encoder, value.getConstants());
-        stringSetSerializer.write(encoder, value.getSuperTypes());
     }
 
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshot.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshot.java
@@ -16,8 +16,6 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import org.gradle.api.Action;
-
 import java.io.File;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -53,11 +51,5 @@ public class ClasspathSnapshot {
     public boolean isAnyClassDuplicated(File classpathEntry) {
         ClasspathEntrySnapshot snapshot = getSnapshot(classpathEntry);
         return isAnyClassDuplicated(snapshot.getClasses());
-    }
-
-    public void forEachSnapshot(Action<? super ClasspathEntrySnapshot> action) {
-        for (ClasspathEntrySnapshot classpathEntrySnapshot : entrySnapshots.values()) {
-            action.execute(classpathEntrySnapshot);
-        }
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassAnalysis.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassAnalysis.java
@@ -30,14 +30,12 @@ public class ClassAnalysis {
     private final Set<String> classDependencies;
     private final boolean dependencyToAll;
     private final IntSet constants;
-    private final Set<String> superTypes;
 
-    public ClassAnalysis(String className, Set<String> classDependencies, boolean dependencyToAll, IntSet constants, Set<String> superTypes) {
+    public ClassAnalysis(String className, Set<String> classDependencies, boolean dependencyToAll, IntSet constants) {
         this.className = className;
         this.classDependencies = ImmutableSet.copyOf(classDependencies);
         this.dependencyToAll = dependencyToAll;
         this.constants = constants.isEmpty() ? IntSets.EMPTY_SET : constants;
-        this.superTypes = ImmutableSet.copyOf(superTypes);
     }
 
     public String getClassName() {
@@ -54,9 +52,5 @@ public class ClassAnalysis {
 
     public boolean isDependencyToAll() {
         return dependencyToAll;
-    }
-
-    public Set<String> getSuperTypes() {
-        return superTypes;
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassChanges.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassChanges.java
@@ -18,18 +18,18 @@ package org.gradle.api.internal.tasks.compile.incremental.deps;
 
 import java.util.Set;
 
-public class AffectedClasses {
+public class ClassChanges {
 
-    private final DependentsSet altered;
+    private final Set<String> modified;
     private final Set<String> addedClasses;
 
-    public AffectedClasses(DependentsSet altered, Set<String> addedClasses) {
-        this.altered = altered;
+    public ClassChanges(Set<String> modified, Set<String> addedClasses) {
+        this.modified = modified;
         this.addedClasses = addedClasses;
     }
 
-    public DependentsSet getAltered() {
-        return altered;
+    public Set<String> getModified() {
+        return modified;
     }
 
     public Set<String> getAdded() {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -17,7 +17,6 @@
 package org.gradle.api.internal.tasks.compile.incremental.deps;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
@@ -35,14 +34,13 @@ public class ClassDependentsAccumulator {
     private final Map<String, Set<String>> dependents = new HashMap<String, Set<String>>();
     private final ImmutableMap.Builder<String, IntSet> classesToConstants = ImmutableMap.builder();
     private final Set<String> seenClasses = Sets.newHashSet();
-    private final Multimap<String, String> parentToChildren = HashMultimap.create();
     private String fullRebuildCause;
 
     public void addClass(ClassAnalysis classAnalysis) {
-        addClass(classAnalysis.getClassName(), classAnalysis.isDependencyToAll(), classAnalysis.getClassDependencies(), classAnalysis.getConstants(), classAnalysis.getSuperTypes());
+        addClass(classAnalysis.getClassName(), classAnalysis.isDependencyToAll(), classAnalysis.getClassDependencies(), classAnalysis.getConstants());
     }
 
-    public void addClass(String className, boolean dependencyToAll, Iterable<String> classDependencies, IntSet constants, Set<String> superTypes) {
+    public void addClass(String className, boolean dependencyToAll, Iterable<String> classDependencies, IntSet constants) {
         if (seenClasses.contains(className)) {
             // same classes may be found in different classpath trees/jars
             // and we keep only the first one
@@ -60,9 +58,6 @@ public class ClassDependentsAccumulator {
             if (!dependency.equals(className) && !dependenciesToAll.contains(dependency)) {
                 addDependency(dependency, className);
             }
-        }
-        for (String superType : superTypes) {
-            parentToChildren.put(superType, className);
         }
     }
 
@@ -105,7 +100,7 @@ public class ClassDependentsAccumulator {
     }
 
     public ClassSetAnalysisData getAnalysis() {
-        return new ClassSetAnalysisData(ImmutableSet.copyOf(seenClasses), getDependentsMap(), getClassesToConstants(), asMap(parentToChildren), fullRebuildCause);
+        return new ClassSetAnalysisData(ImmutableSet.copyOf(seenClasses), getDependentsMap(), getClassesToConstants(), fullRebuildCause);
     }
 
     private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -29,7 +29,6 @@ import org.gradle.internal.serialize.Encoder;
 import org.gradle.internal.serialize.IntSetSerializer;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -40,14 +39,12 @@ public class ClassSetAnalysisData {
     private final Set<String> classes;
     private final Map<String, DependentsSet> dependents;
     private final Map<String, IntSet> classesToConstants;
-    private final Map<String, Set<String>> classesToChildren;
     private final String fullRebuildCause;
 
-    public ClassSetAnalysisData(Set<String> classes, Map<String, DependentsSet> dependents, Map<String, IntSet> classesToConstants, Map<String, Set<String>> classesToChildren, String fullRebuildCause) {
+    public ClassSetAnalysisData(Set<String> classes, Map<String, DependentsSet> dependents, Map<String, IntSet> classesToConstants, String fullRebuildCause) {
         this.classes = classes;
         this.dependents = dependents;
         this.classesToConstants = classesToConstants;
-        this.classesToChildren = classesToChildren;
         this.fullRebuildCause = fullRebuildCause;
     }
 
@@ -80,11 +77,6 @@ public class ClassSetAnalysisData {
             return IntSets.EMPTY_SET;
         }
         return integers;
-    }
-
-    public Set<String> getChildren(String className) {
-        Set<String> children = classesToChildren.get(className);
-        return children == null ? Collections.<String>emptySet() : children;
     }
 
     public static class Serializer extends AbstractSerializer<ClassSetAnalysisData> {
@@ -121,21 +113,9 @@ public class ClassSetAnalysisData {
                 classesToConstantsBuilder.put(className, constants);
             }
 
-            count = decoder.readSmallInt();
-            ImmutableMap.Builder<String, Set<String>> classNameToChildren = ImmutableMap.builder();
-            for (int i = 0; i < count; i++) {
-                String parent = readClassName(decoder, classNameMap);
-                int nameCount = decoder.readSmallInt();
-                ImmutableSet.Builder<String> namesBuilder = ImmutableSet.builder();
-                for (int j = 0; j < nameCount; j++) {
-                    namesBuilder.add(readClassName(decoder, classNameMap));
-                }
-                classNameToChildren.put(parent, namesBuilder.build());
-            }
-
             String fullRebuildCause = decoder.readNullableString();
 
-            return new ClassSetAnalysisData(classes.build(), dependentsBuilder.build(), classesToConstantsBuilder.build(), classNameToChildren.build(), fullRebuildCause);
+            return new ClassSetAnalysisData(classes.build(), dependentsBuilder.build(), classesToConstantsBuilder.build(), fullRebuildCause);
         }
 
         @Override
@@ -157,16 +137,6 @@ public class ClassSetAnalysisData {
                 writeClassName(entry.getKey(), classNameMap, encoder);
                 IntSetSerializer.INSTANCE.write(encoder, entry.getValue());
             }
-
-            encoder.writeSmallInt(value.classesToChildren.size());
-            for (Map.Entry<String, Set<String>> entry : value.classesToChildren.entrySet()) {
-                writeClassName(entry.getKey(), classNameMap, encoder);
-                encoder.writeSmallInt(entry.getValue().size());
-                for (String className : entry.getValue()) {
-                    writeClassName(className, classNameMap, encoder);
-                }
-            }
-
             encoder.writeNullableString(value.fullRebuildCause);
         }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathChangeDependentsFinder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/ClasspathChangeDependentsFinder.java
@@ -93,13 +93,11 @@ public class ClasspathChangeDependentsFinder {
                     @Override
                     public void execute(ClasspathEntrySnapshot classpathEntrySnapshot) {
                         if (classpathEntrySnapshot != previous) {
-                            // we need to find classes in other entries that would potentially extend classes changed
-                            // in the current snapshot (they are intermediates)
                             ClassSetAnalysisData data = classpathEntrySnapshot.getData().getClassAnalysis();
-                            Set<String> children = data.getChildren(dependentClass);
-                            for (String child : children) {
-                                if (dependentClasses.add(child)) {
-                                    queue.add(child);
+                            Set<String> intermediates = data.getDependents(dependentClass).getDependentClasses();
+                            for (String intermediate : intermediates) {
+                                if (dependentClasses.add(intermediate)) {
+                                    queue.add(intermediate);
                                 }
                             }
                         }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathEntrySnapshotTest.groovy
@@ -17,11 +17,8 @@
 package org.gradle.api.internal.tasks.compile.incremental.classpath
 
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysisData
-import org.gradle.api.internal.tasks.compile.incremental.deps.DependentsSet
 import org.gradle.internal.hash.HashCode
 import spock.lang.Specification
-
-import static org.gradle.api.internal.tasks.compile.incremental.deps.DependentsSet.dependents
 
 class ClasspathEntrySnapshotTest extends Specification {
 

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulatorTest.groovy
@@ -31,9 +31,9 @@ class ClassDependentsAccumulatorTest extends Specification {
 
     def "remembers if class is dependency to all"() {
         // a -> b -> c
-        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("b", true,  ["c"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("c", false, ["a"] as Set, IntSets.EMPTY_SET, [] as Set)
+        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  ["c"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", false, ["a"] as Set, IntSets.EMPTY_SET)
 
         expect:
         !accumulator.dependentsMap.a.dependencyToAll
@@ -43,9 +43,9 @@ class ClassDependentsAccumulatorTest extends Specification {
 
     def "remembers if class declares non-private constants"() {
         // a -> b -> c
-        accumulator.addClass("a", false, ["b"], new IntOpenHashSet(1, 2, 3, 5, 8), [] as Set)
-        accumulator.addClass("b", false,  ["c"], new IntOpenHashSet([0, 8]), [] as Set)
-        accumulator.addClass("c", false, [], new IntOpenHashSet([3, 4]), [] as Set)
+        accumulator.addClass("a", false, ["b"], new IntOpenHashSet(1, 2, 3, 5, 8))
+        accumulator.addClass("b", false,  ["c"], new IntOpenHashSet([0, 8]))
+        accumulator.addClass("c", false, [], new IntOpenHashSet([3, 4]))
 
         expect:
         accumulator.classesToConstants.get('a') == [1, 2, 3, 5, 8] as Set
@@ -54,10 +54,10 @@ class ClassDependentsAccumulatorTest extends Specification {
     }
 
     def "accumulates dependents"() {
-        accumulator.addClass("d", true, ['x'], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("a", false, ["b", "c"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("b", true,  ["c", "a"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("c", false, [] as Set, IntSets.EMPTY_SET, [] as Set)
+        accumulator.addClass("d", true, ['x'], IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, ["b", "c"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  ["c", "a"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", false, [] as Set, IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.a.dependentClasses == ['b'] as Set
@@ -68,33 +68,33 @@ class ClassDependentsAccumulatorTest extends Specification {
     }
 
     def "creates keys for all encountered classes which are dependency to another"() {
-        accumulator.addClass("a", false, ["x"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("b", true,  ["a", "b"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("c", true,  [] as Set, IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("e", false,  [] as Set, IntSets.EMPTY_SET, [] as Set)
+        accumulator.addClass("a", false, ["x"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  ["a", "b"], IntSets.EMPTY_SET)
+        accumulator.addClass("c", true,  [] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("e", false,  [] as Set, IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.keySet() == ["a", "b", "c", "x"] as Set
     }
 
     def "knows when class is dependent to all if that class is added first"() {
-        accumulator.addClass("b", true,  [] as Set, IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET, [] as Set)
+        accumulator.addClass("b", true,  [] as Set, IntSets.EMPTY_SET)
+        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.b.dependencyToAll
     }
 
     def "knows when class is dependent to all even if that class is added last"() {
-        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET, [] as Set)
-        accumulator.addClass("b", true,  [] as Set, IntSets.EMPTY_SET, [] as Set)
+        accumulator.addClass("a", false, ["b"], IntSets.EMPTY_SET)
+        accumulator.addClass("b", true,  [] as Set, IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap.b.dependencyToAll
     }
 
     def "filters out self dependencies"() {
-        accumulator.addClass("a", false, ["a", "b"], IntSets.EMPTY_SET, [] as Set)
+        accumulator.addClass("a", false, ["a", "b"], IntSets.EMPTY_SET)
 
         expect:
         accumulator.dependentsMap["b"].dependentClasses == ["a"] as Set

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisDataSerializerTest.groovy
@@ -36,8 +36,7 @@ class ClassSetAnalysisDataSerializerTest extends Specification {
         def data = new ClassSetAnalysisData(["A", "B", "C", "D"] as Set,
             ["A": dependents("B", "C"), "B": dependents("C"), "C": dependents(), "D": dependencyToAll(),],
             [C: new IntOpenHashSet([1, 2]) as IntSet, D: IntSets.EMPTY_SET]
-            ,
-            ['A': ['SA'] as Set, B: ['SB1', 'SB2'] as Set], "Because"
+            ,"Because"
         )
         def os = new ByteArrayOutputStream()
         def e = new OutputStreamBackedEncoder(os)
@@ -56,7 +55,6 @@ class ClassSetAnalysisDataSerializerTest extends Specification {
 
         read.dependents["D"].dependencyToAll
         read.classesToConstants == [C: [1,2] as Set, D: [] as Set]
-        read.classesToChildren == ['A': ['SA'] as Set, B: ['SB1', 'SB2'] as Set]
         read.fullRebuildCause == "Because"
     }
 }

--- a/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
+++ b/subprojects/language-java/src/test/groovy/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisTest.groovy
@@ -27,9 +27,9 @@ class ClassSetAnalysisTest extends Specification {
 
     ClassSetAnalysis analysis(Map<String, DependentsSet> dependents,
                               Map<String, IntSet> classToConstants = [:],
-                              Map<String, Set<String>> classesToChildren = [:], DependentsSet aggregatedTypes = empty(), DependentsSet dependentsOnAll = empty(), String fullRebuildCause = null) {
+                              DependentsSet aggregatedTypes = empty(), DependentsSet dependentsOnAll = empty(), String fullRebuildCause = null) {
         new ClassSetAnalysis(
-            new ClassSetAnalysisData(dependents.keySet(), dependents, classToConstants, classesToChildren, fullRebuildCause),
+            new ClassSetAnalysisData(dependents.keySet(), dependents, classToConstants, fullRebuildCause),
             new AnnotationProcessingData([:], aggregatedTypes.dependentClasses, dependentsOnAll.dependentClasses, null)
         )
     }
@@ -164,8 +164,8 @@ class ClassSetAnalysisTest extends Specification {
 
     def "some classes may depend on any change"() {
         def a = analysis([
-            "A": dependents("B"), "B": empty(), "DependsOnAny" : dependents("C")
-        ], [:], [:], empty(), dependents("DependsOnAny") )
+            "A": dependents("B"), "B": empty(), "DependsOnAny": dependents("C")
+        ], [:], empty(), dependents("DependsOnAny"))
         def deps = a.getRelevantDependents(["A"], IntSets.EMPTY_SET)
 
         expect:
@@ -197,7 +197,7 @@ class ClassSetAnalysisTest extends Specification {
 
     def "all classes are dependencies to all if a full rebuild cause is given"() {
         def a = analysis(
-            [:], [:], [:], empty(), empty(), "Some cause"
+            [:], [:], empty(), empty(), "Some cause"
         )
 
         expect:


### PR DESCRIPTION
The incremental compiler was only considering transitive changes to superclasses, but not anything else. As a result it only worked on first-level dependencies, but not when a second level dependency had changed.

Fixes https://github.com/google/dagger/issues/1436