### PR TITLE
Escape any metacharacters found in current directory lookup.

### DIFF
--- a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+++ b/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 #
 # Copyright 2015 the original author or authors.
@@ -37,7 +37,7 @@ while [ -h "\$PRG" ] ; do
 done
 SAVED="`pwd`"
 cd "`dirname \"\$PRG\"`/${appHomeRelativePath}" >/dev/null
-APP_HOME="`pwd -P`"
+APP_HOME=$(printf "%q" `pwd -P`)
 cd "\$SAVED" >/dev/null
 
 APP_NAME="${applicationName}"


### PR DESCRIPTION
Escape any metacharacters found in current directory lookup, these propagate to the unquoted `--classpath` argument to the JVM.

### Context


This bug appears when running in a directory-name with meta-characters eg: `foo_bar_$anon.1`
If a gradle application started using `unixStartScript.txt` is run from that directory, [APP_HOME](https://github.com/gradle/gradle/blob/115d03dde2e95bef5a125f208d6f41142efd557a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt#L40) is used to discover the directory.

`APP_HOME` then is used to generate the [CLASSPATH](https://github.com/kaiwalyajoshi/gradle/blob/ee3751ed9f2034effc1f0072c2b2ee74b5dce67d/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptTemplateBindingFactory.java#L75)

*NOTE* that any metacharacters in found in `APP_HOME` are *NOT* escaped unlike [JVM Opts](https://github.com/kaiwalyajoshi/gradle/blob/ee3751ed9f2034effc1f0072c2b2ee74b5dce67d/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptTemplateBindingFactory.java#L101)

[CLASSPATH](https://github.com/gradle/gradle/blob/115d03dde2e95bef5a125f208d6f41142efd557a/subprojects/plugins/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt#L181) gets issued to the JVM with the metacharacters such as `$anon` being interpolated to `foo_bar_.1` which breaks the invocation as this path is invalid.

<!--- Why do you believe many users will benefit from this change? -->
This patch fixes a potential bug where directory names can have metacharacters which don't get escaped by the time they're propagated to the `$CLASSPATH` received by the JVM.
This can cause lots of failures for users who may not always have control over how the directory names are generated. 
<!--- Link to relevant issues or forum discussions here -->
We found this bug as part of a bug in [MARATHON-8594](https://jira.mesosphere.com/browse/MARATHON-8594)
While the MARATHON bug is being fixed, this patch is being issued as a supplementary fix for the wider community.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes