### PR TITLE
Provide normalized path in FileChange

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Classpath.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Classpath.java
@@ -31,8 +31,8 @@ import java.lang.annotation.Target;
  * <p>
  *     For jar files, the normalized path is empty.
  *     The content of the jar file is normalized so that time stamps and order of the zip entries in the jar file do not matter.
- *     If a directory is a classpath entry, then the directory itself is ignored.
- *     The files in the directory are sorted and the relative path to the directory is used as normalized path.
+ *     If a directory is a classpath entry, then the root directory itself is ignored.
+ *     The files in the directory are sorted and the relative path to the root directory is used as normalized path.
  * </p>
  *
  * <p><strong>Note:</strong> to stay compatible with versions prior to Gradle 3.2, classpath

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/Classpath.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/Classpath.java
@@ -28,6 +28,13 @@ import java.lang.annotation.Target;
  * <p>This annotation should be attached to the getter method in Java or the property in Groovy.
  * Annotations on setters or just the field in Java are ignored.</p>
  *
+ * <p>
+ *     For jar files, the normalized path is empty.
+ *     The content of the jar file is normalized so that time stamps and order of the zip entries in the jar file do not matter.
+ *     If a directory is a classpath entry, then the directory itself is ignored.
+ *     The files in the directory are sorted and the relative path to the directory is used as normalized path.
+ * </p>
+ *
  * <p><strong>Note:</strong> to stay compatible with versions prior to Gradle 3.2, classpath
  * properties need to be annotated with {@literal @}{@link InputFiles} as well.</p>
  *

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/PathSensitivity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/PathSensitivity.java
@@ -33,6 +33,19 @@ public enum PathSensitivity {
 
     /**
      * Use the location of the file related to a hierarchy.
+     *
+     * <p>
+     *     If the property a contains directory, then the path of the directory will be ignored.
+     *     For files in the directory, the normalized path is the relative path of the file to the directory.
+     *     For files in the root of the file collection, the file name is used as the normalized path.
+     * </p>
+     *
+     * <br />
+     * Example: The property is an input directory.
+     * <ul>
+     *     <li>The path of the input directory is ignored.</li>
+     *     <li>The path of the files in the input directory are considered relative to the input directory.</li>
+     * </ul>
      */
     RELATIVE,
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/tasks/PathSensitivity.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/tasks/PathSensitivity.java
@@ -35,12 +35,12 @@ public enum PathSensitivity {
      * Use the location of the file related to a hierarchy.
      *
      * <p>
-     *     If the property a contains directory, then the path of the directory will be ignored.
-     *     For files in the directory, the normalized path is the relative path of the file to the directory.
      *     For files in the root of the file collection, the file name is used as the normalized path.
+     *     For directories in the root of the file collection, an empty string is used as normalized path.
+     *     For files in directories in the root of the file collection, the normalized path is the relative path of the file to the root directory containing it.
      * </p>
      *
-     * <br />
+     * <br>
      * Example: The property is an input directory.
      * <ul>
      *     <li>The path of the input directory is ignored.</li>

--- a/subprojects/core-api/src/main/java/org/gradle/work/FileChange.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/FileChange.java
@@ -37,4 +37,17 @@ public interface FileChange {
      * The type of change to the file.
      */
     ChangeType getChangeType();
+
+    /**
+     * The normalized path of the file, as specified by the path normalization strategy.
+     *
+     * <p>
+     *    Examples:
+     * </p>
+     * <ul>
+     *     <li>For {@link org.gradle.api.tasks.PathSensitivity#NAME_ONLY} this is the file name.</li>
+     *     <li>For {@literal @}{@link org.gradle.api.tasks.Classpath} this is empty for Jar files and the relative path (i.e. package name) of the class files.</li>
+     * </ul>
+     */
+    String getNormalizedPath();
 }

--- a/subprojects/core-api/src/main/java/org/gradle/work/FileChange.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/FileChange.java
@@ -42,12 +42,8 @@ public interface FileChange {
      * The normalized path of the file, as specified by the path normalization strategy.
      *
      * <p>
-     *    Examples:
+     *    See {@link org.gradle.api.tasks.PathSensitivity}, {@link org.gradle.api.tasks.Classpath} and {@link org.gradle.api.tasks.CompileClasspath} for the different path normalization strategies.
      * </p>
-     * <ul>
-     *     <li>For {@link org.gradle.api.tasks.PathSensitivity#NAME_ONLY} this is the file name.</li>
-     *     <li>For {@literal @}{@link org.gradle.api.tasks.Classpath} this is empty for Jar files and the relative path (i.e. package name) of the class files.</li>
-     * </ul>
      */
     String getNormalizedPath();
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathCompareStrategy.java
@@ -137,18 +137,18 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
 
         void added() {
             if (includeAdded) {
-                changeConsumer.visitChange(DefaultFileChange.added(current.getKey(), propertyTitle, current.getValue().getType()));
+                changeConsumer.visitChange(DefaultFileChange.added(current.getKey(), propertyTitle, current.getValue().getType(), current.getValue().getNormalizedPath()));
             }
             current = nextEntry(currentEntries);
         }
 
         void removed() {
-            changeConsumer.visitChange(DefaultFileChange.removed(previous.getKey(), propertyTitle, previous.getValue().getType()));
+            changeConsumer.visitChange(DefaultFileChange.removed(previous.getKey(), propertyTitle, previous.getValue().getType(), previous.getValue().getNormalizedPath()));
             previous = nextEntry(previousEntries);
         }
 
         void modified() {
-            changeConsumer.visitChange(DefaultFileChange.modified(current.getKey(), propertyTitle, previous.getValue().getType(), current.getValue().getType()));
+            changeConsumer.visitChange(DefaultFileChange.modified(current.getKey(), propertyTitle, previous.getValue().getType(), current.getValue().getType(), current.getValue().getNormalizedPath()));
             previous = nextEntry(previousEntries);
             current = nextEntry(currentEntries);
         }

--- a/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathCompareStrategy.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/fingerprint/classpath/impl/ClasspathCompareStrategy.java
@@ -137,18 +137,21 @@ public class ClasspathCompareStrategy extends AbstractFingerprintCompareStrategy
 
         void added() {
             if (includeAdded) {
-                changeConsumer.visitChange(DefaultFileChange.added(current.getKey(), propertyTitle, current.getValue().getType(), current.getValue().getNormalizedPath()));
+                DefaultFileChange added = DefaultFileChange.added(current.getKey(), propertyTitle, current.getValue().getType(), current.getValue().getNormalizedPath());
+                changeConsumer.visitChange(added);
             }
             current = nextEntry(currentEntries);
         }
 
         void removed() {
-            changeConsumer.visitChange(DefaultFileChange.removed(previous.getKey(), propertyTitle, previous.getValue().getType(), previous.getValue().getNormalizedPath()));
+            DefaultFileChange removed = DefaultFileChange.removed(previous.getKey(), propertyTitle, previous.getValue().getType(), previous.getValue().getNormalizedPath());
+            changeConsumer.visitChange(removed);
             previous = nextEntry(previousEntries);
         }
 
         void modified() {
-            changeConsumer.visitChange(DefaultFileChange.modified(current.getKey(), propertyTitle, previous.getValue().getType(), current.getValue().getType(), current.getValue().getNormalizedPath()));
+            DefaultFileChange modified = DefaultFileChange.modified(current.getKey(), propertyTitle, previous.getValue().getType(), current.getValue().getType(), current.getValue().getNormalizedPath());
+            changeConsumer.visitChange(modified);
             previous = nextEntry(previousEntries);
             current = nextEntry(currentEntries);
         }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpecProvider.java
@@ -20,6 +20,7 @@ import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathEntr
 import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathSnapshot;
 import org.gradle.internal.change.DefaultFileChange;
 import org.gradle.internal.file.FileType;
+import org.gradle.internal.fingerprint.impl.IgnoredPathFingerprintingStrategy;
 import org.gradle.internal.util.Alignment;
 
 import java.io.File;
@@ -52,10 +53,12 @@ public class RecompilationSpecProvider {
         for (Alignment<File> fileAlignment : alignment) {
             switch (fileAlignment.getKind()) {
                 case added:
-                    classpathEntryChangeProcessor.processChange(DefaultFileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile, ""), spec);
+                    DefaultFileChange added = DefaultFileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile, IgnoredPathFingerprintingStrategy.IGNORED_PATH);
+                    classpathEntryChangeProcessor.processChange(added, spec);
                     break;
                 case removed:
-                    classpathEntryChangeProcessor.processChange(DefaultFileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile, ""), spec);
+                    DefaultFileChange removed = DefaultFileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile, IgnoredPathFingerprintingStrategy.IGNORED_PATH);
+                    classpathEntryChangeProcessor.processChange(removed, spec);
                     break;
                 case transformed:
                     // If we detect a transformation in the classpath, we need to recompile, because we could typically be facing the case where
@@ -67,7 +70,8 @@ public class RecompilationSpecProvider {
                     ClasspathEntrySnapshot previousSnapshot = previous.getClasspathEntrySnapshot(key);
                     ClasspathEntrySnapshot snapshot = currentSnapshots.getSnapshot(key);
                     if (previousSnapshot == null || !snapshot.getHash().equals(previousSnapshot.getHash())) {
-                        classpathEntryChangeProcessor.processChange(DefaultFileChange.modified(key.getAbsolutePath(), "classpathEntry", FileType.RegularFile, FileType.RegularFile, ""), spec);
+                        DefaultFileChange modified = DefaultFileChange.modified(key.getAbsolutePath(), "classpathEntry", FileType.RegularFile, FileType.RegularFile, IgnoredPathFingerprintingStrategy.IGNORED_PATH);
+                        classpathEntryChangeProcessor.processChange(modified, spec);
                     }
                     break;
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpecProvider.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/RecompilationSpecProvider.java
@@ -52,10 +52,10 @@ public class RecompilationSpecProvider {
         for (Alignment<File> fileAlignment : alignment) {
             switch (fileAlignment.getKind()) {
                 case added:
-                    classpathEntryChangeProcessor.processChange(DefaultFileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile), spec);
+                    classpathEntryChangeProcessor.processChange(DefaultFileChange.added(fileAlignment.getCurrentValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile, ""), spec);
                     break;
                 case removed:
-                    classpathEntryChangeProcessor.processChange(DefaultFileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile), spec);
+                    classpathEntryChangeProcessor.processChange(DefaultFileChange.removed(fileAlignment.getPreviousValue().getAbsolutePath(), "classpathEntry", FileType.RegularFile, ""), spec);
                     break;
                 case transformed:
                     // If we detect a transformation in the classpath, we need to recompile, because we could typically be facing the case where
@@ -67,7 +67,7 @@ public class RecompilationSpecProvider {
                     ClasspathEntrySnapshot previousSnapshot = previous.getClasspathEntrySnapshot(key);
                     ClasspathEntrySnapshot snapshot = currentSnapshots.getSnapshot(key);
                     if (previousSnapshot == null || !snapshot.getHash().equals(previousSnapshot.getHash())) {
-                        classpathEntryChangeProcessor.processChange(DefaultFileChange.modified(key.getAbsolutePath(), "classpathEntry", FileType.RegularFile, FileType.RegularFile), spec);
+                        classpathEntryChangeProcessor.processChange(DefaultFileChange.modified(key.getAbsolutePath(), "classpathEntry", FileType.RegularFile, FileType.RegularFile, ""), spec);
                     }
                     break;
             }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/change/DefaultFileChange.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/change/DefaultFileChange.java
@@ -30,25 +30,27 @@ public class DefaultFileChange implements Change, FileChange, InputFileDetails {
     private final String title;
     private final FileType previousFileType;
     private final FileType currentFileType;
+    private final String normalizedPath;
 
-    public static DefaultFileChange added(String path, String title, FileType currentFileType) {
-        return new DefaultFileChange(path, ChangeTypeInternal.ADDED, title, FileType.Missing, currentFileType);
+    public static DefaultFileChange added(String path, String title, FileType currentFileType, String normalizedPath) {
+        return new DefaultFileChange(path, ChangeTypeInternal.ADDED, title, FileType.Missing, currentFileType, normalizedPath);
     }
 
-    public static DefaultFileChange removed(String path, String title, FileType previousFileType) {
-        return new DefaultFileChange(path, ChangeTypeInternal.REMOVED, title, previousFileType, FileType.Missing);
+    public static DefaultFileChange removed(String path, String title, FileType previousFileType, String normalizedPath) {
+        return new DefaultFileChange(path, ChangeTypeInternal.REMOVED, title, previousFileType, FileType.Missing, normalizedPath);
     }
 
-    public static DefaultFileChange modified(String path, String title, FileType previousFileType, FileType currentFileType) {
-        return new DefaultFileChange(path, ChangeTypeInternal.MODIFIED, title, previousFileType, currentFileType);
+    public static DefaultFileChange modified(String path, String title, FileType previousFileType, FileType currentFileType, String normalizedPath) {
+        return new DefaultFileChange(path, ChangeTypeInternal.MODIFIED, title, previousFileType, currentFileType, normalizedPath);
     }
 
-    private DefaultFileChange(String path, ChangeTypeInternal change, String title, FileType previousFileType, FileType currentFileType) {
+    private DefaultFileChange(String path, ChangeTypeInternal change, String title, FileType previousFileType, FileType currentFileType, String normalizedPath) {
         this.path = path;
         this.change = change;
         this.title = title;
         this.previousFileType = previousFileType;
         this.currentFileType = currentFileType;
+        this.normalizedPath = normalizedPath;
     }
 
     @Override
@@ -86,8 +88,13 @@ public class DefaultFileChange implements Change, FileChange, InputFileDetails {
     @Override
     public ChangeType getChangeType() {
         // TODO wolfs: Shall we do something about file type Missing -> File
-        // should this be file type ADDED instead of MODIFIED
+        //   should this be file type ADDED instead of MODIFIED
         return change.getPublicType();
+    }
+
+    @Override
+    public String getNormalizedPath() {
+        return normalizedPath;
     }
 
     public ChangeTypeInternal getType() {
@@ -122,11 +129,12 @@ public class DefaultFileChange implements Change, FileChange, InputFileDetails {
             && change == that.change
             && Objects.equal(title, that.title)
             && Objects.equal(previousFileType, that.previousFileType)
-            && Objects.equal(currentFileType, that.currentFileType);
+            && Objects.equal(currentFileType, that.currentFileType)
+            && Objects.equal(normalizedPath, that.normalizedPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(path, change, title, previousFileType, currentFileType);
+        return Objects.hashCode(path, change, title, previousFileType, currentFileType, normalizedPath);
     }
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintCompareStrategy.java
@@ -50,20 +50,20 @@ public class AbsolutePathFingerprintCompareStrategy extends AbstractFingerprintC
                 FileSystemLocationFingerprint previousFingerprint = previous.get(currentAbsolutePath);
                 HashCode previousContentHash = previousFingerprint.getNormalizedContentHash();
                 if (!currentContentHash.equals(previousContentHash)) {
-                    if (!visitor.visitChange(DefaultFileChange.modified(currentAbsolutePath, propertyTitle, previousFingerprint.getType(), currentFingerprint.getType()))) {
+                    if (!visitor.visitChange(DefaultFileChange.modified(currentAbsolutePath, propertyTitle, previousFingerprint.getType(), currentFingerprint.getType(), currentAbsolutePath))) {
                         return false;
                     }
                 }
                 // else, unchanged; check next file
             } else if (includeAdded) {
-                if (!visitor.visitChange(DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType()))) {
+                if (!visitor.visitChange(DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), currentAbsolutePath))) {
                     return false;
                 }
             }
         }
 
         for (String previousAbsolutePath : unaccountedForPreviousFingerprints) {
-            if (!visitor.visitChange(DefaultFileChange.removed(previousAbsolutePath, propertyTitle, previous.get(previousAbsolutePath).getType()))) {
+            if (!visitor.visitChange(DefaultFileChange.removed(previousAbsolutePath, propertyTitle, previous.get(previousAbsolutePath).getType(), previousAbsolutePath))) {
                 return false;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbsolutePathFingerprintCompareStrategy.java
@@ -50,20 +50,23 @@ public class AbsolutePathFingerprintCompareStrategy extends AbstractFingerprintC
                 FileSystemLocationFingerprint previousFingerprint = previous.get(currentAbsolutePath);
                 HashCode previousContentHash = previousFingerprint.getNormalizedContentHash();
                 if (!currentContentHash.equals(previousContentHash)) {
-                    if (!visitor.visitChange(DefaultFileChange.modified(currentAbsolutePath, propertyTitle, previousFingerprint.getType(), currentFingerprint.getType(), currentAbsolutePath))) {
+                    DefaultFileChange modified = DefaultFileChange.modified(currentAbsolutePath, propertyTitle, previousFingerprint.getType(), currentFingerprint.getType(), currentAbsolutePath);
+                    if (!visitor.visitChange(modified)) {
                         return false;
                     }
                 }
                 // else, unchanged; check next file
             } else if (includeAdded) {
-                if (!visitor.visitChange(DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), currentAbsolutePath))) {
+                DefaultFileChange added = DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), currentAbsolutePath);
+                if (!visitor.visitChange(added)) {
                     return false;
                 }
             }
         }
 
         for (String previousAbsolutePath : unaccountedForPreviousFingerprints) {
-            if (!visitor.visitChange(DefaultFileChange.removed(previousAbsolutePath, propertyTitle, previous.get(previousAbsolutePath).getType(), previousAbsolutePath))) {
+            DefaultFileChange removed = DefaultFileChange.removed(previousAbsolutePath, propertyTitle, previous.get(previousAbsolutePath).getType(), previousAbsolutePath);
+            if (!visitor.visitChange(removed)) {
                 return false;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFingerprintCompareStrategy.java
@@ -58,7 +58,7 @@ public abstract class AbstractFingerprintCompareStrategy implements FingerprintC
                         return true;
                     default:
                         for (Map.Entry<String, FileSystemLocationFingerprint> entry : previous.entrySet()) {
-                            Change change = DefaultFileChange.removed(entry.getKey(), propertyTitle, entry.getValue().getType());
+                            Change change = DefaultFileChange.removed(entry.getKey(), propertyTitle, entry.getValue().getType(), entry.getValue().getNormalizedPath());
                             if (!visitor.visitChange(change)) {
                                 return false;
                             }
@@ -89,7 +89,7 @@ public abstract class AbstractFingerprintCompareStrategy implements FingerprintC
     private static boolean reportAllAdded(ChangeVisitor visitor, Map<String, FileSystemLocationFingerprint> current, String propertyTitle, boolean includeAdded) {
         if (includeAdded) {
             for (Map.Entry<String, FileSystemLocationFingerprint> entry : current.entrySet()) {
-                Change change = DefaultFileChange.added(entry.getKey(), propertyTitle, entry.getValue().getType());
+                Change change = DefaultFileChange.added(entry.getKey(), propertyTitle, entry.getValue().getType(), entry.getValue().getNormalizedPath());
                 if (!visitor.visitChange(change)) {
                     return false;
                 }
@@ -106,16 +106,16 @@ public abstract class AbstractFingerprintCompareStrategy implements FingerprintC
             HashCode currentContent = currentFingerprint.getNormalizedContentHash();
             if (!currentContent.equals(previousContent)) {
                 String path = currentEntry.getKey();
-                Change change = DefaultFileChange.modified(path, propertyTitle, previousFingerprint.getType(), currentFingerprint.getType());
+                Change change = DefaultFileChange.modified(path, propertyTitle, previousFingerprint.getType(), currentFingerprint.getType(), currentFingerprint.getNormalizedPath());
                 return visitor.visitChange(change);
             }
             return true;
         } else {
             String previousPath = previousEntry.getKey();
-            Change remove = DefaultFileChange.removed(previousPath, propertyTitle, previousFingerprint.getType());
+            Change remove = DefaultFileChange.removed(previousPath, propertyTitle, previousFingerprint.getType(), previousFingerprint.getNormalizedPath());
             if (includeAdded) {
                 String currentPath = currentEntry.getKey();
-                Change add = DefaultFileChange.added(currentPath, propertyTitle, currentFingerprint.getType());
+                Change add = DefaultFileChange.added(currentPath, propertyTitle, currentFingerprint.getType(), currentFingerprint.getNormalizedPath());
                 return visitor.visitChange(remove) && visitor.visitChange(add);
             } else {
                 return visitor.visitChange(remove);

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
@@ -42,7 +42,8 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
     @Override
     public boolean visitChangesSince(FileCollectionFingerprint oldFingerprint, final String title, boolean includeAdded, ChangeVisitor visitor) {
         for (Map.Entry<String, FileSystemLocationFingerprint> entry : oldFingerprint.getFingerprints().entrySet()) {
-            if (!visitor.visitChange(DefaultFileChange.removed(entry.getKey(), title, entry.getValue().getType(), entry.getValue().getNormalizedPath()))) {
+            DefaultFileChange removed = DefaultFileChange.removed(entry.getKey(), title, entry.getValue().getType(), entry.getValue().getNormalizedPath());
+            if (!visitor.visitChange(removed)) {
                 return false;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprint.java
@@ -42,7 +42,7 @@ public class EmptyCurrentFileCollectionFingerprint implements CurrentFileCollect
     @Override
     public boolean visitChangesSince(FileCollectionFingerprint oldFingerprint, final String title, boolean includeAdded, ChangeVisitor visitor) {
         for (Map.Entry<String, FileSystemLocationFingerprint> entry : oldFingerprint.getFingerprints().entrySet()) {
-            if (!visitor.visitChange(DefaultFileChange.removed(entry.getKey(), title, entry.getValue().getType()))) {
+            if (!visitor.visitChange(DefaultFileChange.removed(entry.getKey(), title, entry.getValue().getType(), entry.getValue().getNormalizedPath()))) {
                 return false;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathCompareStrategy.java
@@ -74,7 +74,7 @@ public class IgnoredPathCompareStrategy extends AbstractFingerprintCompareStrate
             List<FilePathWithType> previousFilesForContent = unaccountedForPreviousFiles.get(normalizedContentHash);
             if (previousFilesForContent.isEmpty()) {
                 if (includeAdded) {
-                    if (!visitor.visitChange(DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType()))) {
+                    if (!visitor.visitChange(DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH))) {
                         return false;
                     }
                 }
@@ -87,7 +87,7 @@ public class IgnoredPathCompareStrategy extends AbstractFingerprintCompareStrate
         Collections.sort(unaccountedForPreviousEntries, ENTRY_COMPARATOR);
         for (Map.Entry<HashCode, FilePathWithType> unaccountedForPreviousEntry : unaccountedForPreviousEntries) {
             FilePathWithType removedFile = unaccountedForPreviousEntry.getValue();
-            if (!visitor.visitChange(DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType()))) {
+            if (!visitor.visitChange(DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH))) {
                 return false;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathCompareStrategy.java
@@ -74,7 +74,8 @@ public class IgnoredPathCompareStrategy extends AbstractFingerprintCompareStrate
             List<FilePathWithType> previousFilesForContent = unaccountedForPreviousFiles.get(normalizedContentHash);
             if (previousFilesForContent.isEmpty()) {
                 if (includeAdded) {
-                    if (!visitor.visitChange(DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH))) {
+                    DefaultFileChange added = DefaultFileChange.added(currentAbsolutePath, propertyTitle, currentFingerprint.getType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH);
+                    if (!visitor.visitChange(added)) {
                         return false;
                     }
                 }
@@ -87,7 +88,8 @@ public class IgnoredPathCompareStrategy extends AbstractFingerprintCompareStrate
         Collections.sort(unaccountedForPreviousEntries, ENTRY_COMPARATOR);
         for (Map.Entry<HashCode, FilePathWithType> unaccountedForPreviousEntry : unaccountedForPreviousEntries) {
             FilePathWithType removedFile = unaccountedForPreviousEntry.getValue();
-            if (!visitor.visitChange(DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH))) {
+            DefaultFileChange removed = DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType(), IgnoredPathFingerprintingStrategy.IGNORED_PATH);
+            if (!visitor.visitChange(removed)) {
                 return false;
             }
         }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/IgnoredPathFingerprintingStrategy.java
@@ -34,6 +34,7 @@ import java.util.Map;
 public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStrategy {
 
     public static final IgnoredPathFingerprintingStrategy INSTANCE = new IgnoredPathFingerprintingStrategy();
+    public static final String IGNORED_PATH = "";
 
     private IgnoredPathFingerprintingStrategy() {
         super("IGNORED_PATH", IgnoredPathCompareStrategy.INSTANCE);
@@ -41,7 +42,7 @@ public class IgnoredPathFingerprintingStrategy extends AbstractFingerprintingStr
 
     @Override
     public String normalizePath(FileSystemLocationSnapshot snapshot) {
-        return "";
+        return IGNORED_PATH;
     }
 
     @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NormalizedPathFingerprintCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NormalizedPathFingerprintCompareStrategy.java
@@ -88,20 +88,21 @@ public class NormalizedPathFingerprintCompareStrategy extends AbstractFingerprin
             if (!addedFilesForNormalizedPath.isEmpty()) {
                 // There might be multiple files with the same normalized path, here we choose one of them
                 FilePathWithType addedFile = addedFilesForNormalizedPath.remove(0);
-                if (!visitor.visitChange(DefaultFileChange.modified(addedFile.getAbsolutePath(), propertyTitle, previousFingerprint.getType(), addedFile.getFileType()))) {
+                if (!visitor.visitChange(DefaultFileChange.modified(addedFile.getAbsolutePath(), propertyTitle, previousFingerprint.getType(), addedFile.getFileType(), normalizedPath))) {
                     return false;
                 }
             } else {
                 FilePathWithType removedFile = unaccountedForPreviousFingerprintEntry.getValue();
-                if (!visitor.visitChange(DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType()))) {
+                if (!visitor.visitChange(DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType(), normalizedPath))) {
                     return false;
                 }
             }
         }
 
         if (includeAdded) {
-            for (FilePathWithType addedFile : addedFilesByNormalizedPath.values()) {
-                if (!visitor.visitChange(DefaultFileChange.added(addedFile.getAbsolutePath(), propertyTitle, addedFile.getFileType()))) {
+            for (Map.Entry<String, FilePathWithType> entry : addedFilesByNormalizedPath.entries()) {
+                FilePathWithType addedFile = entry.getValue();
+                if (!visitor.visitChange(DefaultFileChange.added(addedFile.getAbsolutePath(), propertyTitle, addedFile.getFileType(), entry.getKey()))) {
                     return false;
                 }
             }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NormalizedPathFingerprintCompareStrategy.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/NormalizedPathFingerprintCompareStrategy.java
@@ -88,12 +88,14 @@ public class NormalizedPathFingerprintCompareStrategy extends AbstractFingerprin
             if (!addedFilesForNormalizedPath.isEmpty()) {
                 // There might be multiple files with the same normalized path, here we choose one of them
                 FilePathWithType addedFile = addedFilesForNormalizedPath.remove(0);
-                if (!visitor.visitChange(DefaultFileChange.modified(addedFile.getAbsolutePath(), propertyTitle, previousFingerprint.getType(), addedFile.getFileType(), normalizedPath))) {
+                DefaultFileChange modified = DefaultFileChange.modified(addedFile.getAbsolutePath(), propertyTitle, previousFingerprint.getType(), addedFile.getFileType(), normalizedPath);
+                if (!visitor.visitChange(modified)) {
                     return false;
                 }
             } else {
                 FilePathWithType removedFile = unaccountedForPreviousFingerprintEntry.getValue();
-                if (!visitor.visitChange(DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType(), normalizedPath))) {
+                DefaultFileChange removed = DefaultFileChange.removed(removedFile.getAbsolutePath(), propertyTitle, removedFile.getFileType(), normalizedPath);
+                if (!visitor.visitChange(removed)) {
                     return false;
                 }
             }
@@ -102,7 +104,8 @@ public class NormalizedPathFingerprintCompareStrategy extends AbstractFingerprin
         if (includeAdded) {
             for (Map.Entry<String, FilePathWithType> entry : addedFilesByNormalizedPath.entries()) {
                 FilePathWithType addedFile = entry.getValue();
-                if (!visitor.visitChange(DefaultFileChange.added(addedFile.getAbsolutePath(), propertyTitle, addedFile.getFileType(), entry.getKey()))) {
+                DefaultFileChange added = DefaultFileChange.added(addedFile.getAbsolutePath(), propertyTitle, addedFile.getFileType(), entry.getKey());
+                if (!visitor.visitChange(added)) {
                     return false;
                 }
             }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/change/DefaultFileChangeTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/change/DefaultFileChangeTest.groovy
@@ -25,7 +25,7 @@ class DefaultFileChangeTest extends Specification {
 
     def "change message for ChangeType MODIFIED from #previous to #current is '#message'"() {
         expect:
-        DefaultFileChange.modified("somePath", "test", previous, current).message == "test file somePath ${message}."
+        DefaultFileChange.modified("somePath", "test", previous, current, "").message == "test file somePath ${message}."
 
         where:
         previous             | current              | message
@@ -41,10 +41,10 @@ class DefaultFileChangeTest extends Specification {
         fileChange.message == "test file somePath ${message}."
 
         where:
-        fileChange                                                          | message
-        DefaultFileChange.removed("somePath", "test", FileType.RegularFile) | "has been removed"
-        DefaultFileChange.removed("somePath", "test", FileType.Directory)   | "has been removed"
-        DefaultFileChange.added("somePath", "test", FileType.RegularFile)   | "has been added"
-        DefaultFileChange.added("somePath", "test", FileType.Directory)     | "has been added"
+        fileChange                                                              | message
+        DefaultFileChange.removed("somePath", "test", FileType.RegularFile, "") | "has been removed"
+        DefaultFileChange.removed("somePath", "test", FileType.Directory, "")   | "has been removed"
+        DefaultFileChange.added("somePath", "test", FileType.RegularFile, "")   | "has been added"
+        DefaultFileChange.added("somePath", "test", FileType.Directory, "")     | "has been added"
     }
 }

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprintTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/EmptyCurrentFileCollectionFingerprintTest.groovy
@@ -42,8 +42,8 @@ class EmptyCurrentFileCollectionFingerprintTest extends Specification {
         }
         expect:
         getChanges(fingerprint, empty, includeAdded).toList() == [
-            DefaultFileChange.removed("file1.txt", "test", FileType.RegularFile),
-            DefaultFileChange.removed("file2.txt", "test", FileType.RegularFile)
+            DefaultFileChange.removed("file1.txt", "test", FileType.RegularFile, "file1.txt"),
+            DefaultFileChange.removed("file2.txt", "test", FileType.RegularFile, "file2.txt")
         ]
 
         where:

--- a/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/FingerprintCompareStrategyTest.groovy
+++ b/subprojects/snapshots/src/test/groovy/org/gradle/internal/fingerprint/impl/FingerprintCompareStrategyTest.groovy
@@ -61,11 +61,11 @@ class FingerprintCompareStrategyTest extends Specification {
 
         where:
         strategy     | includeAdded | results
-        NORMALIZED   | true         | [added("one-new")]
+        NORMALIZED   | true         | [added("one-new", "one")]
         NORMALIZED   | false        | []
-        IGNORED_PATH | true         | [added("one-new")]
+        IGNORED_PATH | true         | [added("one-new", "one")]
         IGNORED_PATH | false        | []
-        ABSOLUTE     | true         | [added("one-new")]
+        ABSOLUTE     | true         | [added("one-new", "one")]
         ABSOLUTE     | false        | []
     }
 
@@ -79,14 +79,14 @@ class FingerprintCompareStrategyTest extends Specification {
 
         where:
         strategy   | includeAdded | results
-        NORMALIZED | true         | [added("two-new")]
+        NORMALIZED | true         | [added("two-new", "two")]
         NORMALIZED | false        | []
     }
 
     @Unroll
     def "non-trivial addition with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
-        changesUsingAbsolutePaths(strategy, includeAdded,
+        changes(strategy, includeAdded,
             ["one": fingerprint("one"), "two": fingerprint("two")],
             ["one": fingerprint("one")]
         ) == results
@@ -103,7 +103,7 @@ class FingerprintCompareStrategyTest extends Specification {
         changes(strategy, includeAdded,
             [:],
             ["one-old": fingerprint("one")]
-        ) as List == [removed("one-old")]
+        ) as List == [removed("one-old", "one")]
 
         where:
         strategy   | includeAdded
@@ -119,7 +119,7 @@ class FingerprintCompareStrategyTest extends Specification {
         changes(strategy, includeAdded,
             ["one-new": fingerprint("one")],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two")]
-        ) == [removed("two-old")]
+        ) == [removed("two-old", "two")]
 
         where:
         strategy   | includeAdded
@@ -130,7 +130,7 @@ class FingerprintCompareStrategyTest extends Specification {
     @Unroll
     def "non-trivial removal with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
-        changesUsingAbsolutePaths(strategy, includeAdded,
+        changes(strategy, includeAdded,
             ["one": fingerprint("one")],
             ["one": fingerprint("one"), "two": fingerprint("two")]
         ) == [removed("two")]
@@ -147,7 +147,7 @@ class FingerprintCompareStrategyTest extends Specification {
         changes(strategy, includeAdded,
             ["one-new": fingerprint("one"), "two-new": fingerprint("two", 0x9876cafe)],
             ["one-old": fingerprint("one"), "two-old": fingerprint("two", 0xface1234)]
-        ) == [modified("two-new", FileType.RegularFile, FileType.RegularFile)]
+        ) == [modified("two-new", FileType.RegularFile, FileType.RegularFile, "two")]
 
         where:
         strategy   | includeAdded
@@ -161,7 +161,7 @@ class FingerprintCompareStrategyTest extends Specification {
         changes(NORMALIZED, includeAdded,
             ["two-new": fingerprint("", 0x9876cafe), "one-new": fingerprint("")],
             ["one-old": fingerprint(""), "two-old": fingerprint("", 0xface1234)]
-        ) == [modified("two-new", FileType.RegularFile, FileType.RegularFile)]
+        ) == [modified("two-new", FileType.RegularFile, FileType.RegularFile, "")]
 
         where:
         includeAdded << [true, false]
@@ -170,7 +170,7 @@ class FingerprintCompareStrategyTest extends Specification {
     @Unroll
     def "non-trivial modification with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
-        changesUsingAbsolutePaths(strategy, includeAdded,
+        changes(strategy, includeAdded,
             ["one": fingerprint("one"), "two": fingerprint("two", 0x9876cafe)],
             ["one": fingerprint("one"), "two": fingerprint("two", 0xface1234)]
         ) == [modified("two", FileType.RegularFile, FileType.RegularFile)]
@@ -191,8 +191,8 @@ class FingerprintCompareStrategyTest extends Specification {
 
         where:
         strategy   | includeAdded | results
-        NORMALIZED | true         | [removed("one-old"), added("two-new")]
-        NORMALIZED | false        | [removed("one-old")]
+        NORMALIZED | true         | [removed("one-old", "one"), added("two-new", "two")]
+        NORMALIZED | false        | [removed("one-old", "one")]
     }
 
     @Unroll
@@ -205,14 +205,14 @@ class FingerprintCompareStrategyTest extends Specification {
 
         where:
         strategy   | includeAdded | results
-        NORMALIZED | true         | [removed("three-old"), added("two-new")]
-        NORMALIZED | false        | [removed("three-old")]
+        NORMALIZED | true         | [removed("three-old", "three"), added("two-new", "two")]
+        NORMALIZED | false        | [removed("three-old", "three")]
     }
 
     @Unroll
     def "non-trivial replacement with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
-        changesUsingAbsolutePaths(strategy, includeAdded,
+        changes(strategy, includeAdded,
             ["one": fingerprint("one"), "two": fingerprint("two"), "four": fingerprint("four")],
             ["one": fingerprint("one"), "three": fingerprint("three"), "four": fingerprint("four")]
         ) == results
@@ -240,7 +240,7 @@ class FingerprintCompareStrategyTest extends Specification {
     @Unroll
     def "reordering with absolute paths (#strategy, include added: #includeAdded)"() {
         expect:
-        changesUsingAbsolutePaths(strategy, includeAdded,
+        changes(strategy, includeAdded,
             ["one": fingerprint("one"), "two": fingerprint("two"), "three": fingerprint("three")],
             ["one": fingerprint("one"), "three": fingerprint("three"), "two": fingerprint("two")]
         ) == results
@@ -283,25 +283,19 @@ class FingerprintCompareStrategyTest extends Specification {
         visitor.getChanges().toList()
     }
 
-    def changesUsingAbsolutePaths(FingerprintCompareStrategy strategy, boolean includeAdded, Map<String, FileSystemLocationFingerprint> current, Map<String, FileSystemLocationFingerprint> previous) {
-        def visitor = new CollectingChangeVisitor()
-        strategy.visitChangesSince(visitor, current, previous, "test", includeAdded)
-        visitor.getChanges().toList()
-    }
-
     def fingerprint(String normalizedPath, def hashCode = 0x1234abcd) {
         return new DefaultFileSystemLocationFingerprint(normalizedPath, FileType.RegularFile, HashCode.fromInt((int) hashCode))
     }
 
-    def added(String path) {
-        DefaultFileChange.added(path, "test", FileType.RegularFile)
+    def added(String path, String normalizedPath = path) {
+        DefaultFileChange.added(path, "test", FileType.RegularFile, normalizedPath)
     }
 
-    def removed(String path) {
-        DefaultFileChange.removed(path, "test", FileType.RegularFile)
+    def removed(String path, String normalizedPath = path) {
+        DefaultFileChange.removed(path, "test", FileType.RegularFile, normalizedPath)
     }
 
-    def modified(String path, FileType previous, FileType current) {
-        DefaultFileChange.modified(path, "test", previous, current)
+    def modified(String path, FileType previous, FileType current, String normalizedPath = path) {
+        DefaultFileChange.modified(path, "test", previous, current, normalizedPath)
     }
 }


### PR DESCRIPTION
This allows incremental tasks to query the normalized path of the changed file, so it can e.g. determine the location of the output from it.