### PR TITLE
 Isolate plugin spec builders using classpath hash

### DIFF
--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 description = "Kotlin DSL Gradle Plugins deployed to the Plugin Portal"
 
 group = "org.gradle.kotlin"
-version = "1.2.6"
+version = "1.2.7"
 
 base.archivesBaseName = "plugins"
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -50,6 +50,7 @@ import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.psi.psiUtil.toVisibility
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 
+import org.junit.Ignore
 import org.junit.Test
 
 import java.io.File
@@ -429,17 +430,35 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
     @Test
     fun `can use plugin spec builders in multi-project builds with local and external plugins`() {
 
+        testPluginSpecBuildersInMultiProjectBuildWithPluginsFromPackage(null)
+    }
+
+    @Ignore("wip")
+    @Test
+    fun `can use plugin spec builders in multi-project builds with local and external plugins sharing package name`() {
+
+        testPluginSpecBuildersInMultiProjectBuildWithPluginsFromPackage("p")
+    }
+
+    private
+    fun testPluginSpecBuildersInMultiProjectBuildWithPluginsFromPackage(packageName: String?) {
+
+        val packageDeclaration = packageName?.let { "package $it" } ?: ""
+        val packageQualifier = packageName?.let { "$it." } ?: ""
+
         withProjectRoot(newDir("external-plugins")) {
             withFolders {
                 "external-foo" {
                     withKotlinDslPlugin()
                     withFile("src/main/kotlin/external-foo.gradle.kts", """
+                        $packageDeclaration
                         println("*external-foo applied*")
                     """)
                 }
                 "external-bar" {
                     withKotlinDslPlugin()
                     withFile("src/main/kotlin/external-bar.gradle.kts", """
+                        $packageDeclaration
                         println("*external-bar applied*")
                     """)
                 }
@@ -457,7 +476,8 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
             "buildSrc" {
                 "local-foo" {
                     withFile("src/main/kotlin/local-foo.gradle.kts", """
-                        plugins { `external-foo` }
+                        $packageDeclaration
+                        plugins { $packageQualifier`external-foo` }
                     """)
                     withKotlinDslPlugin().appendText("""
                         dependencies {
@@ -467,7 +487,8 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
                 }
                 "local-bar" {
                     withFile("src/main/kotlin/local-bar.gradle.kts", """
-                        plugins { `external-bar` }
+                        $packageDeclaration
+                        plugins { $packageQualifier`external-bar` }
                     """)
                     withKotlinDslPlugin().appendText("""
                         dependencies {
@@ -489,8 +510,8 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
         }
         withBuildScript("""
             plugins {
-                `local-foo`
-                `local-bar`
+                $packageQualifier`local-foo`
+                $packageQualifier`local-bar`
             }
         """)
 

--- a/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
+++ b/subprojects/kotlin-dsl-plugins/src/integTest/kotlin/org/gradle/kotlin/dsl/plugins/precompiled/PrecompiledScriptPluginAccessorsTest.kt
@@ -50,7 +50,6 @@ import org.jetbrains.kotlin.descriptors.Visibility
 import org.jetbrains.kotlin.psi.psiUtil.toVisibility
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
 
-import org.junit.Ignore
 import org.junit.Test
 
 import java.io.File
@@ -433,7 +432,6 @@ class PrecompiledScriptPluginAccessorsTest : AbstractPrecompiledScriptPluginTest
         testPluginSpecBuildersInMultiProjectBuildWithPluginsFromPackage(null)
     }
 
-    @Ignore("wip")
     @Test
     fun `can use plugin spec builders in multi-project builds with local and external plugins sharing package name`() {
 

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/DefaultPrecompiledScriptPluginsSupport.kt
@@ -152,10 +152,17 @@ class DefaultPrecompiledScriptPluginsSupport : PrecompiledScriptPluginsSupport {
         kotlinCompilerArgsConsumer: Consumer<List<String>>
     ) {
         enableOn(object : PrecompiledScriptPluginsSupport.Target {
-            override val project get() = project
-            override val kotlinSourceDirectorySet get() = kotlinSourceDirectorySet
-            override val kotlinCompileTask get() = kotlinCompileTask
-            override fun applyKotlinCompilerArgs(args: List<String>) = kotlinCompilerArgsConsumer.accept(args)
+            override val project
+                get() = project
+
+            override val kotlinSourceDirectorySet
+                get() = kotlinSourceDirectorySet
+
+            override val kotlinCompileTask
+                get() = kotlinCompileTask
+
+            override fun applyKotlinCompilerArgs(args: List<String>) =
+                kotlinCompilerArgsConsumer.accept(args)
         })
     }
 }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ClassPathSensitiveTask.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ClassPathSensitiveTask.kt
@@ -21,34 +21,29 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Internal
 
-import org.gradle.internal.classloader.ClasspathHasher
 import org.gradle.internal.classpath.ClassPath
-import org.gradle.internal.classpath.DefaultClassPath
-
 import org.gradle.internal.hash.HashCode
 
-import org.gradle.kotlin.dsl.support.serviceOf
+import org.gradle.kotlin.dsl.provider.plugins.precompiled.HashedClassPath
 
 
 abstract class ClassPathSensitiveTask : DefaultTask() {
 
+    @get:Internal
+    internal
+    lateinit var hashedClassPath: HashedClassPath
+
     @get:Classpath
-    lateinit var classPathFiles: FileCollection
-
-    // TODO:kotlin-dsl Replace (classPathFiles, classPath, classPathHash) by a single HashedClassPath instance shared by all tasks
-    @get:Internal
-    protected
-    val classPath by lazy {
-        DefaultClassPath.of(classPathFiles.files)
-    }
+    val classPathFiles: FileCollection
+        get() = hashedClassPath.classPathFiles
 
     @get:Internal
     protected
-    val classPathHash by lazy {
-        hashOf(classPath)
-    }
+    val classPath: ClassPath
+        get() = hashedClassPath.classPath
 
-    private
-    fun hashOf(classPath: ClassPath): HashCode =
-        project.serviceOf<ClasspathHasher>().hash(classPath)
+    @get:Internal
+    protected
+    val classPathHash: HashCode
+        get() = hashedClassPath.hash
 }

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/CompilePrecompiledScriptPluginPlugins.kt
@@ -17,7 +17,6 @@
 package org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks
 
 import org.gradle.api.file.Directory
-import org.gradle.api.internal.AbstractTask
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.InputFiles
@@ -33,10 +32,10 @@ import org.gradle.kotlin.dsl.support.compileKotlinScriptModuleTo
 
 
 @CacheableTask
-open class CompilePrecompiledScriptPluginPlugins : ClassPathSensitiveTask() {
+abstract class CompilePrecompiledScriptPluginPlugins : ClassPathSensitiveTask(), SharedAccessorsPackageAware {
 
     @get:OutputDirectory
-    var outputDir = directoryProperty()
+    val outputDir = directoryProperty()
 
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFiles
@@ -67,8 +66,3 @@ open class CompilePrecompiledScriptPluginPlugins : ClassPathSensitiveTask() {
         }
     }
 }
-
-
-internal
-fun AbstractTask.implicitImportsForPrecompiledScriptPlugins() =
-    project.implicitImports() + "gradle.kotlin.dsl.plugins.*" // TODO:kotlin-dsl read this value from GenerateExternalPluginSpecBuilder

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/ConfigurePrecompiledScriptDependenciesResolver.kt
@@ -23,11 +23,10 @@ import org.gradle.api.tasks.TaskAction
 
 import org.gradle.kotlin.dsl.precompile.PrecompiledScriptDependenciesResolver.EnvironmentProperties.kotlinDslImplicitImports
 import org.gradle.kotlin.dsl.support.ImplicitImports
-
 import org.gradle.kotlin.dsl.support.serviceOf
 
 
-open class ConfigurePrecompiledScriptDependenciesResolver : DefaultTask() {
+abstract class ConfigurePrecompiledScriptDependenciesResolver : DefaultTask(), SharedAccessorsPackageAware {
 
     @Internal
     val metadataDir = project.objects.directoryProperty()

--- a/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/SharedAccessorsPackageAware.kt
+++ b/subprojects/kotlin-dsl-provider-plugins/src/main/kotlin/org/gradle/kotlin/dsl/provider/plugins/precompiled/tasks/SharedAccessorsPackageAware.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.provider.plugins.precompiled.tasks
+
+import org.gradle.api.Task
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+
+
+interface SharedAccessorsPackageAware {
+
+    @get:Input
+    val sharedAccessorsPackage: Property<String>
+}
+
+
+internal
+fun <T> T.implicitImportsForPrecompiledScriptPlugins() where T : Task, T : SharedAccessorsPackageAware =
+    project.implicitImports() + "${sharedAccessorsPackage.get()}.*"

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -71,7 +71,7 @@ dependencies {
 // --- Enable automatic generation of API extensions -------------------
 val apiExtensionsOutputDir = layout.buildDirectory.dir("generated-sources/kotlin")
 
-val publishedKotlinDslPluginVersion = "1.2.5" // TODO:kotlin-dsl
+val publishedKotlinDslPluginVersion = "1.2.6" // TODO:kotlin-dsl
 
 tasks {
 

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/PrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/PrecompiledScriptPluginsSupport.kt
@@ -26,10 +26,20 @@ import java.util.function.Consumer
 
 interface PrecompiledScriptPluginsSupport {
 
+    @Deprecated("Use enableOn(Host)")
     fun enableOn(
         project: Project,
         kotlinSourceDirectorySet: SourceDirectorySet,
         kotlinCompileTask: TaskProvider<out Task>,
         kotlinCompilerArgsConsumer: Consumer<List<String>>
     )
+
+    fun enableOn(target: Target): Boolean
+
+    interface Target {
+        val project: Project
+        val kotlinSourceDirectorySet: SourceDirectorySet
+        val kotlinCompileTask: TaskProvider<out Task>
+        fun applyKotlinCompilerArgs(args: List<String>)
+    }
 }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/PrecompiledScriptPluginsSupport.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/PrecompiledScriptPluginsSupport.kt
@@ -26,7 +26,7 @@ import java.util.function.Consumer
 
 interface PrecompiledScriptPluginsSupport {
 
-    @Deprecated("Use enableOn(Host)")
+    @Deprecated("Use enableOn(Target)")
     fun enableOn(
         project: Project,
         kotlinSourceDirectorySet: SourceDirectorySet,


### PR DESCRIPTION
So plugin spec group classes from multiple plugin modules won't conflict.

This PR also reduces the overhead of applying the `kotlin-dsl` plugin to projects without precompiled script plugins to a minimum. 