### PR TITLE
Take advantage of type-safe accessors in precompiled script plugins (take 2)

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-module.gradle.kts
@@ -29,9 +29,8 @@ plugins {
 }
 
 // including all sources
-val main by sourceSets
-tasks.named<Jar>("jar") {
-    from(main.allSource)
+tasks.jar {
+    from(sourceSets.main.get().allSource)
     manifest.attributes.apply {
         put("Implementation-Title", "Gradle Kotlin DSL (${project.name})")
         put("Implementation-Version", archiveVersion.get())

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-plugin-bundle.gradle.kts
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/plugins/kotlin-dsl-plugin-bundle.gradle.kts
@@ -44,7 +44,7 @@ afterEvaluate {
 
 
 tasks {
-    "validateTaskProperties"(ValidateTaskProperties::class) {
+    validateTaskProperties {
         failOnWarning = true
         enableStricterValidation = true
     }

--- a/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/api-parameter-names-index.gradle.kts
+++ b/buildSrc/subprojects/plugins/src/main/kotlin/gradlebuild/api-parameter-names-index.gradle.kts
@@ -35,7 +35,12 @@ val parameterNamesIndex by tasks.registering(ParameterNamesIndex::class) {
     if (file("src/main/groovy").isDirectory) {
         classpath.from(tasks.named<GroovyCompile>("compileGroovy"))
     }
-    destinationFile.set(gradlebuildJava.generatedResourcesDir.resolve("${base.archivesBaseName}-parameter-names.properties"))
+    destinationFile.set(
+        gradlebuildJava.generatedResourcesDir.resolve("${base.archivesBaseName}-parameter-names.properties")
+    )
 }
 
-main.output.dir(gradlebuildJava.generatedResourcesDir, "builtBy" to parameterNamesIndex)
+main.output.dir(
+    gradlebuildJava.generatedResourcesDir,
+    "builtBy" to parameterNamesIndex
+)

--- a/buildSrc/subprojects/profiling/src/main/kotlin/gradlebuild/jmh.gradle.kts
+++ b/buildSrc/subprojects/profiling/src/main/kotlin/gradlebuild/jmh.gradle.kts
@@ -16,20 +16,17 @@
 
 package gradlebuild
 
-import me.champeau.gradle.JMHPluginExtension
-
 plugins {
     id("me.champeau.gradle.jmh")
 }
 
 configurations {
-
-    getByName("jmhImplementation") {
-        extendsFrom(configurations["implementation"])
+    jmhImplementation {
+        extendsFrom(configurations.implementation.get())
     }
 }
 
-configure<JMHPluginExtension> {
+jmh {
     isIncludeTests = false
     resultFormat = "CSV"
 }

--- a/buildSrc/subprojects/uber-plugins/uber-plugins.gradle.kts
+++ b/buildSrc/subprojects/uber-plugins/uber-plugins.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
     implementation(project(":binaryCompatibility"))
+    implementation(project(":buildquality"))
     implementation(project(":cleanup"))
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))


### PR DESCRIPTION
Reverting the reversion of #8758 due to a performance test failure.
