### PR TITLE
Use InputChanges in native tasks

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/taskfactory/DefaultTaskClassInfoStore.java
@@ -68,7 +68,7 @@ public class DefaultTaskClassInfoStore implements TaskClassInfoStore {
                 }
                 if (taskActionFactory instanceof AbstractIncrementalTaskActionFactory) {
                     if (incremental) {
-                        throw new GradleException(String.format("Cannot have multiple @TaskAction methods accepting an %s parameter.", IncrementalTaskInputs.class.getSimpleName()));
+                        throw new GradleException(String.format("Cannot have multiple @TaskAction methods accepting an %s or %s parameter.", InputChanges.class.getSimpleName(), IncrementalTaskInputs.class.getSimpleName()));
                     }
                     incremental = true;
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskBuildOperationType.java
@@ -16,7 +16,6 @@
 
 package org.gradle.api.internal.tasks.execution;
 
-import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.operations.BuildOperationType;
 import org.gradle.internal.scan.NotUsedByScanPlugin;
 import org.gradle.internal.scan.UsedByScanPlugin;
@@ -124,7 +123,7 @@ public final class ExecuteTaskBuildOperationType implements BuildOperationType<E
         /**
          * Returns if this task was executed incrementally.
          *
-         * @see IncrementalTaskInputs#isIncremental()
+         * @see org.gradle.work.InputChanges#isIncremental()
          */
         @NotUsedByScanPlugin("used to report incrementality to TAPI progress listeners")
         boolean isIncremental();

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -38,6 +38,7 @@ import org.gradle.internal.service.ServiceRegistryBuilder
 import org.gradle.internal.service.scopes.ExecutionGlobalServices
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.work.InputChanges
 import spock.lang.Unroll
 
 import java.util.concurrent.Callable
@@ -48,6 +49,7 @@ import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTa
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.BrokenTaskWithInputDir
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.BrokenTaskWithInputFiles
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.NamedBean
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskUsingInputChanges
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithBooleanInput
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithBridgeMethod
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithDestroyable
@@ -59,8 +61,10 @@ import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTa
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithInputFiles
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithJavaBeanCornerCaseProperties
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithLocalState
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithMixedMultipleIncrementalActions
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithMultiParamAction
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithMultipleIncrementalActions
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithMultipleInputChangesActions
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithMultipleMethods
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithMultipleProperties
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithNestedBean
@@ -79,7 +83,10 @@ import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTa
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOutputFile
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOutputFiles
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOverloadedActions
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOverloadedIncrementalAndInputChangesActions
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOverloadedInputChangesActions
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOverriddenIncrementalAction
+import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOverriddenInputChangesAction
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithOverriddenMethod
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithProtectedMethod
 import static org.gradle.api.internal.project.taskfactory.AnnotationProcessingTasks.TaskWithSingleParamAction
@@ -158,6 +165,19 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         0 * _
     }
 
+    def createsContextualActionForInputChangesTaskAction() {
+        given:
+        def action = Mock(Action)
+        def task = expectTaskCreated(TaskUsingInputChanges, action)
+
+        when:
+        execute(task)
+
+        then:
+        1 * action.execute(_ as InputChanges)
+        0 * _
+    }
+
     def createsContextualActionForOverriddenIncrementalTaskAction() {
         given:
         def action = Mock(Action)
@@ -169,6 +189,20 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
 
         then:
         1 * action.execute(_ as IncrementalTaskInputs)
+        0 * _
+    }
+
+    def createsContextualActionForOverriddenInputChangesTaskAction() {
+        given:
+        def action = Mock(Action)
+        def superAction = Mock(Action)
+        def task = expectTaskCreated(TaskWithOverriddenInputChangesAction, action, superAction)
+
+        when:
+        execute(task)
+
+        then:
+        1 * action.execute(_ as InputChanges)
         0 * _
     }
 
@@ -191,12 +225,16 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         e.message == failureMessage
 
         where:
