### PR TITLE
Re-use scheduled transform result only when available

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/Node.java
@@ -90,6 +90,10 @@ public abstract class Node implements Comparable<Node> {
         return getNodeFailure() != null || getExecutionFailure() != null;
     }
 
+    public boolean isExecuted() {
+        return state == ExecutionState.EXECUTED;
+    }
+
     /**
      * Returns any error that happened during the execution of the node itself,
      * i.e. a task action has thrown an exception.

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -236,6 +236,73 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
         output.count("> Transform artifact lib2.jar (project :lib) with MakeGreenToRedThings") == 1
     }
 
+    def "executes transform immediately when required during task graph building"() {
+        buildFile << declareAttributes() << withJarTasks() << """
+            import org.gradle.api.artifacts.transform.TransformParameters
+
+            abstract class MakeGreen implements TransformAction<TransformParameters.None> {
+                @InputArtifact
+                abstract Provider<FileSystemLocation> getInputArtifact()
+                
+                @Override                
+                void transform(TransformOutputs outputs) {
+                    outputs.file(inputArtifact.get().asFile.name + ".green").text = "very green"
+                }
+            }
+
+            project(':util') {
+                dependencies {
+                    compile project(':lib')
+                }
+            }
+    
+            project(':app') {
+                dependencies {
+                    compile project(':util')
+                    
+                    registerTransform(MakeGreen) {
+                        from.attribute(artifactType, 'jar')
+                        to.attribute(artifactType, 'green')
+                    }                    
+                }
+                configurations {
+                    green {
+                        extendsFrom(compile)
+                        canBeResolved = true
+                        canBeConsumed = false
+                        attributes {
+                            attribute(artifactType, 'green')
+                        }
+                    }
+                }
+            
+                tasks.register("resolveAtConfigurationTime").configure {
+                    inputs.files(configurations.green)
+                    configurations.green.each { println it }
+                    doLast { }                    
+                }
+                tasks.register("declareTransformAsInput").configure {
+                    inputs.files(configurations.green)
+                    doLast {
+                        configurations.green.each { println it }
+                    }
+                }
+                
+                tasks.register("withDependency").configure {
+                    dependsOn("resolveAtConfigurationTime")
+                }
+                tasks.register("toBeFinalized").configure {
+                    // We require the task via a finalizer, so the transform node is in UNKNOWN state.
+                    finalizedBy("declareTransformAsInput")
+                }
+            }
+        """
+
+        expect:
+        fails(":app:toBeFinalized", "withDependency")
+        failure.assertHasCause("Transformation MakeGreen has been scheduled and is now required, but did not execute, yet.")
+    }
+
     def "each file is transformed once per set of configuration parameters"() {
         given:
         buildFile << declareAttributes() << withJarTasks() << withLibJarDependency("lib3.jar") << """
@@ -1525,7 +1592,7 @@ ${getFileSizerBody(fileValue, 'outputs.dir(', 'outputs.file(')}
                         }
                     }
                 }
-                task resolve(type: Resolve) {
+                tasks.register("resolve", Resolve) {
                     artifacts = configurations.compile.incoming.artifactView {
                         attributes { it.attribute(artifactType, 'size') }
                     }.artifacts

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -298,9 +298,11 @@ class ArtifactTransformCachingIntegrationTest extends AbstractHttpDependencyReso
             }
         """
 
-        expect:
-        fails(":app:toBeFinalized", "withDependency")
-        failure.assertHasCause("Transformation MakeGreen has been scheduled and is now required, but did not execute, yet.")
+        when:
+        run(":app:toBeFinalized", "withDependency", "--info")
+        then:
+        output.count("Transforming artifact lib1.jar (project :lib) with MakeGreen") == 2
+        output.count("Transforming artifact lib2.jar (project :lib) with MakeGreen") == 2
     }
 
     def "each file is transformed once per set of configuration parameters"() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -222,7 +222,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 }
 
                 @Override
-                public Optional<TransformationNode> getExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+                public Optional<TransformationNode> getIfExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
                     return Optional.empty();
                 }
             };

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -222,7 +222,7 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 }
 
                 @Override
-                public Optional<TransformationNode> getCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+                public Optional<TransformationNode> getExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
                     return Optional.empty();
                 }
             };

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeRegistry.java
@@ -45,7 +45,7 @@ public class DefaultTransformationNodeRegistry implements TransformationNodeRegi
     }
 
     @Override
-    public Optional<TransformationNode> getExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+    public Optional<TransformationNode> getIfExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
         List<Equivalence.Wrapper<TransformationStep>> transformationChain = unpackTransformation(transformation);
         ArtifactTransformKey transformKey = new ArtifactTransformKey(artifactId, transformationChain);
         TransformationNode node = transformations.get(transformKey);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformationNodeRegistry.java
@@ -45,11 +45,11 @@ public class DefaultTransformationNodeRegistry implements TransformationNodeRegi
     }
 
     @Override
-    public Optional<TransformationNode> getCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
+    public Optional<TransformationNode> getExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation) {
         List<Equivalence.Wrapper<TransformationStep>> transformationChain = unpackTransformation(transformation);
         ArtifactTransformKey transformKey = new ArtifactTransformKey(artifactId, transformationChain);
         TransformationNode node = transformations.get(transformKey);
-        if (node != null && node.isComplete()) {
+        if (node != null && node.isExecuted()) {
             return Optional.of(node);
         }
         return Optional.empty();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeRegistry.java
@@ -25,5 +25,5 @@ import java.util.Optional;
 public interface TransformationNodeRegistry {
     Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ExecutionGraphDependenciesResolver dependenciesResolver);
 
-    Optional<TransformationNode> getCompleted(ComponentArtifactIdentifier artifactId, Transformation transformation);
+    Optional<TransformationNode> getExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationNodeRegistry.java
@@ -25,5 +25,5 @@ import java.util.Optional;
 public interface TransformationNodeRegistry {
     Collection<TransformationNode> getOrCreate(ResolvedArtifactSet artifactSet, Transformation transformation, ExecutionGraphDependenciesResolver dependenciesResolver);
 
-    Optional<TransformationNode> getExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation);
+    Optional<TransformationNode> getIfExecuted(ComponentArtifactIdentifier artifactId, Transformation transformation);
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -56,7 +56,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     @Override
     public void artifactAvailable(ResolvableArtifact artifact) {
         ComponentArtifactIdentifier artifactId = artifact.getId();
-        Optional<TransformationNode> node = transformationNodeRegistry.getExecuted(artifactId, transformation);
+        Optional<TransformationNode> node = transformationNodeRegistry.getIfExecuted(artifactId, transformation);
         if (node.isPresent()) {
             artifactResults.put(artifactId, new PrecomputedTransformationResult(node.get().getTransformedSubject()));
         } else {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -56,7 +56,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     @Override
     public void artifactAvailable(ResolvableArtifact artifact) {
         ComponentArtifactIdentifier artifactId = artifact.getId();
-        Optional<TransformationNode> node = transformationNodeRegistry.getCompleted(artifactId, transformation);
+        Optional<TransformationNode> node = transformationNodeRegistry.getExecuted(artifactId, transformation);
         if (node.isPresent()) {
             artifactResults.put(artifactId, new PrecomputedTransformationResult(node.get().getTransformedSubject()));
         } else {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -172,7 +172,7 @@ class DefaultArtifactTransformsTest extends Specification {
         }
         _ * transformation.getDisplayName() >> "transform"
         _ * transformation.requiresDependencies() >> false
-        _ * transformationNodeRegistry.getExecuted(_, _) >> Optional.empty()
+        _ * transformationNodeRegistry.getIfExecuted(_, _) >> Optional.empty()
 
         1 * transformation.transform({ it.files == [sourceArtifactFile]}, _ as ExecutionGraphDependenciesResolver, _) >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2)))
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -172,7 +172,7 @@ class DefaultArtifactTransformsTest extends Specification {
         }
         _ * transformation.getDisplayName() >> "transform"
         _ * transformation.requiresDependencies() >> false
-        _ * transformationNodeRegistry.getCompleted(_, _) >> Optional.empty()
+        _ * transformationNodeRegistry.getExecuted(_, _) >> Optional.empty()
 
         1 * transformation.transform({ it.files == [sourceArtifactFile]}, _ as ExecutionGraphDependenciesResolver, _) >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2)))
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -52,7 +52,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         listener.artifactAvailable(artifact)
 
         then:
-        1 * transformationNodeRegistry.getCompleted(artifactId, transformation) >> Optional.empty()
+        1 * transformationNodeRegistry.getExecuted(artifactId, transformation) >> Optional.empty()
         1 * transformation.transform({ it.files == [artifactFile] }, _ as ExecutionGraphDependenciesResolver, _)
     }
 
@@ -61,7 +61,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         listener.artifactAvailable(artifact)
 
         then:
-        1 * transformationNodeRegistry.getCompleted(artifactId, transformation) >> Optional.of(node)
+        1 * transformationNodeRegistry.getExecuted(artifactId, transformation) >> Optional.of(node)
         1 * node.getTransformedSubject() >> Try.successful(TransformationSubject.initial(artifact.id, artifact.file).createSubjectFromResult(ImmutableList.of()))
         0 * transformation.transform(_, _ as ExecutionGraphDependenciesResolver, _)
     }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -52,7 +52,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         listener.artifactAvailable(artifact)
 
         then:
-        1 * transformationNodeRegistry.getExecuted(artifactId, transformation) >> Optional.empty()
+        1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.empty()
         1 * transformation.transform({ it.files == [artifactFile] }, _ as ExecutionGraphDependenciesResolver, _)
     }
 
@@ -61,7 +61,7 @@ class TransformingAsyncArtifactListenerTest extends Specification {
         listener.artifactAvailable(artifact)
 
         then:
-        1 * transformationNodeRegistry.getExecuted(artifactId, transformation) >> Optional.of(node)
+        1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.of(node)
         1 * node.getTransformedSubject() >> Try.successful(TransformationSubject.initial(artifact.id, artifact.file).createSubjectFromResult(ImmutableList.of()))
         0 * transformation.transform(_, _ as ExecutionGraphDependenciesResolver, _)
     }


### PR DESCRIPTION
`Node.isComplete` returns true, even when the node has not been
executed. The result of a scheduled transform can only be re-used when
the transform actually executed.

This fixes a problem which has been discovered as part of #8895.