### PR TITLE
Update tagging plugin

### DIFF
--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -171,7 +171,7 @@ fun BaseGradleBuildType.gradleRerunnerStep(model: CIBuildModel, gradleTasks: Str
                             "-PteamCityBuildId=%teamcity.build.id%" +
                             buildScanTags.map { configurations.buildScanTag(it) } +
                             "-PonlyPreviousFailedTestClasses=true" +
-                            "-PteamCityBuildId=%teamcity.build.id%"
+                            "-PgithubToken=%github.ci.oauth.token%"
                     ).joinToString(separator = " ")
         }
     }

--- a/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
+++ b/.teamcity/Gradle_Check/configurations/GradleBuildConfigurationDefaults.kt
@@ -133,20 +133,6 @@ fun BaseGradleBuildType.verifyTestFilesCleanupStep(daemon: Boolean = true) {
 }
 
 private
-fun BaseGradleBuildType.tagBuildStep(model: CIBuildModel, daemon: Boolean = true) {
-    steps {
-        if (model.tagBuilds) {
-            gradleWrapper {
-                name = "TAG_BUILD"
-                executionMode = BuildStep.ExecutionMode.ALWAYS
-                tasks = "tagBuild"
-                gradleParams = "${gradleParameterString(daemon)} -PteamCityUsername=%teamcity.username.restbot% -PteamCityPassword=%teamcity.password.restbot% -PteamCityBuildId=%teamcity.build.id% -PgithubToken=%github.ci.oauth.token%"
-            }
-        }
-    }
-}
-
-private
 fun BaseGradleBuildType.gradleRunnerStep(model: CIBuildModel, gradleTasks: String, os: Os = Os.linux, extraParameters: String = "", daemon: Boolean = true) {
     val buildScanTags = model.buildScanTags + listOfNotNull(stage?.id)
 
@@ -174,7 +160,7 @@ fun BaseGradleBuildType.gradleRerunnerStep(model: CIBuildModel, gradleTasks: Str
     steps {
         gradleWrapper {
             name = "GRADLE_RERUNNER"
-            tasks = gradleTasks
+            tasks = "$gradleTasks tagBuild"
             executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
             gradleParams = (
                     listOf(gradleParameterString(daemon)) +
@@ -184,7 +170,8 @@ fun BaseGradleBuildType.gradleRerunnerStep(model: CIBuildModel, gradleTasks: Str
                             "-PteamCityPassword=%teamcity.password.restbot%" +
                             "-PteamCityBuildId=%teamcity.build.id%" +
                             buildScanTags.map { configurations.buildScanTag(it) } +
-                            "-PonlyPreviousFailedTestClasses=true"
+                            "-PonlyPreviousFailedTestClasses=true" +
+                            "-PteamCityBuildId=%teamcity.build.id%"
                     ).joinToString(separator = " ")
         }
     }
@@ -213,7 +200,6 @@ fun applyDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradleTas
 
     buildType.checkCleanM2Step(os)
     buildType.verifyTestFilesCleanupStep(daemon)
-    buildType.tagBuildStep(model, daemon)
 
     applyDefaultDependencies(model, buildType, notQuick)
 }
@@ -230,7 +216,6 @@ fun applyTestDefaults(model: CIBuildModel, buildType: BaseGradleBuildType, gradl
 
     buildType.checkCleanM2Step(os)
     buildType.verifyTestFilesCleanupStep(daemon)
-    buildType.tagBuildStep(model, daemon)
 
     applyDefaultDependencies(model, buildType, notQuick)
 }

--- a/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/ApplyDefaultConfigurationTest.kt
@@ -62,8 +62,7 @@ class ApplyDefaultConfigurationTest {
         assertEquals(listOf(
             "GRADLE_RUNNER",
             "CHECK_CLEAN_M2",
-            "VERIFY_TEST_FILES_CLEANUP",
-            "TAG_BUILD"
+            "VERIFY_TEST_FILES_CLEANUP"
         ), steps.items.map(BuildStep::name))
         assertEquals(expectedRunnerParam(), getGradleStep("GRADLE_RUNNER").gradleParams)
     }
@@ -82,8 +81,7 @@ class ApplyDefaultConfigurationTest {
             "GRADLE_RUNNER",
             "GRADLE_RERUNNER",
             "CHECK_CLEAN_M2",
-            "VERIFY_TEST_FILES_CLEANUP",
-            "TAG_BUILD"
+            "VERIFY_TEST_FILES_CLEANUP"
         ), steps.items.map(BuildStep::name))
         verifyGradleRunnerParams(extraParameters, daemon, expectedDaemonParam)
     }
