### PR TITLE
Warn on unexpected `kotlin-dsl` plugins version

### DIFF
--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/codegen/CodeGenerationTask.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/codegen/CodeGenerationTask.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codegen
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+import java.io.File
+
+
+abstract class CodeGenerationTask : DefaultTask() {
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    protected
+    abstract fun File.writeFiles(): Unit
+
+    @Suppress("unused")
+    @TaskAction
+    fun run() {
+        outputDir.get().asFile.apply {
+            recreate()
+            writeFiles()
+        }
+    }
+
+    protected
+    fun File.writeFile(relativePath: String, text: String) {
+        resolve(relativePath).apply {
+            parentFile.mkdirs()
+            writeText(text)
+        }
+    }
+
+    private
+    fun File.recreate() {
+        deleteRecursively()
+        mkdirs()
+    }
+}
+
+
+internal
+const val licenseHeader = """/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */"""

--- a/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/codegen/GenerateKotlinDslPluginsExtensions.kt
+++ b/buildSrc/subprojects/kotlin-dsl/src/main/kotlin/codegen/GenerateKotlinDslPluginsExtensions.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codegen
+
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+
+import java.io.File
+
+
+@Suppress("unused")
+abstract class GenerateKotlinDslPluginsExtensions : CodeGenerationTask() {
+
+    @get:Input
+    abstract val kotlinDslPluginsVersion: Property<Any>
+
+    override fun File.writeFiles() {
+        writeFile(
+            "org/gradle/kotlin/dsl/plugins/Version.kt",
+            """$licenseHeader
+package org.gradle.kotlin.dsl.plugins
+
+
+internal
+val appliedKotlinDslPluginsVersion = "${kotlinDslPluginsVersion.get()}"
+""")
+    }
+}

--- a/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
+++ b/subprojects/kotlin-dsl-plugins/kotlin-dsl-plugins.gradle.kts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import build.futureKotlin
+import build.kotlin
+import codegen.GenerateKotlinDslPluginsExtensions
 import org.gradle.gradlebuild.test.integrationtests.IntegrationTest
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
-import build.futureKotlin
 import plugins.bundledGradlePlugin
 
 plugins {
@@ -32,6 +34,17 @@ base.archivesBaseName = "plugins"
 
 gradlebuildJava {
     moduleType = ModuleType.INTERNAL
+}
+
+val generatedSourcesDir = layout.buildDirectory.dir("generated-sources/kotlin")
+
+val generateSources by tasks.registering(GenerateKotlinDslPluginsExtensions::class) {
+    outputDir.set(generatedSourcesDir)
+    kotlinDslPluginsVersion.set(project.version)
+}
+
+sourceSets.main {
+    kotlin.srcDir(files(generatedSourcesDir).builtBy(generateSources))
 }
 
 dependencies {

--- a/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
+++ b/subprojects/kotlin-dsl-plugins/src/main/kotlin/org/gradle/kotlin/dsl/plugins/dsl/KotlinDslPlugin.kt
@@ -18,12 +18,15 @@ package org.gradle.kotlin.dsl.plugins.dsl
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
+import org.gradle.kotlin.dsl.*
 
+import org.gradle.kotlin.dsl.plugins.appliedKotlinDslPluginsVersion
 import org.gradle.kotlin.dsl.plugins.base.KotlinDslBasePlugin
 import org.gradle.kotlin.dsl.plugins.precompiled.PrecompiledScriptPlugins
 
-import org.gradle.kotlin.dsl.*
+import org.gradle.kotlin.dsl.support.expectedKotlinDslPluginsVersion
+
+import org.gradle.plugin.devel.plugins.JavaGradlePluginPlugin
 
 
 /**
@@ -41,8 +44,21 @@ class KotlinDslPlugin : Plugin<Project> {
 
     override fun apply(project: Project): Unit = project.run {
 
+        warnOnUnexpectedKotlinDslPluginVersion()
+
         apply<JavaGradlePluginPlugin>()
         apply<KotlinDslBasePlugin>()
         apply<PrecompiledScriptPlugins>()
+    }
+
+    private
+    fun Project.warnOnUnexpectedKotlinDslPluginVersion() {
+        if (expectedKotlinDslPluginsVersion != appliedKotlinDslPluginsVersion) {
+            logger.warn(
+                "This version of Gradle expects version '{}' of the `kotlin-dsl` plugin but version '{}' has been applied to {}. " +
+                    "Let Gradle control the version of `kotlin-dsl` by removing any explicit `kotlin-dsl` version constraints from your build logic.",
+                expectedKotlinDslPluginsVersion, appliedKotlinDslPluginsVersion, project
+            )
+        }
     }
 }

--- a/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractPluginTest.kt
+++ b/subprojects/kotlin-dsl-test-fixtures/src/main/kotlin/org/gradle/kotlin/dsl/fixtures/AbstractPluginTest.kt
@@ -71,7 +71,7 @@ open class AbstractPluginTest : AbstractKotlinIntegrationTest() {
             """
         }
 
-    private
+    protected
     val futurePluginVersions by lazy {
         loadPropertiesFromResource("/future-plugin-versions.properties")
             ?: throw IllegalStateException("/future-plugin-versions.properties resource not found. Run intTestImage.")

--- a/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
+++ b/subprojects/kotlin-dsl/kotlin-dsl.gradle.kts
@@ -81,7 +81,7 @@ tasks {
     }
 
     val generateKotlinDependencyExtensions by registering(GenerateKotlinDependencyExtensions::class) {
-        outputFile.set(apiExtensionsOutputDir.get().file("org/gradle/kotlin/dsl/KotlinDependencyExtensions.kt"))
+        outputDir.set(apiExtensionsOutputDir)
         embeddedKotlinVersion.set(kotlinVersion)
         kotlinDslPluginsVersion.set(publishedKotlinDslPluginVersion)
     }


### PR DESCRIPTION
Each Gradle release is meant to be used with a specific version of the `kotlin-dsl` plugin and compatibility between arbitrary Gradle releases and `kotlin-dsl` plugin versions is not guaranteed.

Using an unexpected version of the `kotlin-dsl` plugin in a build can cause hard to diagnose problems.

## Current Behaviour

Users are allowed to change the version of the `kotlin-dsl` plugin without warnings even though that might cause hard to diagnose problems down the line.

## Expected Behaviour

A warning should be emitted whenever an unexpected version of the `kotlin-dsl` plugin is detected.