### PR TITLE
Skip buildSrc checks by default on `gradle/gradle`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,8 @@ Install: `./gradlew install -Pgradle_installPath=/any/path`. Use: `/any/path/bin
 
 You can debug Gradle by adding `-Dorg.gradle.debug=true` when executing. Gradle will wait for you to attach a debugger at `localhost:5005` by default.
 
+If you made changes to build logic in `buildSrc`, you can test them by executing `./gradlew help -PbuildSrcCheck=true`.
+
 ### Creating Commits And Writing Commit Messages
 
 The commit messages that accompany your code changes are an important piece of documentation, please follow these guidelines when writing commit messages:

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -95,8 +95,25 @@ dependencies {
     }
 }
 
-// Set gradlebuild.skipBuildSrcChecks Gradle property to "true" to disable all buildSrc verification tasks
-if (findProperty("gradlebuild.skipBuildSrcChecks") == "true") {
+
+// TODO Avoid duplication of what defines a CI Server with BuildEnvironment
+val isCiServer: Boolean by extra { "CI" in System.getenv() }
+
+
+/**
+ * Controls whether verification tasks are skipped.
+ *
+ * Set the `buildSrcCheck` Gradle property to `true` to run the verification tasks.
+ * Set it to `false` to skip the verification tasks.
+ *
+ * When that property is unset, defaults to `false` on CI, to `true` otherwise.
+ */
+val isSkipBuildSrcVerification: Boolean =
+    (findProperty("buildSrcCheck") as String?)
+        ?.let { it == "false" }
+        ?: !isCiServer
+
+if (isSkipBuildSrcVerification) {
     allprojects {
         tasks.matching { it.group == LifecycleBasePlugin.VERIFICATION_GROUP }.configureEach {
             enabled = false
@@ -104,8 +121,6 @@ if (findProperty("gradlebuild.skipBuildSrcChecks") == "true") {
     }
 }
 
-// TODO Avoid duplication of what defines a CI Server with BuildEnvironment
-val isCiServer: Boolean by extra { "CI" in System.getenv() }
 if (isCiServer) {
     gradle.buildFinished {
         allprojects.forEach { project ->

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -82,7 +82,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.runs = runs
-        runner.args = extraGradleBuildArguments() + ["-PbuildSrcCheck=false"]
+        runner.args = extraGradleBuildArguments() + ["-PbuildSrcCheck=false", "-Pgradlebuild.skipBuildSrcChecks=true"]
 
         and:
         def changingClassFilePath = "buildSrc/${buildSrcProjectDir}src/main/groovy/ChangingClass.groovy"

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -82,7 +82,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.runs = runs
-        runner.args = extraGradleBuildArguments() + ["-Pgradlebuild.skipBuildSrcChecks=true"]
+        runner.args = extraGradleBuildArguments() + ["-buildSrcCheck=false"]
 
         and:
         def changingClassFilePath = "buildSrc/${buildSrcProjectDir}src/main/groovy/ChangingClass.groovy"

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/inception/GradleInceptionPerformanceTest.groovy
@@ -82,7 +82,7 @@ class GradleInceptionPerformanceTest extends AbstractCrossVersionPerformanceTest
         runner.testProject = testProject
         runner.tasksToRun = ['help']
         runner.runs = runs
-        runner.args = extraGradleBuildArguments() + ["-buildSrcCheck=false"]
+        runner.args = extraGradleBuildArguments() + ["-PbuildSrcCheck=false"]
 
         and:
         def changingClassFilePath = "buildSrc/${buildSrcProjectDir}src/main/groovy/ChangingClass.groovy"


### PR DESCRIPTION
Disable buildSrc verification tasks by default, enable them on CI by default, allow to control whether they are enabled via a project property.
