### PR TITLE
Deprecate using `File` as InputArtifact

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * Attached to a property that should receive the <em>input artifact</em> for an artifact transform. This is the artifact that the transform should be applied to.
  *
  * <p>
- *     The input artifact can be injected as a plain {@link File} or a {@link Provider}&lt;{@link org.gradle.api.file.FileSystemLocation}&gt;.
+ *     The input artifact can be injected as a {@link Provider}&lt;{@link org.gradle.api.file.FileSystemLocation}&gt;.
  * </p>
  *
  * @since 5.3

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformCachingIntegrationTest.groovy
@@ -1508,7 +1508,11 @@ ${getFileSizerBody(fileValue, 'new File(outputDirectory, ', 'new File(outputDire
                 }
 
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
+                
+                private File getInput() {
+                    inputArtifact.get().asFile
+                }
                 
                 void transform(TransformOutputs outputs) {
 ${getFileSizerBody(fileValue, 'outputs.dir(', 'outputs.file(')}

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformInputArtifactIntegrationTest.groovy
@@ -41,9 +41,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     assert input.file
                 }
@@ -77,9 +78,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact ${annotation}
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -190,9 +192,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
 
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact ${annotation}
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     if (input.exists()) {
                         println "processing \${input.name}"
                     } else {
@@ -320,9 +323,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     if (input.exists()) {
                         println "processing \${input.name}"
                     } else {
@@ -382,9 +386,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.text + ".green")
                     output.text = input.text + ".green"
@@ -421,9 +426,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.text + ".green")
                     output.text = input.text + ".green"
@@ -502,9 +508,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.list().length + ".green"
@@ -593,9 +600,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -675,9 +683,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.list().length + ".green"
@@ -764,9 +773,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.list().length + ".green"
@@ -866,9 +876,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.NONE)
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.text + ".green")
                     output.text = input.text + ".green"
