### PR TITLE
Optimize `ModuleVersionResolveException`

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/exceptions/DefaultMultiCauseExceptionNoStackTrace.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/exceptions/DefaultMultiCauseExceptionNoStackTrace.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.internal.exceptions;
+
+import org.gradle.internal.Factory;
+
+/**
+ * A specialized version of multi cause exception that is cheaper to create
+ * because we avoid to fill a stack trace, and the message MUST be generated lazily.
+ */
+@Contextual
+public class DefaultMultiCauseExceptionNoStackTrace extends DefaultMultiCauseException {
+    public DefaultMultiCauseExceptionNoStackTrace(Factory<String> messageFactory) {
+        super(messageFactory);
+    }
+
+    public DefaultMultiCauseExceptionNoStackTrace(Factory<String> messageFactory, Throwable... causes) {
+        super(messageFactory, causes);
+    }
+
+    public DefaultMultiCauseExceptionNoStackTrace(Factory<String> messageFactory, Iterable<? extends Throwable> causes) {
+        super(messageFactory, causes);
+    }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildDependencySubstitutions.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/CompositeBuildDependencySubstitutions.java
@@ -82,13 +82,15 @@ public class CompositeBuildDependencySubstitutions implements Action<DependencyS
             LOGGER.info("Found project '" + match + "' as substitute for module '" + candidateId + "'.");
             return match;
         }
-        SortedSet<String> sortedProjects = Sets.newTreeSet(CollectionUtils.collect(providingProjects, new Transformer<String, ProjectComponentIdentifier>() {
-            @Override
-            public String transform(ProjectComponentIdentifier projectComponentIdentifier) {
-                return projectComponentIdentifier.getDisplayName();
-            }
-        }));
-        String failureMessage = String.format("Module version '%s' is not unique in composite: can be provided by %s.", selector.getDisplayName(), sortedProjects);
-        throw new ModuleVersionResolveException(selector, failureMessage);
+        throw new ModuleVersionResolveException(selector, () -> {
+            SortedSet<String> sortedProjects = Sets.newTreeSet(CollectionUtils.collect(providingProjects, new Transformer<String, ProjectComponentIdentifier>() {
+                @Override
+                public String transform(ProjectComponentIdentifier projectComponentIdentifier) {
+                    return projectComponentIdentifier.getDisplayName();
+                }
+            }));
+
+            return String.format("Module version '%s' is not unique in composite: can be provided by %s.", selector.getDisplayName(), sortedProjects);
+        });
     }
 }

--- a/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
+++ b/subprojects/composite-builds/src/main/java/org/gradle/composite/internal/DefaultIncludedBuildTaskGraph.java
@@ -73,7 +73,7 @@ public class DefaultIncludedBuildTaskGraph implements IncludedBuildTaskGraph {
             if (sourceBuild.equals(nextTarget)) {
                 candidateCycle.add(nextTarget);
                 ProjectComponentSelector selector = new DefaultProjectComponentSelector(candidateCycle.get(0), Path.ROOT, Path.ROOT, ":", ImmutableAttributes.EMPTY, Collections.emptyList());
-                throw new ModuleVersionResolveException(selector, "Included build dependency cycle: " + reportCycle(candidateCycle));
+                throw new ModuleVersionResolveException(selector, () -> "Included build dependency cycle: " + reportCycle(candidateCycle));
             }
 
             checkNoCycles(sourceBuild, nextTarget, candidateCycle);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultComponentMetadataProcessor.java
@@ -181,7 +181,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
         }
 
         if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
-            throw new ModuleVersionResolveException(updatedMetadata.getModuleVersionId(), String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().getDisplayName(), updatedMetadata.getStatusScheme()));
+            throw new ModuleVersionResolveException(updatedMetadata.getModuleVersionId(), () -> String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().getDisplayName(), updatedMetadata.getStatusScheme()));
         }
         return updatedMetadata;
     }
