### PR TITLE
Fix native alignment using a platform

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.resolve.platforms
+
+import org.gradle.api.JavaVersion
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
+import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
+import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
+
+@RequiredFeatures(
+    [
+        @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true"),
+        @RequiredFeature(feature = GradleMetadataResolveRunner.REPOSITORY_TYPE, value="maven"),
+    ]
+)
+class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModuleDependencyResolveTest {
+    def "publishes a platform with native alignment"() {
+        settingsFile << """
+            rootProject.name = 'root'
+            include "platform"
+            include "core"
+            include "lib"
+        """
+        file("platform/build.gradle") << """
+            plugins {
+                id 'java-platform'
+            }
+            
+            dependencies {
+                constraints {
+                    api(project(":core")) { because "platform alignment" }
+                    api(project(":lib")) { because "platform alignment" }
+                }
+            }
+            
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.javaPlatform
+                    }
+                }
+            }
+        """
+        file("core/build.gradle") << """
+            plugins {
+                id 'java-library'
+            }
+            dependencies {
+                api(platform(project(":platform")))
+                api(project(":lib"))
+            }
+            
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+        file("lib/build.gradle") << """
+            plugins {
+                id 'java-library'
+                id 'maven-publish'
+            }
+            dependencies {
+                api(platform(project(":platform")))
+            }
+            
+            publishing {
+                publications {
+                    maven(MavenPublication) {
+                        from components.java
+                    }
+                }
+            }
+        """
+        file("build.gradle") << """
+            allprojects {
+                group = 'com.acme.foo'
+                version = rootProject.getProperty('ver')
+            }
+            subprojects {
+                apply plugin: 'maven-publish'
+                publishing {
+                   repositories {
+                       maven { url = "${mavenRepo.rootDir}" }
+                   }
+                }
+            }
+        """
+
+        when:
+        run "publishAllPublicationsToMavenRepo", "-Pver=1.0"
+        run "publishAllPublicationsToMavenRepo", "-Pver=1.1"
+
+        then:
+        ['1.0', '1.1'].each { v ->
+            def platform = mavenRepo.module("com.acme.foo", "platform", v)
+            platform.assertPublished()
+            platform.hasGradleMetadataRedirectionMarker()
+            platform.parsedModuleMetadata.variant("apiElements") {
+                constraint("com.acme.foo:core:$v") {
+                    exists()
+                }
+                constraint("com.acme.foo:lib:$v") {
+                    exists()
+                }
+                noMoreDependencies()
+            }
+            def core = mavenRepo.module("com.acme.foo", "core", v)
+            core.assertPublished()
+            core.hasGradleMetadataRedirectionMarker()
+            core.parsedModuleMetadata.variant("apiElements") {
+                dependency("com.acme.foo:lib:$v") {
+                    exists()
+                }
+                dependency("com.acme.foo:platform:$v") {
+                    exists()
+                }
+                noMoreDependencies()
+            }
+            def lib = mavenRepo.module("com.acme.foo", "lib", v)
+            lib.assertPublished()
+            lib.hasGradleMetadataRedirectionMarker()
+            lib.parsedModuleMetadata.variant("apiElements") {
+                dependency("com.acme.foo:platform:$v") {
+                    exists()
+                }
+                noMoreDependencies()
+            }
+        }
+
+        when:
+        settingsFile.text = """
+            rootProject.name = 'consumer'
+            enableFeaturePreview('GRADLE_METADATA')
+        """
+
+        buildFile.text = """
+            apply plugin: 'java-library'
+            repositories {
+                maven { url = "${mavenHttpRepo.uri}" }
+            }
+            dependencies {
+                implementation("com.acme.foo:core:1.0")
+                implementation("com.acme.foo:lib:1.1")
+            }
+        """
+        resolve = new ResolveTestFixture(buildFile, "compileClasspath")
+        resolve.prepare()
+
+        repositoryInteractions {
+            'com.acme.foo' {
+                'core' {
+                    '1.0' {
+                        expectGetMetadata()
+                    }
+                    '1.1' {
+                        expectResolve()
+                    }
+                }
+                'lib' {
+                    '1.1' {
+                        expectResolve()
+                    }
+                }
+                'platform' {
+                    '1.0' {
+                        expectGetMetadata()
+                    }
+                    '1.1' {
+                        expectGetMetadata()
+                    }
+                }
+
+            }
+        }
+
+        run ':checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(":", ":consumer:") {
+                edge('com.acme.foo:core:1.0', 'com.acme.foo:core:1.1') {
+                    byConstraint("platform alignment")
+                    variant "apiElements", [
+                        'org.gradle.category':'library',
+                        'org.gradle.dependency.bundling':'external',
+                        'org.gradle.jvm.version': JavaVersion.current().majorVersion,
+                        'org.gradle.status':'release',
+                        'org.gradle.usage': 'java-api-jars']
+                    module('com.acme.foo:platform:1.1') {
+                        variant "apiElements", [
+                            'org.gradle.category':'platform',
+                            'org.gradle.status':'release',
+                            'org.gradle.usage': 'java-api']
+                        constraint('com.acme.foo:core:1.1')
+                        constraint('com.acme.foo:lib:1.1')
+                        noArtifacts()
+                    }
+                    module('com.acme.foo:lib:1.1') {
+                        variant "apiElements", [
+                            'org.gradle.category':'library',
+                            'org.gradle.dependency.bundling':'external',
+                            'org.gradle.jvm.version': JavaVersion.current().majorVersion,
+                            'org.gradle.status':'release',
+                            'org.gradle.usage': 'java-api-jars']
+                        byConstraint("platform alignment")
+                    }
+                }
+                module('com.acme.foo:lib:1.1') {
+                    variant "apiElements", [
+                        'org.gradle.category':'library',
+                        'org.gradle.dependency.bundling':'external',
+                        'org.gradle.jvm.version': JavaVersion.current().majorVersion,
+                        'org.gradle.status':'release',
+                        'org.gradle.usage': 'java-api-jars']
+                    module('com.acme.foo:platform:1.1') {
+                        variant "apiElements", [
+                            'org.gradle.category':'platform',
+                            'org.gradle.status':'release',
+                            'org.gradle.usage': 'java-api']
+                    }
+                }
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/platforms/NativeAlignmentWithJavaPlatformResolveIntegrationTest.groovy
@@ -23,6 +23,8 @@ import org.gradle.integtests.fixtures.RequiredFeatures
 import org.gradle.integtests.fixtures.resolve.ResolveTestFixture
 import org.gradle.integtests.resolve.AbstractModuleDependencyResolveTest
 
+import static org.gradle.util.TextUtil.escapeString
+
 @RequiredFeatures(
     [
         @RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true"),
@@ -100,7 +102,7 @@ class NativeAlignmentWithJavaPlatformResolveIntegrationTest extends AbstractModu
                 apply plugin: 'maven-publish'
                 publishing {
                    repositories {
-                       maven { url = "${mavenRepo.rootDir}" }
+                       maven { url = "${escapeString(mavenRepo.rootDir)}" }
                    }
                 }
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultProjectDependencyConstraint.java
@@ -32,9 +32,10 @@ import java.util.Collections;
  * A limited use, project dependency constraint mostly aimed at publishing
  * platforms.
  */
-public class DefaultProjectDependencyConstraint implements DependencyConstraint {
+public class DefaultProjectDependencyConstraint implements DependencyConstraintInternal {
     private final ProjectDependency projectDependency;
     private String reason;
+    private boolean force;
 
     public DefaultProjectDependencyConstraint(ProjectDependency projectDependency) {
         this.projectDependency = projectDependency;
@@ -103,5 +104,15 @@ public class DefaultProjectDependencyConstraint implements DependencyConstraint 
     public ModuleIdentifier getModule() {
         String group = projectDependency.getGroup();
         return DefaultModuleIdentifier.newId(group != null ? group : "", projectDependency.getName());
+    }
+
+    @Override
+    public void setForce(boolean force) {
+        this.force = force;
+    }
+
+    @Override
+    public boolean isForce() {
+        return force;
     }
 }

--- a/subprojects/docs/src/docs/userguide/managing_transitive_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/managing_transitive_dependencies.adoc
@@ -200,9 +200,54 @@ It's easy to end up with a set of versions which do not work well together.
 To fix this, Gradle supports dependency version alignment, which is supported by the concept of platform. A platform represents a set of modules which "work well together".
 Either because they are actually published as a whole (when one of the members of the platform is published, all other modules are also published with the same version), or because someone tested modules and indicates that they work well together (typically, the Spring Platform).
 
-=== Declaring participation in a platform
+=== Aligning versions natively with Gradle
 
-We can fix the example above by declaring that all Jackson modules "belong to" the same platform.
+Gradle natively supports alignment of modules produced by Gradle.
+This is a direct consequence of the transitivity of <<sec:dependency_constraints, dependency constraints>>.
+So if you have a multi-project build, and that you wish that consumers get the same version of all your modules, Gradle provides a simple way to do this using the <<java_platform_plugin.adoc#,Java Platform Plugin>>.
+
+For example, if you have a project that consists of 3 modules:
+
+- `lib`
+- `utils`
+- `core`, depending on `lib` and `utils`
+
+And a consumer that declares the following dependencies:
+
+- `core` version 1.0
+- `lib` version 1.1
+
+then by default resolution would select `core:1.0` and `lib:1.1`, because `lib` has no dependency on `core`.
+We can fix this by adding a new module in our project, a _platform_, that will add constraints on all the modules of your project:
+
+.The platform module
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/platform",files="build.gradle[tags=platform]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/platform",files="build.gradle.kts[tags=platform]"]
+====
+
+Once this is done, we need to make sure that all modules now _depend on the platform_, like this:
+
+.Declaring a dependency on the platform
+====
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/core",files="build.gradle[tags=dependencies]"]
+include::sample[dir="userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/core",files="build.gradle.kts[tags=dependencies]"]
+====
+
+It is important that the platform contains a constraint on all the components, but also that each component has a dependency on the platform.
+By doing this, whenever Gradle will add a dependency to a module of the platform on the graph, it will _also_ include constraints on the other modules of the platform.
+This means that if we see another module belonging to the same platform, we will automatically upgrade to the same version.
+
+In our example, it means that we first see `core:1.0`, which brings a platform `1.0` with constraints on `lib:1.0` and `lib:1.0`.
+Then we add `lib:1.1` which has a dependency on `platform:1.1`.
+By conflict resolution, we select the `1.1` platform, which has a constraint on `core:1.1`.
+Then we conflict resolve between `core:1.0` and `core:1.1`, which means that `core` and `lib` are now aligned properly.
+
+NOTE: This behavior is enforced for published components only if you use Gradle Module Metadata.
+
+=== Aligning versions of modules not published with Gradle
+
+Whenever the publisher doesn't use Gradle, like in our Jackson example, we can explain to Gradle that that all Jackson modules "belong to" the same platform and benefit from the same behavior as with native alignment:
 
 .A dependency version alignment rule
 ====

--- a/subprojects/docs/src/docs/userguide/managing_transitive_dependencies.adoc
+++ b/subprojects/docs/src/docs/userguide/managing_transitive_dependencies.adoc
@@ -234,10 +234,6 @@ A virtual platform is considered specially by the engine and participates in dep
 On the other hand, we can find "real" platforms published on public repositories. Typical examples include BOMs, like the Spring BOM. They differ in the sense that a published platform may refer to modules which are effectively different things.
 For example the Spring BOM declares dependencies on Spring as well as Apache Groovy. Obviously those things are versioned differently, so it doesn't make sense to align in this case. In other words, if a platform is _published_, Gradle trusts its metadata, and will not try to align dependency versions of this platform.
 
-[NOTE]
-====
-Gradle doesn't yet support publishing platforms. It can <<bom_import, consume BOMs>>, or declare participation to a virtual platform, but it's not yet possible to declare and publish an adhoc platform module.
-====
 
 [[sec:capabilities]]
 == Component capabilities

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/align-dependency-versions.sample.conf
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/align-dependency-versions.sample.conf
@@ -1,0 +1,9 @@
+commands: [{
+    execution-subdirectory: groovy
+    executable: gradle
+    args: publishAllPublicationsToMavenRepository
+}, {
+    execution-subdirectory: kotlin
+    executable: gradle
+    args: publishAllPublicationsToMavenRepository
+}]

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+allprojects {
+    group = 'com.acme'
+    version = '1.0'
+}
+
+subprojects {
+    apply plugin: 'maven-publish'
+
+
+    publishing {
+        repositories {
+            maven {
+                url "${rootProject.buildDir}/repo"
+            }
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/core/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/core/build.gradle
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java-library'
+}
+
+// tag::dependencies[]
+dependencies {
+    // Each project has a dependency on the platform
+    api(platform(project(":platform")))
+    
+    // And any additional dependency required
+    implementation(project(":lib"))
+    implementation(project(":utils"))
+}
+// end::dependencies[]
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/lib/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/lib/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    // Each project has a dependency on the platform
+    api(platform(project(":platform")))
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/platform/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/platform/build.gradle
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::platform[]
+plugins {
+    id 'java-platform'
+}
+
+dependencies {
+    // The platform declares constraints on all components that
+    // require alignment
+    constraints {
+        api(project(":core"))
+        api(project(":lib"))
+        api(project(":utils"))
+    }
+}
+// end::platform[]
+
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.javaPlatform
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/settings.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/settings.gradle
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "dependency-alignment-with-platform"
+
+include "core", "lib", "utils", "platform"
+
+enableFeaturePreview('GRADLE_METADATA')
+

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/utils/build.gradle
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/groovy/utils/build.gradle
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    // Each project has a dependency on the platform
+    api(platform(project(":platform")))
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/build.gradle.kts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+allprojects {
+    group = "com.acme"
+    version = "1.0"
+}
+
+subprojects {
+    apply(plugin = "maven-publish")
+
+    extensions.configure<PublishingExtension> {
+        repositories {
+            maven {
+                setUrl("${rootProject.buildDir}/repo")
+            }
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/core/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/core/build.gradle.kts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `java-library`
+}
+
+// tag::dependencies[]
+dependencies {
+    // Each project has a dependency on the platform
+    api(platform(project(":platform")))
+    
+    // And any additional dependency required
+    implementation(project(":lib"))
+    implementation(project(":utils"))
+}
+// end::dependencies[]
+
+publishing {
+    publications {
+        create("maven", MavenPublication::class.java) {
+            from(components["java"])
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/lib/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/lib/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    // Each project has a dependency on the platform
+    api(platform(project(":platform")))
+}
+
+publishing {
+    publications {
+        create("maven", MavenPublication::class.java) {
+            from(components["java"])
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/platform/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/platform/build.gradle.kts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// tag::platform[]
+plugins {
+    `java-platform`
+}
+
+dependencies {
+    // The platform declares constraints on all components that
+    // require alignment
+    constraints {
+        api(project(":core"))
+        api(project(":lib"))
+        api(project(":utils"))
+    }
+}
+// end::platform[]
+
+
+publishing {
+    publications {
+        create("maven", MavenPublication::class.java) {
+            from(components["javaPlatform"])
+        }
+    }
+}

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/settings.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/settings.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+rootProject.name = "dependency-alignment-with-platform"
+
+include("core", "lib", "utils", "platform")
+
+enableFeaturePreview("GRADLE_METADATA")
+

--- a/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/utils/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/dependencyManagement/managingTransitiveDependencies/dependencyAlignmentWithPlatform/kotlin/utils/build.gradle.kts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    `java-library`
+}
+
+dependencies {
+    // Each project has a dependency on the platform
+    api(platform(project(":platform")))
+}
+
+publishing {
+    publications {
+        create("maven", MavenPublication::class.java) {
+            from(components["java"])
+        }
+    }
+}


### PR DESCRIPTION
### Context

This PR fixes the fact that we can't use the Java Platform Plugin to declare a platform for alignment: there was a `ClassCastException` because project dependencies didn't implement the required internal interface.
