### PR TITLE
Run tasks upon Eclipse synchronization

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java
@@ -95,7 +95,7 @@ public class EclipsePlugin extends IdePlugin {
         getLifecycleTask().configure(withDescription("Generates all Eclipse files."));
         getCleanTask().configure(withDescription("Cleans all Eclipse files."));
 
-        EclipseModel model = project.getExtensions().create("eclipse", EclipseModel.class);
+        EclipseModel model = project.getExtensions().create("eclipse", EclipseModel.class, project);
 
         configureEclipseProject((ProjectInternal) project, model);
         configureEclipseJdt(project, model);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseModel.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseModel.java
@@ -19,7 +19,12 @@ package org.gradle.plugins.ide.eclipse.model;
 import com.google.common.base.Preconditions;
 import groovy.lang.Closure;
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.xml.XmlTransformer;
 import org.gradle.plugins.ide.api.XmlFileContentMerger;
 
@@ -66,6 +71,12 @@ public class EclipseModel {
     private EclipseJdt jdt;
 
     private EclipseWtp wtp;
+
+    private final DefaultTaskDependency synchronizationTasks;
+
+    public EclipseModel(Project project) {
+        this.synchronizationTasks = new DefaultTaskDependency(((ProjectInternal) project).getTasks());
+    }
 
     /**
      * Injects and returns an instance of {@link ObjectFactory}.
@@ -215,6 +226,32 @@ public class EclipseModel {
      */
     public void jdt(Action<? super EclipseJdt> action) {
         action.execute(getJdt());
+    }
+
+    /**
+     * The tasks to execute before the Eclipse synchronization starts.
+     * <p>
+     * This property doesn't have a direct effect to the Gradle Eclipse plugin's behaviour. It is used, however, by
+     * Buildship to execute the configured tasks each time before the user imports the project or before a project
+     * synchronization starts.
+     *
+     * @return the tasks names
+     * @since 5.4
+     */
+    @Incubating
+    public TaskDependency getSynchronizationTasks() {
+        return synchronizationTasks;
+    }
+
+    /**
+     * Set tasks to be executed before the Eclipse synchronization.
+     *
+     * @see #getSynchronizationTasks()
+     * @since 5.4
+     */
+    @Incubating
+    public void synchronizationTasks(Object... synchronizationTasks) {
+        this.synchronizationTasks.add(synchronizationTasks);
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseModel.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseModel.java
@@ -74,6 +74,16 @@ public class EclipseModel {
 
     private final DefaultTaskDependency synchronizationTasks;
 
+    public EclipseModel() {
+        synchronizationTasks = new DefaultTaskDependency();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @since 5.4
+     */
+    @Incubating
     public EclipseModel(Project project) {
         this.synchronizationTasks = new DefaultTaskDependency(((ProjectInternal) project).getTasks());
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunEclipseSynchronizationTasksBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunEclipseSynchronizationTasksBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.tooling;
+
+import org.gradle.StartParameter;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+import org.gradle.tooling.provider.model.ToolingModelBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RunEclipseSynchronizationTasksBuilder implements ToolingModelBuilder {
+    @Override
+    public boolean canBuild(String modelName) {
+        return modelName.equals("org.gradle.tooling.model.eclipse.RunEclipseSynchronizationTasks");
+    }
+
+    @Override
+    public Object buildAll(String modelName, Project project) {
+        StartParameter startParameter = project.getGradle().getStartParameter();
+        List<String> taskPaths = new ArrayList<String>();
+        taskPaths.addAll(startParameter.getTaskNames());
+
+        for (Project p : project.getAllprojects()) {
+            EclipseModel model = p.getExtensions().findByType(EclipseModel.class);
+            if (model != null) {
+                for (Task t : model.getSynchronizationTasks().getDependencies(null)) {
+                    taskPaths.add(t.getPath());
+                }
+            }
+        }
+
+        if (taskPaths.isEmpty()) {
+            // If no tasks is specified then the default tasks will be executed.
+            // To work around this, we assign a new empty task for execution.
+            String placeHolderTaskName = placeHolderTaskName(project, "nothing");
+            project.task(placeHolderTaskName);
+            taskPaths.add(placeHolderTaskName);
+        }
+
+        project.getGradle().getStartParameter().setTaskNames(taskPaths);
+        return null;
+    }
+
+    private String placeHolderTaskName(Project project, String baseName) {
+        if (project.getTasks().findByName(baseName) == null) {
+            return baseName;
+        } else {
+            return placeHolderTaskName(project, baseName + "_");
+        }
+    }
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
@@ -51,6 +51,7 @@ public class ToolingModelServices extends AbstractPluginServiceRegistry {
                 public void execute(ToolingModelBuilderRegistry registry) {
                     GradleProjectBuilder gradleProjectBuilder = new GradleProjectBuilder();
                     IdeaModelBuilder ideaModelBuilder = new IdeaModelBuilder(gradleProjectBuilder, services);
+                    registry.register(new RunEclipseSynchronizationTasksBuilder());
                     registry.register(new EclipseModelBuilder(gradleProjectBuilder, services));
                     registry.register(ideaModelBuilder);
                     registry.register(gradleProjectBuilder);

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/EclipseModelTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/EclipseModelTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.Action
 import org.gradle.api.JavaVersion
 import org.gradle.api.XmlProvider
 import org.gradle.api.internal.PropertiesTransformer
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.internal.xml.XmlTransformer
 import org.gradle.plugins.ide.api.PropertiesFileContentMerger
 import org.gradle.plugins.ide.api.XmlFileContentMerger
@@ -27,7 +28,7 @@ import spock.lang.Specification
 
 class EclipseModelTest extends Specification {
 
-    EclipseModel model = new EclipseModel()
+    EclipseModel model = new EclipseModel(Mock(ProjectInternal))
 
     def setup() {
         model.classpath = new EclipseClasspath(null)

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/IntermediateResultHandlerCollector.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/IntermediateResultHandlerCollector.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r54;
+
+import org.gradle.tooling.IntermediateResultHandler;
+
+public class IntermediateResultHandlerCollector<T> implements IntermediateResultHandler<T> {
+    private T result = null;
+
+    @Override
+    public void onComplete(T result) {
+        this.result = result;
+    }
+
+    public T getResult() {
+        return result;
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/LoadEclipseModel.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/LoadEclipseModel.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r54;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+
+import java.io.Serializable;
+
+public class LoadEclipseModel implements BuildAction<EclipseProject>, Serializable {
+
+    @Override
+    public EclipseProject execute(BuildController controller) {
+        return controller.getModel(EclipseProject.class);
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/RunEclipseSynchronizationTasksCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/RunEclipseSynchronizationTasksCrossVersionSpec.groovy
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r54
+
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.plugins.ide.eclipse.model.EclipseModel
+
+@TargetGradleVersion(">=5.4")
+@ToolingApiVersion(">=5.4")
+class RunEclipseSynchronizationTasksCrossVersionSpec extends ToolingApiSpecification {
+    def setup() {
+        file("sub1").mkdirs()
+
+        buildFile << """
+            apply plugin: 'eclipse'
+
+            task foo {
+            }
+
+            task bar {
+            }
+
+            project(":sub") {
+                apply plugin: 'eclipse'
+
+                task bar {
+                }
+            }
+        """
+        settingsFile << "include 'sub'"
+    }
+
+    def "can run tasks upon Eclipse synchronization"() {
+        setup:
+        buildFile << "eclipse { synchronizationTasks 'foo' }"
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseModel>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunSyncTasks(), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":foo")
+    }
+
+    def "can use task reference in sync task list"() {
+        setup:
+        buildFile << "eclipse { synchronizationTasks foo }"
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseModel>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunSyncTasks(), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":foo")
+    }
+
+    def "task paths are resolved correctly"() {
+        setup:
+        buildFile << """
+            project(':sub') {
+                eclipse {
+                    synchronizationTasks 'bar'
+                }
+            }
+        """
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseModel>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunSyncTasks(), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":sub:bar")
+    }
+
+
+    def "execute placeholder task when no task is configured for synchronization"() {
+        setup:
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseModel>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunSyncTasks(), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":nothing")
+    }
+
+    def "does not override client-specified tasks"() {
+        setup:
+        buildFile << "eclipse { synchronizationTasks bar }"
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseModel>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunSyncTasks(), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks("foo")
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":foo")
+        taskExecuted(out, ":bar")
+    }
+
+
+    def "placeholder task never overlaps with project task"() {
+        setup:
+        buildFile << """
+            task nothing {
+            }
+            
+            task nothing_ {
+            }
+        """
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseModel>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunSyncTasks(), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        !taskExecuted(out, ":nothing")
+        !taskExecuted(out, ":nothing_")
+        taskExecuted(out, ":nothing__")
+    }
+
+    private def taskExecuted(ByteArrayOutputStream out, String taskPath) {
+        out.toString().contains("> Task $taskPath ")
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/TellGradleToRunSyncTasks.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/TellGradleToRunSyncTasks.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r54;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.RunEclipseSynchronizationTasks;
+
+import java.io.Serializable;
+
+public class TellGradleToRunSyncTasks implements BuildAction<Void>, Serializable {
+
+    @Override
+    public Void execute(BuildController controller) {
+            controller.getModel(RunEclipseSynchronizationTasks.class);
+        return null;
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/RunEclipseSynchronizationTasks.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/RunEclipseSynchronizationTasks.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.model.eclipse;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A tooling model that instructs Gradle to run tasks from the Eclipse plugin configuration.
+ *
+ * This is a special tooling model as it does not provide any information. However, when requested, Gradle will
+ * override the client-provided tasks with the ones stored in the {@code eclipse.synchronizationTasks} property.
+ *
+ * This allows Buildship to run tasks before the model loading and load the models in a single step.
+ *
+ * @since 5.4
+ */
+@Incubating
+public interface RunEclipseSynchronizationTasks {
+}


### PR DESCRIPTION
This PR implements the Gradle side of the [Run tasks upon synchronization](https://github.com/eclipse/buildship/issues/265) Buildship story. It contributes a new `eclipse.synchronizationTasks` configuration. By using the phased build action API, clients can execute the tasks just before loading the Eclipse model. Also, the task information never needs to leave the Gradle process. 