### PR TITLE
Make Docbook2Xml task incremental

### DIFF
--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    groovy
+    `java-gradle-plugin`
+}
+
 dependencies {
     api("com.google.guava:guava:26.0-jre")
     api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")

--- a/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/Docbook2XhtmlFunctionalTest.groovy
+++ b/buildSrc/subprojects/build/src/test/groovy/org/gradle/build/docs/Docbook2XhtmlFunctionalTest.groovy
@@ -1,0 +1,39 @@
+package org.gradle.build.docs
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class Docbook2XhtmlFunctionalTest extends Specification {
+    @Rule TemporaryFolder testProjectDir = new TemporaryFolder()
+    File settingsFile
+    File buildFile
+
+    def setup() {
+        settingsFile = testProjectDir.newFile('settings.gradle')
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def "convert some docbook"() {
+        given:
+        settingsFile << "rootProject.name = 'hello-world'"
+        buildFile << """
+            import org.gradle.build.docs.Docbook2Xhtml
+
+            task docbookHtml(type: Docbook2Xhtml) {
+            }
+        """
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testProjectDir.root)
+                .withArguments('docbookHtml')
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.output.contains('Hello world!')
+        result.task(":helloWorld").outcome == org.gradle.testkit.runner.TaskOutcome.SUCCESS
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-5.4-20190320000558+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The task we use to convert the dsl docbook to html is very slow. I took 15 minutes on my machine, mostly since it is spinning up a JVM for each docbook file.
If we can make the task incremental and use the worker API instead of spinning up a new JVM, it should be much faster.