-        type                               | failureMessage
-        TaskWithMultipleIncrementalActions | "Cannot have multiple @TaskAction methods accepting an IncrementalTaskInputs parameter."
-        TaskWithStaticMethod               | "Cannot use @TaskAction annotation on static method TaskWithStaticMethod.doStuff()."
-        TaskWithMultiParamAction           | "Cannot use @TaskAction annotation on method TaskWithMultiParamAction.doStuff() as this method takes multiple parameters."
-        TaskWithSingleParamAction          | "Cannot use @TaskAction annotation on method TaskWithSingleParamAction.doStuff() because int is not a valid parameter to an action method."
-        TaskWithOverloadedActions          | "Cannot use @TaskAction annotation on multiple overloads of method TaskWithOverloadedActions.doStuff()"
+        type                                                | failureMessage
+        TaskWithMultipleIncrementalActions                  | "Cannot have multiple @TaskAction methods accepting an InputChanges or IncrementalTaskInputs parameter."
+        TaskWithStaticMethod                                | "Cannot use @TaskAction annotation on static method TaskWithStaticMethod.doStuff()."
+        TaskWithMultiParamAction                            | "Cannot use @TaskAction annotation on method TaskWithMultiParamAction.doStuff() as this method takes multiple parameters."
+        TaskWithSingleParamAction                           | "Cannot use @TaskAction annotation on method TaskWithSingleParamAction.doStuff() because int is not a valid parameter to an action method."
+        TaskWithOverloadedActions                           | "Cannot use @TaskAction annotation on multiple overloads of method TaskWithOverloadedActions.doStuff()"
+        TaskWithOverloadedInputChangesActions               | "Cannot use @TaskAction annotation on multiple overloads of method TaskWithOverloadedInputChangesActions.doStuff()"
+        TaskWithOverloadedIncrementalAndInputChangesActions | "Cannot use @TaskAction annotation on multiple overloads of method TaskWithOverloadedIncrementalAndInputChangesActions.doStuff()"
+        TaskWithMultipleInputChangesActions                 | "Cannot have multiple @TaskAction methods accepting an InputChanges or IncrementalTaskInputs parameter."
+        TaskWithMixedMultipleIncrementalActions             | "Cannot have multiple @TaskAction methods accepting an InputChanges or IncrementalTaskInputs parameter."
     }
 
     @Unroll

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTasks.java
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.OutputFiles;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
+import org.gradle.work.InputChanges;
 
 import java.io.File;
 import java.util.List;
@@ -146,6 +147,53 @@ public class AnnotationProcessingTasks {
         }
     }
 
+    public static class TaskWithOverloadedActions extends DefaultTask {
+        @TaskAction
+        public void doStuff() {}
+
+        @TaskAction
+        public void doStuff(IncrementalTaskInputs changes) {}
+    }
+
+    public static class TaskUsingInputChanges extends DefaultTask {
+        private final Action<InputChanges> action;
+
+        public TaskUsingInputChanges(Action<InputChanges> action) {
+            this.action = action;
+        }
+
+        @TaskAction
+        public void doStuff(InputChanges changes) {
+            action.execute(changes);
+        }
+    }
+
+    public static class TaskWithOverriddenInputChangesAction extends TaskUsingInputChanges {
+        private final Action<InputChanges> action;
+
+        public TaskWithOverriddenInputChangesAction(Action<InputChanges> action, Action<InputChanges> superAction) {
+            super(superAction);
+            this.action = action;
+        }
+
+        @Override
+        @TaskAction
+        public void doStuff(InputChanges changes) {
+            action.execute(changes);
+        }
+    }
+
+    public static class TaskWithMultipleInputChangesActions extends DefaultTask {
+
+        @TaskAction
+        public void doStuff(InputChanges changes) {
+        }
+
+        @TaskAction
+        public void doStuff2(InputChanges changes) {
+        }
+    }
+
     public static class TaskWithMultipleIncrementalActions extends DefaultTask {
 
         @TaskAction
@@ -157,12 +205,31 @@ public class AnnotationProcessingTasks {
         }
     }
 
