### PR TITLE
Simplify worker api isolated classloader structure

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/DefaultClassPathProvider.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/DefaultClassPathProvider.java
@@ -32,6 +32,9 @@ public class DefaultClassPathProvider implements ClassPathProvider {
         if (name.equals("GRADLE_INSTALLATION_BEACON")) {
             return moduleRegistry.getModule("gradle-installation-beacon").getImplementationClasspath();
         }
+        if (name.equals("LANGUAGE-GROOVY")) {
+            return moduleRegistry.getModule("gradle-language-groovy").getAllRequiredModulesClasspath();
+        }
         if (name.equals("ANT")) {
             ClassPath classpath = ClassPath.EMPTY;
             classpath = classpath.plus(moduleRegistry.getExternalModule("ant").getClasspath());

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultClassLoaderRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultClassLoaderRegistry.java
@@ -43,21 +43,7 @@ public class DefaultClassLoaderRegistry implements ClassLoaderRegistry {
     }
 
     private FilteringClassLoader.Spec apiSpecFor(ClassLoader classLoader) {
-        FilteringClassLoader.Spec apiSpec = new FilteringClassLoader.Spec();
-        GradleApiSpecProvider.Spec apiAggregate = new GradleApiSpecAggregator(classLoader, instantiator).aggregate();
-        for (String resource : apiAggregate.getExportedResources()) {
-            apiSpec.allowResource(resource);
-        }
-        for (String resourcePrefix : apiAggregate.getExportedResourcePrefixes()) {
-            apiSpec.allowResources(resourcePrefix);
-        }
-        for (Class<?> clazz : apiAggregate.getExportedClasses()) {
-            apiSpec.allowClass(clazz);
-        }
-        for (String packageName : apiAggregate.getExportedPackages()) {
-            apiSpec.allowPackage(packageName);
-        }
-        return apiSpec;
+        return GradleApiUtil.apiSpecFor(classLoader, instantiator);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleApiUtil.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleApiUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.internal.classloader.FilteringClassLoader;
+import org.gradle.internal.reflect.Instantiator;
+
+public class GradleApiUtil {
+    public static FilteringClassLoader.Spec apiSpecFor(ClassLoader classLoader, Instantiator instantiator) {
+        FilteringClassLoader.Spec apiSpec = new FilteringClassLoader.Spec();
+        GradleApiSpecProvider.Spec apiAggregate = new GradleApiSpecAggregator(classLoader, instantiator).aggregate();
+        for (String resource : apiAggregate.getExportedResources()) {
+            apiSpec.allowResource(resource);
+        }
+        for (String resourcePrefix : apiAggregate.getExportedResourcePrefixes()) {
+            apiSpec.allowResources(resourcePrefix);
+        }
+        for (Class<?> clazz : apiAggregate.getExportedClasses()) {
+            apiSpec.allowClass(clazz);
+        }
+        for (String packageName : apiAggregate.getExportedPackages()) {
+            apiSpec.allowPackage(packageName);
+        }
+        return apiSpec;
+    }
+}

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -59,7 +59,10 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         // that's why we add it here. The following assumes that any Groovy compiler version supported by Gradle
         // is compatible with Gradle's current Ant version.
         Collection<File> antFiles = classPathRegistry.getClassPath("ANT").getAsFiles();
-        Iterable<File> groovyFiles = Iterables.concat(spec.getGroovyClasspath(), antFiles);
+        // TODO We should infer a minimal classpath from delegate instead
+        Collection<File> languageGroovyFiles = classPathRegistry.getClassPath("LANGUAGE-GROOVY").getAsFiles();
+        Iterable<File> classpath = Iterables.concat(spec.getGroovyClasspath(), antFiles, languageGroovyFiles);
+
         JavaForkOptions javaForkOptions = new BaseForkOptionsConverter(forkOptionsFactory).transform(mergeForkOptions(javaOptions, groovyOptions));
         javaForkOptions.setWorkingDir(daemonWorkingDir);
         if (jvmVersionDetector.getJavaVersion(javaForkOptions.getExecutable()).isJava9Compatible()) {
@@ -68,9 +71,10 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
 
         return new DaemonForkOptionsBuilder(forkOptionsFactory)
             .javaForkOptions(javaForkOptions)
-            .classpath(groovyFiles)
+            .classpath(classpath)
             .sharedPackages(SHARED_PACKAGES)
             .keepAliveMode(KeepAliveMode.SESSION)
+            .withoutGradleApi()
             .build();
     }
 }

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -32,7 +32,7 @@ import org.gradle.internal.jvm.inspection.JvmVersionDetector;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.process.JavaForkOptions;
 import org.gradle.process.internal.JavaForkOptionsFactory;
-import org.gradle.workers.internal.ClassLoaderHierarchyNode;
+import org.gradle.workers.internal.ClassLoaderStructure;
 import org.gradle.workers.internal.DaemonForkOptions;
 import org.gradle.workers.internal.DaemonForkOptionsBuilder;
 import org.gradle.workers.internal.KeepAliveMode;
@@ -66,7 +66,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         // is compatible with Gradle's current Ant version.
         Collection<File> antFiles = classPathRegistry.getClassPath("ANT").getAsFiles();
         Iterable<File> classpath = Iterables.concat(spec.getGroovyClasspath(), antFiles);
-        VisitableURLClassLoader.Spec userClasspath = new VisitableURLClassLoader.Spec("worker-loader", DefaultClassPath.of(classpath).getAsURLs());
+        VisitableURLClassLoader.Spec targetGroovyClasspath = new VisitableURLClassLoader.Spec("worker-loader", DefaultClassPath.of(classpath).getAsURLs());
 
         // TODO We should infer a minimal classpath from delegate instead
         Collection<File> languageGroovyFiles = classPathRegistry.getClassPath("LANGUAGE-GROOVY").getAsFiles();
@@ -77,9 +77,9 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
             gradleAndUserFilter.allowPackage(sharedPackage);
         }
 
-        ClassLoaderHierarchyNode classLoaderHierarchy =
-                new ClassLoaderHierarchyNode(getMinimalGradleFilter())
-                        .withChild(userClasspath)
+        ClassLoaderStructure classLoaderStructure =
+                new ClassLoaderStructure(getMinimalGradleFilter())
+                        .withChild(targetGroovyClasspath)
                         .withChild(gradleAndUserFilter)
                         .withChild(compilerClasspath);
 
@@ -94,7 +94,7 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
             .classpath(classpath)
             .sharedPackages(SHARED_PACKAGES)
             .keepAliveMode(KeepAliveMode.SESSION)
-            .withClassLoaderHierarchy(classLoaderHierarchy)
+            .withClassLoaderStrucuture(classLoaderStructure)
             .build();
     }
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderHierarchyNode.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderHierarchyNode.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.workers.internal;
+
+import com.google.common.base.Objects;
+import org.gradle.internal.classloader.ClassLoaderSpec;
+
+public class ClassLoaderHierarchyNode {
+    private final ClassLoaderSpec self;
+    private final ClassLoaderHierarchyNode parent;
+
+    public ClassLoaderHierarchyNode(ClassLoaderSpec self) {
+        this.self = self;
+        this.parent = null;
+    }
+
+    public ClassLoaderHierarchyNode(ClassLoaderSpec self, ClassLoaderHierarchyNode parent) {
+        this.self = self;
+        this.parent = parent;
+    }
+
+    public ClassLoaderHierarchyNode withChild(ClassLoaderSpec spec) {
+        ClassLoaderHierarchyNode childNode = new ClassLoaderHierarchyNode(spec, this);
+        return childNode;
+    }
+
+    public ClassLoaderSpec getSpec() {
+        return self;
+    }
+
+    public ClassLoaderHierarchyNode getParent() {
+        return parent;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClassLoaderHierarchyNode that = (ClassLoaderHierarchyNode) o;
+        return Objects.equal(self, that.self) &&
+                Objects.equal(parent, that.parent);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(self, parent);
+    }
+}

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderStructure.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/ClassLoaderStructure.java
@@ -19,22 +19,22 @@ package org.gradle.workers.internal;
 import com.google.common.base.Objects;
 import org.gradle.internal.classloader.ClassLoaderSpec;
 
