### PR TITLE
Run tasks upon Eclipse auto-build

### DIFF
--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseModel.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseModel.java
@@ -74,8 +74,11 @@ public class EclipseModel {
 
     private final DefaultTaskDependency synchronizationTasks;
 
+    private final DefaultTaskDependency autoBuildTasks;
+
     public EclipseModel() {
         synchronizationTasks = new DefaultTaskDependency();
+        autoBuildTasks = new DefaultTaskDependency();
     }
 
     /**
@@ -86,6 +89,7 @@ public class EclipseModel {
     @Incubating
     public EclipseModel(Project project) {
         this.synchronizationTasks = new DefaultTaskDependency(((ProjectInternal) project).getTasks());
+        this.autoBuildTasks = new DefaultTaskDependency(((ProjectInternal) project).getTasks());
     }
 
     /**
@@ -239,7 +243,7 @@ public class EclipseModel {
     }
 
     /**
-     * The tasks to execute before the Eclipse synchronization starts.
+     * Returns the tasks to be executed before the Eclipse synchronization starts.
      * <p>
      * This property doesn't have a direct effect to the Gradle Eclipse plugin's behaviour. It is used, however, by
      * Buildship to execute the configured tasks each time before the user imports the project or before a project
@@ -262,6 +266,31 @@ public class EclipseModel {
     @Incubating
     public void synchronizationTasks(Object... synchronizationTasks) {
         this.synchronizationTasks.add(synchronizationTasks);
+    }
+
+    /**
+     * Returns the tasks to be executed during the Eclipse auto-build.
+     * <p>
+     * This property doesn't have a direct effect to the Gradle Eclipse plugin's behaviour. It is used, however, by
+     * Buildship to execute the configured tasks each time when the Eclipse automatic build is triggered for the project.
+     *
+     * @return the tasks names
+     * @since 5.4
+     */
+    @Incubating
+    public TaskDependency getAutoBuildTasks() {
+        return autoBuildTasks;
+    }
+
+    /**
+     * Set tasks to be executed during the Eclipse auto-build.
+     *
+     * @see #getAutoBuildTasks()
+     * @since 5.4
+     */
+    @Incubating
+    public void autoBuildTasks(Object... autoBuildTasks) {
+        this.autoBuildTasks.add(autoBuildTasks);
     }
 
     /**

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
@@ -51,7 +51,7 @@ public class ToolingModelServices extends AbstractPluginServiceRegistry {
                 public void execute(ToolingModelBuilderRegistry registry) {
                     GradleProjectBuilder gradleProjectBuilder = new GradleProjectBuilder();
                     IdeaModelBuilder ideaModelBuilder = new IdeaModelBuilder(gradleProjectBuilder, services);
-                    registry.register(new RunEclipseSynchronizationTasksBuilder());
+                    registry.register(new RunEclipseTasksBuilder());
                     registry.register(new EclipseModelBuilder(gradleProjectBuilder, services));
                     registry.register(ideaModelBuilder);
                     registry.register(gradleProjectBuilder);

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/RunEclipseAutoBuildTasksCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/RunEclipseAutoBuildTasksCrossVersionSpec.groovy
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r54
+
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+
+@TargetGradleVersion(">=5.4")
+@ToolingApiVersion(">=5.4")
+class RunEclipseAutoBuildTasksCrossVersionSpec extends ToolingApiSpecification {
+    def setup() {
+        file("sub1").mkdirs()
+
+        buildFile << """
+            apply plugin: 'eclipse'
+
+            task foo {
+            }
+
+            task bar {
+            }
+
+            project(":sub") {
+                apply plugin: 'eclipse'
+
+                task bar {
+                }
+            }
+        """
+        settingsFile << "include 'sub'"
+    }
+
+    def "can run tasks upon Eclipse auto-build"() {
+        setup:
+        buildFile << "eclipse { autoBuildTasks 'foo' }"
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunAutoBuildTasks(), projectsLoadedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":foo")
+    }
+
+    def "can use task reference in sync task list"() {
+        setup:
+        buildFile << "eclipse { autoBuildTasks foo }"
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunAutoBuildTasks(), projectsLoadedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":foo")
+    }
+
+    def "task paths are resolved correctly"() {
+        setup:
+        buildFile << """
+            project(':sub') {
+                eclipse {
+                    autoBuildTasks 'bar'
+                }
+            }
+        """
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunAutoBuildTasks(), projectsLoadedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":sub:bar")
+    }
+
+
+    def "execute placeholder task when no task is configured for auto-build"() {
+        setup:
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunAutoBuildTasks(), projectsLoadedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":nothing")
+    }
+
+    def "does not override client-specified tasks"() {
+        setup:
+        buildFile << "eclipse { autoBuildTasks bar }"
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunAutoBuildTasks(), projectsLoadedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks("foo")
+                .run()
+        }
+
+        then:
+        taskExecuted(out, ":foo")
+        taskExecuted(out, ":bar")
+    }
+
+
+    def "placeholder task never overlaps with project task"() {
+        setup:
+        buildFile << """
+            task nothing {
+            }
+
+            task nothing_ {
+            }
+        """
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def out = new ByteArrayOutputStream()
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunAutoBuildTasks(), projectsLoadedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        !taskExecuted(out, ":nothing")
+        !taskExecuted(out, ":nothing_")
+        taskExecuted(out, ":nothing__")
+    }
+
+    private def taskExecuted(ByteArrayOutputStream out, String taskPath) {
+        out.toString().contains("> Task $taskPath ")
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/TellGradleToRunAutoBuildTasks.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r54/TellGradleToRunAutoBuildTasks.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r54;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.RunEclipseAutoBuildTasks;
+
+import java.io.Serializable;
+
+public class TellGradleToRunAutoBuildTasks implements BuildAction<Void>, Serializable {
+
+    @Override
+    public Void execute(BuildController controller) {
+            controller.getModel(RunEclipseAutoBuildTasks.class);
+        return null;
+    }
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/RunEclipseAutoBuildTasks.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/RunEclipseAutoBuildTasks.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.model.eclipse;
+
+import org.gradle.api.Incubating;
+
+/**
+ * A tooling model that instructs Gradle to run tasks from the Eclipse plugin configuration.
+ *
+ * Similarly to {@link RunEclipseSynchronizationTasks}, this is a special tooling model as it does
+ * not provide any information. However, when requested, Gradle will override the client-provided
+ * tasks with the ones stored in the {@code eclipse.autoBuildTasks} property.
+ *
+ * @since 5.4
+ */
+@Incubating
+public interface RunEclipseAutoBuildTasks {
+}


### PR DESCRIPTION
This PR adds an `autoBuildTasks` property to the `eclipse` plugin configuration. With this, Buildship can execute the tasks each time the Eclipse auto-build is triggered without reading the property on the client-side and sending back. 

This is an additional feature for #8823.