### PR TITLE
Allow receiving Provider<FileSystemLocation> for InputArtifact

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts.transform;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.InjectionPointQualifier;
 
 import java.io.File;
@@ -29,12 +30,16 @@ import java.lang.annotation.Target;
 /**
  * Attached to a property that should receive the <em>input artifact</em> for an artifact transform. This is the artifact that the transform should be applied to.
  *
+ * <p>
+ *     The input artifact can be injected as a plain {@link File} or a {@link Provider}&lt;{@link org.gradle.api.file.FileSystemLocation}&gt;.
+ * </p>
+ *
  * @since 5.3
  */
 @Incubating
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @Documented
-@InjectionPointQualifier(supportedTypes = File.class)
+@InjectionPointQualifier(supportedTypes = { File.class, Provider.class })
 public @interface InputArtifact {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/SkipWhenEmpty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/SkipWhenEmpty.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  *
  * <p>If all of the inputs declared with this annotation are empty, the task will be skipped with a "NO-SOURCE" message.</p>
  *
- * <p>Inputs annotated with this annotation can be queried for changes via {@link org.gradle.work.InputChanges#getFileChanges(Object)}.</p>
+ * <p>Inputs annotated with this annotation can be queried for changes via {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.file.FileCollection)}.</p>
  *
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/SkipWhenEmpty.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/SkipWhenEmpty.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  *
  * <p>If all of the inputs declared with this annotation are empty, the task will be skipped with a "NO-SOURCE" message.</p>
  *
- * <p>Inputs annotated with this annotation can be queried for changes via {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.file.FileCollection)}.</p>
+ * <p>Inputs annotated with this annotation can be queried for changes via {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.file.FileCollection)} or {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.provider.Provider)}.</p>
  *
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>

--- a/subprojects/core-api/src/main/java/org/gradle/work/Incremental.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/Incremental.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * Track input changes for the annotated parameter.
  *
  * <p>
