### PR TITLE
Fix the native unit test plugins when building applications with multiple variants

### DIFF
--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/cpp/plugins/CppUnitTestPlugin.java
@@ -192,12 +192,12 @@ public class CppUnitTestPlugin implements Plugin<Project> {
             // Configure test binary to link against tested component compiled objects
             ConfigurableFileCollection testableObjects = project.files();
             if (target instanceof CppApplication) {
+                // TODO - this should be an outgoing variant of the component under test
                 TaskProvider<UnexportMainSymbol> unexportMainSymbol = tasks.register(testExecutable.getNames().getTaskName("relocateMainFor"), UnexportMainSymbol.class, task -> {
-                    task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("obj/main/for-test"));
+                    String dirName = ((DefaultCppBinary) testedBinary).getNames().getDirName();
+                    task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("obj/for-test/" + dirName));
                     task.getObjects().from(testedBinary.getObjects());
                 });
-                // TODO: builtBy unnecessary?
-                testableObjects.builtBy(unexportMainSymbol);
                 testableObjects.from(unexportMainSymbol.map(task -> task.getRelocatedObjects()));
             } else {
                 testableObjects.from(testedBinary.getObjects());

--- a/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
+++ b/subprojects/testing-native/src/main/java/org/gradle/nativeplatform/test/xctest/plugins/XCTestConventionPlugin.java
@@ -261,11 +261,10 @@ public class XCTestConventionPlugin implements Plugin<Project> {
             ConfigurableFileCollection testableObjects = project.files();
             if (testedComponent instanceof SwiftApplication) {
                 TaskProvider<UnexportMainSymbol> unexportMainSymbol = tasks.register("relocateMainForTest", UnexportMainSymbol.class, task -> {
-                    task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("obj/main/for-test"));
+                    String dirName = ((DefaultSwiftBinary) testedBinary).getNames().getDirName();
+                    task.getOutputDirectory().set(project.getLayout().getBuildDirectory().dir("obj/for-test/" + dirName));
                     task.getObjects().from(testedBinary.getObjects());
                 });
-                // TODO: builtBy unnecessary?
-                testableObjects.builtBy(unexportMainSymbol);
                 testableObjects.from(unexportMainSymbol.map(task -> task.getRelocatedObjects()));
             } else {
                 testableObjects.from(testedBinary.getObjects());


### PR DESCRIPTION

### Context

This PR uses a separate directory per variant of the component under test to contain the relocated object files for that variant, rather than writing them all to the same directory.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
