### PR TITLE
Handle task caching reasons without having to pass around context

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/TaskExecutionContext.java
@@ -72,13 +72,6 @@ public interface TaskExecutionContext {
 
     TaskProperties getTaskProperties();
 
-    /**
-     * Returns if caching for this task is enabled.
-     */
-    boolean isTaskCachingEnabled();
-
-    void setTaskCachingEnabled(boolean enabled);
-
     Optional<OverlappingOutputs> getOverlappingOutputs();
 
     void setOverlappingOutputs(OverlappingOutputs overlappingOutputs);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/DefaultTaskExecutionContext.java
@@ -42,7 +42,6 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
     private TaskExecutionMode taskExecutionMode;
     private TaskOutputCachingBuildCacheKey buildCacheKey;
     private TaskProperties properties;
-    private boolean taskCachingEnabled;
     private Long executionTime;
     private ExecutingBuildOperation snapshotTaskInputsBuildOperation;
 
@@ -134,16 +133,6 @@ public class DefaultTaskExecutionContext implements TaskExecutionContext {
     @Override
     public TaskProperties getTaskProperties() {
         return properties;
-    }
-
-    @Override
-    public boolean isTaskCachingEnabled() {
-        return taskCachingEnabled;
-    }
-
-    @Override
-    public void setTaskCachingEnabled(boolean taskCachingEnabled) {
-        this.taskCachingEnabled = taskCachingEnabled;
     }
 
     @Override

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuterTest.groovy
@@ -77,6 +77,7 @@ class ExecuteActionsTaskExecuterTest extends Specification {
     def outputChangeListener = Mock(OutputChangeListener)
     def cancellationToken = new DefaultBuildCancellationToken()
     def changeDetector = new DefaultExecutionStateChangeDetector()
+    def taskOutputCachingStateResolver = Mock(TaskOutputCachingStateResolver)
     def workExecutor = new DefaultWorkExecutor<IncrementalContext, UpToDateResult>(
         new ResolveChangesStep<>(changeDetector,
             new SkipUpToDateStep<>(
@@ -92,7 +93,16 @@ class ExecuteActionsTaskExecuterTest extends Specification {
             )
         )
     )
-    def executer = new ExecuteActionsTaskExecuter(false, taskFingerprinter, executionHistoryStore, buildOperationExecutor, asyncWorkTracker, actionListener, workExecutor)
+    def executer = new ExecuteActionsTaskExecuter(
+        false,
+        taskFingerprinter,
+        executionHistoryStore,
+        buildOperationExecutor,
+        asyncWorkTracker,
+        actionListener,
+        taskOutputCachingStateResolver,
+        workExecutor
+    )
 
     def setup() {
         ProjectInternal project = Mock(ProjectInternal)

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/CacheHandler.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/CacheHandler.java
@@ -25,4 +25,15 @@ import java.util.function.Function;
 public interface CacheHandler {
     <T> Optional<T> load(Function<BuildCacheKey, Optional<T>> loader);
     void store(Consumer<BuildCacheKey> storer);
+
+    CacheHandler NO_OP = new CacheHandler() {
+        @Override
+        public <T> Optional<T> load(Function<BuildCacheKey, Optional<T>> loader) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void store(Consumer<BuildCacheKey> storer) {
+        }
+    };
 }


### PR DESCRIPTION
This simplifies the way we determine whether or not we should cache a task.
