### PR TITLE
Use InputChanges for tasks extending SourceTask

### DIFF
--- a/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/tasks/SourceTaskTest.groovy
@@ -40,5 +40,33 @@ class SourceTaskTest extends AbstractTaskTest {
         expect:
         task.source.asList() == [file1, file2]
     }
+
+    def "can prepend to source"() {
+        given:
+        File file1 = temporaryFolder.file('file1.txt').createFile()
+        File file2 = temporaryFolder.file('file2.txt').createFile()
+        file2.createNewFile()
+
+        task.source = file1
+        task.source = project.layout.files(file2) + task.source
+
+        expect:
+        task.source.asList() == [file2, file1]
+    }
+
+    def "can do complicated replacement"() {
+        given:
+        File file1 = temporaryFolder.file('file1.txt').createFile()
+        File file2 = temporaryFolder.file('file2.txt').createFile()
+        File file3 = temporaryFolder.file('file3.txt').createFile()
+        file2.createNewFile()
+        file3.createNewFile()
+
+        task.source = file1
+        task.source = task.source + project.layout.files(file2) + task.source + project.layout.files(file3)
+
+        expect:
+        task.source.asList() == [file1, file2, file3]
+    }
 }
 

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,18 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.api.plugins.antlr.AntlrTask",
+            "member": "Method org.gradle.api.plugins.antlr.AntlrTask.execute(org.gradle.api.tasks.incremental.IncrementalTaskInputs)",
+            "acceptation": "Migrated to the new incremental tasks API",
+            "changes": [
+                "Method has been removed"
+            ]
+        },
+        {
+            "type": "org.gradle.api.plugins.antlr.AntlrTask",
+            "member": "Method org.gradle.api.plugins.antlr.AntlrTask.execute(org.gradle.work.InputChanges)",
+            "acceptation": "Migrated to the new incremental tasks API",
+            "changes": []
+        }
+    ]
 }


### PR DESCRIPTION
The PR use the new incremental API (aka `InputChanges`) for the incremental tasks `AntlrTask` and `TwirlCompile`, both which are extending `SourceTask`.