### PR TITLE
Unlink the software model chapters from multi page userguide

### DIFF
--- a/subprojects/docs/src/docs/userguide/native_software.adoc
+++ b/subprojects/docs/src/docs/userguide/native_software.adoc
@@ -16,11 +16,10 @@
 = Building native software
 
 
-[NOTE]
+[CAUTION]
 ====
-
-The https://blog.gradle.org/state-and-future-of-the-gradle-software-model[software model] is being retired and the plugins mentioned in this chapter will eventually be deprecated and removed. We recommend new projects looking to build C++ applications and libraries use the newer <<cpp_plugins.adoc#cpp_plugin,replacement plugins>>.
-
+The https://blog.gradle.org/state-and-future-of-the-gradle-software-model[software model] is being retired and the plugins mentioned in this chapter will eventually be deprecated and removed.
+We recommend new projects looking to build C++ applications and libraries use the newer <<cpp_plugins.adoc#cpp_plugin,replacement plugins>>.
 ====
 
 The native software plugins add support for building native software components, such as executables or shared libraries, from code written in C++, C and other languages. While many excellent build tools exist for this space of software development, Gradle offers developers its trademark power and flexibility together with dependency management practices more traditionally found in the JVM development space.

--- a/subprojects/docs/src/docs/userguide/rule_source.adoc
+++ b/subprojects/docs/src/docs/userguide/rule_source.adoc
@@ -15,6 +15,13 @@
 [[rule_source]]
 = Implementing model rules in a plugin
 
+[CAUTION]
+====
+Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated].
+New plugins should not use this concept.
+Instead, use the standard approach described in the <<custom_plugins.adoc#custom_plugins, Writing Custom Plugins>> chapter.
+====
+
 A plugin can define rules by extending link:{javadocPath}/org/gradle/model/RuleSource.html[RuleSource] and adding methods that define the rules. The plugin class can either extend link:{javadocPath}/org/gradle/model/RuleSource.html[RuleSource] directly or can implement link:{javadocPath}/org/gradle/api/Plugin.html[Plugin] and include a nested link:{javadocPath}/org/gradle/model/RuleSource.html[RuleSource] subclass.
 
 Refer to the API docs for link:{javadocPath}/org/gradle/model/RuleSource.html[RuleSource] for more details.

--- a/subprojects/docs/src/docs/userguide/software_model.adoc
+++ b/subprojects/docs/src/docs/userguide/software_model.adoc
@@ -17,7 +17,9 @@
 
 [CAUTION]
 ====
-Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated]. New plugins should not use this concept.
+Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated].
+New plugins should not use this concept.
+Instead, use the standard approach described in the <<custom_plugins.adoc#custom_plugins, Writing Custom Plugins>> chapter.
 ====
 
 Rule based model configuration enables _configuration logic to itself have dependencies_ on other elements of configuration, and to make use of the resolved states of those other elements of configuration while performing its own configuration.

--- a/subprojects/docs/src/docs/userguide/software_model_concepts.adoc
+++ b/subprojects/docs/src/docs/userguide/software_model_concepts.adoc
@@ -17,7 +17,9 @@
 
 [CAUTION]
 ====
-Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated]. New plugins should not use this concept.
+Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated].
+New plugins should not use this concept.
+Instead, use the standard approach described in the <<custom_plugins.adoc#custom_plugins, Writing Custom Plugins>> chapter.
 ====
 
 The software model describes how a piece of software is built and how the components of the software relate to each other. The software model is organized around some key concepts:
@@ -28,3 +30,5 @@ The software model describes how a piece of software is built and how the compon
 * A _binary_ represents some output that is built for a component. A component may produce multiple different output binaries. For example, for a C++ library, both a shared library and a static library binary may be produced. Each binary is initially configured to be built from the component sources, but additional source sets can be added to specific binary variants.
 * A _variant_ represents some mutually exclusive binary of a component. A library, for example, might target Java 7 and Java 8, effectively producing two distinct binaries: a Java 7 Jar and a Java 8 Jar. These are different variants of the library.
 * The _API_ of a library represents the artifacts and dependencies that are required to compile against that library. The API typically consists of a binary together with a set of dependencies.
+
+The <<software_model_extend.adoc#software_model_extend, software model can be extended>>, enabling deep modeling of specific domains via richly typed DSLs.

--- a/subprojects/docs/src/docs/userguide/software_model_extend.adoc
+++ b/subprojects/docs/src/docs/userguide/software_model_extend.adoc
@@ -17,7 +17,9 @@
 
 [CAUTION]
 ====
-Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated]. New plugins should not use this concept.
+Rule based configuration link:https://blog.gradle.org/state-and-future-of-the-gradle-software-model[will be deprecated].
+New plugins should not use this concept.
+Instead, use the standard approach described in the <<custom_plugins.adoc#custom_plugins, Writing Custom Plugins>> chapter.
 ====
 
 == Introduction

--- a/subprojects/docs/src/main/resources/header.html
+++ b/subprojects/docs/src/main/resources/header.html
@@ -197,11 +197,6 @@
             <li><a class="nav-dropdown" data-toggle="collapse" href="#cpp-projects" aria-expanded="false" aria-controls="cpp-projects">C++ Projects</a>
                 <ul id="cpp-projects">
                     <li><a href="cpp_plugins.html">Building C++ projects</a></li>
-                    <li><a href="native_software.html">Building other native language projects</a></li>
-                    <li><a href="software_model_concepts.html">Software Model Concepts</a></li>
-                    <li><a href="software_model.html">Rule-based Model Configuration</a></li>
-                    <li><a href="rule_source.html">Implementing Model Rules in a Plugin</a></li>
-                    <li><a href="software_model_extend.html">Extending the Software Model</a></li>
                 </ul>
             </li>
             <li><a class="nav-dropdown" data-toggle="collapse" href="#advanced-techniques" aria-expanded="false" aria-controls="advanced-techniques">Advanced Techniques</a>


### PR DESCRIPTION
The software model chapters are left intact for the single page given we
don't want to remove the chapters from the PDF version of the user
documentation.

### Context
Fixes https://github.com/gradle/gradle-native-private/issues/221

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative%2Funlink-software-model-documentation)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
