### PR TITLE
Disable local cache in seed build

### DIFF
--- a/.teamcity/Gradle_Check/configurations/CompileAll.kt
+++ b/.teamcity/Gradle_Check/configurations/CompileAll.kt
@@ -23,7 +23,7 @@ class CompileAll(model: CIBuildModel, stage: Stage) : BaseGradleBuildType(model,
     applyDefaults(
         model,
         this,
-        "compileAllBuild -PignoreIncomingBuildReceipt=true",
+        "compileAllBuild -PignoreIncomingBuildReceipt=true -DdisableLocalCache=true",
         extraParameters = buildScanTag("CompileAll")
     )
 

--- a/gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts
+++ b/gradle/shared-with-buildSrc/build-cache-configuration.settings.gradle.kts
@@ -27,6 +27,7 @@ val remoteCacheUsername = System.getProperty("gradle.cache.remote.username", "")
 val remoteCachePassword = System.getProperty("gradle.cache.remote.password", "")
 
 val isRemoteBuildCacheEnabled = remoteCacheUrl != null && gradle.startParameter.isBuildCacheEnabled && !gradle.startParameter.isOffline
+val disableLocalCache = System.getProperty("disableLocalCache")?.toBoolean() ?: false
 if (isRemoteBuildCacheEnabled) {
     buildCache {
         remote(HttpBuildCache::class.java) {
@@ -38,6 +39,14 @@ if (isRemoteBuildCacheEnabled) {
                     password = remoteCachePassword
                 }
             }
+        }
+    }
+}
+
+if (disableLocalCache) {
+    buildCache {
+        local {
+            isEnabled = false
         }
     }
 }


### PR DESCRIPTION
### Context

See https://github.com/gradle/gradle-private/issues/2035

We want to disable local cache for the seed build so we can always get remote cache hit/store to delay the cache eviction.

Result: https://e.grdev.net/s/uew6bknty35p6/performance/buildCache#local-cache