### PR TITLE
Add references to lifecycle tasks in CLI chapter

### DIFF
--- a/subprojects/docs/src/docs/userguide/command_line_interface.adoc
+++ b/subprojects/docs/src/docs/userguide/command_line_interface.adoc
@@ -61,6 +61,8 @@ $ gradle myTask
 
 You can learn about what projects and tasks are available in the <<#sec:command_line_project_reporting, project reporting section>>.
 
+Most builds support a common set of tasks known as <<more_about_tasks#sec:lifecycle_tasks,_lifecycle tasks_>>. These include the `build`, `assemble`, and `check` tasks.
+
 === Executing tasks in multi-project builds
 In a <<intro_multi_project_builds.adoc#intro_multi_project_builds, multi-project build>>, subproject tasks can be executed with ":" separating subproject name and task name. The following are equivalent _when run from the root project_.
 

--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -1232,9 +1232,9 @@ Lifecycle tasks are tasks that do not do work themselves. They typically do not 
 * a buildable thing (e.g., create a debug 32-bit executable for native components with `debug32MainExecutable`)
 * a convenience task to execute many of the same logical tasks (e.g., run all compilation tasks with `compileAll`)
 
-Many Gradle plug-ins define their own lifecycle tasks to make it convenient to do specific things. When developing your own plugins, you should consider using your own lifecycle tasks or hooking into some of the tasks already provided by Gradle. See the Java plugin <<java_plugin.adoc#sec:java_tasks,tasks>> for an example.
+The Base Plugin defines several <<base_plugin#sec:base_tasks,standard lifecycle tasks>>, such as `build`, `assemble`, and `check`. All the core language plugins, like the <<java_plugin#java_plugin,Java Plugin>>, apply the Base Plugin and hence have the same base set of lifecycle tasks.
 
-Unless a lifecycle task has actions, its outcome is determined by its dependencies. If any of the task's dependencies are executed, the lifecycle task will be considered executed. If all of the task's dependencies are up-to-date, skipped or from cache, the lifecycle task will be considered up-to-date.
+Unless a lifecycle task has actions, its <<sec:task_outcomes,outcome>> is determined by its task dependencies. If any of those dependencies are executed, the lifecycle task will be considered `EXECUTED`. If all of the task dependencies are up to date, skipped or from cache, the lifecycle task will be considered `UP-TO-DATE`.
 
 [[sec:the_idea_behind_gradle_tasks]]
 == Summary


### PR DESCRIPTION
Many people search for "gradle build command", which lands them on the CLI
chapter. This change ensures that the chapter links to an explanation of the
lifecycle tasks as well as naming the main ones. Hopefully this will get them
where they want in the docs.

Implements #dotorg-docs/346.