@@ -952,9 +963,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @PathSensitive(PathSensitivity.${sensitivity})
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -1018,9 +1030,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact @${annotation}
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -1118,9 +1131,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             @CacheableTransform
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact @${annotation}
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"
@@ -1222,9 +1236,10 @@ class ArtifactTransformInputArtifactIntegrationTest extends AbstractDependencyRe
             
             abstract class MakeGreen implements TransformAction<TransformParameters.None> {
                 @InputArtifact @Classpath
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + ".green"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -807,7 +807,7 @@ $fileSizer
             
             abstract class IdentityTransform implements TransformAction<TransformParameters.None> {
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInput()
                 
                 void transform(TransformOutputs outputs) {
                     println("Transforming")
@@ -1668,11 +1668,11 @@ Found the following transforms:
 
             abstract class MyTransform implements TransformAction<TransformParameters.None> {
                 @InputArtifact
-                abstract File getInput() 
+                abstract Provider<FileSystemLocation> getInput() 
 
                 void transform(TransformOutputs outputs) {
                     println "Hello?"
-                    def output = outputs.${method}(new File(input, "some/dir/does-not-exist"))
+                    def output = outputs.${method}(new File(input.get().asFile, "some/dir/does-not-exist"))
                     assert !output.parentFile.directory
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIsolationIntegrationTest.groovy
@@ -93,13 +93,14 @@ class Resolve extends Copy {
                 }
 
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
 
                 CountRecorder() {
                     println "Creating CountRecorder"
                 }
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     def output = outputs.file(input.name + ".txt")
                     def counter = parameters.counter
                     println "Transforming \${input.name} to \${output.name}"

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -102,7 +102,7 @@ class ArtifactTransformValuesInjectionIntegrationTest extends AbstractDependency
 
         where:
         inputArtifactType              | convertToFile   | expectedDeprecation
-        'File'                         | ''              | 'Injecting the input artifact as a File has been deprecated. This is scheduled to be removed in Gradle 6.0. Declare the input artifact as Provider<FileSystemLocation> instead.'
+        'File'                         | ''              | 'Injecting the input artifact of a transform as a File has been deprecated. This is scheduled to be removed in Gradle 6.0. Declare the input artifact as Provider<FileSystemLocation> instead.'
         'Provider<FileSystemLocation>' | '.get().asFile' | null
     }
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithDependenciesIntegrationTest.groovy
@@ -112,9 +112,10 @@ abstract class TestTransform implements TransformAction<Parameters> {
     abstract FileCollection getInputArtifactDependencies()
 
     @InputArtifact
-    abstract File getInput()
+    abstract Provider<FileSystemLocation> getInputArtifact()
 
     void transform(TransformOutputs outputs) {
+        def input = inputArtifact.get().asFile
         println "\${parameters.transformName} received dependencies files \${inputArtifactDependencies*.name} for processing \${input.name}"
         assert inputArtifactDependencies.every { it.exists() }
 
@@ -129,9 +130,10 @@ abstract class TestTransform implements TransformAction<Parameters> {
 abstract class SimpleTransform implements TransformAction<TransformParameters.None> {
 
     @InputArtifact
-    abstract File getInput()
+    abstract Provider<FileSystemLocation> getInputArtifact()
 
     void transform(TransformOutputs outputs) {
+        def input = inputArtifact.get().asFile
         def output = outputs.file(input.name + ".txt")
         def workspace = output.parentFile
         assert workspace.directory && workspace.list().length == 0
@@ -420,9 +422,10 @@ abstract class NoneTransform implements TransformAction<TransformParameters.None
     abstract FileCollection getInputArtifactDependencies()
 
     @InputArtifact
-    abstract File getInput()
+    abstract Provider<FileSystemLocation> getInputArtifact()
 
     void transform(TransformOutputs outputs) {
+        def input = inputArtifact.get().asFile
         println "Single step transform received dependencies files \${inputArtifactDependencies*.name} for processing \${input.name}"
 
         def output = outputs.file(input.name + ".txt")
@@ -516,9 +519,10 @@ abstract class ClasspathTransform implements TransformAction<TransformParameters
     abstract FileCollection getInputArtifactDependencies()
 
     @InputArtifact
-    abstract File getInput()
+    abstract Provider<FileSystemLocation> getInputArtifact()
 
     void transform(TransformOutputs outputs) {
+        def input = inputArtifact.get().asFile
         println "Single step transform received dependencies files \${inputArtifactDependencies*.name} for processing \${input.name}"
 
         def output = outputs.file(input.name + ".txt")

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformWithFileInputsIntegrationTest.groovy
@@ -38,9 +38,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 }
             
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name} using \${parameters.someFiles*.name}"
                     def output = outputs.file(input.name + ".green")
                     def paramContent = parameters.someFiles.collect { it.file ? it.text : it.list().length }.join("")
@@ -153,9 +154,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
         buildFile << """
             abstract class MakeRed implements TransformAction<TransformParameters.None> {
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name} wit MakeRedAction"
                     def output = outputs.file(input.name + ".red")
                     output.text = "ok"
@@ -288,9 +290,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 }
             
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name} using \${parameters.someFile.get().asFile.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + parameters.someFile.get().asFile.text + ".green"
@@ -339,9 +342,10 @@ class ArtifactTransformWithFileInputsIntegrationTest extends AbstractDependencyR
                 }
             
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
                 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     println "processing \${input.name} using \${parameters.someDir.get().asFile.name}"
                     def output = outputs.file(input.name + ".green")
                     output.text = input.text + parameters.someDir.get().asFile.list().length + ".green"

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -62,6 +62,7 @@ import org.gradle.internal.service.UnknownServiceException;
 import org.gradle.internal.snapshot.ValueSnapshot;
 import org.gradle.internal.snapshot.ValueSnapshotter;
 import org.gradle.model.internal.type.ModelType;
+import org.gradle.util.DeprecationLogger;
 import org.gradle.work.InputChanges;
 
 import javax.annotation.Nullable;
@@ -299,7 +300,10 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
 
         public TransformServiceLookup(Provider<FileSystemLocation> inputFileProvider, @Nullable TransformParameters parameters, @Nullable ArtifactTransformDependencies artifactTransformDependencies, @Nullable InputChanges inputChanges) {
             ImmutableList.Builder<InjectionPoint> builder = ImmutableList.builder();
-            builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, File.class, () -> inputFileProvider.get().getAsFile()));
+            builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, File.class, () -> {
+                DeprecationLogger.nagUserOfDeprecated("Injecting the input artifact as a File", "Declare the input artifact as Provider<FileSystemLocation> instead.");
+                return inputFileProvider.get().getAsFile();
+            }));
             builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, FILE_SYSTEM_LOCATION_PROVIDER, () -> inputFileProvider));
             if (parameters != null) {
                 builder.add(InjectionPoint.injectedByType(parameters.getClass(), () -> parameters));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -301,7 +301,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
         public TransformServiceLookup(Provider<FileSystemLocation> inputFileProvider, @Nullable TransformParameters parameters, @Nullable ArtifactTransformDependencies artifactTransformDependencies, @Nullable InputChanges inputChanges) {
             ImmutableList.Builder<InjectionPoint> builder = ImmutableList.builder();
             builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, File.class, () -> {
-                DeprecationLogger.nagUserOfDeprecated("Injecting the input artifact as a File", "Declare the input artifact as Provider<FileSystemLocation> instead.");
+                DeprecationLogger.nagUserOfDeprecated("Injecting the input artifact of a transform as a File", "Declare the input artifact as Provider<FileSystemLocation> instead.");
                 return inputFileProvider.get().getAsFile();
             }));
             builder.add(InjectionPoint.injectedByAnnotation(InputArtifact.class, FILE_SYSTEM_LOCATION_PROVIDER, () -> inputFileProvider));

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/UnzipTransform.java
@@ -22,6 +22,8 @@ import org.gradle.api.artifacts.transform.InputArtifact;
 import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformOutputs;
 import org.gradle.api.artifacts.transform.TransformParameters;
+import org.gradle.api.file.FileSystemLocation;
+import org.gradle.api.provider.Provider;
 import org.gradle.internal.UncheckedException;
 
 import java.io.BufferedInputStream;
@@ -42,14 +44,15 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
 public interface UnzipTransform extends TransformAction<TransformParameters.None> {
 
     @InputArtifact
-    File getZippedFile();
+    Provider<FileSystemLocation> getZippedFile();
 
     @Override
     default void transform(TransformOutputs outputs) {
-        String unzippedDirName = removeExtension(getZippedFile().getName());
+        File zippedFile = getZippedFile().get().getAsFile();
+        String unzippedDirName = removeExtension(zippedFile.getName());
         File unzipDir = outputs.dir(unzippedDirName);
         try {
-            unzipTo(getZippedFile(), unzipDir);
+            unzipTo(zippedFile, unzipDir);
         } catch (IOException e) {
             throw UncheckedException.throwAsUncheckedException(e);
         }

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/FindGradleSources.kt
@@ -20,6 +20,8 @@ import org.gradle.api.artifacts.transform.InputArtifact
 import org.gradle.api.artifacts.transform.TransformAction
 import org.gradle.api.artifacts.transform.TransformOutputs
 import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.kotlin.dsl.support.unzipTo
@@ -33,7 +35,7 @@ import java.io.File
  */
 abstract class FindGradleSources : TransformAction<TransformParameters.None> {
     @get:InputArtifact
-    abstract val input: File
+    abstract val input: Provider<FileSystemLocation>
 
     override fun transform(outputs: TransformOutputs) {
         registerSourceDirectories(outputs)
@@ -56,16 +58,16 @@ abstract class FindGradleSources : TransformAction<TransformParameters.None> {
 
     private
     fun unzippedDistroDir(): File? =
-        input.listFiles().singleOrNull()
+        input.get().asFile.listFiles().singleOrNull()
 }
 
 
 abstract class UnzipDistribution : TransformAction<TransformParameters.None> {
     @get:PathSensitive(PathSensitivity.NONE)
     @get:InputArtifact
-    abstract val input: File
+    abstract val input: Provider<FileSystemLocation>
 
     override fun transform(outputs: TransformOutputs) {
-        unzipTo(outputs.dir("unzipped-distribution"), input)
+        unzipTo(outputs.dir("unzipped-distribution"), input.get().asFile)
     }
 }

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/AbstractConsoleBuildPhaseFunctionalTest.groovy
@@ -314,9 +314,10 @@ abstract class AbstractConsoleBuildPhaseFunctionalTest extends AbstractConsoleGr
                 @InputArtifactDependencies
                 abstract FileCollection getDependencies()
                 @InputArtifact
-                abstract File getInput()
+                abstract Provider<FileSystemLocation> getInputArtifact()
 
                 void transform(TransformOutputs outputs) {
+                    def input = inputArtifact.get().asFile
                     ${server.callFromBuild('size-transform')}
                     File output = outputs.registerOutput(input.name + parameters.suffix)
                     output.text = String.valueOf(input.length())

--- a/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
+++ b/subprojects/plugin-development/src/integTest/groovy/org/gradle/plugin/devel/tasks/ValidateTaskPropertiesIntegrationTest.groovy
@@ -640,6 +640,8 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
     def "can validate properties of an artifact transform action"() {
         file("src/main/java/MyTransformAction.java") << """
             import org.gradle.api.*;
+            import org.gradle.api.provider.*;
+            import org.gradle.api.file.*;
             import org.gradle.api.tasks.*;
             import org.gradle.api.artifacts.transform.*;
             import java.io.*;
@@ -665,7 +667,7 @@ class ValidateTaskPropertiesIntegrationTest extends AbstractIntegrationSpec {
 
                 // Valid because it is annotated
                 @InputArtifact
-                public abstract File getGoodInput();
+                public abstract Provider<FileSystemLocation> getGoodInput();
 
                 // Invalid because it has no annotation
                 public long getBadTime() {


### PR DESCRIPTION
Only `Provider`s can be queried for incremental inputs, so let's only allow `Provider<FileSystemLocation>` as input artifact for artifact transforms.