### PR TITLE
 Task logger should have fallback operation id during execution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -63,7 +63,7 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.logging.compatbridge.LoggingManagerInternalCompatibilityBridge;
-import org.gradle.internal.logging.slf4j.ContextAwareBuildLogger;
+import org.gradle.internal.logging.slf4j.DefaultContextAwareTaskLogger;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scripts.ScriptOrigin;
@@ -122,7 +122,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private final TaskStateInternal state;
 
-    private Logger logger = new ContextAwareBuildLogger(BUILD_LOGGER);
+    private Logger logger = new DefaultContextAwareTaskLogger(BUILD_LOGGER);
 
     private final TaskMutator taskMutator;
     private ObservableList observableActionList;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/AbstractTask.java
@@ -63,6 +63,7 @@ import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.execution.history.changes.InputChangesInternal;
 import org.gradle.internal.extensibility.ExtensibleDynamicObject;
 import org.gradle.internal.logging.compatbridge.LoggingManagerInternalCompatibilityBridge;
+import org.gradle.internal.logging.slf4j.ContextAwareBuildLogger;
 import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.scripts.ScriptOrigin;
@@ -121,7 +122,7 @@ public abstract class AbstractTask implements TaskInternal, DynamicObjectAware {
 
     private final TaskStateInternal state;
 
-    private Logger logger = BUILD_LOGGER;
+    private Logger logger = new ContextAwareBuildLogger(BUILD_LOGGER);
 
     private final TaskMutator taskMutator;
     private ObservableList observableActionList;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
@@ -61,10 +61,10 @@ public class EventFiringTaskExecuter implements TaskExecuter {
                 try {
                     taskExecutionListener.beforeExecute(task);
                     BuildOperationRef currentOperation = buildOperationExecutor.getCurrentOperation();
-                    if (logger != null){
+                    if (logger instanceof ContextAwareTaskLogger) {
                         contextAwareTaskLogger = (ContextAwareTaskLogger) logger;
                         contextAwareTaskLogger.setFallbackBuildOperationId(currentOperation.getId());
-                    } 
+                    }
                 } catch (Throwable t) {
                     state.setOutcome(new TaskExecutionException(task, t));
                     return TaskExecuterResult.WITHOUT_OUTPUTS;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
@@ -57,14 +57,18 @@ public class EventFiringTaskExecuter implements TaskExecuter {
 
             private TaskExecuterResult executeTask(BuildOperationContext operationContext) {
                 Logger logger = task.getLogger();
-                ContextAwareTaskLogger contextAwareBuildLogger = null;
+                ContextAwareTaskLogger contextAwareTaskLogger = null;
                 try {
                     taskExecutionListener.beforeExecute(task);
                     BuildOperationRef currentOperation = buildOperationExecutor.getCurrentOperation();
-//                    if(logger instanceof ContextAwareTaskLogger) {
-                        contextAwareBuildLogger = (ContextAwareTaskLogger) logger;
-                        contextAwareBuildLogger.setFallbackBuildOperationId(currentOperation.getId());
-//                    }
+                    if (logger != null){
+                        contextAwareTaskLogger = (ContextAwareTaskLogger) logger;
+                        contextAwareTaskLogger.setFallbackBuildOperationId(currentOperation.getId());
+                    } else {
+                        for (Class<?> anInterface : logger.getClass().getInterfaces()) {
+                            System.out.println("### = " + anInterface);
+                        }
+                    }
                 } catch (Throwable t) {
                     state.setOutcome(new TaskExecutionException(task, t));
                     return TaskExecuterResult.WITHOUT_OUTPUTS;
@@ -72,8 +76,8 @@ public class EventFiringTaskExecuter implements TaskExecuter {
 
                 TaskExecuterResult result = delegate.execute(task, state, context);
 
-                if(contextAwareBuildLogger != null){
-                    contextAwareBuildLogger.setFallbackBuildOperationId(null);
+                if (contextAwareTaskLogger != null) {
+                    contextAwareTaskLogger.setFallbackBuildOperationId(null);
                 }
                 operationContext.setResult(new ExecuteTaskBuildOperationResult(
                     state,

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
@@ -24,7 +24,7 @@ import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.tasks.TaskExecutionException;
-import org.gradle.internal.logging.slf4j.ContextAwareBuildLogger;
+import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger;
 import org.gradle.internal.operations.BuildOperationCategory;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -57,14 +57,14 @@ public class EventFiringTaskExecuter implements TaskExecuter {
 
             private TaskExecuterResult executeTask(BuildOperationContext operationContext) {
                 Logger logger = task.getLogger();
-                ContextAwareBuildLogger contextAwareBuildLogger = null;
+                ContextAwareTaskLogger contextAwareBuildLogger = null;
                 try {
                     taskExecutionListener.beforeExecute(task);
                     BuildOperationRef currentOperation = buildOperationExecutor.getCurrentOperation();
-                    if(logger instanceof ContextAwareBuildLogger) {
-                        contextAwareBuildLogger = (ContextAwareBuildLogger) logger;
+//                    if(logger instanceof ContextAwareTaskLogger) {
+                        contextAwareBuildLogger = (ContextAwareTaskLogger) logger;
                         contextAwareBuildLogger.setFallbackBuildOperationId(currentOperation.getId());
-                    }
+//                    }
                 } catch (Throwable t) {
                     state.setOutcome(new TaskExecutionException(task, t));
                     return TaskExecuterResult.WITHOUT_OUTPUTS;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/EventFiringTaskExecuter.java
@@ -64,11 +64,7 @@ public class EventFiringTaskExecuter implements TaskExecuter {
                     if (logger != null){
                         contextAwareTaskLogger = (ContextAwareTaskLogger) logger;
                         contextAwareTaskLogger.setFallbackBuildOperationId(currentOperation.getId());
-                    } else {
-                        for (Class<?> anInterface : logger.getClass().getInterfaces()) {
-                            System.out.println("### = " + anInterface);
-                        }
-                    }
+                    } 
                 } catch (Throwable t) {
                     state.setOutcome(new TaskExecutionException(task, t));
                     return TaskExecuterResult.WITHOUT_OUTPUTS;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -259,8 +259,8 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                         LOGGER.info("Custom actions are attached to {}.", task);
                     }
                     if (context.isTaskCachingEnabled()
-                            && context.getTaskExecutionMode().isAllowedToUseCachedResults()
-                            && context.getBuildCacheKey().isValid()
+                        && context.getTaskExecutionMode().isAllowedToUseCachedResults()
+                        && context.getBuildCacheKey().isValid()
                     ) {
                         return loader.apply(context.getBuildCacheKey());
                     } else {
@@ -271,8 +271,8 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                 @Override
                 public void store(Consumer<BuildCacheKey> storer) {
                     if (buildCacheEnabled
-                            && context.isTaskCachingEnabled()
-                            && context.getBuildCacheKey().isValid()
+                        && context.isTaskCachingEnabled()
+                        && context.getBuildCacheKey().isValid()
                     ) {
                         storer.accept(context.getBuildCacheKey());
                     }
@@ -422,4 +422,5 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
             super(message, causes);
         }
     }
+
 }

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.api.tasks.TaskInstantiationException
 import org.gradle.internal.Actions
 import org.gradle.internal.event.ListenerManager
+import org.gradle.internal.logging.slf4j.ContextAwareBuildLogger
 import spock.lang.Issue
 
 import java.util.concurrent.Callable
@@ -526,7 +527,8 @@ class DefaultTaskTest extends AbstractTaskTest {
 
     def "can replace task logger"() {
         expect:
-        task.logger == AbstractTask.BUILD_LOGGER
+        task.logger instanceof ContextAwareBuildLogger
+        task.logger.delegate == AbstractTask.BUILD_LOGGER
 
         when:
         def logger = Mock(Logger)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/DefaultTaskTest.groovy
@@ -30,7 +30,7 @@ import org.gradle.api.tasks.TaskExecutionException
 import org.gradle.api.tasks.TaskInstantiationException
 import org.gradle.internal.Actions
 import org.gradle.internal.event.ListenerManager
-import org.gradle.internal.logging.slf4j.ContextAwareBuildLogger
+import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 import spock.lang.Issue
 
 import java.util.concurrent.Callable
@@ -527,7 +527,7 @@ class DefaultTaskTest extends AbstractTaskTest {
 
     def "can replace task logger"() {
         expect:
-        task.logger instanceof ContextAwareBuildLogger
+        task.logger instanceof ContextAwareTaskLogger
         task.logger.delegate == AbstractTask.BUILD_LOGGER
 
         when:

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/base/KotlinDslBasePlugin.kt
@@ -42,7 +42,6 @@ import org.gradle.kotlin.dsl.*
 class KotlinDslBasePlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
-
         apply<EmbeddedKotlinPlugin>()
         createOptionsExtension()
         apply<KotlinDslCompilerPlugins>()

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -71,11 +71,12 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
 
 
 private
-fun KotlinCompile.applyExperimentalWarning(experimentalWarning: Boolean) =
+fun KotlinCompile.applyExperimentalWarning(experimentalWarning: Boolean) {
     replaceLoggerWith(
         if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger as ContextAwareTaskLogger, project.toString(), project.experimentalWarningLink)
         else KotlinCompilerWarningSilencingLogger(logger as ContextAwareTaskLogger)
     )
+}
 
 
 object KotlinCompilerArguments {

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslCompilerPlugins.kt
@@ -23,6 +23,7 @@ import org.gradle.api.logging.Logger
 
 import org.gradle.api.internal.DocumentationRegistry
 import org.gradle.api.internal.TaskInternal
+import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -72,8 +73,8 @@ class KotlinDslCompilerPlugins : Plugin<Project> {
 private
 fun KotlinCompile.applyExperimentalWarning(experimentalWarning: Boolean) =
     replaceLoggerWith(
-        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger, project.toString(), project.experimentalWarningLink)
-        else KotlinCompilerWarningSilencingLogger(logger)
+        if (experimentalWarning) KotlinCompilerWarningSubstitutingLogger(logger as ContextAwareTaskLogger, project.toString(), project.experimentalWarningLink)
+        else KotlinCompilerWarningSilencingLogger(logger as ContextAwareTaskLogger)
     )
 
 
@@ -93,10 +94,10 @@ fun KotlinCompile.replaceLoggerWith(logger: Logger) {
 
 private
 class KotlinCompilerWarningSubstitutingLogger(
-    private val delegate: Logger,
+    private val delegate: ContextAwareTaskLogger,
     private val target: String,
     private val link: String
-) : Logger by delegate {
+) : ContextAwareTaskLogger by delegate {
 
     override fun warn(message: String) {
         if (message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) delegate.warn(kotlinDslPluginExperimentalWarning(target, link))
@@ -107,8 +108,8 @@ class KotlinCompilerWarningSubstitutingLogger(
 
 private
 class KotlinCompilerWarningSilencingLogger(
-    private val delegate: Logger
-) : Logger by delegate {
+    private val delegate: ContextAwareTaskLogger
+) : ContextAwareTaskLogger by delegate {
 
     override fun warn(message: String) {
         if (!message.contains(KotlinCompilerArguments.samConversionForKotlinFunctions)) {

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/BuildOperationAwareLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/BuildOperationAwareLogger.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.slf4j;
+
+import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
+import org.gradle.internal.operations.OperationIdentifier;
+
+abstract class BuildOperationAwareLogger implements Logger {
+
+    abstract void log(LogLevel logLevel, Throwable throwable, String message, OperationIdentifier operationIdentifier);
+
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/ContextAwareBuildLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/ContextAwareBuildLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,84 +17,95 @@
 package org.gradle.internal.logging.slf4j;
 
 import org.gradle.api.logging.LogLevel;
+import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import org.gradle.internal.logging.events.LogEvent;
-import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.operations.CurrentBuildOperationRef;
 import org.gradle.internal.operations.OperationIdentifier;
-import org.gradle.internal.time.Clock;
 import org.slf4j.Marker;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 
-public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
+public class ContextAwareBuildLogger implements Logger {
 
-    private final String name;
-    private final OutputEventListenerBackedLoggerContext context;
-    private final Clock clock;
+    private final BuildOperationAwareLogger delegate;
+    private OperationIdentifier fallbackOperationIdentifier = null;
 
-    public OutputEventListenerBackedLogger(String name, OutputEventListenerBackedLoggerContext context, Clock clock) {
-        this.name = name;
-        this.context = context;
-        this.clock = clock;
+    public ContextAwareBuildLogger(Logger delegate) {
+        this.delegate = (BuildOperationAwareLogger) delegate;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    private boolean isLevelAtMost(LogLevel levelLimit) {
-        return levelLimit.compareTo(context.getLevel()) >= 0;
-    }
-
-    public boolean isTraceEnabled() {
-        return false;
-    }
-
-    public boolean isTraceEnabled(Marker marker) {
-        return isTraceEnabled();
-    }
-
-    public boolean isDebugEnabled() {
-        return isLevelAtMost(LogLevel.DEBUG);
-    }
-
-    public boolean isDebugEnabled(Marker marker) {
-        return isDebugEnabled();
-    }
-
-    public boolean isInfoEnabled() {
-        return isLevelAtMost(LogLevel.INFO);
-    }
-
-    public boolean isInfoEnabled(Marker marker) {
-        return isLevelAtMost(toLogLevel(marker));
-    }
-
-    public boolean isWarnEnabled() {
-        return isLevelAtMost(LogLevel.WARN);
-    }
-
-    public boolean isWarnEnabled(Marker marker) {
-        return isWarnEnabled();
-    }
-
-    public boolean isErrorEnabled() {
-        return isLevelAtMost(LogLevel.ERROR);
-    }
-
-    public boolean isErrorEnabled(Marker marker) {
-        return isErrorEnabled();
+    public void setFallbackBuildOperationId(OperationIdentifier operationIdentifier) {
+        this.fallbackOperationIdentifier = operationIdentifier;
     }
 
     @Override
     public boolean isLifecycleEnabled() {
-        return isLevelAtMost(LogLevel.LIFECYCLE);
+        return delegate.isLifecycleEnabled();
     }
 
     @Override
     public boolean isQuietEnabled() {
-        return isLevelAtMost(LogLevel.QUIET);
+        return delegate.isQuietEnabled();
+    }
+
+    @Override
+    public boolean isEnabled(LogLevel level) {
+        return delegate.isEnabled(level);
+    }
+
+    @Override
+    public String getName() {
+        return delegate.getName();
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return delegate.isTraceEnabled();
+    }
+
+    @Override
+    public boolean isTraceEnabled(Marker marker) {
+        return delegate.isTraceEnabled(marker);
+    }
+
+    @Override
+    public boolean isDebugEnabled() {
+        return delegate.isDebugEnabled();
+    }
+
+    @Override
+    public boolean isDebugEnabled(Marker marker) {
+        return delegate.isDebugEnabled(marker);
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return delegate.isInfoEnabled();
+    }
+
+    @Override
+    public boolean isInfoEnabled(Marker marker) {
+        return delegate.isInfoEnabled(marker);
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return delegate.isWarnEnabled();
+    }
+
+    @Override
+    public boolean isWarnEnabled(Marker marker) {
+        return delegate.isWarnEnabled(marker);
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return delegate.isErrorEnabled();
+    }
+
+    @Override
+    public boolean isErrorEnabled(Marker marker) {
+        return delegate.isErrorEnabled(marker);
     }
 
     public void trace(String msg) {
@@ -129,18 +140,10 @@ public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
 
     private void log(LogLevel logLevel, Throwable throwable, String message) {
         OperationIdentifier buildOperationId = CurrentBuildOperationRef.instance().getId();
-        log(logLevel, throwable, message, buildOperationId);
-    }
-
-    void log(LogLevel logLevel, Throwable throwable, String message, OperationIdentifier operationIdentifier) {
-        LogEvent logEvent = new LogEvent(clock.getCurrentTime(), name, logLevel, message, throwable, operationIdentifier);
-        OutputEventListener outputEventListener = context.getOutputEventListener();
-        try {
-            outputEventListener.onOutput(logEvent);
-        } catch (Throwable e) {
-            // fall back to standard out
-            e.printStackTrace(System.out);
+        if (buildOperationId == null) {
+            buildOperationId = fallbackOperationIdentifier;
         }
+        delegate.log(logLevel, throwable, message, buildOperationId);
     }
 
     private void log(LogLevel logLevel, Throwable throwable, String format, Object arg) {
@@ -283,11 +286,6 @@ public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
         if (isQuietEnabled()) {
             log(LogLevel.QUIET, throwable, message);
         }
-    }
-
-    @Override
-    public boolean isEnabled(LogLevel level) {
-        return isLevelAtMost(level);
     }
 
     @Override
@@ -478,14 +476,6 @@ public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
         if (isErrorEnabled(marker)) {
             log(LogLevel.ERROR, t, msg);
         }
-    }
-
-    public OutputEventListenerBackedLoggerContext getContext() {
-        return context;
-    }
-
-    public Clock getClock() {
-        return clock;
     }
 
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/ContextAwareTaskLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/ContextAwareTaskLogger.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.logging.slf4j;
+
+import org.gradle.api.logging.Logger;
+import org.gradle.internal.operations.OperationIdentifier;
+
+public interface ContextAwareTaskLogger extends Logger {
+    void setFallbackBuildOperationId(OperationIdentifier operationIdentifier);
+}

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/DefaultContextAwareTaskLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/DefaultContextAwareTaskLogger.java
@@ -25,12 +25,12 @@ import org.slf4j.Marker;
 import org.slf4j.helpers.FormattingTuple;
 import org.slf4j.helpers.MessageFormatter;
 
-public class ContextAwareBuildLogger implements Logger {
+public class DefaultContextAwareTaskLogger implements ContextAwareTaskLogger {
 
-    private final BuildOperationAwareLogger delegate;
+    private BuildOperationAwareLogger delegate;
     private OperationIdentifier fallbackOperationIdentifier = null;
 
-    public ContextAwareBuildLogger(Logger delegate) {
+    public DefaultContextAwareTaskLogger(Logger delegate) {
         this.delegate = (BuildOperationAwareLogger) delegate;
     }
 

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLogger.java
@@ -480,12 +480,5 @@ public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
         }
     }
 
-    public OutputEventListenerBackedLoggerContext getContext() {
-        return context;
-    }
-
-    public Clock getClock() {
-        return clock;
-    }
 
 }

--- a/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLogger.java
+++ b/subprojects/logging/src/main/java/org/gradle/internal/logging/slf4j/OutputEventListenerBackedLogger.java
@@ -128,8 +128,7 @@ public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
     }
 
     private void log(LogLevel logLevel, Throwable throwable, String message) {
-        OperationIdentifier buildOperationId = CurrentBuildOperationRef.instance().getId();
-        log(logLevel, throwable, message, buildOperationId);
+        log(logLevel, throwable, message, CurrentBuildOperationRef.instance().getId());
     }
 
     void log(LogLevel logLevel, Throwable throwable, String message, OperationIdentifier operationIdentifier) {
@@ -154,7 +153,6 @@ public class OutputEventListenerBackedLogger extends BuildOperationAwareLogger {
     private void log(LogLevel logLevel, Throwable throwable, String format, Object[] args) {
         FormattingTuple tuple = MessageFormatter.arrayFormat(format, args);
         Throwable loggedThrowable = throwable == null ? tuple.getThrowable() : throwable;
-
         log(logLevel, loggedThrowable, tuple.getMessage());
     }
 


### PR DESCRIPTION
### Context

When tasks use external threads, output is not linked to the task execution build operation id. This fixes this problem by explicitly assigning the task execution build operation id as fallback to the task logger.
