### PR TITLE
Report flaky performance test to issue tracker

### DIFF
--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -260,7 +260,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
 enum class PerformanceTestType(val taskId: String, val timeout : Int, val defaultBaselines: String = "", val extraParameters : String = "") {
     test("PerformanceTest", 420, "defaults"),
     experiment("PerformanceExperiment", 420, "defaults"),
-    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit"),
+    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit", "-PgithubToken=%github.ci.oauth.token%"),
     historical("FullPerformanceTest", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
 
     fun asId(model : CIBuildModel): String {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -260,7 +260,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
 enum class PerformanceTestType(val taskId: String, val timeout : Int, val defaultBaselines: String = "", val extraParameters : String = "") {
     test("PerformanceTest", 420, "defaults"),
     experiment("PerformanceExperiment", 420, "defaults"),
-    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit", "-PgithubToken=%github.ci.oauth.token%"),
+    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit"),
     historical("FullPerformanceTest", 2280, "2.14.1,3.5.1,4.0,last", "--checks none");
 
     fun asId(model : CIBuildModel): String {

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -84,7 +84,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
 
     private RESTClient client
 
-    private Map<String, Scenario> scheduledBuilds = [:]
+    protected Map<String, Scenario> scheduledBuilds = [:]
 
     private Map<String, ScenarioResult> finishedBuilds = [:]
 

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -134,13 +134,16 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
     }
 
     @Override
+    @TypeChecked(TypeCheckingMode.SKIP)
     protected List<ScenarioBuildResultData> generateResultsForReport() {
         finishedBuilds.collect { workerBuildId, scenarioResult ->
             new ScenarioBuildResultData(
                 teamCityBuildId: workerBuildId,
                 scenarioName: scheduledBuilds.get(workerBuildId).id,
-                webUrl: scenarioResult.buildResult.webUrl.toString(),
-                status: scenarioResult.buildResult.status.toString(),
+                webUrl: scenarioResult.buildResult.webUrl,
+                status: scenarioResult.buildResult.status,
+                agentName: scenarioResult.buildResult.agent.name,
+                agentUrl: scenarioResult.buildResult.agent.webUrl,
                 testFailure: collectFailures(scenarioResult.testSuite))
         }
     }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -140,6 +140,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
             new ScenarioBuildResultData(
                 teamCityBuildId: workerBuildId,
                 scenarioName: scheduledBuilds.get(workerBuildId).id,
+                scenarioClass: scenarioResult.testSuite.name,
                 webUrl: scenarioResult.buildResult.webUrl,
                 status: scenarioResult.buildResult.status,
                 agentName: scenarioResult.buildResult.agent.name,

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -51,6 +51,7 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
                     spec.args(reportDir.path, resultJson.path, getProject().getName())
                     spec.systemProperties(databaseParameters)
                     spec.systemProperty("org.gradle.performance.execution.channel", channel)
+                    spec.systemProperty("githubToken", project.findProperty("githubToken"))
                     spec.setClasspath(ReportGenerationPerformanceTest.this.getClasspath())
                 }
             })

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -81,5 +81,7 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
         String testFailure
         // SUCCESS/FAILURE/UNKNOWN
         String status
+        String agentName
+        String agentUrl
     }
 }

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -77,6 +77,7 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
     static class ScenarioBuildResultData {
         String teamCityBuildId
         String scenarioName
+        String scenarioClass
         String webUrl
         String testFailure
         // SUCCESS/FAILURE/UNKNOWN

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     compile(library("commons_math"))
     compile(library("jcl_to_slf4j"))
     compile("org.openjdk.jmc:flightrecorder:7.0.0-SNAPSHOT")
-    compile("org.gradle.ci.health:tagging:0.62")
+    compile("org.gradle.ci.health:tagging:0.63")
 
     runtime("com.h2database:h2:1.4.192")
 }

--- a/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
+++ b/subprojects/internal-performance-testing/internal-performance-testing.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     compile(library("commons_math"))
     compile(library("jcl_to_slf4j"))
     compile("org.openjdk.jmc:flightrecorder:7.0.0-SNAPSHOT")
+    compile("org.gradle.ci.health:tagging:0.62")
 
     runtime("com.h2database:h2:1.4.192")
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractTablePageGenerator.java
@@ -197,8 +197,6 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
                 scenarios.forEach(scenario -> renderScenario(counter.incrementAndGet(), scenario));
             }
 
