### PR TITLE
Fix Javadoc links to Java API

### DIFF
--- a/subprojects/docs/docs.gradle
+++ b/subprojects/docs/docs.gradle
@@ -293,7 +293,7 @@ def userguideSinglePage = tasks.register("userguideSinglePage", CacheableAsciido
         'source-highlighter': 'coderay'
 }
 
-def javaApiUrl = "https://docs.oracle.com/en/java/javase/11/docs/api"
+def javaApiUrl = "https://docs.oracle.com/javase/8/docs/api"
 def groovyApiUrl = "http://docs.groovy-lang.org/docs/groovy-${groovyVersion}/html/gapi"
 def mavenApiUrl = "http://maven.apache.org/ref/${libraries.maven3.version}/maven-model/apidocs"
 
@@ -307,6 +307,7 @@ def javadocAll = tasks.register("javadocAll", Javadoc) {
     options.charSet = 'utf-8'
     options.addStringOption 'Xdoclint:syntax,html,reference', '-quiet'
     options.addStringOption "stylesheetfile", stylesheetFile.absolutePath
+    options.addStringOption "source", "8"
     source ProjectGroups.INSTANCE.getPublicJavaProjects(project).collect { project -> project.sourceSets.main.allJava }
     destinationDir = new File(docsDir, 'javadoc')
     classpath = configurations.gradleApiRuntime


### PR DESCRIPTION
Revert
https://github.com/gradle/gradle/commit/568a0b932fc7e879c7f212db14d19a9499ce1a3c
and use `--source 8` instead until fix makes his way to JDK used on CI.

### Context
See https://github.com/gradle/gradle/issues/8809

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Ffix-javadoc)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
