### PR TITLE
Fix Kotlin DSL sample in Organizing Gradle Projects

### DIFF
--- a/subprojects/docs/src/samples/userguide/organizingGradleProjects/separatedTestTypes/kotlin/gradle/integration-test.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/organizingGradleProjects/separatedTestTypes/kotlin/gradle/integration-test.gradle.kts
@@ -1,6 +1,6 @@
+// tag::custom-source-set[]
 val sourceSets = the<SourceSetContainer>()
 
-// tag::custom-source-set[]
 sourceSets {
     create("integTest") {
         java.srcDir(file("src/integTest/java"))


### PR DESCRIPTION
An important bit of that sample was hidden outside the included snippet making following the manual error prone.