### PR TITLE
Use SLF4J Logger in more places

### DIFF
--- a/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/command/BuildCacheCommandFactory.java
+++ b/subprojects/build-cache-packaging/src/main/java/org/gradle/caching/internal/command/BuildCacheCommandFactory.java
@@ -18,8 +18,6 @@ package org.gradle.caching.internal.command;
 
 import com.google.common.collect.ImmutableSortedMap;
 import org.gradle.api.internal.cache.StringInterner;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.internal.CacheableEntity;
 import org.gradle.caching.internal.controller.BuildCacheLoadCommand;
@@ -37,6 +35,8 @@ import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemMirror;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.MissingFileSnapshot;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -47,7 +47,7 @@ import java.util.Map;
 
 public class BuildCacheCommandFactory {
 
-    private static final Logger LOGGER = Logging.getLogger(BuildCacheCommandFactory.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(BuildCacheCommandFactory.class);
 
     private final BuildCacheEntryPacker packer;
     private final OriginMetadataFactory originMetadataFactory;

--- a/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BaseBuildCacheServiceHandle.java
+++ b/subprojects/build-cache/src/main/java/org/gradle/caching/internal/controller/service/BaseBuildCacheServiceHandle.java
@@ -16,17 +16,17 @@
 
 package org.gradle.caching.internal.controller.service;
 
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.caching.BuildCacheEntryReader;
 import org.gradle.caching.BuildCacheKey;
 import org.gradle.caching.BuildCacheService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 public class BaseBuildCacheServiceHandle implements BuildCacheServiceHandle {
 
-    private static final Logger LOGGER = Logging.getLogger(OpFiringBuildCacheServiceHandle.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(OpFiringBuildCacheServiceHandle.class);
 
     protected final BuildCacheService service;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/AbiExtractingClasspathResourceHasher.java
@@ -17,14 +17,14 @@ package org.gradle.api.internal.changedetection.state;
 
 import com.google.common.io.ByteStreams;
 import org.gradle.api.internal.tasks.compile.ApiClassExtractor;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
 import org.gradle.internal.snapshot.RegularFileSnapshot;
 import org.objectweb.asm.ClassReader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -36,7 +36,7 @@ import java.util.Collections;
 import java.util.zip.ZipEntry;
 
 public class AbiExtractingClasspathResourceHasher implements ResourceHasher {
-    private static final Logger LOGGER = Logging.getLogger(AbiExtractingClasspathResourceHasher.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbiExtractingClasspathResourceHasher.class);
 
     private HashCode hashClassBytes(InputStream inputStream) throws IOException {
         // Use the ABI as the hash

--- a/subprojects/core/src/main/java/org/gradle/api/internal/classloading/ClassInfoCleaningGroovySystemLoader.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/classloading/ClassInfoCleaningGroovySystemLoader.java
@@ -17,8 +17,8 @@
 package org.gradle.api.internal.classloading;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
@@ -28,7 +28,7 @@ import java.util.Iterator;
 
 public class ClassInfoCleaningGroovySystemLoader implements GroovySystemLoader {
 
-    private final static Logger LOG = Logging.getLogger(ClassInfoCleaningGroovySystemLoader.class);
+    private final static Logger LOG = LoggerFactory.getLogger(ClassInfoCleaningGroovySystemLoader.class);
 
     private final Method removeFromGlobalClassValue;
     private final Method globalClassSetIteratorMethod;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/initialization/loadercache/DefaultClassLoaderCache.java
@@ -23,8 +23,6 @@ import com.google.common.collect.HashMultiset;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Sets;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.initialization.SessionLifecycleListener;
 import org.gradle.internal.classloader.ClassLoaderUtils;
 import org.gradle.internal.classloader.ClasspathHasher;
@@ -33,13 +31,15 @@ import org.gradle.internal.classloader.HashingClassLoaderFactory;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.Stoppable;
 import org.gradle.internal.hash.HashCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Set;
 
 public class DefaultClassLoaderCache implements ClassLoaderCache, Stoppable, SessionLifecycleListener {
-    private static final Logger LOGGER = Logging.getLogger(DefaultClassLoaderCache.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClassLoaderCache.class);
 
     private final Object lock = new Object();
     private final Map<ClassLoaderId, CachedClassLoader> byId = Maps.newHashMap();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/ClassPathToClassLoaderCache.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/ClassPathToClassLoaderCache.java
@@ -20,12 +20,12 @@ import com.google.common.collect.Sets;
 import org.gradle.api.Action;
 import org.gradle.api.internal.classloading.GroovySystemLoader;
 import org.gradle.api.internal.classloading.GroovySystemLoaderFactory;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.Factory;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.concurrent.Stoppable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +42,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * the cache.
  */
 public class ClassPathToClassLoaderCache implements Stoppable {
-    private final static Logger LOG = Logging.getLogger(ClassPathToClassLoaderCache.class);
+    private final static Logger LOG = LoggerFactory.getLogger(ClassPathToClassLoaderCache.class);
 
     private final FinalizerThread finalizerThread;
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/FinalizerThread.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/antbuilder/FinalizerThread.java
@@ -16,9 +16,9 @@
 package org.gradle.api.internal.project.antbuilder;
 
 import com.google.common.collect.Maps;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.classpath.ClassPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.ref.ReferenceQueue;
 import java.util.Map;
@@ -29,7 +29,7 @@ import static org.gradle.api.internal.project.antbuilder.Cleanup.Mode.CLOSE_CLAS
 import static org.gradle.api.internal.project.antbuilder.Cleanup.Mode.DONT_CLOSE_CLASSLOADER;
 
 class FinalizerThread extends Thread {
-    private final static Logger LOG = Logging.getLogger(FinalizerThread.class);
+    private final static Logger LOG = LoggerFactory.getLogger(FinalizerThread.class);
 
     private final ReferenceQueue<CachedClassLoader> referenceQueue;
     private final AtomicBoolean stopped = new AtomicBoolean();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/CleanupStaleOutputsExecuter.java
@@ -24,8 +24,6 @@ import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.properties.FilePropertySpec;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.internal.execution.OutputChangeListener;
 import org.gradle.internal.execution.history.OutputFilesRepository;
@@ -34,6 +32,8 @@ import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.util.GFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.HashSet;
@@ -43,7 +43,7 @@ public class CleanupStaleOutputsExecuter implements TaskExecuter {
 
     public static final String CLEAN_STALE_OUTPUTS_DISPLAY_NAME = "Clean stale outputs";
 
-    private final Logger logger = Logging.getLogger(CleanupStaleOutputsExecuter.class);
+    private final Logger logger = LoggerFactory.getLogger(CleanupStaleOutputsExecuter.class);
     private final BuildOperationExecutor buildOperationExecutor;
     private final OutputChangeListener outputChangeListener;
     private final TaskExecuter executer;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -32,8 +32,6 @@ import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.properties.CacheableOutputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.InputFilePropertySpec;
 import org.gradle.api.internal.tasks.properties.OutputFilePropertySpec;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.StopActionException;
 import org.gradle.api.tasks.StopExecutionException;
 import org.gradle.api.tasks.TaskExecutionException;
@@ -61,6 +59,8 @@ import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.operations.RunnableBuildOperation;
 import org.gradle.internal.work.AsyncWorkTracker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -75,7 +75,7 @@ import java.util.function.Function;
  * A {@link TaskExecuter} which executes the actions of a task.
  */
 public class ExecuteActionsTaskExecuter implements TaskExecuter {
-    private static final Logger LOGGER = Logging.getLogger(ExecuteActionsTaskExecuter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExecuteActionsTaskExecuter.class);
 
     private final boolean buildCacheEnabled;
     private final TaskFingerprinter taskFingerprinter;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBuildCacheKeyExecuter.java
@@ -22,20 +22,19 @@ import org.gradle.api.internal.tasks.TaskExecuterResult;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
-import org.gradle.api.logging.LogLevel;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.caching.internal.tasks.BuildCacheKeyInputs;
 import org.gradle.caching.internal.tasks.TaskCacheKeyCalculator;
 import org.gradle.caching.internal.tasks.TaskOutputCachingBuildCacheKey;
 import org.gradle.internal.execution.history.BeforeExecutionState;
 import org.gradle.util.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.function.Function;
 
 public class ResolveBuildCacheKeyExecuter implements TaskExecuter {
 
-    private static final Logger LOGGER = Logging.getLogger(ResolveBuildCacheKeyExecuter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResolveBuildCacheKeyExecuter.class);
     private static final BuildCacheKeyInputs NO_CACHE_KEY_INPUTS = new BuildCacheKeyInputs(
         null,
         null,
@@ -111,8 +110,11 @@ public class ResolveBuildCacheKeyExecuter implements TaskExecuter {
                 public TaskOutputCachingBuildCacheKey apply(BeforeExecutionState beforeExecutionState) {
                     TaskOutputCachingBuildCacheKey cacheKey = calculator.calculate(task, beforeExecutionState, properties, buildCacheDebugLogging);
                     if (properties.hasDeclaredOutputs() && cacheKey.isValid()) { // A task with no outputs has no cache key.
-                        LogLevel logLevel = buildCacheDebugLogging ? LogLevel.LIFECYCLE : LogLevel.INFO;
-                        LOGGER.log(logLevel, "Build cache key for {} is {}", task, cacheKey.getHashCode());
+                        if (buildCacheDebugLogging) {
+                            LOGGER.warn("Build cache key for {} is {}", task, cacheKey.getHashCode());
+                        } else {
+                            LOGGER.info("Build cache key for {} is {}", task, cacheKey.getHashCode());
+                        }
                     }
                     return cacheKey;
                 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipEmptySourceFilesTaskExecuter.java
@@ -26,8 +26,6 @@ import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
 import org.gradle.api.internal.tasks.properties.TaskProperties;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.Cast;
 import org.gradle.internal.cleanup.BuildOutputCleanupRegistry;
 import org.gradle.internal.execution.OutputChangeListener;
@@ -35,6 +33,8 @@ import org.gradle.internal.execution.history.AfterPreviousExecutionState;
 import org.gradle.internal.execution.history.ExecutionHistoryStore;
 import org.gradle.internal.fingerprint.FileCollectionFingerprint;
 import org.gradle.util.GFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
@@ -42,7 +42,7 @@ import java.io.File;
  * A {@link TaskExecuter} which skips tasks whose source file collection is empty.
  */
 public class SkipEmptySourceFilesTaskExecuter implements TaskExecuter {
-    private static final Logger LOGGER = Logging.getLogger(SkipEmptySourceFilesTaskExecuter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkipEmptySourceFilesTaskExecuter.class);
     private final TaskInputsListener taskInputsListener;
     private final BuildOutputCleanupRegistry buildOutputCleanupRegistry;
     private final OutputChangeListener outputChangeListener;
@@ -63,7 +63,6 @@ public class SkipEmptySourceFilesTaskExecuter implements TaskExecuter {
         FileCollection sourceFiles = properties.getSourceFiles();
         if (properties.hasSourceFiles() && sourceFiles.isEmpty()) {
             AfterPreviousExecutionState previousExecution = context.getAfterPreviousExecution();
-            @SuppressWarnings("RedundantTypeArguments")
             ImmutableSortedMap<String, FileCollectionFingerprint> outputFiles = previousExecution == null
                 ? ImmutableSortedMap.<String, FileCollectionFingerprint>of()
                 : previousExecution.getOutputFileProperties();

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipOnlyIfTaskExecuter.java
@@ -23,14 +23,14 @@ import org.gradle.api.internal.tasks.TaskExecuterResult;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link org.gradle.api.internal.tasks.TaskExecuter} which skips tasks whose onlyIf predicate evaluates to false
  */
 public class SkipOnlyIfTaskExecuter implements TaskExecuter {
-    private static final Logger LOGGER = Logging.getLogger(SkipOnlyIfTaskExecuter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkipOnlyIfTaskExecuter.class);
     private final TaskExecuter executer;
 
     public SkipOnlyIfTaskExecuter(TaskExecuter executer) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/SkipTaskWithNoActionsExecuter.java
@@ -23,14 +23,14 @@ import org.gradle.api.internal.tasks.TaskExecuterResult;
 import org.gradle.api.internal.tasks.TaskExecutionContext;
 import org.gradle.api.internal.tasks.TaskExecutionOutcome;
 import org.gradle.api.internal.tasks.TaskStateInternal;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link org.gradle.api.internal.tasks.TaskExecuter} which skips tasks that have no actions.
  */
 public class SkipTaskWithNoActionsExecuter implements TaskExecuter {
-    private static final Logger LOGGER = Logging.getLogger(SkipTaskWithNoActionsExecuter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SkipTaskWithNoActionsExecuter.class);
     private final TaskExecutionGraph taskExecutionGraph;
     private final TaskExecuter executer;
 

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/VersionSpecificCacheCleanupAction.java
@@ -21,14 +21,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.SortedSetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.specs.Spec;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.gradle.util.GFileUtils;
 import org.gradle.util.GradleVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.io.File;
@@ -41,7 +41,7 @@ import static org.gradle.api.internal.changedetection.state.CrossBuildFileHashCa
 public class VersionSpecificCacheCleanupAction implements DirectoryCleanupAction {
 
     @VisibleForTesting static final String MARKER_FILE_PATH = FILE_HASHES_CACHE_KEY + "/" + FILE_HASHES_CACHE_KEY + ".lock";
-    private static final Logger LOGGER = Logging.getLogger(VersionSpecificCacheCleanupAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(VersionSpecificCacheCleanupAction.class);
     private static final long CLEANUP_INTERVAL_IN_HOURS = 24;
 
     private final VersionSpecificCacheDirectoryScanner versionSpecificCacheDirectoryScanner;

--- a/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
+++ b/subprojects/core/src/main/java/org/gradle/cache/internal/WrapperDistributionCleanupAction.java
@@ -26,11 +26,11 @@ import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.RegexFileFilter;
 import org.apache.commons.lang.StringUtils;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.cache.CleanupProgressMonitor;
 import org.gradle.internal.IoActions;
 import org.gradle.util.GradleVersion;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -56,7 +56,7 @@ import static org.gradle.util.CollectionUtils.single;
 public class WrapperDistributionCleanupAction implements DirectoryCleanupAction {
 
     @VisibleForTesting static final String WRAPPER_DISTRIBUTION_FILE_PATH = "wrapper/dists";
-    private static final Logger LOGGER = Logging.getLogger(WrapperDistributionCleanupAction.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(WrapperDistributionCleanupAction.class);
 
     private static final ImmutableMap<String, Pattern> JAR_FILE_PATTERNS_BY_PREFIX;
     private static final String BUILD_RECEIPT_ZIP_ENTRY_PATH = StringUtils.removeStart(GradleVersion.RESOURCE_NAME, "/");

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultPlanExecutor.java
@@ -19,8 +19,6 @@ package org.gradle.execution.plan;
 import org.gradle.api.Action;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.Transformer;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.MutableBoolean;
@@ -34,6 +32,8 @@ import org.gradle.internal.time.TimeFormatting;
 import org.gradle.internal.time.Timer;
 import org.gradle.internal.work.WorkerLeaseRegistry.WorkerLease;
 import org.gradle.internal.work.WorkerLeaseService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.concurrent.Executor;
@@ -45,7 +45,7 @@ import static org.gradle.internal.resources.ResourceLockState.Disposition.RETRY;
 
 @NonNullApi
 public class DefaultPlanExecutor implements PlanExecutor {
-    private static final Logger LOGGER = Logging.getLogger(DefaultPlanExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPlanExecutor.class);
     private final int executorCount;
     private final ExecutorFactory executorFactory;
     private final WorkerLeaseService workerLeaseService;

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/SingleFirePendingChangesListener.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/SingleFirePendingChangesListener.java
@@ -16,11 +16,11 @@
 
 package org.gradle.internal.filewatch;
 
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SingleFirePendingChangesListener implements PendingChangesListener {
-    private static final Logger LOGGER = Logging.getLogger(SingleFirePendingChangesListener.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(SingleFirePendingChangesListener.class);
 
     private final PendingChangesListener delegate;
     private boolean seenChanges;

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchPointsRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchPointsRegistry.java
@@ -23,14 +23,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.gradle.api.internal.file.FileSystemSubset;
 import org.gradle.api.internal.file.ImmutableDirectoryTree;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
 class WatchPointsRegistry {
-    private final static Logger LOG = Logging.getLogger(WatchPointsRegistry.class);
+    private final static Logger LOG = LoggerFactory.getLogger(WatchPointsRegistry.class);
     private final CombinedRootSubset rootSubset = new CombinedRootSubset();
     private ImmutableSet<? extends File> allRequestedRoots;
     private final boolean createNewStartingPointsUnderExistingRoots;

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceRegistrar.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchServiceRegistrar.java
@@ -19,13 +19,13 @@ package org.gradle.internal.filewatch.jdk7;
 import com.google.common.base.Throwables;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.file.FileSystemSubset;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.filewatch.FileWatcher;
 import org.gradle.internal.filewatch.FileWatcherEvent;
 import org.gradle.internal.filewatch.FileWatcherListener;
 import org.gradle.internal.os.OperatingSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
@@ -48,7 +48,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 class WatchServiceRegistrar implements FileWatcherListener {
-    private final static Logger LOG = Logging.getLogger(WatchServiceRegistrar.class);
+    private final static Logger LOG = LoggerFactory.getLogger(WatchServiceRegistrar.class);
     private static final boolean FILE_TREE_WATCHING_SUPPORTED = OperatingSystem.current().isWindows() && !JavaVersion.current().isJava9Compatible();
     private static final WatchEvent.Modifier[] WATCH_MODIFIERS = instantiateWatchModifiers();
     private static final WatchEvent.Kind[] WATCH_KINDS = new WatchEvent.Kind[]{StandardWatchEventKinds.ENTRY_CREATE, StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY};

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -20,10 +20,10 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.JavaVersion;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.ForkOptions;
 import org.gradle.util.GUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import java.util.Collection;
 import java.util.List;
 
 public class JavaCompilerArgumentsBuilder {
-    public static final Logger LOGGER = Logging.getLogger(JavaCompilerArgumentsBuilder.class);
+    public static final Logger LOGGER = LoggerFactory.getLogger(JavaCompilerArgumentsBuilder.class);
     public static final String USE_UNSHARED_COMPILER_TABLE_OPTION = "-XDuseUnsharedTable=true";
     public static final String EMPTY_SOURCE_PATH_REF_DIR = "emptySourcePathRef";
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/IncrementalCompilerDecorator.java
@@ -26,17 +26,17 @@ import org.gradle.api.internal.tasks.compile.incremental.recomp.PreviousCompilat
 import org.gradle.api.internal.tasks.compile.incremental.recomp.PreviousCompilationData;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.PreviousCompilationOutputAnalyzer;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpecProvider;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Decorates a non-incremental Java compiler (like javac) so that it can be invoked incrementally.
  */
 public class IncrementalCompilerDecorator {
 
-    private static final Logger LOG = Logging.getLogger(IncrementalCompilerDecorator.class);
+    private static final Logger LOG = LoggerFactory.getLogger(IncrementalCompilerDecorator.class);
     private final ClasspathSnapshotMaker classpathSnapshotMaker;
     private final TaskScopedCompileCaches compileCaches;
     private final CleaningJavaCompiler cleaningCompiler;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/SelectiveCompiler.java
@@ -24,18 +24,18 @@ import org.gradle.api.internal.tasks.compile.incremental.recomp.CurrentCompilati
 import org.gradle.api.internal.tasks.compile.incremental.recomp.PreviousCompilation;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpec;
 import org.gradle.api.internal.tasks.compile.incremental.recomp.RecompilationSpecProvider;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.incremental.IncrementalTaskInputs;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.gradle.language.base.internal.compile.Compiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 
 class SelectiveCompiler implements org.gradle.language.base.internal.compile.Compiler<JavaCompileSpec> {
-    private static final Logger LOG = Logging.getLogger(SelectiveCompiler.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SelectiveCompiler.class);
     private final IncrementalTaskInputs inputs;
     private final PreviousCompilation previousCompilation;
     private final CleaningJavaCompiler cleaningCompiler;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshotMaker.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/ClasspathSnapshotMaker.java
@@ -16,16 +16,16 @@
 
 package org.gradle.api.internal.tasks.compile.incremental.classpath;
 
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
 public class ClasspathSnapshotMaker implements ClasspathSnapshotProvider {
 
-    private static final Logger LOG = Logging.getLogger(ClasspathSnapshotMaker.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ClasspathSnapshotMaker.class);
 
     private final ClasspathSnapshotFactory classpathSnapshotFactory;
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/classpath/DefaultClasspathEntrySnapshotter.java
@@ -22,12 +22,12 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassDependenciesAnalyzer;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassAnalysis;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassDependentsAccumulator;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.IoActions;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
@@ -36,7 +36,7 @@ import java.util.Map;
 import static org.gradle.internal.FileUtils.hasExtension;
 
 public class DefaultClasspathEntrySnapshotter {
-    private static final Logger LOGGER = Logging.getLogger(DefaultClasspathEntrySnapshotter.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClasspathEntrySnapshotter.class);
 
     private final FileHasher fileHasher;
     private final StreamHasher hasher;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/CompilationSourceDirs.java
@@ -21,8 +21,9 @@ import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.api.internal.file.FileCollectionLeafVisitor;
 import org.gradle.api.internal.file.FileTreeInternal;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.util.PatternSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.List;
@@ -36,7 +37,7 @@ import java.util.List;
  */
 @NonNullApi
 public class CompilationSourceDirs {
-    private static final org.gradle.api.logging.Logger LOG = Logging.getLogger(CompilationSourceDirs.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CompilationSourceDirs.class);
 
     private final FileTreeInternal sources;
     private SourceRoots sourceRoots;

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/PreviousCompilationOutputAnalyzer.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/recomp/PreviousCompilationOutputAnalyzer.java
@@ -21,19 +21,19 @@ import org.gradle.api.internal.tasks.compile.incremental.analyzer.ClassDependenc
 import org.gradle.api.internal.tasks.compile.incremental.classpath.ClasspathEntrySnapshot;
 import org.gradle.api.internal.tasks.compile.incremental.classpath.DefaultClasspathEntrySnapshotter;
 import org.gradle.api.internal.tasks.compile.incremental.deps.ClassSetAnalysis;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.internal.hash.FileHasher;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.StreamHasher;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 
 //TODO reuse cached result from downstream users of our classes directory
 public class PreviousCompilationOutputAnalyzer {
-    private static final Logger LOG = Logging.getLogger(PreviousCompilationOutputAnalyzer.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PreviousCompilationOutputAnalyzer.class);
 
     private final DefaultClasspathEntrySnapshotter snapshotter;
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
@@ -28,11 +28,11 @@ import com.google.common.io.LineProcessor;
 import org.apache.tools.zip.ZipEntry;
 import org.apache.tools.zip.ZipFile;
 import org.gradle.api.internal.tasks.compile.incremental.processing.IncrementalAnnotationProcessorType;
-import org.gradle.api.logging.Logger;
 import org.gradle.cache.internal.FileContentCache;
 import org.gradle.cache.internal.FileContentCacheFactory;
 import org.gradle.internal.FileUtils;
 import org.gradle.internal.serialize.ListSerializer;
+import org.slf4j.Logger;
 
 import java.io.File;
 import java.io.IOException;

--- a/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/tasks/javadoc/internal/JavadocGenerator.java
@@ -17,8 +17,6 @@
 package org.gradle.api.tasks.javadoc.internal;
 
 import org.gradle.api.GradleException;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.external.javadoc.internal.JavadocExecHandleBuilder;
@@ -27,10 +25,12 @@ import org.gradle.process.internal.ExecAction;
 import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.process.internal.ExecException;
 import org.gradle.util.GFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class JavadocGenerator implements Compiler<JavadocSpec> {
 
-    private final static Logger LOG = Logging.getLogger(JavadocGenerator.class);
+    private final static Logger LOG = LoggerFactory.getLogger(JavadocGenerator.class);
 
     private final ExecActionFactory execActionFactory;
 

--- a/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
+++ b/subprojects/language-java/src/main/java/org/gradle/language/java/internal/JavaLanguagePluginServiceRegistry.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.tasks.compile.incremental.IncrementalCompilerFact
 import org.gradle.api.internal.tasks.compile.incremental.cache.GeneralCompileCaches;
 import org.gradle.api.internal.tasks.compile.processing.AnnotationProcessorDetector;
 import org.gradle.api.internal.tasks.compile.tooling.JavaCompileTaskSuccessResultPostProcessor;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.logging.configuration.LoggingConfiguration;
 import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.cache.internal.FileContentCacheFactory;
@@ -40,6 +39,7 @@ import org.gradle.language.java.artifact.JavadocArtifact;
 import org.gradle.tooling.events.OperationType;
 import org.gradle.tooling.internal.provider.BuildClientSubscriptions;
 import org.gradle.tooling.internal.provider.SubscribableBuildActionRunnerRegistration;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 
@@ -86,7 +86,7 @@ public class JavaLanguagePluginServiceRegistry extends AbstractPluginServiceRegi
         }
 
         public AnnotationProcessorDetector createAnnotationProcessorDetector(FileContentCacheFactory cacheFactory, LoggingConfiguration loggingConfiguration) {
-            return new AnnotationProcessorDetector(cacheFactory, Logging.getLogger(AnnotationProcessorDetector.class), loggingConfiguration.getShowStacktrace() != ShowStacktrace.INTERNAL_EXCEPTIONS);
+            return new AnnotationProcessorDetector(cacheFactory, LoggerFactory.getLogger(AnnotationProcessorDetector.class), loggingConfiguration.getShowStacktrace() != ShowStacktrace.INTERNAL_EXCEPTIONS);
         }
     }
 

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -19,9 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.internal.TaskOutputsInternal;
-import org.gradle.api.logging.LogLevel;
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.WorkResults;
 import org.gradle.cache.PersistentStateCache;
@@ -29,6 +26,8 @@ import org.gradle.internal.hash.HashCode;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.tasks.SimpleStaleClassCleaner;
 import org.gradle.nativeplatform.toolchain.internal.NativeCompileSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.util.Collections;
@@ -36,7 +35,7 @@ import java.util.List;
 
 @NonNullApi
 public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements Compiler<T> {
-    private final Logger logger = Logging.getLogger(IncrementalNativeCompiler.class);
+    private final Logger logger = LoggerFactory.getLogger(IncrementalNativeCompiler.class);
 
     private final Compiler<T> delegateCompiler;
     private final TaskOutputsInternal outputs;
@@ -87,7 +86,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
                 } else {
                     boolean containsHeader = headers.contains(header);
                     if (containsHeader) {
-                        logger.log(LogLevel.WARN, getCantUsePCHMessage(spec.getPreCompiledHeader(), sourceFile));
+                        logger.warn(getCantUsePCHMessage(spec.getPreCompiledHeader(), sourceFile));
                     }
                 }
             }


### PR DESCRIPTION
Use only an SLF4J Logger instead of the Gradle Logger in places where it is enough. This is going to make this code more easy to reuse as it doesn't depend on `:logging` anymore.