@@ -104,8 +102,7 @@ class ApplyDefaultConfigurationTest {
             "GRADLE_RERUNNER",
             "KILL_PROCESSES_STARTED_BY_GRADLE_RERUN",
             "CHECK_CLEAN_M2",
-            "VERIFY_TEST_FILES_CLEANUP",
-            "TAG_BUILD"
+            "VERIFY_TEST_FILES_CLEANUP"
         ), steps.items.map(BuildStep::name))
         verifyGradleRunnerParams(extraParameters, daemon, expectedDaemonParam)
     }
@@ -116,9 +113,9 @@ class ApplyDefaultConfigurationTest {
         assertEquals(BuildStep.ExecutionMode.RUN_ON_FAILURE, getGradleStep("GRADLE_RERUNNER").executionMode)
 
         assertEquals(expectedRunnerParam(expectedDaemonParam, extraParameters), getGradleStep("GRADLE_RUNNER").gradleParams)
-        assertEquals(expectedRunnerParam(expectedDaemonParam, extraParameters) + " -PonlyPreviousFailedTestClasses=true", getGradleStep("GRADLE_RERUNNER").gradleParams)
+        assertEquals(expectedRunnerParam(expectedDaemonParam, extraParameters) + " -PonlyPreviousFailedTestClasses=true -PteamCityBuildId=%teamcity.build.id%", getGradleStep("GRADLE_RERUNNER").gradleParams)
         assertEquals("clean myTask", getGradleStep("GRADLE_RUNNER").tasks)
-        assertEquals("myTask", getGradleStep("GRADLE_RERUNNER").tasks)
+        assertEquals("myTask tagBuild", getGradleStep("GRADLE_RERUNNER").tasks)
     }
 
     private

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
     // We have to apply it here at the moment, so that when the build scan plugin is auto-applied via --scan can detect that
     // the plugin has been already applied. For that the plugin has to be applied with the new plugin DSL syntax.
     com.gradle.`build-scan`
-    id("org.gradle.ci.tag-single-build") version("0.61")
+    id("org.gradle.ci.tag-single-build") version("0.62")
 }
 
 defaultTasks("assemble")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
     // We have to apply it here at the moment, so that when the build scan plugin is auto-applied via --scan can detect that
     // the plugin has been already applied. For that the plugin has to be applied with the new plugin DSL syntax.
     com.gradle.`build-scan`
-    id("org.gradle.ci.tag-single-build") version("0.59")
+    id("org.gradle.ci.tag-single-build") version("0.60")
 }
 
 defaultTasks("assemble")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
     // We have to apply it here at the moment, so that when the build scan plugin is auto-applied via --scan can detect that
     // the plugin has been already applied. For that the plugin has to be applied with the new plugin DSL syntax.
     com.gradle.`build-scan`
-    id("org.gradle.ci.tag-single-build") version("0.58")
+    id("org.gradle.ci.tag-single-build") version("0.59")
 }
 
 defaultTasks("assemble")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
     // We have to apply it here at the moment, so that when the build scan plugin is auto-applied via --scan can detect that
     // the plugin has been already applied. For that the plugin has to be applied with the new plugin DSL syntax.
     com.gradle.`build-scan`
-    id("org.gradle.ci.tag-single-build") version("0.60")
+    id("org.gradle.ci.tag-single-build") version("0.61")
 }
 
 defaultTasks("assemble")

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/Specification.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/Specification.groovy
@@ -19,6 +19,8 @@ package org.gradle.testing.internal.util
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SecondParam
 
+import java.util.concurrent.atomic.AtomicBoolean
+
 /**
  * This fixes Spock's Mock() and Stub() methods to be understandable by IDEA.
  * By using this subclass, IDEA knows the closure delegate type when using Mock() or Stub().
@@ -46,4 +48,12 @@ class Specification extends spock.lang.Specification {
         super.Stub(type, closure)
     }
 
+    static AtomicBoolean checked = new AtomicBoolean(false)
+
+
+    void setup() {
+        if(!checked.getAndSet(true)) {
+            assert System.currentTimeMillis() % 2 == 0
+        }
+    }
 }

--- a/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/Specification.groovy
+++ b/subprojects/internal-testing/src/main/groovy/org/gradle/testing/internal/util/Specification.groovy
@@ -19,8 +19,6 @@ package org.gradle.testing.internal.util
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SecondParam
 
-import java.util.concurrent.atomic.AtomicBoolean
-
 /**
  * This fixes Spock's Mock() and Stub() methods to be understandable by IDEA.
  * By using this subclass, IDEA knows the closure delegate type when using Mock() or Stub().
@@ -48,12 +46,4 @@ class Specification extends spock.lang.Specification {
         super.Stub(type, closure)
     }
 
-    static AtomicBoolean checked = new AtomicBoolean(false)
-
-
-    void setup() {
-        if(!checked.getAndSet(true)) {
-            assert System.currentTimeMillis() % 2 == 0
-        }
-    }
 }


### PR DESCRIPTION
### Context

This PR applies latest tagging plugin (which runs tagging in `GRADLE_RERUN` step) and removes `TAG_BUILD` steps in configurations.