### PR TITLE
Fix test failures appearing starting with Swift 4.2

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftIncrementalBuildIntegrationTest.groovy
@@ -32,6 +32,7 @@ import org.gradle.nativeplatform.fixtures.app.SourceElement
 import org.gradle.nativeplatform.fixtures.app.SwiftApp
 import org.gradle.nativeplatform.fixtures.app.SwiftLib
 import org.gradle.test.fixtures.file.TestFile
+import org.gradle.util.VersionNumber
 
 @RequiresInstalledToolChain(ToolChainRequirement.SWIFTC)
 class SwiftIncrementalBuildIntegrationTest extends AbstractInstalledToolChainIntegrationSpec {
@@ -347,6 +348,9 @@ class SwiftIncrementalBuildIntegrationTest extends AbstractInstalledToolChainInt
             result.add(swiftdocFileFor(swiftFile).relativizeFrom(intermediateFilesDir).path)
             result.add(dependFileFor(swiftFile).relativizeFrom(intermediateFilesDir).path)
             result.add(swiftDepsFileFor(swiftFile).relativizeFrom(intermediateFilesDir).path)
+        }
+        if (toolChain.version.compareTo(VersionNumber.parse("4.2")) >= 0) {
+            result.add("module.swiftdeps~moduleonly")
         }
         result.add("module.swiftdeps")
         result.add("output-file-map.json")


### PR DESCRIPTION
The ~moduleonly files appeared in Swift 4.2 releases. It's an extra file
that we need to assert for.

### Context
Fixes https://github.com/gradle/gradle-native-private/issues/190

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fnative-swift-moduleonly)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