@@ -201,7 +201,7 @@ public class DefaultComponentMetadataProcessor implements ComponentMetadataProce
             updatedMetadata = details.asImmutable();
         }
         if (!updatedMetadata.getStatusScheme().contains(updatedMetadata.getStatus())) {
-            throw new ModuleVersionResolveException(updatedMetadata.getId(), String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().toString(), updatedMetadata.getStatusScheme()));
+            throw new ModuleVersionResolveException(updatedMetadata.getId(), () -> String.format("Unexpected status '%s' specified for %s. Expected one of: %s", updatedMetadata.getStatus(), updatedMetadata.getId().toString(), updatedMetadata.getStatusScheme()));
         }
         return updatedMetadata;
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ErrorHandlingModuleComponentRepository.java
@@ -145,11 +145,10 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
             performOperationWithRetries(result,
                     () -> delegate.listModuleVersions(dependency, result),
-                    () -> new ModuleVersionResolveException(dependency.getSelector(), BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    () -> new ModuleVersionResolveException(dependency.getSelector(), () -> BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
                     throwable -> {
                         ModuleComponentSelector selector = dependency.getSelector();
-                        String message = "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".";
-                        return new ModuleVersionResolveException(selector, message, throwable);
+                        return new ModuleVersionResolveException(selector, () -> "Failed to list versions for " + selector.getGroup() + ":" + selector.getModule() + ".", throwable);
                     });
         }
 
@@ -157,7 +156,7 @@ public class ErrorHandlingModuleComponentRepository implements ModuleComponentRe
         public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
             performOperationWithRetries(result,
                     () -> delegate.resolveComponentMetaData(moduleComponentIdentifier, requestMetaData, result),
-                    () -> new ModuleVersionResolveException(moduleComponentIdentifier, BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
+                    () -> new ModuleVersionResolveException(moduleComponentIdentifier, () -> BLACKLISTED_REPOSITORY_ERROR_MESSAGE),
                     throwable -> new ModuleVersionResolveException(moduleComponentIdentifier, throwable)
             );
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/NoRepositoriesResolver.java
@@ -67,7 +67,7 @@ public class NoRepositoriesResolver implements ComponentResolvers, DependencyToC
 
     @Override
     public void resolve(DependencyMetadata dependency, VersionSelector acceptor, VersionSelector rejector, BuildableComponentIdResolveResult result) {
-        result.failed(new ModuleVersionNotFoundException(dependency.getSelector(), String.format("Cannot resolve external dependency %s because no repositories are defined.", dependency.getSelector())));
+        result.failed(new ModuleVersionNotFoundException(dependency.getSelector(), () -> String.format("Cannot resolve external dependency %s because no repositories are defined.", dependency.getSelector())));
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/StartParameterResolutionOverride.java
@@ -88,12 +88,12 @@ public class StartParameterResolutionOverride {
 
         @Override
         public void listModuleVersions(ModuleDependencyMetadata dependency, BuildableModuleVersionListingResolveResult result) {
-            result.failed(new ModuleVersionResolveException(dependency.getSelector(), String.format("No cached version listing for %s available for offline mode.", dependency.getSelector())));
+            result.failed(new ModuleVersionResolveException(dependency.getSelector(), () -> String.format("No cached version listing for %s available for offline mode.", dependency.getSelector())));
         }
 
         @Override
         public void resolveComponentMetaData(ModuleComponentIdentifier moduleComponentIdentifier, ComponentOverrideMetadata requestMetaData, BuildableModuleComponentMetaDataResolveResult result) {
-            result.failed(new ModuleVersionResolveException(moduleComponentIdentifier, String.format("No cached version of %s available for offline mode.", moduleComponentIdentifier.getDisplayName())));
+            result.failed(new ModuleVersionResolveException(moduleComponentIdentifier, () -> String.format("No cached version of %s available for offline mode.", moduleComponentIdentifier.getDisplayName())));
         }
 
         @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/projectmodule/ProjectDependencyResolver.java
@@ -97,7 +97,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
             ProjectComponentIdentifier projectId = componentIdentifierFactory.createProjectComponentIdentifier(selector);
             LocalComponentMetadata componentMetaData = localComponentRegistry.getComponent(projectId);
             if (componentMetaData == null) {
-                result.failed(new ModuleVersionResolveException(selector, projectId + " not found."));
+                result.failed(new ModuleVersionResolveException(selector, () -> projectId + " not found."));
             } else {
                 result.resolved(componentMetaData);
             }
@@ -110,7 +110,7 @@ public class ProjectDependencyResolver implements ComponentMetaDataResolver, Dep
             ProjectComponentIdentifier projectId = (ProjectComponentIdentifier) identifier;
             LocalComponentMetadata componentMetaData = localComponentRegistry.getComponent(projectId);
             if (componentMetaData == null) {
-                result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(projectId), projectId + " not found."));
+                result.failed(new ModuleVersionResolveException(DefaultProjectComponentSelector.newSelector(projectId), () -> projectId + " not found."));
             } else {
                 result.resolved(componentMetaData);
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/DefaultResolutionResultBuilder.java
@@ -102,7 +102,7 @@ public class DefaultResolutionResultBuilder {
             ModuleComponentSelector failureComponentSelector = DefaultModuleComponentSelector.newSelector(failureSelector.getModule(), failureSelector.getVersion());
             root.addDependency(dependencyResultFactory.createUnresolvedDependency(failureComponentSelector, root, true,
                     ComponentSelectionReasons.of(new DefaultComponentSelectionDescriptor(ComponentSelectionCause.CONSTRAINT, Describables.of("Dependency locking"))),
-                new ModuleVersionResolveException(failureComponentSelector, "Dependency lock state out of date", failure.getProblem())));
+                new ModuleVersionResolveException(failureComponentSelector, () -> "Dependency lock state out of date", failure.getProblem())));
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionNotFoundException.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Lists;
 import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentSelector;
+import org.gradle.internal.Factory;
 import org.gradle.internal.logging.text.TreeFormatter;
 
 import java.util.Collection;
@@ -29,7 +30,7 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
      * This is used by {@link ModuleVersionResolveException#withIncomingPaths(java.util.Collection)}.
      */
     @SuppressWarnings("UnusedDeclaration")
-    public ModuleVersionNotFoundException(ComponentSelector selector, String message) {
+    public ModuleVersionNotFoundException(ComponentSelector selector, Factory<String> message) {
         super(selector, message);
     }
 
@@ -45,32 +46,34 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
         super(selector, format(selector, attemptedLocations));
     }
 
-    private static String format(ModuleComponentSelector selector, Collection<String> locations, Collection<String> unmatchedVersions, Collection<RejectedVersion> rejectedVersions) {
-        TreeFormatter builder = new TreeFormatter();
-        if (unmatchedVersions.isEmpty() && rejectedVersions.isEmpty()) {
-            builder.node(String.format("Could not find any matches for %s as no versions of %s:%s are available.", selector, selector.getGroup(), selector.getModule()));
-        } else {
-            builder.node(String.format("Could not find any version that matches %s.", selector));
-            if (!unmatchedVersions.isEmpty()) {
-                builder.node("Versions that do not match");
-                appendSizeLimited(builder, unmatchedVersions);
-            }
-            if (!rejectedVersions.isEmpty()) {
-                Collection<RejectedVersion> byRule = Lists.newArrayListWithExpectedSize(rejectedVersions.size());
-                Collection<RejectedVersion> byAttributes = Lists.newArrayListWithExpectedSize(rejectedVersions.size());
-                mapRejections(rejectedVersions, byRule, byAttributes);
-                if (!byRule.isEmpty()) {
-                    builder.node("Versions rejected by component selection rules");
-                    appendSizeLimited(builder, byRule);
+    private static Factory<String> format(ModuleComponentSelector selector, Collection<String> locations, Collection<String> unmatchedVersions, Collection<RejectedVersion> rejectedVersions) {
+        return () -> {
+            TreeFormatter builder = new TreeFormatter();
+            if (unmatchedVersions.isEmpty() && rejectedVersions.isEmpty()) {
+                builder.node(String.format("Could not find any matches for %s as no versions of %s:%s are available.", selector, selector.getGroup(), selector.getModule()));
+            } else {
+                builder.node(String.format("Could not find any version that matches %s.", selector));
+                if (!unmatchedVersions.isEmpty()) {
+                    builder.node("Versions that do not match");
+                    appendSizeLimited(builder, unmatchedVersions);
                 }
-                if (!byAttributes.isEmpty()) {
-                    builder.node("Versions rejected by attribute matching");
-                    appendSizeLimited(builder, byAttributes);
+                if (!rejectedVersions.isEmpty()) {
+                    Collection<RejectedVersion> byRule = Lists.newArrayListWithExpectedSize(rejectedVersions.size());
+                    Collection<RejectedVersion> byAttributes = Lists.newArrayListWithExpectedSize(rejectedVersions.size());
+                    mapRejections(rejectedVersions, byRule, byAttributes);
+                    if (!byRule.isEmpty()) {
+                        builder.node("Versions rejected by component selection rules");
+                        appendSizeLimited(builder, byRule);
+                    }
+                    if (!byAttributes.isEmpty()) {
+                        builder.node("Versions rejected by attribute matching");
+                        appendSizeLimited(builder, byAttributes);
+                    }
                 }
             }
-        }
-        addLocations(builder, locations);
-        return builder.toString();
+            addLocations(builder, locations);
+            return builder.toString();
+        };
     }
 
     private static void mapRejections(Collection<RejectedVersion> in, Collection<RejectedVersion> outByRule, Collection<RejectedVersion> outByAttributes) {
@@ -83,18 +86,22 @@ public class ModuleVersionNotFoundException extends ModuleVersionResolveExceptio
         }
     }
 
-    private static String format(ModuleVersionIdentifier id, Collection<String> locations) {
-        TreeFormatter builder = new TreeFormatter();
-        builder.node(String.format("Could not find %s.", id));
-        addLocations(builder, locations);
-        return builder.toString();
+    private static Factory<String> format(ModuleVersionIdentifier id, Collection<String> locations) {
+        return () -> {
+            TreeFormatter builder = new TreeFormatter();
+            builder.node(String.format("Could not find %s.", id));
+            addLocations(builder, locations);
+            return builder.toString();
+        };
     }
 
-    private static String format(ModuleComponentSelector selector, Collection<String> locations) {
-        TreeFormatter builder = new TreeFormatter();
-        builder.node(String.format("Could not find any version that matches %s.", selector));
-        addLocations(builder, locations);
-        return builder.toString();
+    private static Factory<String> format(ModuleComponentSelector selector, Collection<String> locations) {
+        return () -> {
+            TreeFormatter builder = new TreeFormatter();
+            builder.node(String.format("Could not find any version that matches %s.", selector));
+            addLocations(builder, locations);
+            return builder.toString();
+        };
     }
 
     private static void appendSizeLimited(TreeFormatter builder, Collection<?> values) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/resolve/ModuleVersionResolveException.java
@@ -22,10 +22,11 @@ import org.gradle.api.artifacts.component.ComponentSelector;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.dependencies.DefaultImmutableVersionConstraint;
+import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.component.external.model.DefaultModuleComponentSelector;
 import org.gradle.internal.exceptions.Contextual;
-import org.gradle.internal.exceptions.DefaultMultiCauseException;
+import org.gradle.internal.exceptions.DefaultMultiCauseExceptionNoStackTrace;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,16 +35,16 @@ import java.util.Formatter;
 import java.util.List;
 
 @Contextual
-public class ModuleVersionResolveException extends DefaultMultiCauseException {
+public class ModuleVersionResolveException extends DefaultMultiCauseExceptionNoStackTrace {
     private final List<List<? extends ComponentIdentifier>> paths = new ArrayList<List<? extends ComponentIdentifier>>();
     private final ComponentSelector selector;
 
-    public ModuleVersionResolveException(ComponentSelector selector, String message, Throwable cause) {
+    public ModuleVersionResolveException(ComponentSelector selector, Factory<String> message, Throwable cause) {
         super(message, cause);
         this.selector = selector;
     }
 
-    public ModuleVersionResolveException(ComponentSelector selector, String message) {
+    public ModuleVersionResolveException(ComponentSelector selector, Factory<String> message) {
         super(message);
         this.selector = selector;
     }
@@ -58,15 +59,15 @@ public class ModuleVersionResolveException extends DefaultMultiCauseException {
         initCauses(causes);
     }
 
-    public ModuleVersionResolveException(ModuleVersionSelector selector, String message) {
+    public ModuleVersionResolveException(ModuleVersionSelector selector, Factory<String> message) {
         this(DefaultModuleComponentSelector.newSelector(selector), message);
     }
 
-    public ModuleVersionResolveException(ModuleVersionIdentifier id, String message) {
+    public ModuleVersionResolveException(ModuleVersionIdentifier id, Factory<String> message) {
         this(DefaultModuleComponentSelector.newSelector(id.getModule(), DefaultImmutableVersionConstraint.of(id.getVersion())), message);
     }
 
-    public ModuleVersionResolveException(ModuleComponentIdentifier id, String messageFormat) {
+    public ModuleVersionResolveException(ModuleComponentIdentifier id, Factory<String> messageFormat) {
         this(DefaultModuleComponentSelector.newSelector(DefaultModuleIdentifier.newId(id.getGroup(), id.getModule()), DefaultImmutableVersionConstraint.of(id.getVersion())), messageFormat);
     }
 
@@ -93,8 +94,8 @@ public class ModuleVersionResolveException extends DefaultMultiCauseException {
         return selector;
     }
 
-    protected static String format(String messageFormat, ComponentSelector selector) {
-        return String.format(messageFormat, selector.getDisplayName());
+    protected static Factory<String> format(String messageFormat, ComponentSelector selector) {
+        return () -> String.format(messageFormat, selector.getDisplayName());
     }
 
     /**
@@ -130,10 +131,15 @@ public class ModuleVersionResolveException extends DefaultMultiCauseException {
 
     protected ModuleVersionResolveException createCopy() {
         try {
-            return getClass().getConstructor(ComponentSelector.class, String.class).newInstance(selector, getMessage());
+            String message = getMessage();
+            return getClass().getConstructor(ComponentSelector.class, Factory.class).newInstance(selector, new Factory<String>() {
+                @Override
+                public String create() {
+                    return message;
+                }
+            });
         } catch (Exception e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }
     }
-
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/ivyresolve/ResolverProviderComponentMetaDataResolverTest.groovy
@@ -31,6 +31,7 @@ import org.gradle.internal.resolve.result.BuildableComponentResolveResult
 import spock.lang.Specification
 
 class ResolverProviderComponentMetaDataResolverTest extends Specification {
+    final org.gradle.internal.Factory<String> broken = { "broken" }
     final metaData = metaData("1.2")
     final moduleComponentId = DefaultModuleComponentIdentifier.newId(DefaultModuleIdentifier.newId("group", "project"), "1.0")
     final componentRequestMetaData = Mock(ComponentOverrideMetadata)
@@ -445,7 +446,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
 
         then:
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.failed(new ModuleVersionResolveException(id, "broken"))
+            result.failed(new ModuleVersionResolveException(id, broken))
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
             result.resolved(metaData)
@@ -478,7 +479,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
         then:
         1 * localAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
-            result.failed(new ModuleVersionResolveException(id, "broken"))
+            result.failed(new ModuleVersionResolveException(id, broken))
         }
         1 * localAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _)
         1 * remoteAccess2.resolveComponentMetaData(moduleComponentId, componentRequestMetaData, _) >> { id, meta, result ->
@@ -503,7 +504,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
 
     def "rethrows failure to resolve local dependency when not available in any repository"() {
         given:
-        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), "broken")
+        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), broken)
         def repo1 = addRepo1()
         def repo2 = addRepo2()
 
@@ -530,7 +531,7 @@ class ResolverProviderComponentMetaDataResolverTest extends Specification {
 
     def "rethrows failure to resolve remote dependency when not available in any repository"() {
         given:
-        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), "broken")
+        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), broken)
         def repo1 = addRepo1()
         def repo2 = addRepo2()
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/DependencyGraphBuilderTest.groovy
@@ -1069,7 +1069,8 @@ class DependencyGraphBuilderTest extends Specification {
         def dependencyMetaData = dependsOn(args, from, to.moduleVersionId)
         selectorResolvesTo(dependencyMetaData, to.id, to.moduleVersionId)
         1 * metaDataResolver.resolve(to.id, _, _) >> { ComponentIdentifier id, ComponentOverrideMetadata requestMetaData, BuildableComponentResolveResult result ->
-            result.failed(new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken"))
+            org.gradle.internal.Factory<String> broken = { "broken" }
+            result.failed(new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), broken))
         }
     }
 
@@ -1084,7 +1085,8 @@ class DependencyGraphBuilderTest extends Specification {
     def brokenSelector(Map<String, ?> args = [:], def from, String to) {
         def dependencyMetaData = dependsOn(args, from, newId("group", to, "1.0"))
         1 * idResolver.resolve(dependencyMetaData, _, _, _) >> { DependencyMetadata dep, VersionSelector acceptor, VersionSelector rejector, BuildableComponentIdResolveResult result ->
-            result.failed(new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), "broken"))
+            org.gradle.internal.Factory<String> broken = { "broken" }
+            result.failed(new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), new DefaultMutableVersionConstraint("c")), broken))
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/result/CachingDependencyResultFactoryTest.groovy
@@ -74,15 +74,16 @@ class CachingDependencyResultFactoryTest extends Specification {
     def "creates and caches unresolved dependencies"() {
         def fromModule = newModule('from')
         def selectedModule = Mock(ComponentSelectionReason)
+        org.gradle.internal.Factory<String> broken = { " foo" }
 
         when:
-        def dep = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
-        def same = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def dep = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), broken))
+        def same = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), broken))
 
-        def differentRequested = factory.createUnresolvedDependency(selector('xxx'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('xxx'), "foo"))
-        def differentFrom = factory.createUnresolvedDependency(selector('requested'), newModule('xxx'), false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
-        def differentConstraint = factory.createUnresolvedDependency(selector('requested'), fromModule, true, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
-        def differentFailure = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), "foo"))
+        def differentRequested = factory.createUnresolvedDependency(selector('xxx'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('xxx'), broken))
+        def differentFrom = factory.createUnresolvedDependency(selector('requested'), newModule('xxx'), false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), broken))
+        def differentConstraint = factory.createUnresolvedDependency(selector('requested'), fromModule, true, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), broken))
+        def differentFailure = factory.createUnresolvedDependency(selector('requested'), fromModule, false, selectedModule, new ModuleVersionResolveException(moduleVersionSelector('requested'), broken))
 
         then:
         dep.is(same)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/result/DefaultResolutionResultTest.groovy
@@ -132,11 +132,12 @@ class DefaultResolutionResultTest extends Specification {
             'test project'
         )
         def mid = DefaultModuleVersionIdentifier.newId("foo", "bar", "1.0")
+        org.gradle.internal.Factory<String> broken = { "too bad" }
         def dep = new DefaultUnresolvedDependencyResult(
             Stub(ComponentSelector), false,
             Stub(ComponentSelectionReason),
             new DefaultResolvedComponentResult(mid, Stub(ComponentSelectionReason), projectId, [Stub(ResolvedVariantResult)], null),
-            new ModuleVersionNotFoundException(Stub(ModuleComponentSelector), "too bad")
+            new ModuleVersionNotFoundException(Stub(ModuleComponentSelector), broken)
         )
         def edge = new UnresolvedDependencyEdge(dep)
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentIdResolveResultTest.groovy
@@ -61,7 +61,8 @@ class DefaultBuildableComponentIdResolveResultTest extends Specification {
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), "broken")
+        org.gradle.internal.Factory<String> broken = { "too bad" }
+        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), broken)
 
         when:
         result.failed(failure)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableComponentResolveResultTest.groovy
@@ -73,7 +73,8 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "cannot get id when resolve failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
+        org.gradle.internal.Factory<String> broken = { "too bad" }
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), broken)
 
         when:
         result.failed(failure)
@@ -85,7 +86,8 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "cannot get meta-data when resolve failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
+        org.gradle.internal.Factory<String> broken = { "too bad" }
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), broken)
 
         when:
         result.failed(failure)
@@ -137,8 +139,9 @@ class DefaultBuildableComponentResolveResultTest extends Specification {
     }
 
     def "copies failure result to an id resolve result"() {
+        org.gradle.internal.Factory<String> broken = { "too bad" }
         def idResult = Mock(BuildableComponentIdResolveResult)
-        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), "broken")
+        def failure = new ModuleVersionResolveException(Stub(ModuleVersionSelector), broken)
 
         given:
         result.attempted("a")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleComponentMetaDataResolveResultTest.groovy
@@ -44,7 +44,8 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
+        org.gradle.internal.Factory<String> broken = { "too bad" }
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), broken)
 
         when:
         descriptor.failed(failure)
@@ -112,8 +113,9 @@ class DefaultBuildableModuleComponentMetaDataResolveResultTest extends Specifica
     }
 
     def "cannot get meta-data when failed"() {
+        org.gradle.internal.Factory<String> broken = { "too bad" }
         given:
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), broken)
         descriptor.failed(failure)
 
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleVersionListingResolveResultTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/internal/resolve/result/DefaultBuildableModuleVersionListingResolveResultTest.groovy
@@ -45,7 +45,8 @@ class DefaultBuildableModuleVersionListingResolveResultTest extends Specificatio
     }
 
     def "can mark as failed"() {
-        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), "broken")
+        org.gradle.internal.Factory<String> broken = { "too bad" }
+        def failure = new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId("a", "b"), "c"), broken)
 
         when:
         descriptor.failed(failure)

--- a/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
+++ b/subprojects/dependency-management/src/testFixtures/groovy/org/gradle/api/internal/artifacts/result/ResolutionResultDataBuilder.groovy
@@ -40,7 +40,8 @@ class ResolutionResultDataBuilder {
 
     static DefaultUnresolvedDependencyResult newUnresolvedDependency(String group='x', String module='x', String version='1', String selectedVersion='1') {
         def requested = newSelector(group, module, version)
-        new DefaultUnresolvedDependencyResult(requested, false, ComponentSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), version), "broken"))
+        org.gradle.internal.Factory<String> broken = { "broken" }
+        new DefaultUnresolvedDependencyResult(requested, false, ComponentSelectionReasons.requested(), newModule(group, module, selectedVersion), new ModuleVersionResolveException(newSelector(DefaultModuleIdentifier.newId(group, module), version), broken))
     }
 
     static DefaultResolvedComponentResult newModule(String group='a', String module='a', String version='1', ComponentSelectionReason selectionReason = ComponentSelectionReasons.requested(), ResolvedVariantResult variant = newVariant(), String repoId = null) {

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
@@ -30,6 +30,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.excludes.Modul
 import org.gradle.api.internal.artifacts.type.ArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.component.ArtifactType;
+import org.gradle.internal.Factory;
 import org.gradle.internal.component.external.model.MetadataSourcedComponentArtifacts;
 import org.gradle.internal.component.local.model.LocalComponentMetadata;
 import org.gradle.internal.component.local.model.PublishArtifactLocalArtifactMetadata;
@@ -135,13 +136,25 @@ public class LocalLibraryDependencyResolver implements DependencyToComponentIdRe
             return;
         }
 
-        Collection<? extends Binary> matchingVariants = chooseMatchingVariants(selectedLibrary, variant);
+        final Collection<? extends Binary> matchingVariants = chooseMatchingVariants(selectedLibrary, variant);
         if (matchingVariants.isEmpty()) {
             // no compatible variant found
-            Iterable<? extends Binary> values = selectedLibrary.getVariants();
-            result.failed(new ModuleVersionResolveException(selector, errorMessageBuilder.noCompatibleVariantErrorMessage(libraryName, values)));
+            final Iterable<? extends Binary> values = selectedLibrary.getVariants();
+            result.failed(new ModuleVersionResolveException(selector, new Factory<String>() {
+                @Nullable
+                @Override
+                public String create() {
+                    return errorMessageBuilder.noCompatibleVariantErrorMessage(libraryName, values);
+                }
+            }));
         } else if (matchingVariants.size() > 1) {
-            result.failed(new ModuleVersionResolveException(selector, errorMessageBuilder.multipleCompatibleVariantsErrorMessage(libraryName, matchingVariants)));
+            result.failed(new ModuleVersionResolveException(selector, new Factory<String>() {
+                @Nullable
+                @Override
+                public String create() {
+                    return errorMessageBuilder.multipleCompatibleVariantsErrorMessage(libraryName, matchingVariants);
+                }
+            }));
         } else {
             Binary selectedBinary = matchingVariants.iterator().next();
             // TODO:Cedric This is not quite right. We assume that if we are asking for a specific binary, then we resolve to the assembly instead

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/OfflineVcsVersionWorkingDirResolver.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/OfflineVcsVersionWorkingDirResolver.java
@@ -36,7 +36,7 @@ public class OfflineVcsVersionWorkingDirResolver implements VcsVersionWorkingDir
     public File selectVersion(ModuleComponentSelector selector, VersionControlRepositoryConnection repository) {
         VersionRef previousVersion = persistentCache.getVersionForSelector(repository, selector.getVersionConstraint());
         if (previousVersion == null) {
-            throw new ModuleVersionResolveException(selector, String.format("Cannot resolve %s from %s in offline mode.", selector.getDisplayName(), repository.getDisplayName()));
+            throw new ModuleVersionResolveException(selector, () -> String.format("Cannot resolve %s from %s in offline mode.", selector.getDisplayName(), repository.getDisplayName()));
         }
 
         // Reuse the same version as last build

--- a/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
+++ b/subprojects/version-control/src/main/java/org/gradle/vcs/internal/resolver/VcsDependencyResolver.java
@@ -119,7 +119,7 @@ public class VcsDependencyResolver implements DependencyToComponentIdResolver, C
                     }
                 });
                 if (entry == null) {
-                    result.failed(new ModuleVersionResolveException(depSelector, spec.getDisplayName() + " did not contain a project publishing the specified dependency."));
+                    result.failed(new ModuleVersionResolveException(depSelector, () -> spec.getDisplayName() + " did not contain a project publishing the specified dependency."));
                 } else {
                     LocalComponentMetadata componentMetaData = localComponentRegistry.getComponent(entry.right);
                     result.resolved(componentMetaData);


### PR DESCRIPTION
### Context

During resolution, we may throw a lot of `ModuleVersionResolveException`
or `ModuleVersionNotFoundException`. Often, one per repository, when
a version is not found in that repository. But in the end, the version
may be found, or a different version may be selected, in which case we
don't care about the failure, which is only used if _no version_ could
be selected.

As a consequence, we had a lot of overhead in both generating a stack
trace **and** an error message, that would never be used.

This commit reworks those special exceptions used during resolution so
that we avoid filling the stack trace (we don't care) and we create
the message lazily (only if it will actually be used).

### Limitations

Despite those changes we are still a bit inefficient in case of "missing version": this PR does NOT try to optimize this use case, which is that whenever we try to resolve a module _without_ version, we could maybe avoid asking the repositories altogether, and avoid caching missing (?). However this is not so simple because there are cases were the _only_ edge to a module would be one without version, and in this case we _do_ want an error message.