- *     Inputs annotated with {@link Incremental} can be queried for changes via {@link InputChanges#getFileChanges(org.gradle.api.file.FileCollection)}.
+ *     Inputs annotated with {@link Incremental} can be queried for changes via {@link InputChanges#getFileChanges(org.gradle.api.file.FileCollection)} or {@link org.gradle.work.InputChanges#getFileChanges(org.gradle.api.provider.Provider)}.
  * </p>
  *
  * @since 5.4

--- a/subprojects/core-api/src/main/java/org/gradle/work/Incremental.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/Incremental.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  * Track input changes for the annotated parameter.
  *
  * <p>
- *     Inputs annotated with {@link Incremental} can be queried for changes via {@link InputChanges#getFileChanges(Object)}.
+ *     Inputs annotated with {@link Incremental} can be queried for changes via {@link InputChanges#getFileChanges(org.gradle.api.file.FileCollection)}.
  * </p>
  *
  * @since 5.4

--- a/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
@@ -94,7 +94,7 @@ public interface InputChanges {
      * <p>When {@link #isIncremental()} is {@code false}, then all elements of the parameter are returned as {@link ChangeType#ADDED}.</p>
      *
      * <p>
-     *     Only input file properties annotated with {@link Incremental} or {@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
+     *     Only input file properties annotated with {@literal @}{@link Incremental} or {@literal @}{@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
      * </p>
      *
      * @param parameter The value of the parameter to query.
@@ -108,11 +108,11 @@ public interface InputChanges {
      *
      * <p>
      *     This method allows querying properties of type {@link org.gradle.api.file.RegularFileProperty} and {@link org.gradle.api.file.DirectoryProperty} for changes.
-     *     These two types are typically used for {@link org.gradle.api.tasks.InputFile} and {@link org.gradle.api.tasks.InputDirectory} properties.
+     *     These two types are typically used for {@literal @}{@link org.gradle.api.tasks.InputFile} and {@literal @}{@link org.gradle.api.tasks.InputDirectory} properties.
      * </p>
      *
      * <p>
-     *     Only input file properties annotated with {@link Incremental} or {@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
+     *     Only input file properties annotated with {@literal @}{@link Incremental} or {@literal @}{@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
      * </p>
      *
      * @param parameter The value of the parameter to query.

--- a/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
@@ -97,9 +97,9 @@ public interface InputChanges {
      *     Only input file properties annotated with {@link Incremental} or {@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
      * </p>
      *
-     * @param parameterValue The value of the parameter to query.
+     * @param parameter The value of the parameter to query.
      */
-    Iterable<FileChange> getFileChanges(FileCollection parameterValue);
+    Iterable<FileChange> getFileChanges(FileCollection parameter);
 
     /**
      * Changes for a parameter.
@@ -107,10 +107,15 @@ public interface InputChanges {
      * <p>When {@link #isIncremental()} is {@code false}, then all elements of the parameter are returned as {@link ChangeType#ADDED}.</p>
      *
      * <p>
+     *     This method allows querying properties of type {@link org.gradle.api.file.RegularFileProperty} and {@link org.gradle.api.file.DirectoryProperty} for changes.
+     *     These two types are typically used for {@link org.gradle.api.tasks.InputFile} and {@link org.gradle.api.tasks.InputDirectory} properties.
+     * </p>
+     *
+     * <p>
      *     Only input file properties annotated with {@link Incremental} or {@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
      * </p>
      *
-     * @param parameterValue The value of the parameter to query.
+     * @param parameter The value of the parameter to query.
      */
-    Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameterValue);
+    Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameter);
 }

--- a/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
@@ -17,6 +17,9 @@
 package org.gradle.work;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
 
 /**
  * Provides access to any input files that need to be processed by an incremental work action.
@@ -26,9 +29,9 @@ import org.gradle.api.Incubating;
  * The work action can then query what changed for an input parameter since the last execution to only process the changes.
  *
  * <pre class='autoTested'>
- * class IncrementalReverseTask extends DefaultTask {
+ * abstract class IncrementalReverseTask extends DefaultTask {
  *     {@literal @}InputDirectory
- *     def File inputDir
+ *     abstract DirectoryProperty getInputDir()
  *
  *     {@literal @}OutputDirectory
  *     def File outputDir
@@ -40,16 +43,14 @@ import org.gradle.api.Incubating;
  *         }
  *
  *         inputChanges.getFileChanges(inputDir).each { change -&gt;
- *             switch (change.changeType) {
- *                 case REMOVED:
- *                     def targetFile = project.file("$outputDir/${change.file.name}")
- *                     if (targetFile.exists()) {
- *                         targetFile.delete()
- *                     }
- *                     break
- *                 default:
- *                     def targetFile = project.file("$outputDir/${change.file.name}")
- *                     targetFile.text = change.file.text.reverse()
+ *             if (change.changeType == ChangeType.REMOVED) {
+ *                 def targetFile = project.file("$outputDir/${change.file.name}")
+ *                 if (targetFile.exists()) {
+ *                     targetFile.delete()
+ *                 }
+ *             } else {
+ *                 def targetFile = project.file("$outputDir/${change.file.name}")
+ *                 targetFile.text = change.file.text.reverse()
  *             }
  *         }
  *     }
@@ -76,13 +77,13 @@ public interface InputChanges {
      * When <code>true</code>:
      * </p>
      * <ul>
-     *     <li>{@link #getFileChanges(Object)} reports changes to the input files compared to the previous execution.</li>
+     *     <li>{@link #getFileChanges(FileCollection)} and {@link #getFileChanges(Provider)} report changes to the input files compared to the previous execution.</li>
      * </ul>
      * <p>
      * When <code>false</code>:
      * </p>
      * <ul>
-     *     <li>Every input file is reported via {@link #getFileChanges(Object)} as if it was {@link ChangeType#ADDED}.</li>
+     *     <li>Every input file is reported via {@link #getFileChanges(FileCollection)} and {@link #getFileChanges(Provider)} as if it was {@link ChangeType#ADDED}.</li>
      * </ul>
      */
     boolean isIncremental();
@@ -98,5 +99,18 @@ public interface InputChanges {
      *
      * @param parameterValue The value of the parameter to query.
      */
-    Iterable<FileChange> getFileChanges(Object parameterValue);
+    Iterable<FileChange> getFileChanges(FileCollection parameterValue);
+
+    /**
+     * Changes for a parameter.
+     *
+     * <p>When {@link #isIncremental()} is {@code false}, then all elements of the parameter are returned as {@link ChangeType#ADDED}.</p>
+     *
+     * <p>
+     *     Only input file properties annotated with {@link Incremental} or {@link org.gradle.api.tasks.SkipWhenEmpty} can be queried for changes.
+     * </p>
+     *
+     * @param parameterValue The value of the parameter to query.
+     */
+    Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameterValue);
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractIncrementalTasksIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/AbstractIncrementalTasksIntegrationTest.groovy
@@ -57,7 +57,7 @@ abstract class AbstractIncrementalTasksIntegrationTest extends AbstractIntegrati
     abstract class BaseIncrementalTask extends DefaultTask {
         ${inputDirAnnotation}
         @InputDirectory
-        def File inputDir
+        abstract DirectoryProperty getInputDir()
 
         @TaskAction
         $taskAction

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -85,10 +85,10 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
     @Issue("https://github.com/gradle/gradle/issues/4166")
     def "file in input dir appears in task inputs for #inputAnnotation"() {
         buildFile << """
-            class MyTask extends DefaultTask {
+            abstract class MyTask extends DefaultTask {
                 @${inputAnnotation}
                 @Incremental
-                File input
+                abstract DirectoryProperty getInput()
                 @OutputFile
                 File output
                 
@@ -129,7 +129,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
             abstract class WithNonIncrementalInput extends BaseIncrementalTask {
                 
                 @InputFile
-                File nonIncrementalInput
+                abstract RegularFileProperty getNonIncrementalInput()
                 
                 @Override
                 void execute(InputChanges inputChanges) {
@@ -146,7 +146,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
 
         expect:
         fails("withNonIncrementalInput")
-        failure.assertHasCause("Cannot query incremental changes: No property found for value ${file("nonIncremental").absolutePath}. Incremental properties: inputDir.")
+        failure.assertHasCause("Cannot query incremental changes: No property found for value property(interface org.gradle.api.file.RegularFile, fixed(class org.gradle.api.internal.file.DefaultFilePropertyFactory\$FixedFile, ${file( "nonIncremental").absolutePath})). Incremental properties: inputDir.")
     }
 
     def "changes to non-incremental input parameters cause a rebuild"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -19,8 +19,10 @@ package org.gradle.api.internal.artifacts.transform;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher;
 import org.gradle.internal.fingerprint.AbsolutePathInputNormalizer;
@@ -66,7 +68,8 @@ public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
     }
 
     @Override
-    public ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies, @Nullable InputChanges inputChanges) {
+    public ImmutableList<File> transform(Provider<FileSystemLocation> inputArtifactProvider, File outputDir, ArtifactTransformDependencies dependencies, @Nullable InputChanges inputChanges) {
+        File inputArtifact = inputArtifactProvider.get().getAsFile();
         ArtifactTransform transformer = newTransformer();
         transformer.setOutputDirectory(outputDir);
         List<File> outputs = transformer.transform(inputArtifact);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -19,8 +19,10 @@ package org.gradle.api.internal.artifacts.transform;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Describable;
 import org.gradle.api.artifacts.transform.ArtifactTransform;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.FileNormalizer;
 import org.gradle.internal.fingerprint.FileCollectionFingerprinterRegistry;
 import org.gradle.internal.hash.HashCode;
@@ -54,7 +56,7 @@ public interface Transformer extends Describable, TaskDependencyContainer {
      */
     boolean isCacheable();
 
-    ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies, @Nullable InputChanges inputChanges);
+    ImmutableList<File> transform(Provider<FileSystemLocation> inputArtifactProvider, File outputDir, ArtifactTransformDependencies dependencies, @Nullable InputChanges inputChanges);
 
     /**
      * The hash of the secondary inputs of the transformer.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -18,6 +18,7 @@ package org.gradle.api.internal.artifacts.transform
 
 import com.google.common.collect.ImmutableList
 import org.gradle.api.artifacts.transform.ArtifactTransform
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder
@@ -27,6 +28,7 @@ import org.gradle.api.internal.changedetection.state.DefaultWellKnownFileLocatio
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.tasks.TaskDependencyResolveContext
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.FileNormalizer
 import org.gradle.internal.classloader.ClassLoaderHierarchyHasher
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
@@ -137,8 +139,8 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         }
 
         @Override
-        ImmutableList<File> transform(File inputArtifact, File outputDir, ArtifactTransformDependencies dependencies, InputChanges inputChanges) {
-            return ImmutableList.copyOf(transformationAction.apply(inputArtifact, outputDir))
+        ImmutableList<File> transform(Provider<FileSystemLocation> inputArtifactProvider, File outputDir, ArtifactTransformDependencies dependencies, InputChanges inputChanges) {
+            return ImmutableList.copyOf(transformationAction.apply(inputArtifactProvider.get().asFile, outputDir))
         }
 
         @Override

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/IncrementalInputChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/IncrementalInputChanges.java
@@ -16,6 +16,9 @@
 
 package org.gradle.internal.execution.history.changes;
 
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.incremental.InputFileDetails;
 import org.gradle.internal.Cast;
 import org.gradle.internal.change.CollectingChangeVisitor;
@@ -37,7 +40,16 @@ public class IncrementalInputChanges implements InputChangesInternal {
     }
 
     @Override
-    public Iterable<FileChange> getFileChanges(Object parameterValue) {
+    public Iterable<FileChange> getFileChanges(FileCollection parameterValue) {
+        return getObjectFileChanges(parameterValue);
+    }
+
+    @Override
+    public Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameterValue) {
+        return getObjectFileChanges(parameterValue);
+    }
+
+    private Iterable<FileChange> getObjectFileChanges(Object parameterValue) {
         String propertyName = incrementalInputProperties.getPropertyNameFor(parameterValue);
         CollectingChangeVisitor visitor = new CollectingChangeVisitor();
         changes.accept(propertyName, visitor);

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/IncrementalInputChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/IncrementalInputChanges.java
@@ -40,17 +40,17 @@ public class IncrementalInputChanges implements InputChangesInternal {
     }
 
     @Override
-    public Iterable<FileChange> getFileChanges(FileCollection parameterValue) {
-        return getObjectFileChanges(parameterValue);
+    public Iterable<FileChange> getFileChanges(FileCollection parameter) {
+        return getObjectFileChanges(parameter);
     }
 
     @Override
-    public Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameterValue) {
-        return getObjectFileChanges(parameterValue);
+    public Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameter) {
+        return getObjectFileChanges(parameter);
     }
 
-    private Iterable<FileChange> getObjectFileChanges(Object parameterValue) {
-        String propertyName = incrementalInputProperties.getPropertyNameFor(parameterValue);
+    private Iterable<FileChange> getObjectFileChanges(Object parameter) {
+        String propertyName = incrementalInputProperties.getPropertyNameFor(parameter);
         CollectingChangeVisitor visitor = new CollectingChangeVisitor();
         changes.accept(propertyName, visitor);
         return Cast.uncheckedNonnullCast(visitor.getChanges());

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/NonIncrementalInputChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/NonIncrementalInputChanges.java
@@ -44,17 +44,17 @@ public class NonIncrementalInputChanges implements InputChangesInternal {
     }
 
     @Override
-    public Iterable<FileChange> getFileChanges(FileCollection parameterValue) {
-        return getObjectFileChanges(parameterValue);
+    public Iterable<FileChange> getFileChanges(FileCollection parameter) {
+        return getObjectFileChanges(parameter);
     }
 
     @Override
-    public Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameterValue) {
-        return getObjectFileChanges(parameterValue);
+    public Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameter) {
+        return getObjectFileChanges(parameter);
     }
 
-    public Iterable<FileChange> getObjectFileChanges(Object parameterValue) {
-        CurrentFileCollectionFingerprint currentFileCollectionFingerprint = currentInputs.get(incrementalInputProperties.getPropertyNameFor(parameterValue));
+    public Iterable<FileChange> getObjectFileChanges(Object parameter) {
+        CurrentFileCollectionFingerprint currentFileCollectionFingerprint = currentInputs.get(incrementalInputProperties.getPropertyNameFor(parameter));
         return () -> getAllFileChanges(currentFileCollectionFingerprint).iterator();
     }
 

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/NonIncrementalInputChanges.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/changes/NonIncrementalInputChanges.java
@@ -17,6 +17,9 @@
 package org.gradle.internal.execution.history.changes;
 
 import com.google.common.collect.ImmutableSortedMap;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.incremental.InputFileDetails;
 import org.gradle.internal.Cast;
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint;
@@ -41,7 +44,16 @@ public class NonIncrementalInputChanges implements InputChangesInternal {
     }
 
     @Override
-    public Iterable<FileChange> getFileChanges(Object parameterValue) {
+    public Iterable<FileChange> getFileChanges(FileCollection parameterValue) {
+        return getObjectFileChanges(parameterValue);
+    }
+
+    @Override
+    public Iterable<FileChange> getFileChanges(Provider<? extends FileSystemLocation> parameterValue) {
+        return getObjectFileChanges(parameterValue);
+    }
+
+    public Iterable<FileChange> getObjectFileChanges(Object parameterValue) {
         CurrentFileCollectionFingerprint currentFileCollectionFingerprint = currentInputs.get(incrementalInputProperties.getPropertyNameFor(parameterValue));
         return () -> getAllFileChanges(currentFileCollectionFingerprint).iterator();
     }

--- a/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
+++ b/subprojects/execution/src/test/groovy/org/gradle/internal/execution/history/changes/NonIncrementalInputChangesTest.groovy
@@ -18,6 +18,8 @@ package org.gradle.internal.execution.history.changes
 
 import com.google.common.collect.ImmutableBiMap
 import com.google.common.collect.ImmutableSortedMap
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
 import org.gradle.internal.fingerprint.CurrentFileCollectionFingerprint
 import org.gradle.internal.fingerprint.impl.AbsolutePathFingerprintingStrategy
 import org.gradle.internal.fingerprint.impl.DefaultCurrentFileCollectionFingerprint
@@ -30,12 +32,13 @@ class NonIncrementalInputChangesTest extends Specification {
     def "can iterate changes more than once"() {
         def fingerprint = DefaultCurrentFileCollectionFingerprint.from([new RegularFileSnapshot("/some/where", "where", HashCode.fromInt(1234), 0)], AbsolutePathFingerprintingStrategy.INCLUDE_MISSING)
 
-        def changes = new NonIncrementalInputChanges(ImmutableSortedMap.<String, CurrentFileCollectionFingerprint>of("input", fingerprint), new DefaultIncrementalInputProperties(ImmutableBiMap.of("input", "value")))
+        Provider<FileSystemLocation> value = Mock()
+        def changes = new NonIncrementalInputChanges(ImmutableSortedMap.<String, CurrentFileCollectionFingerprint>of("input", fingerprint), new DefaultIncrementalInputProperties(ImmutableBiMap.of("input", value)))
         def expectedChangedFiles = [new File("/some/where")]
 
         when:
         def allFileChanges = changes.allFileChanges
-        def fileChanges = changes.getFileChanges("value")
+        def fileChanges = changes.getFileChanges(value)
 
         then:
         allFileChanges*.file == expectedChangedFiles


### PR DESCRIPTION
So that we can limit the `InputChanges` API to only query only `Provider<? extends FileSystemLocation>` and `FileCollection`.