-
-
             private String getTextColorCss(ScenarioBuildResultData scenario, ScenarioBuildResultData.ExecutionData executionData) {
                 if(scenario.isCrossBuild()) {
                     return "text-dark";

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results
+
+import groovy.transform.CompileStatic
+import groovy.transform.TypeChecked
+import groovy.transform.TypeCheckingMode
+import org.gradle.ci.common.model.FlakyTest
+import org.gradle.ci.github.GitHubIssuesClient
+import org.gradle.ci.tagging.flaky.KnownFlakyTestProvider
+import org.gradle.performance.results.ScenarioBuildResultData.ExecutionData
+import org.kohsuke.github.GHIssue
+import org.kohsuke.github.GHIssueState
+
+import static org.gradle.ci.github.GitHubIssuesClient.CI_TRACKED_FLAKINESS_LABEL
+import static org.gradle.ci.github.GitHubIssuesClient.FROM_BOT_PREFIX
+import static org.gradle.ci.github.GitHubIssuesClient.MESSAGE_PREFIX
+import static org.gradle.ci.github.GitHubIssuesClient.TEST_NAME_PREFIX
+
+@CompileStatic
+class FlakinessIssueReporter {
+    static final String GITHUB_FIX_IT_LABEL = "fix-it"
+    private final KnownFlakyTestProvider provider
+    private final GitHubIssuesClient gitHubIssuesClient
+
+    FlakinessIssueReporter(GitHubIssuesClient gitHubIssuesClient, KnownFlakyTestProvider provider) {
+        this.provider = provider
+        this.gitHubIssuesClient = gitHubIssuesClient
+    }
+
+    void report(ScenarioBuildResultData flakyScenario) {
+        FlakyTest knownFlakyTest = findKnownFlakyTest(flakyScenario)
+        if (knownFlakyTest) {
+            if (issueClosed(knownFlakyTest)) {
+                knownFlakyTest.issue.reopen()
+            }
+            if (!hasFixItLabel(knownFlakyTest)) {
+                knownFlakyTest.issue.addLabels(GITHUB_FIX_IT_LABEL)
+            }
+        } else {
+            knownFlakyTest = openNewFlakyTestIssue(flakyScenario)
+        }
+
+        commentCurrentFailureToIssue(flakyScenario, knownFlakyTest.issue)
+    }
+
+    @TypeChecked(TypeCheckingMode.SKIP)
+    void commentCurrentFailureToIssue(ScenarioBuildResultData scenario, GHIssue issue) {
+        issue.comment("""
+${FROM_BOT_PREFIX}
+
+Url: ${scenario.webUrl}
+Agent: [${scenario.agentName}](${scenario.agentUrl})
+Details:
+
+```
+| Iteration | Difference | Confidence |
+|---|---|---|
+${assembleTable(scenario)}
+```
+""")
+    }
+
+    private static String assembleTable(ScenarioBuildResultData scenario) {
+        scenario.executions.withIndex().collect { ExecutionData execution, int index ->
+            "|${index + 1}|${execution.differenceDisplay}|${execution.formattedConfidence}|"
+        }.join('\n')
+    }
+
+    private FlakyTest openNewFlakyTestIssue(ScenarioBuildResultData flakyScenario) {
+        String testName = flakyScenario.scenarioName
+        String title = "Flaky performance test: ${testName}"
+        String message = "Flaky performance test scenario"
+        String body = """
+${FROM_BOT_PREFIX}
+
+${TEST_NAME_PREFIX}$testName
+
+${MESSAGE_PREFIX}$message
+"""
+
+        GHIssue issue = gitHubIssuesClient.createBuildToolInvalidFailureIssue(title, body, [CI_TRACKED_FLAKINESS_LABEL])
+        return new FlakyTest(issue: issue)
+    }
+
+    private FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario) {
+        return provider.knownInvalidFailures.find { scenario.scenarioName == it.name }
+    }
+
+    private static boolean issueClosed(FlakyTest flakyTest) {
+        return flakyTest.issue.state == GHIssueState.CLOSED
+    }
+
+    private static boolean hasFixItLabel(FlakyTest flakyTest) {
+        return flakyTest.issue.getLabels().collect { it.name }.contains(GITHUB_FIX_IT_LABEL)
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
@@ -59,19 +59,18 @@ class FlakinessIssueReporter {
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)
-    void commentCurrentFailureToIssue(ScenarioBuildResultData scenario, GHIssue issue) {
+    static void commentCurrentFailureToIssue(ScenarioBuildResultData scenario, GHIssue issue) {
         issue.comment("""
 ${FROM_BOT_PREFIX}
 
-Url: ${scenario.webUrl}
+Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
+Worker url: ${scenario.webUrl}
 Agent: [${scenario.agentName}](${scenario.agentUrl})
 Details:
 
-```
 | Iteration | Difference | Confidence |
 |---|---|---|
 ${assembleTable(scenario)}
-```
 """)
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
@@ -82,7 +82,7 @@ ${assembleTable(scenario)}
 
     private FlakyTest openNewFlakyTestIssue(ScenarioBuildResultData flakyScenario) {
         String title = "Flaky performance test: ${flakyScenario.flakyIssueTestName}"
-        String message = "Flaky performance test scenario"
+        String message = "we're slower than"
         String body = """
 ${FROM_BOT_PREFIX}
 
@@ -96,7 +96,7 @@ ${MESSAGE_PREFIX}$message
     }
 
     private FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario) {
-        return provider.knownInvalidFailures.find { scenario.flakyIssueTestName == it.name }
+        return provider.knownInvalidFailures.find { scenario.flakyIssueTestName.contains(it.name) }
     }
 
     private static boolean issueClosed(FlakyTest flakyTest) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIssueReporter.groovy
@@ -81,13 +81,12 @@ ${assembleTable(scenario)}
     }
 
     private FlakyTest openNewFlakyTestIssue(ScenarioBuildResultData flakyScenario) {
-        String testName = flakyScenario.scenarioName
-        String title = "Flaky performance test: ${testName}"
+        String title = "Flaky performance test: ${flakyScenario.flakyIssueTestName}"
         String message = "Flaky performance test scenario"
         String body = """
 ${FROM_BOT_PREFIX}
 
-${TEST_NAME_PREFIX}$testName
+${TEST_NAME_PREFIX}${flakyScenario.flakyIssueTestName}
 
 ${MESSAGE_PREFIX}$message
 """
@@ -97,7 +96,7 @@ ${MESSAGE_PREFIX}$message
     }
 
     private FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario) {
-        return provider.knownInvalidFailures.find { scenario.scenarioName == it.name }
+        return provider.knownInvalidFailures.find { scenario.flakyIssueTestName == it.name }
     }
 
     private static boolean issueClosed(FlakyTest flakyTest) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
@@ -16,6 +16,9 @@
 
 package org.gradle.performance.results;
 
+import org.gradle.ci.github.DefaultGitHubIssuesClient;
+import org.gradle.ci.github.GitHubIssuesClient;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -26,7 +29,11 @@ public class FlakinessReportGenerator extends AbstractReportGenerator<CrossVersi
 
     @Override
     protected void renderIndexPage(ResultsStore store, File resultJson, File outputDirectory) throws IOException {
-        new FileRenderer().render(store, new FlakinessIndexPageGenerator(store, resultJson), new File(outputDirectory, "index.html"));
+        GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(System.getProperty("githubToken"));
+        FlakinessIndexPageGenerator reporter = new FlakinessIndexPageGenerator(store, resultJson, gitHubIssuesClient);
+        new FileRenderer().render(store, reporter, new File(outputDirectory, "index.html"));
+
+        reporter.reportToIssueTracker();
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -36,8 +36,7 @@ class ScenarioBuildResultData {
     List<ExecutionData> recentExecutions = []
 
     String getFlakyIssueTestName() {
-        String testClassSimpleName = scenarioClass.split(/\./)[-1]
-        return "${testClassSimpleName}.${scenarioName}"
+        return "${scenarioClass}.${scenarioName}"
     }
 
     boolean isCrossVersion() {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -25,6 +25,7 @@ class ScenarioBuildResultData {
     private static final int FLAKINESS_DETECTION_THRESHOLD = 99
     String teamCityBuildId
     String scenarioName
+    String scenarioClass
     String webUrl
     String agentName
     String agentUrl
@@ -33,6 +34,11 @@ class ScenarioBuildResultData {
     boolean crossBuild
     List<ExecutionData> currentBuildExecutions = []
     List<ExecutionData> recentExecutions = []
+
+    String getFlakyIssueTestName() {
+        String testClassSimpleName = scenarioClass.split(/\./)[-1]
+        return "${testClassSimpleName}.${scenarioName}"
+    }
 
     boolean isCrossVersion() {
         return !crossBuild

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/ScenarioBuildResultData.groovy
@@ -26,6 +26,8 @@ class ScenarioBuildResultData {
     String teamCityBuildId
     String scenarioName
     String webUrl
+    String agentName
+    String agentUrl
     String testFailure
     String status
     boolean crossBuild

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results
+
+import org.gradle.ci.common.model.FlakyTest
+import org.gradle.ci.github.GitHubIssuesClient
+import org.gradle.ci.tagging.flaky.KnownFlakyTestProvider
+import org.kohsuke.github.GHIssue
+import org.kohsuke.github.GHIssueState
+import spock.lang.Specification
+import spock.lang.Subject
+
+import static org.gradle.ci.github.GitHubIssuesClient.CI_TRACKED_FLAKINESS_LABEL
+import static org.gradle.performance.results.FlakinessIssueReporter.GITHUB_FIX_IT_LABEL
+
+class FlakinessIssueReporterTest extends Specification {
+    GitHubIssuesClient issuesClient = Mock(GitHubIssuesClient)
+    KnownFlakyTestProvider flakyTestProvider = Mock(KnownFlakyTestProvider)
+
+    @Subject
+    FlakinessIssueReporter reporter = new FlakinessIssueReporter(issuesClient, flakyTestProvider)
+
+    ScenarioBuildResultData scenario = new ScenarioBuildResultData(
+        scenarioName: 'myScenario',
+        webUrl: 'myUrl',
+        agentName: 'myAgent',
+        agentUrl: 'myAgentUrl',
+        currentBuildExecutions: [
+            new MockExecutionData(100, 1),
+            new MockExecutionData(98, -1)
+        ]
+    )
+
+    def 'known flaky issue gets commented, reopened and labeled as fix-it'() {
+        given:
+        GHIssue issue = Mock(GHIssue)
+        1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'otherScenario'), new FlakyTest(name: 'myScenario', issue: issue)]
+        1 * issue.state >> GHIssueState.CLOSED
+        1 * issue.labels >> []
+
+        when:
+        reporter.report(scenario)
+
+        then:
+        1 * issue.reopen()
+        1 * issue.addLabels(GITHUB_FIX_IT_LABEL)
+        1 * issue.comment("""
+FROM-BOT
+
+Url: myUrl
+Agent: [myAgent](myAgentUrl)
+Details:
+
+```
+| Iteration | Difference | Confidence |
+|---|---|---|
+|1|1.0 %|100.0%|
+|2|-1.0 %|98.0%|
+```
+""")
+    }
+
+    def 'new issue is created if none found'() {
+        given:
+        GHIssue issue = Mock(GHIssue)
+        1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'otherScenario')]
+
+        when:
+        reporter.report(scenario)
+
+        then:
+        1 * issuesClient.createBuildToolInvalidFailureIssue('Flaky performance test: myScenario',
+            """
+FROM-BOT
+
+TEST_NAME: myScenario
+
+MESSAGE: Flaky performance test scenario
+"""
+            , [CI_TRACKED_FLAKINESS_LABEL]) >> issue
+        1 * issue.comment("""
+FROM-BOT
+
+Url: myUrl
+Agent: [myAgent](myAgentUrl)
+Details:
+
+```
+| Iteration | Difference | Confidence |
+|---|---|---|
+|1|1.0 %|100.0%|
+|2|-1.0 %|98.0%|
+```
+""")
+    }
+
+    class MockExecutionData extends ScenarioBuildResultData.ExecutionData {
+        double confidencePercentage
+        double differencePercentage
+
+        MockExecutionData(double confidencePercentage, double differencePercentage) {
+            super(System.currentTimeMillis(), "commitId", null, null)
+            this.confidencePercentage = confidencePercentage
+            this.differencePercentage = differencePercentage
+        }
+
+        @Override
+        String getDifferenceDisplay() {
+            return "${differencePercentage} %"
+        }
+    }
+}

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
@@ -61,16 +61,15 @@ class FlakinessIssueReporterTest extends Specification {
         1 * issue.comment("""
 FROM-BOT
 
-Url: myUrl
+Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
+Worker url: myUrl
 Agent: [myAgent](myAgentUrl)
 Details:
 
-```
 | Iteration | Difference | Confidence |
 |---|---|---|
 |1|1.0 %|100.0%|
 |2|-1.0 %|98.0%|
-```
 """)
     }
 
@@ -95,16 +94,15 @@ MESSAGE: Flaky performance test scenario
         1 * issue.comment("""
 FROM-BOT
 
-Url: myUrl
+Coordinator url: https://builds.gradle.org/viewLog.html?buildId=${System.getenv("BUILD_ID")}
+Worker url: myUrl
 Agent: [myAgent](myAgentUrl)
 Details:
 
-```
 | Iteration | Difference | Confidence |
 |---|---|---|
 |1|1.0 %|100.0%|
 |2|-1.0 %|98.0%|
-```
 """)
     }
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
@@ -36,6 +36,7 @@ class FlakinessIssueReporterTest extends Specification {
 
     ScenarioBuildResultData scenario = new ScenarioBuildResultData(
         scenarioName: 'myScenario',
+        scenarioClass: 'my.AwesomeClass',
         webUrl: 'myUrl',
         agentName: 'myAgent',
         agentUrl: 'myAgentUrl',
@@ -48,7 +49,7 @@ class FlakinessIssueReporterTest extends Specification {
     def 'known flaky issue gets commented, reopened and labeled as fix-it'() {
         given:
         GHIssue issue = Mock(GHIssue)
-        1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'otherScenario'), new FlakyTest(name: 'myScenario', issue: issue)]
+        1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'AwesomeClass.otherScenario'), new FlakyTest(name: 'AwesomeClass.myScenario', issue: issue)]
         1 * issue.state >> GHIssueState.CLOSED
         1 * issue.labels >> []
 
@@ -82,11 +83,11 @@ Details:
         reporter.report(scenario)
 
         then:
-        1 * issuesClient.createBuildToolInvalidFailureIssue('Flaky performance test: myScenario',
+        1 * issuesClient.createBuildToolInvalidFailureIssue('Flaky performance test: AwesomeClass.myScenario',
             """
 FROM-BOT
 
-TEST_NAME: myScenario
+TEST_NAME: AwesomeClass.myScenario
 
 MESSAGE: Flaky performance test scenario
 """

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/FlakinessIssueReporterTest.groovy
@@ -49,7 +49,7 @@ class FlakinessIssueReporterTest extends Specification {
     def 'known flaky issue gets commented, reopened and labeled as fix-it'() {
         given:
         GHIssue issue = Mock(GHIssue)
-        1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'AwesomeClass.otherScenario'), new FlakyTest(name: 'AwesomeClass.myScenario', issue: issue)]
+        1 * flakyTestProvider.knownInvalidFailures >> [new FlakyTest(name: 'my.AwesomeClass.otherScenario'), new FlakyTest(name: 'my.AwesomeClass.myScenario', issue: issue)]
         1 * issue.state >> GHIssueState.CLOSED
         1 * issue.labels >> []
 
@@ -83,13 +83,13 @@ Details:
         reporter.report(scenario)
 
         then:
-        1 * issuesClient.createBuildToolInvalidFailureIssue('Flaky performance test: AwesomeClass.myScenario',
+        1 * issuesClient.createBuildToolInvalidFailureIssue('Flaky performance test: my.AwesomeClass.myScenario',
             """
 FROM-BOT
 
-TEST_NAME: AwesomeClass.myScenario
+TEST_NAME: my.AwesomeClass.myScenario
 
-MESSAGE: Flaky performance test scenario
+MESSAGE: we're slower than
 """
             , [CI_TRACKED_FLAKINESS_LABEL]) >> issue
         1 * issue.comment("""


### PR DESCRIPTION
### Context

This closes https://github.com/gradle/gradle-private/issues/1793

We want to report flaky performance scenarios to private issue tracker, as we did for all other functional flaky tests. This PR adds a step to `FlakinessReportGenerator`, which creates/comments issues in `gradle-private`.