-public class ClassLoaderHierarchyNode {
+public class ClassLoaderStructure {
     private final ClassLoaderSpec self;
-    private final ClassLoaderHierarchyNode parent;
+    private final ClassLoaderStructure parent;
 
-    public ClassLoaderHierarchyNode(ClassLoaderSpec self) {
+    public ClassLoaderStructure(ClassLoaderSpec self) {
         this.self = self;
         this.parent = null;
     }
 
-    public ClassLoaderHierarchyNode(ClassLoaderSpec self, ClassLoaderHierarchyNode parent) {
+    public ClassLoaderStructure(ClassLoaderSpec self, ClassLoaderStructure parent) {
         this.self = self;
         this.parent = parent;
     }
 
-    public ClassLoaderHierarchyNode withChild(ClassLoaderSpec spec) {
-        ClassLoaderHierarchyNode childNode = new ClassLoaderHierarchyNode(spec, this);
+    public ClassLoaderStructure withChild(ClassLoaderSpec spec) {
+        ClassLoaderStructure childNode = new ClassLoaderStructure(spec, this);
         return childNode;
     }
 
@@ -42,7 +42,7 @@ public class ClassLoaderHierarchyNode {
         return self;
     }
 
-    public ClassLoaderHierarchyNode getParent() {
+    public ClassLoaderStructure getParent() {
         return parent;
     }
 
@@ -54,7 +54,7 @@ public class ClassLoaderHierarchyNode {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        ClassLoaderHierarchyNode that = (ClassLoaderHierarchyNode) o;
+        ClassLoaderStructure that = (ClassLoaderStructure) o;
         return Objects.equal(self, that.self) &&
                 Objects.equal(parent, that.parent);
     }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptions.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptions.java
@@ -27,20 +27,20 @@ import java.util.Set;
 
 public class DaemonForkOptions {
     private final JavaForkOptionsInternal forkOptions;
-    // TODO classpath will be replaced by classLoaderHierarchy once we make worker daemons match isolated workers
+    // TODO classpath will be replaced by classLoaderStructure once we make worker daemons match isolated workers
     private final Iterable<File> classpath;
     private final Iterable<String> sharedPackages;
     private final KeepAliveMode keepAliveMode;
-    private final ClassLoaderHierarchyNode classLoaderHierarchy;
+    private final ClassLoaderStructure classLoaderStructure;
 
     DaemonForkOptions(JavaForkOptionsInternal forkOptions, Iterable<File> classpath,
                       Iterable<String> sharedPackages, KeepAliveMode keepAliveMode,
-                      ClassLoaderHierarchyNode classLoaderHierarchyNode) {
+                      ClassLoaderStructure classLoaderStructure) {
         this.forkOptions = forkOptions;
         this.classpath = classpath;
         this.sharedPackages = sharedPackages;
         this.keepAliveMode = keepAliveMode;
-        this.classLoaderHierarchy = classLoaderHierarchyNode;
+        this.classLoaderStructure = classLoaderStructure;
     }
 
     public Iterable<File> getClasspath() {
@@ -59,8 +59,8 @@ public class DaemonForkOptions {
         return forkOptions;
     }
 
-    public ClassLoaderHierarchyNode getClassLoaderHierarchy() {
-        return classLoaderHierarchy;
+    public ClassLoaderStructure getClassLoaderStructure() {
+        return classLoaderStructure;
     }
 
     public boolean isCompatibleWith(DaemonForkOptions other) {
@@ -68,7 +68,7 @@ public class DaemonForkOptions {
                 && getNormalizedClasspath(classpath).containsAll(getNormalizedClasspath(other.getClasspath()))
                 && getNormalizedSharedPackages(sharedPackages).containsAll(getNormalizedSharedPackages(other.sharedPackages))
                 && keepAliveMode == other.getKeepAliveMode()
-                && Objects.equal(classLoaderHierarchy, other.getClassLoaderHierarchy());
+                && Objects.equal(classLoaderStructure, other.getClassLoaderStructure());
     }
 
     // one way to merge fork options, good for current use case
@@ -77,7 +77,7 @@ public class DaemonForkOptions {
             throw new IllegalArgumentException("Cannot merge a fork options object with a different keep alive mode (this: " + keepAliveMode + ", other: " + other.getKeepAliveMode() + ").");
         }
 
-        if (!Objects.equal(classLoaderHierarchy, other.getClassLoaderHierarchy())) {
+        if (!Objects.equal(classLoaderStructure, other.getClassLoaderStructure())) {
             throw new IllegalArgumentException("Cannot merge a fork options object with a different value for classloader hierarchy.");
         }
 
@@ -86,7 +86,7 @@ public class DaemonForkOptions {
         Set<String> mergedAllowedPackages = getNormalizedSharedPackages(sharedPackages);
         mergedAllowedPackages.addAll(getNormalizedSharedPackages(other.sharedPackages));
 
-        return new DaemonForkOptions(forkOptions.mergeWith(other.forkOptions), mergedClasspath, mergedAllowedPackages, keepAliveMode, classLoaderHierarchy);
+        return new DaemonForkOptions(forkOptions.mergeWith(other.forkOptions), mergedClasspath, mergedAllowedPackages, keepAliveMode, classLoaderStructure);
     }
 
     private Set<File> getNormalizedClasspath(Iterable<File> classpath) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
@@ -29,6 +29,7 @@ public class DaemonForkOptionsBuilder {
     private Iterable<File> classpath = Collections.emptyList();
     private Iterable<String> sharedPackages = Collections.emptyList();
     private KeepAliveMode keepAliveMode = KeepAliveMode.DAEMON;
+    private boolean withoutGradleApi;
 
     public DaemonForkOptionsBuilder(JavaForkOptionsFactory forkOptionsFactory) {
         this.forkOptionsFactory = forkOptionsFactory;
@@ -55,8 +56,13 @@ public class DaemonForkOptionsBuilder {
         return this;
     }
 
+    public DaemonForkOptionsBuilder withoutGradleApi() {
+        this.withoutGradleApi = true;
+        return this;
+    }
+
     public DaemonForkOptions build() {
-        return new DaemonForkOptions(buildJavaForkOptions(), classpath, sharedPackages, keepAliveMode);
+        return new DaemonForkOptions(buildJavaForkOptions(), classpath, sharedPackages, keepAliveMode, withoutGradleApi);
     }
 
     private JavaForkOptionsInternal buildJavaForkOptions() {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
@@ -26,11 +26,11 @@ import java.util.Collections;
 public class DaemonForkOptionsBuilder {
     private final JavaForkOptionsInternal javaForkOptions;
     private final JavaForkOptionsFactory forkOptionsFactory;
-    // TODO classpath will be replaced by classLoaderHierarchy once we make worker daemons match isolated workers
+    // TODO classpath will be replaced by classLoaderStructure once we make worker daemons match isolated workers
     private Iterable<File> classpath = Collections.emptyList();
     private Iterable<String> sharedPackages = Collections.emptyList();
     private KeepAliveMode keepAliveMode = KeepAliveMode.DAEMON;
-    private ClassLoaderHierarchyNode classLoaderHierarchy = null;
+    private ClassLoaderStructure classLoaderStructure = null;
 
     public DaemonForkOptionsBuilder(JavaForkOptionsFactory forkOptionsFactory) {
         this.forkOptionsFactory = forkOptionsFactory;
@@ -57,13 +57,13 @@ public class DaemonForkOptionsBuilder {
         return this;
     }
 
-    public DaemonForkOptionsBuilder withClassLoaderHierarchy(ClassLoaderHierarchyNode classLoaderHierarchyNode) {
-        this.classLoaderHierarchy = classLoaderHierarchyNode;
+    public DaemonForkOptionsBuilder withClassLoaderStrucuture(ClassLoaderStructure classLoaderStructure) {
+        this.classLoaderStructure = classLoaderStructure;
         return this;
     }
 
     public DaemonForkOptions build() {
-        return new DaemonForkOptions(buildJavaForkOptions(), classpath, sharedPackages, keepAliveMode, classLoaderHierarchy);
+        return new DaemonForkOptions(buildJavaForkOptions(), classpath, sharedPackages, keepAliveMode, classLoaderStructure);
     }
 
     private JavaForkOptionsInternal buildJavaForkOptions() {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DaemonForkOptionsBuilder.java
@@ -26,10 +26,11 @@ import java.util.Collections;
 public class DaemonForkOptionsBuilder {
     private final JavaForkOptionsInternal javaForkOptions;
     private final JavaForkOptionsFactory forkOptionsFactory;
+    // TODO classpath will be replaced by classLoaderHierarchy once we make worker daemons match isolated workers
     private Iterable<File> classpath = Collections.emptyList();
     private Iterable<String> sharedPackages = Collections.emptyList();
     private KeepAliveMode keepAliveMode = KeepAliveMode.DAEMON;
-    private boolean withoutGradleApi;
+    private ClassLoaderHierarchyNode classLoaderHierarchy = null;
 
     public DaemonForkOptionsBuilder(JavaForkOptionsFactory forkOptionsFactory) {
         this.forkOptionsFactory = forkOptionsFactory;
@@ -56,13 +57,13 @@ public class DaemonForkOptionsBuilder {
         return this;
     }
 
-    public DaemonForkOptionsBuilder withoutGradleApi() {
-        this.withoutGradleApi = true;
+    public DaemonForkOptionsBuilder withClassLoaderHierarchy(ClassLoaderHierarchyNode classLoaderHierarchyNode) {
+        this.classLoaderHierarchy = classLoaderHierarchyNode;
         return this;
     }
 
     public DaemonForkOptions build() {
-        return new DaemonForkOptions(buildJavaForkOptions(), classpath, sharedPackages, keepAliveMode, withoutGradleApi);
+        return new DaemonForkOptions(buildJavaForkOptions(), classpath, sharedPackages, keepAliveMode, classLoaderHierarchy);
     }
 
     private JavaForkOptionsInternal buildJavaForkOptions() {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -18,7 +18,6 @@ package org.gradle.workers.internal;
 
 import org.gradle.concurrent.ParallelismConfiguration;
 import org.gradle.initialization.GradleUserHomeDirProvider;
-import org.gradle.internal.classloader.ClassLoaderFactory;
 import org.gradle.internal.concurrent.ExecutorFactory;
 import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.instantiation.InstantiatorFactory;
@@ -57,12 +56,12 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
 
     private static class BuildSessionScopeServices {
 
-        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, MemoryManager memoryManager, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
+        WorkerDaemonFactory createWorkerDaemonFactory(WorkerDaemonClientsManager workerDaemonClientsManager, BuildOperationExecutor buildOperationExecutor) {
             return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationExecutor);
         }
 
-        IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(ClassLoaderFactory classLoaderFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
-            return new IsolatedClassloaderWorkerFactory(classLoaderFactory, buildOperationExecutor);
+        IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(BuildOperationExecutor buildOperationExecutor) {
+            return new IsolatedClassloaderWorkerFactory(buildOperationExecutor);
         }
 
         WorkerDirectoryProvider createWorkerDirectoryProvider(GradleUserHomeDirProvider gradleUserHomeDirProvider) {

--- a/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsMergeTest.groovy
+++ b/subprojects/workers/src/test/groovy/org/gradle/workers/internal/DaemonForkOptionsMergeTest.groovy
@@ -17,6 +17,7 @@
 package org.gradle.workers.internal
 
 import org.gradle.api.internal.file.TestFiles
+import org.gradle.internal.classloader.ClassLoaderSpec
 import org.gradle.process.JavaForkOptions
 import spock.lang.Specification
 
@@ -90,6 +91,21 @@ class DaemonForkOptionsMergeTest extends Specification {
             .sharedPackages(["baz.bar", "other"])
             .keepAliveMode(KeepAliveMode.DAEMON)
             .build()
+
+        when:
+        options1.mergeWith(options2)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
+
+    def "throws an exception when merging options with different classloader structures"() {
+        options2 = new DaemonForkOptionsBuilder(TestFiles.execFactory())
+                .javaForkOptions(forkOptions)
+                .classpath([new File("lib/lib2.jar"), new File("lib/lib3.jar")])
+                .sharedPackages(["baz.bar", "other"])
+                .withClassLoaderStrucuture(new ClassLoaderStructure(Mock(ClassLoaderSpec)))
+                .build()
 
         when:
         options1.mergeWith(options2)


### PR DESCRIPTION
This simplifies the classloader structure when `IsolationMode.CLASSLOADER` is used.  This does two things:

- By default, isolated workers will have a simple isolated classloader with access to the Gradle API.
- Groovy compilers require a special classloader structure to allow the compiler to target a different version of Groovy than the one Gradle uses.  This is made possible by allowing the compiler to specify the structure it requires (instead of specifying a flat classpath).  This capability is only available internally and is not a part of the worker API.

The goal is to have the worker daemon classloader match this simplified structure.  We'll tackle this in a follow up PR.