### PR TITLE
Fix ParallelTestTaskIntegrationTest test failure

### DIFF
--- a/subprojects/plugins/src/integTest/groovy/org/gradle/java/ParallelTestTaskIntegrationTest.groovy
+++ b/subprojects/plugins/src/integTest/groovy/org/gradle/java/ParallelTestTaskIntegrationTest.groovy
@@ -30,7 +30,7 @@ import java.util.concurrent.CountDownLatch
 @IgnoreIf({ !GradleContextualExecuter.isParallel() })
 class ParallelTestTaskIntegrationTest extends AbstractIntegrationSpec {
     String getVersion() {
-        return "1.6"
+        return "1.7"
     }
 
     JavaVersion getJavaVersion() {


### PR DESCRIPTION
We run tests with Java 12 which no longer supports Java 6 as a source option which makes the `ParallelTestTaskIntegrationTest` fail: https://builds.gradle.org/viewLog.html?buildId=21422747&buildTypeId=Gradle_Check_Parallel_7_plugins