-    public static class TaskWithOverloadedActions extends DefaultTask {
+    public static class TaskWithMixedMultipleIncrementalActions extends DefaultTask {
+
+        @TaskAction
+        public void doStuff(IncrementalTaskInputs changes) {
+        }
+
+        @TaskAction
+        public void doStuff2(InputChanges changes) {
+        }
+    }
+
+    public static class TaskWithOverloadedInputChangesActions extends DefaultTask {
         @TaskAction
         public void doStuff() {}
 
         @TaskAction
+        public void doStuff(InputChanges changes) {}
+    }
+
+    public static class TaskWithOverloadedIncrementalAndInputChangesActions extends DefaultTask {
+        @TaskAction
         public void doStuff(IncrementalTaskInputs changes) {}
+
+        @TaskAction
+        public void doStuff(InputChanges changes) {}
     }
 
     public static class TaskWithSingleParamAction extends DefaultTask {

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.language.rc.tasks.WindowsResourceCompile",
+            "member": "Method org.gradle.language.rc.tasks.WindowsResourceCompile.compile(org.gradle.work.InputChanges)",
+            "acceptation": "Migrated to the new incremental tasks API",
+            "changes": []
+        }
+    ]
 }

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -5,6 +5,28 @@
             "member": "Method org.gradle.language.rc.tasks.WindowsResourceCompile.compile(org.gradle.work.InputChanges)",
             "acceptation": "Migrated to the new incremental tasks API",
             "changes": []
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask",
+            "member": "Method org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.compile(org.gradle.work.InputChanges)",
+            "acceptation": "Migrated to the new incremental tasks API",
+            "changes": []
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.AbstractNativePCHCompileTask",
+            "member": "Class org.gradle.language.nativeplatform.tasks.AbstractNativePCHCompileTask",
+            "acceptation": "Migrated to the new incremental tasks API",
+            "changes": [
+                "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.compile(org.gradle.api.tasks.incremental.IncrementalTaskInputs)"
+            ]
+        },
+        {
+            "type": "org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask",
+            "member": "Class org.gradle.language.nativeplatform.tasks.AbstractNativeSourceCompileTask",
+            "acceptation": "Migrated to the new incremental tasks API",
+            "changes": [
+                "org.gradle.language.nativeplatform.tasks.AbstractNativeCompileTask.compile(org.gradle.api.tasks.incremental.IncrementalTaskInputs)"
+            ]
         }
     ]
 }

--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildStaleOutputsIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/cpp/CppIncrementalBuildStaleOutputsIntegrationTest.groovy
@@ -122,7 +122,7 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
 
         executable("app/build/exe/main/debug/app").assertDoesNotExist()
         file("app/build/exe/main/debug").assertDoesNotExist()
-        file("app/build/obj/main/debug").assertHasDescendants()
+        file("app/build/obj/main/debug").assertDoesNotExist()
         installation("app/build/install/main/debug").assertNotInstalled()
 
         sharedLibrary("greeter/build/lib/main/debug/greeter").assertExists()
@@ -159,7 +159,7 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
 
         executable("build/exe/main/debug/app").assertDoesNotExist()
         file("build/exe/main/debug").assertDoesNotExist()
-        file("build/obj/main/debug").assertHasDescendants()
+        file("build/obj/main/debug").assertDoesNotExist()
         installation("build/install/main/debug").assertNotInstalled()
     }
 
@@ -192,7 +192,7 @@ class CppIncrementalBuildStaleOutputsIntegrationTest extends AbstractInstalledTo
 
         sharedLibrary("build/lib/main/debug/hello").assertDoesNotExist()
         file("build/lib/main/debug").assertDoesNotExist()
-        file("build/obj/main/debug").assertHasDescendants()
+        file("build/obj/main/debug").assertDoesNotExist()
     }
 
     private List<String> expectIntermediateDescendants(SourceElement sourceElement) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -33,6 +33,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.Cast;
@@ -261,7 +262,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     /**
      * Returns the source files to be compiled.
      */
