### PR TITLE
Remove usage of `mavenLocal()` from `:integTest`

### DIFF
--- a/subprojects/integ-test/integ-test.gradle.kts
+++ b/subprojects/integ-test/integ-test.gradle.kts
@@ -6,10 +6,6 @@ plugins {
     gradlebuild.classycle
 }
 
-repositories {
-    mavenLocal()
-}
-
 dependencies {
     integTestCompile(library("groovy"))
     integTestCompile(library("ant"))


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
See https://github.com/gradle/gradle-private/issues/2027

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fremove-maven-local-repo)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
