### PR TITLE
Extend error message when copy task fails because of a missing property.

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/CopyTaskIntegrationSpec.groovy
@@ -89,7 +89,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         when:
         fails 'copy'
         then:
-        failure.assertHasCause("Could not copy file '${file("src/two/two.a")}' to '${file("dest/two.a")}'.")
+        failure.assertHasCause("Could not copy file '${file("src/two/two.a")}' to '${file("dest/two.a")}'. Reason: Missing property 'one'.")
     }
 
     def "useful help message when property cannot be expanded in filter chain"() {
@@ -107,7 +107,7 @@ class CopyTaskIntegrationSpec extends AbstractIntegrationSpec {
         when:
         fails 'copy'
         then:
-        failure.assertHasCause("Could not copy file '${file("src/two/two.a")}' to '${file("dest/two.a")}'.")
+        failure.assertHasCause("Could not copy file '${file("src/two/two.a")}' to '${file("dest/two.a")}'. Reason: Missing property 'two'.")
     }
 
     def "multiple source with inherited include and exclude patterns"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FilterChain.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/copy/FilterChain.java
@@ -16,9 +16,11 @@
 package org.gradle.api.internal.file.copy;
 
 import groovy.lang.Closure;
+import groovy.lang.MissingPropertyException;
 import groovy.text.SimpleTemplateEngine;
 import groovy.text.Template;
 import org.apache.tools.ant.util.ReaderInputStream;
+import org.gradle.api.GradleException;
 import org.gradle.api.InvalidUserDataException;
 import org.gradle.api.Transformer;
 import org.gradle.api.UncheckedIOException;
@@ -124,6 +126,8 @@ public class FilterChain implements Transformer<InputStream, InputStream> {
                     return new StringReader(writer.toString());
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
+                } catch (MissingPropertyException e) {
+                    throw new GradleException(String.format("Missing property '%s'.", e.getProperty()), e);
                 }
             }
         });

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileTreeElement.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileTreeElement.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.api.internal.file;
 
+import groovy.lang.MissingPropertyException;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.GradleException;
 import org.gradle.api.UncheckedIOException;
@@ -79,6 +80,8 @@ public abstract class AbstractFileTreeElement implements FileTreeElement {
             }
             chmod.chmod(target, getMode());
             return true;
+        } catch (GradleException e) {
+            throw new GradleException(String.format("Could not copy %s to '%s'. Reason: %s", getDisplayName(), target, e.getMessage()), e);
         } catch (Exception e) {
             throw new GradleException(String.format("Could not copy %s to '%s'.", getDisplayName(), target), e);
         }


### PR DESCRIPTION
Signed-off-by: Dominik Giger <mail@dgiger.com>

### Context
I spent some time trying to figure out why a copy task is failing. After some time I realized the file is also expanded and one of the properties was missing in my properties. So I figured it would be useful to have a more descriptive error message for this use case.
I did not write any tests for this since it is such a trivial change.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
