### PR TITLE
Non-cacheable should be provided as caching disabled reason

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/tasks/TaskCacheabilityReasonIntegrationTest.groovy
@@ -95,7 +95,7 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
         assertCachingDisabledFor null, null
     }
 
-    def "cacheability for a task with no outputs is NO_OUTPUTS_DECLARED"() {
+    def "cacheability for a cacheable task with no outputs is NO_OUTPUTS_DECLARED"() {
         buildFile << """
             @CacheableTask
             class NoOutputs extends DefaultTask {
@@ -109,6 +109,21 @@ class TaskCacheabilityReasonIntegrationTest extends AbstractIntegrationSpec impl
         withBuildCache().run "noOutputs"
         then:
         assertCachingDisabledFor NO_OUTPUTS_DECLARED, "No outputs declared"
+    }
+
+    def "cacheability for a non-cacheable task with no outputs is NOT_ENABLED_FOR_TASK"() {
+        buildFile << """
+            class NoOutputs extends DefaultTask {
+                @TaskAction
+                void generate() {}
+            }
+            
+            task noOutputs(type: NoOutputs) {}
+        """
+        when:
+        withBuildCache().run "noOutputs"
+        then:
+        assertCachingDisabledFor NOT_ENABLED_FOR_TASK, "Caching has not been enabled for the task"
     }
 
     @Unroll

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteActionsTaskExecuter.java
@@ -268,10 +268,6 @@ public class ExecuteActionsTaskExecuter implements TaskExecuter {
                 LOGGER.info("Custom actions are attached to {}.", task);
             }
 
-            if (!context.getTaskProperties().hasDeclaredOutputs()) {
-                return Optional.of(NO_OUTPUTS_DECLARED);
-            }
-
             return taskCacheabilityResolver.shouldDisableCaching(
                 context.getTaskProperties().hasDeclaredOutputs(),
                 context.getTaskProperties().getOutputFileProperties(),


### PR DESCRIPTION
for a task which does not have caching enabled, even if it doesn't
declare outputs.