### PR TITLE
Deprecate old transforms API

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/dsl/DependencyHandler.java
@@ -440,9 +440,11 @@ public interface DependencyHandler {
     /**
      * Registers an artifact transform.
      *
+     * @deprecated use {@link #registerTransform(Class, Action)} instead.
      * @see org.gradle.api.artifacts.transform.ArtifactTransform
      * @since 3.5
      */
+    @Deprecated
     void registerTransform(Action<? super VariantTransform> registrationAction);
 
     /**

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ArtifactTransform.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/ArtifactTransform.java
@@ -28,8 +28,10 @@ import java.util.List;
  * <li>The objects provided to {@link org.gradle.api.ActionConfiguration#setParams(Object...)}.</li>
  * </ul>
  *
+ * @deprecated Use {@link TransformAction} instead.
  * @since 3.4
  */
+@Deprecated
 public abstract class ArtifactTransform {
     private File outputDirectory;
 

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/VariantTransform.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/VariantTransform.java
@@ -24,7 +24,9 @@ import org.gradle.api.attributes.AttributeContainer;
  * Registration of an variant transform.
  *
  * @since 3.5
+ * @deprecated Use {@link TransformSpec} instead.
  */
+@Deprecated
 public interface VariantTransform {
     /**
      * Attributes that match the variant that is consumed.

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationRegistrationFactory.java
@@ -137,6 +137,7 @@ public class DefaultTransformationRegistrationFactory implements TransformationR
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransform> implementation, Object[] params) {
         Transformer transformer = new LegacyTransformer(implementation, params, legacyActionInstantiationScheme, from, classLoaderHierarchyHasher, isolatableFactory);
         return new DefaultArtifactTransformRegistration(from, to, new TransformationStep(transformer, transformerInvoker, domainObjectProjectStateHandler, fileCollectionFingerprinterRegistry));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -143,6 +143,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
         }
     }
 
+    @SuppressWarnings("deprecation")
     @NonExtensible
     public static class UntypedRegistration extends RecordingRegistration implements VariantTransform {
         private Action<? super ActionConfiguration> configAction;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/LegacyTransformer.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
+@SuppressWarnings("deprecation")
 public class LegacyTransformer extends AbstractTransformer<ArtifactTransform> {
 
     private final Instantiator instantiator;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformation.java
@@ -24,7 +24,7 @@ import org.gradle.internal.Try;
 import javax.annotation.Nullable;
 
 /**
- * The internal API equivalent of {@link org.gradle.api.artifacts.transform.ArtifactTransform}, which is also aware of our cache infrastructure.
+ * The internal API equivalent of {@link org.gradle.api.artifacts.transform.TransformAction}, which is also aware of our cache infrastructure.
  *
  * This can encapsulate a single transformation step using a single transformer or a chain of transformation steps.
  */

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationRegistrationFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationRegistrationFactory.java
@@ -26,5 +26,6 @@ import javax.annotation.Nullable;
 
 public interface TransformationRegistrationFactory {
     ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends TransformAction> implementation, @Nullable TransformParameters parameterObject);
+    @SuppressWarnings("deprecation")
     ArtifactTransformRegistration create(ImmutableAttributes from, ImmutableAttributes to, Class<? extends ArtifactTransform> implementation, Object[] params);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/Transformer.java
@@ -18,7 +18,6 @@ package org.gradle.api.internal.artifacts.transform;
 
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Describable;
-import org.gradle.api.artifacts.transform.ArtifactTransform;
 import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.tasks.TaskDependencyContainer;
@@ -34,7 +33,7 @@ import java.io.File;
 /**
  * The actual code which needs to be executed to transform a file.
  *
- * This encapsulates the public interface {@link ArtifactTransform} into an internal type.
+ * This encapsulates the public interface {@link org.gradle.api.artifacts.transform.TransformAction} into an internal type.
  */
 public interface Transformer extends Describable, TaskDependencyContainer {
     Class<?> getImplementationClass();

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/ConsumerProvidedVariantFinderTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.api.internal.artifacts.transform
 import com.google.common.collect.ImmutableList
 import junit.framework.AssertionFailedError
 import org.gradle.api.Transformer
-import org.gradle.api.artifacts.transform.ArtifactTransform
 import org.gradle.api.attributes.Attribute
 import org.gradle.api.attributes.AttributeContainer
 import org.gradle.api.internal.artifacts.ArtifactTransformRegistration
@@ -47,14 +46,6 @@ class ConsumerProvidedVariantFinderTest extends Specification {
     def c1 = attributes().attribute(a1, "1").attribute(a2, 1).asImmutable()
     def c2 = attributes().attribute(a1, "1").attribute(a2, 2).asImmutable()
     def c3 = attributes().attribute(a1, "1").attribute(a2, 3).asImmutable()
-
-    static class Transform extends ArtifactTransform {
-        Transformer<List<File>, File> transformer
-
-        List<File> transform(File input) {
-            return transformer.transform(input)
-        }
-    }
 
     /**
      * Match all AttributeContainer that contains the same attributes.

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -17,7 +17,7 @@
 package org.gradle.api.internal.artifacts.transform
 
 import com.google.common.collect.ImmutableList
-import org.gradle.api.artifacts.transform.ArtifactTransform
+import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.internal.artifacts.DefaultBuildIdentifier
 import org.gradle.api.internal.artifacts.DefaultProjectComponentIdentifier
@@ -113,8 +113,8 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         }
 
         @Override
-        Class<? extends ArtifactTransform> getImplementationClass() {
-            return ArtifactTransform.class
+        Class<?> getImplementationClass() {
+            return TransformAction.class
         }
 
         @Override

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/AbstractGradleExecuter.java
@@ -1198,7 +1198,7 @@ public abstract class AbstractGradleExecuter implements GradleExecuter {
                     if (line.matches(".*use(s)? or override(s)? a deprecated API\\.")) {
                         // A javac warning, ignore
                         i++;
-                    } else if (line.matches("w: .* is deprecated\\..*")) {
+                    } else if (line.matches(".*w: .* is deprecated\\..*")) {
                         // A kotlinc warning, ignore
                         i++;
                     } else if (isDeprecationMessageInHelpDescription(line)) {


### PR DESCRIPTION
Only add `@Deprecated` for now. We will start nagging when the new API is used in more third party plugins.