-    @Incremental
+    @SkipWhenEmpty
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     public ConfigurableFileCollection getSource() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/tasks/AbstractNativeCompileTask.java
@@ -35,7 +35,6 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
-import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.Cast;
 import org.gradle.internal.operations.logging.BuildOperationLogger;
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory;
@@ -50,6 +49,8 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.work.Incremental;
+import org.gradle.work.InputChanges;
 
 import javax.inject.Inject;
 import java.util.LinkedHashMap;
@@ -114,7 +115,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     }
 
     @TaskAction
-    public void compile(IncrementalTaskInputs inputs) {
+    public void compile(InputChanges inputs) {
         BuildOperationLogger operationLogger = getOperationLoggerFactory().newOperationLogger(getName(), getTemporaryDir());
         NativeCompileSpec spec = createCompileSpec();
         spec.setTargetPlatform(targetPlatform.get());
@@ -260,6 +261,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
     /**
      * Returns the source files to be compiled.
      */
+    @Incremental
     @InputFiles
     @PathSensitive(PathSensitivity.RELATIVE)
     public ConfigurableFileCollection getSource() {
@@ -301,6 +303,7 @@ public abstract class AbstractNativeCompileTask extends DefaultTask {
      *
      * @since 4.3
      */
+    @Incremental
     @InputFiles
     @PathSensitive(PathSensitivity.NAME_ONLY)
     protected FileCollection getHeaderDependencies() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -32,7 +32,6 @@ import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
-import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.Cast;
 import org.gradle.internal.operations.logging.BuildOperationLogger;
 import org.gradle.internal.operations.logging.BuildOperationLoggerFactory;
@@ -47,6 +46,8 @@ import org.gradle.nativeplatform.toolchain.NativeToolChain;
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainInternal;
 import org.gradle.nativeplatform.toolchain.internal.PlatformToolProvider;
+import org.gradle.work.Incremental;
+import org.gradle.work.InputChanges;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -79,7 +80,7 @@ public class WindowsResourceCompile extends DefaultTask {
         incrementalCompiler = getIncrementalCompilerBuilder().newCompiler(this, source, includes, macros, Providers.FALSE);
         getInputs().property("outputType", new Callable<String>() {
             @Override
-            public String call() throws Exception {
+            public String call() {
                 NativeToolChainInternal nativeToolChain = (NativeToolChainInternal) toolChain.get();
                 NativePlatformInternal nativePlatform = (NativePlatformInternal) targetPlatform.get();
                 return NativeToolChainInternal.Identifier.identify(nativeToolChain, nativePlatform);
@@ -98,7 +99,7 @@ public class WindowsResourceCompile extends DefaultTask {
     }
 
     @TaskAction
-    public void compile(IncrementalTaskInputs inputs) {
+    public void compile(InputChanges inputs) {
         BuildOperationLogger operationLogger = getOperationLoggerFactory().newOperationLogger(getName(), getTemporaryDir());
 
         NativeCompileSpec spec = new DefaultWindowsResourceCompileSpec();
@@ -161,6 +162,7 @@ public class WindowsResourceCompile extends DefaultTask {
     /**
      * Returns the header directories to be used for compilation.
      */
+    @Incremental
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public ConfigurableFileCollection getIncludes() {
@@ -177,6 +179,7 @@ public class WindowsResourceCompile extends DefaultTask {
     /**
      * Returns the source files to be compiled.
      */
+    @Incremental
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public ConfigurableFileCollection getSource() {
@@ -218,6 +221,7 @@ public class WindowsResourceCompile extends DefaultTask {
      *
      * @since 4.5
      */
+    @Incremental
     @InputFiles
     @PathSensitive(PathSensitivity.NAME_ONLY)
     protected FileCollection getHeaderDependencies() {

--- a/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/rc/tasks/WindowsResourceCompile.java
@@ -30,6 +30,7 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.internal.Cast;
@@ -179,7 +180,7 @@ public class WindowsResourceCompile extends DefaultTask {
     /**
      * Returns the source files to be compiled.
      */
-    @Incremental
+    @SkipWhenEmpty
     @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     public ConfigurableFileCollection getSource() {


### PR DESCRIPTION
This PR uses the new incremental API (aka `InputChanges`) in the native tasks.