### PR TITLE
Hide `NamedDomainObjectContainerDelegate<T>.delegate` property

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/NamedDomainObjectContainerDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/NamedDomainObjectContainerDelegate.kt
@@ -40,6 +40,7 @@ import java.util.SortedSet
  */
 abstract class NamedDomainObjectContainerDelegate<T> : NamedDomainObjectContainer<T> {
 
+    internal
     abstract val delegate: NamedDomainObjectContainer<T>
 
     override fun contains(element: T): Boolean =


### PR DESCRIPTION
It shouldn't have been public in the first place.