### PR TITLE
Support optional incremental inputs

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -278,7 +278,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
                 void run(InputChanges changes) {
                     new File(outputDirectory, "output.txt").text = "Success"
                     changes.getFileChanges(input).each {
-                        println it
+                        println "Changes > \$it"
                     }                    
                 }
             }
@@ -302,8 +302,8 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         run("myTask", "-PinputFile=inputFile")
 
         then:
-        output.contains("Input file ${file("inputFile").absolutePath} has been added.")
-        output.contains("Input file ${file("inputFile/someContents.txt").absolutePath} has been added.")
+        output.contains("Changes > Input file ${file("inputFile").absolutePath} has been added.")
+        output.contains("Changes > Input file ${file("inputFile/someContents.txt").absolutePath} has been added.")
 
         where:
         propertyDefinition << ["abstract DirectoryProperty getInput()", "abstract RegularFileProperty getInput()"]

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -262,13 +262,13 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         succeeds("myTask")
     }
 
-    def "values are required for incremental inputs"() {
-        buildFile << """
-
+    def "empty providers can be queried for incremental changes"() {
+        file("buildSrc").deleteDir()
+        buildFile.text = """
             abstract class MyTask extends DefaultTask {
                 @Incremental
                 @Optional
-                @InputDirectory
+                @InputFiles
                 ${propertyDefinition}
 
                 @OutputDirectory
@@ -277,23 +277,36 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
                 @TaskAction
                 void run(InputChanges changes) {
                     new File(outputDirectory, "output.txt").text = "Success"
+                    changes.getFileChanges(input).each {
+                        println it
+                    }                    
                 }
             }
 
             task myTask(type: MyTask) {
                 outputDirectory = file("build/output")
+                if (project.findProperty("inputFile")) {
+                    input = file(project.property("inputFile"))
+                }
             }
         """
 
         file("input").createDir()
 
         expect:
-        fails("myTask")
-        failure.assertHasDescription("Execution failed for task ':myTask'.")
-        failure.assertHasCause("Must specify a value for incremental input property 'input'.")
+        succeeds("myTask")
+
+        when:
+        file("inputFile").createDir()
+        file("inputFile/someContents.txt").text = "input"
+        run("myTask", "-PinputFile=inputFile")
+
+        then:
+        output.contains("Input file ${file("inputFile").absolutePath} has been added.")
+        output.contains("Input file ${file("inputFile/someContents.txt").absolutePath} has been added.")
 
         where:
-        propertyDefinition << ["abstract DirectoryProperty getInput()", "abstract RegularFileProperty getInput()", "File input"]
+        propertyDefinition << ["abstract DirectoryProperty getInput()", "abstract RegularFileProperty getInput()"]
     }
 
     @Unroll

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
@@ -59,7 +59,7 @@ public class StaticValue implements PropertyValue {
 
     @Nullable
     @Override
-    public Object getValue() {
+    public Object getUnprocessedValue() {
         return value;
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/StaticValue.java
@@ -56,4 +56,10 @@ public class StaticValue implements PropertyValue {
         }
         return value;
     }
+
+    @Nullable
+    @Override
+    public Object getValue() {
+        return value;
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultInputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultInputFilePropertySpec.java
@@ -45,6 +45,6 @@ public class DefaultInputFilePropertySpec extends AbstractFilePropertySpec imple
     @Override
     @Nullable
     public Object getValue() {
-        return value.call();
+        return value.getValue();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultInputFilePropertySpec.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultInputFilePropertySpec.java
@@ -45,6 +45,6 @@ public class DefaultInputFilePropertySpec extends AbstractFilePropertySpec imple
     @Override
     @Nullable
     public Object getValue() {
-        return value.getValue();
+        return value.getUnprocessedValue();
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValue.java
@@ -37,7 +37,7 @@ public interface PropertyValue extends Callable<Object> {
      * The unprocessed value of the underlying property.
      */
     @Nullable
-    Object getValue();
+    Object getUnprocessedValue();
 
     void attachProducer(Task producer);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValue.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/PropertyValue.java
@@ -17,14 +17,27 @@
 package org.gradle.api.internal.tasks.properties;
 
 import org.gradle.api.Task;
+import org.gradle.api.provider.Provider;
 
 import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 
 public interface PropertyValue extends Callable<Object> {
+    /**
+     * The value of the underlying property, replacing an empty provider by {@literal null}.
+     *
+     * This is required for allowing optional provider properties - all code which unpacks providers calls {@link Provider#get()} and would fail if an optional provider is passed.
+     * Returning {@literal null} from a {@link Callable} is ignored, and {@link PropertyValue} is a {@link Callable}.
+     */
     @Nullable
     @Override
     Object call();
+
+    /**
+     * The unprocessed value of the underlying property.
+     */
+    @Nullable
+    Object getValue();
 
     void attachProducer(Task producer);
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
@@ -89,6 +89,12 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
             throw UncheckedException.throwAsUncheckedException(exception);
         }
 
+        @Nullable
+        @Override
+        public Object getValue() {
+            return call();
+        }
+
         @Override
         public void attachProducer(Task producer) {
             // Ignore
@@ -104,6 +110,12 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
         @Nullable
         @Override
         public Object call() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Object getValue() {
             return null;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/annotations/NestedBeanAnnotationHandler.java
@@ -91,7 +91,7 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
 
         @Nullable
         @Override
-        public Object getValue() {
+        public Object getUnprocessedValue() {
             return call();
         }
 
@@ -115,7 +115,7 @@ public class NestedBeanAnnotationHandler implements PropertyAnnotationHandler {
 
         @Nullable
         @Override
-        public Object getValue() {
+        public Object getUnprocessedValue() {
             return null;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -128,7 +128,7 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
 
         @Nullable
         @Override
-        public Object getValue() {
+        public Object getUnprocessedValue() {
             return valueSupplier.get();
         }
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/AbstractNestedRuntimeBeanNode.java
@@ -125,5 +125,11 @@ public abstract class AbstractNestedRuntimeBeanNode extends RuntimeBeanNode<Obje
             }
             return value;
         }
+
+        @Nullable
+        @Override
+        public Object getValue() {
+            return valueSupplier.get();
+        }
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
@@ -19,10 +19,10 @@ package org.gradle.api.internal.tasks.properties.bean;
 import com.google.common.annotations.VisibleForTesting;
 import org.codehaus.groovy.runtime.ConvertedClosure;
 import org.gradle.api.Task;
-import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.api.internal.tasks.properties.PropertyValue;
 import org.gradle.api.internal.tasks.properties.PropertyVisitor;
 import org.gradle.api.internal.tasks.properties.TypeMetadata;
+import org.gradle.internal.reflect.ParameterValidationContext;
 import org.gradle.util.ClosureBackedAction;
 import org.gradle.util.ConfigureUtil;
 
@@ -82,6 +82,11 @@ class NestedRuntimeBeanNode extends AbstractNestedRuntimeBeanNode {
 
         @Override
         public Object call() {
+            return getValue();
+        }
+
+        @Override
+        public Object getValue() {
             return beanClass;
         }
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/bean/NestedRuntimeBeanNode.java
@@ -82,11 +82,11 @@ class NestedRuntimeBeanNode extends AbstractNestedRuntimeBeanNode {
 
         @Override
         public Object call() {
-            return getValue();
+            return getUnprocessedValue();
         }
 
         @Override
-        public Object getValue() {
+        public Object getUnprocessedValue() {
             return beanClass;
         }
 


### PR DESCRIPTION
Optional inputs, which use `Provider`s, can now also be queried for incremental changes.