### PR TITLE
Add gradlePluginPortal(Action<>) to RepositoryHandler

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/RepositoryHandler.java
@@ -89,6 +89,16 @@ public interface RepositoryHandler extends ArtifactRepositoryContainer {
      */
     @Incubating
     ArtifactRepository gradlePluginPortal();
+    
+    /**
+     * Adds a repository which looks in Gradle Central Plugin Repository for dependencies.
+     * 
+     * @param action a configuration action
+     * @return the added resolver
+     * @since 5.4
+     */
+    @Incubating
+    ArtifactRepository gradlePluginPortal(Action<? super ArtifactRepository> action);
 
     /**
      * Adds a repository which looks in Bintray's JCenter repository for dependencies.

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/GradlePluginPortalDependencyResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/GradlePluginPortalDependencyResolveIntegrationTest.groovy
@@ -22,7 +22,17 @@ import org.gradle.util.TestPrecondition
 @Requires(TestPrecondition.ONLINE)
 class GradlePluginPortalDependencyResolveIntegrationTest extends AbstractDependencyResolutionTest {
 
-    def gradlePluginPortalRepository = "repositories { gradlePluginPortal() }"
+    def gradlePluginPortalRepository = """
+        repositories { 
+            gradlePluginPortal() 
+            gradlePluginPortal { // just test this syntax works.
+                name = "otherPluginPortal"
+                content {
+                    includeGroup 'org.sample'
+                }
+            }            
+        }
+    """
     def pluginClasspathDependency = "org.gradle:gradle-hello-world-plugin:0.2"
 
     def "buildscript dependencies can be resolved from gradlePluginPortal()"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dsl/DefaultRepositoryHandler.java
@@ -72,6 +72,11 @@ public class DefaultRepositoryHandler extends DefaultArtifactRepositoryContainer
     public ArtifactRepository gradlePluginPortal() {
         return addRepository(repositoryFactory.createGradlePluginPortal(), GRADLE_PLUGIN_PORTAL_REPO_NAME);
     }
+    
+    @Override
+    public ArtifactRepository gradlePluginPortal(Action<? super ArtifactRepository> action) {
+        return addRepository(repositoryFactory.createGradlePluginPortal(), GRADLE_PLUGIN_PORTAL_REPO_NAME, action);
+    }
 
     public MavenArtifactRepository mavenCentral() {
         return addRepository(repositoryFactory.createMavenCentralRepository(), DEFAULT_MAVEN_CENTRAL_REPO_NAME);


### PR DESCRIPTION
### Context
This is a "follow up" of #8636 
I think @ljacomet has just overseen the `gradlePluginPortal` 😅.

I hope it is ok and break nothing to change the PluginPortal from a `ArtifactRepository` to an  `MavenArtifactRepository`. But since it is an "up cast" nothing should break ✊.

I also have added the `@Incubating` because the `gradlePluginPortal()` have this as well...

Changes in the `accepted-public-api-changes.json` (like [here](https://github.com/gradle/gradle/pull/8636/files#diff-d47ed06f7d6d79e3f3c3fc7268b7939e)) and in the "changelog" ([here](https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/release/notes.md)) should be done afterwards as well 👍 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] ~Update User Guide, DSL Reference, and Javadoc for public-facing changes~
- [ ] ~Ensure that tests pass locally: `./gradlew <changed-subproject>:check`~

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
