### PR TITLE
Add documentation for InputChanges

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
@@ -55,7 +55,7 @@ import org.gradle.api.provider.Provider;
  *
  * <p>
  * In the case where Gradle is unable to determine which input files need to be reprocessed, then all of the input files will be reported as {@link ChangeType#ADDED}.
- * In that case, the output files of the work are removed prior to executing the work action.
+ * When such a full rebuild happens, the output files of the work are removed prior to executing the work action.
  * Cases where this occurs include:
  * <ul>
  *     <li>There is no history available from a previous execution.</li>

--- a/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/InputChanges.java
@@ -30,26 +30,22 @@ import org.gradle.api.provider.Provider;
  *
  * <pre class='autoTested'>
  * abstract class IncrementalReverseTask extends DefaultTask {
+ *     {@literal @}Incremental
  *     {@literal @}InputDirectory
  *     abstract DirectoryProperty getInputDir()
  *
  *     {@literal @}OutputDirectory
- *     def File outputDir
+ *     abstract DirectoryProperty getOutputDir()
  *
  *     {@literal @}TaskAction
  *     void execute(InputChanges inputChanges) {
- *         if (!inputChanges.incremental) {
- *             project.delete(outputDir.listFiles())
- *         }
- *
  *         inputChanges.getFileChanges(inputDir).each { change -&gt;
+ *             if (change.fileType == FileType.DIRECTORY) return
+ *
+ *             def targetFile = outputDir.file(change.normalizedPath).get().asFile
  *             if (change.changeType == ChangeType.REMOVED) {
- *                 def targetFile = project.file("$outputDir/${change.file.name}")
- *                 if (targetFile.exists()) {
- *                     targetFile.delete()
- *                 }
+ *                 targetFile.delete()
  *             } else {
- *                 def targetFile = project.file("$outputDir/${change.file.name}")
  *                 targetFile.text = change.file.text.reverse()
  *             }
  *         }
@@ -59,6 +55,7 @@ import org.gradle.api.provider.Provider;
  *
  * <p>
  * In the case where Gradle is unable to determine which input files need to be reprocessed, then all of the input files will be reported as {@link ChangeType#ADDED}.
+ * In that case, the output files of the work are removed prior to executing the work action.
  * Cases where this occurs include:
  * <ul>
  *     <li>There is no history available from a previous execution.</li>

--- a/subprojects/docs/src/docs/dsl/dsl.xml
+++ b/subprojects/docs/src/docs/dsl/dsl.xml
@@ -160,9 +160,6 @@
                 <td>org.gradle.api.file.SourceDirectorySet</td>
             </tr>
             <tr>
-                <td>org.gradle.api.tasks.incremental.IncrementalTaskInputs</td>
-            </tr>
-            <tr>
                 <td>org.gradle.api.artifacts.Configuration</td>
             </tr>
             <tr>
@@ -197,6 +194,9 @@
             </tr>
             <tr>
                 <td>org.gradle.api.resources.TextResourceFactory</td>
+            </tr>
+            <tr>
+                <td>org.gradle.work.InputChanges</td>
             </tr>
         </table>
     </section>

--- a/subprojects/docs/src/docs/dsl/dsl.xml
+++ b/subprojects/docs/src/docs/dsl/dsl.xml
@@ -160,6 +160,9 @@
                 <td>org.gradle.api.file.SourceDirectorySet</td>
             </tr>
             <tr>
+                <td>org.gradle.api.tasks.incremental.IncrementalTaskInputs</td>
+            </tr>
+            <tr>
                 <td>org.gradle.api.artifacts.Configuration</td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/dsl/org.gradle.work.InputChanges.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.work.InputChanges.xml
@@ -1,0 +1,40 @@
+<!--
+  ~ Copyright 2019 the original author or authors.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<section>
+    <section>
+        <title>Properties</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr><td>incremental</td></tr>
+        </table>
+    </section>
+    <section>
+        <title>Methods</title>
+        <table>
+            <thead>
+                <tr>
+                    <td>Name</td>
+                </tr>
+            </thead>
+            <tr><td>getFileChanges</td></tr>
+        </table>
+    </section>
+</section>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -1,6 +1,6 @@
 The Gradle team is excited to announce Gradle @version@.
 
-This release features a [new API for Incremental Changes](#incremental-changes-api), updates to [building native software with Gradle](#native-support), [Swift 5 Support](#swift5-support), [running Gradle on JDK12](#jdk12-support) and more.
+This release features a [new API for Incremental Tasks](#incremental-tasks-api), updates to [building native software with Gradle](#native-support), [Swift 5 Support](#swift5-support), [running Gradle on JDK12](#jdk12-support) and more.
 
 Read the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html) to learn about breaking changes and considerations for upgrading from Gradle 5.0.
 If upgrading from Gradle 4.x, please read [upgrading from Gradle 4.x to 5.0](userguide/upgrading_version_4.html) first.
@@ -21,11 +21,19 @@ Switch your build to use Gradle @version@ by updating your wrapper properties:
 
 `./gradlew wrapper --gradle-version=@version@`
 
-<a name="incremental-changes-api"/>
+<a name="incremental-tasks-api"/>
 
-## New API for Incremental Changes
+## New API for Incremental Tasks
 
-The new [`org.gradle.work.InputChanges`](dsl/org.gradle.work.InputChanges.html) API allows querying for changes to individual input file properties.
+With Gradle, it's very simple to implement a task that is skipped when all of its inputs and outputs are up to date (see [Incremental Builds](userguide/more_about_tasks.html#sec:up_to_date_checks)).
+However, there are times when only a few input files have changed since the last execution, and you'd like to avoid reprocessing all of the unchanged inputs.
+Tasks only reprocessing out-of-date input files are called _incremental tasks_.
+Up to Gradle 5.4, for implementing an incremental task you would use [`IncrementalTaskInputs`](dsl/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html).
+
+Now you can use the new [`InputChanges`](dsl/org.gradle.work.InputChanges.html) API for implementing incremental tasks.
+This API addresses some shortcomings of the old API, first and foremost that it is now possible to query for changes of individual input file properties, instead of receiving the changes for all input file properties at once.
+Additionally, the file type and the normalized path can be queried for each change, and the old outputs of the task are automatically removed on non-incremental execution.
+
 See the [userguide section](userguide/custom_tasks.html#incremental_tasks) for more information on how to implement incremental tasks using the new API.
 
 ```

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -26,7 +26,7 @@ Switch your build to use Gradle @version@ by updating your wrapper properties:
 ## New API for Incremental Changes
 
 The new [`org.gradle.work.InputChanges`](dsl/org.gradle.work.InputChanges.html) API allows querying for changes to individual input file properties.
-See the [userguide section](userguide/custom_tasks.html#incremental_tasks) for more information how to implement incremental tasks using the new API.
+See the [userguide section](userguide/custom_tasks.html#incremental_tasks) for more information on how to implement incremental tasks using the new API.
 
 ```kotlin
 inputChanges.getFileChanges(inputDir).forEach { change ->

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -28,7 +28,7 @@ Switch your build to use Gradle @version@ by updating your wrapper properties:
 The new [`org.gradle.work.InputChanges`](dsl/org.gradle.work.InputChanges.html) API allows querying for changes to individual input file properties.
 See the [userguide section](userguide/custom_tasks.html#incremental_tasks) for more information on how to implement incremental tasks using the new API.
 
-```kotlin
+```
 inputChanges.getFileChanges(inputDir).forEach { change ->
     val targetFile = outputDir.file(change.normalizedPath).get().asFile
     if (change.changeType == ChangeType.REMOVED) {

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -140,6 +140,7 @@ If you'd like to optimize your build so that only out-of-date input files are re
 ====
 There is the link:{javadocPath}/org/gradle/api/tasks/incremental/IncrementalTaskInputs.html[IncrementalTaskInputs] API, which is available in Gradle versions before 5.4.
 The usage of this API is discouraged, since it does not allow querying individual input properties for changes.
+The `IncrementalTaskInputs` API will be deprecated an eventually removed.
 If you need to use the old API, have a look at the documentation in the link:https://docs.gradle.org/5.3.1/userguide/custom_tasks.html#incremental_tasks[userguide for Gradle 5.3.1].
 ====
 

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -134,11 +134,11 @@ include::{samplesPath}/customPlugin/groovy/plugin/src/test/groovy/org/gradle/Gre
 
 With Gradle, it's very simple to implement a task that is skipped when all of its inputs and outputs are up to date (see <<more_about_tasks.adoc#sec:up_to_date_checks,Incremental Builds>>). However, there are times when only a few input files have changed since the last execution, and you'd like to avoid reprocessing all of the unchanged inputs. This can be particularly useful for a transformer task, that converts input files to output files on a 1:1 basis.
 
-If you'd like to optimize your build so that only out-of-date inputs are processed, you can do so with an _incremental task_.
+If you'd like to optimize your build so that only out-of-date input files are reprocessed, you can do so with an _incremental task_.
 
 [NOTE]
 ====
-There is the link:{javadocPath}/org/gradle/api/tasks/incremental/IncrementalTaskInputs.html[IncrementalTaskInputs] API, which is available in Gradle versions smaller than 5.4.
+There is the link:{javadocPath}/org/gradle/api/tasks/incremental/IncrementalTaskInputs.html[IncrementalTaskInputs] API, which is available in Gradle versions before 5.4.
 The usage of this API is discouraged, since it does not allow querying individual input properties for changes.
 If you need to use the old API, have a look at the documentation in the link:https://docs.gradle.org/5.3.1/userguide/custom_tasks.html#incremental_tasks[userguide for Gradle 5.3.1].
 ====
@@ -152,9 +152,9 @@ Moreover, the task needs to declare at least one incremental file input property
 
 [IMPORTANT]
 ====
-For being able to query incremental changes for an input property, the getter of that property always needs to return the same value.
+To query incremental changes for an input file property, the getter of that property always needs to return the same instance.
 The easiest way to accomplish this is to use `link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty]`, `link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]` or `link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[ConfigurableFileCollection]` as type of the property.
-See the chapter on <<lazy_configuration.adoc#lazy_configuration,lazy configuration>>, especially the sections about <<lazy_configuration.adoc#sec:lazy_properties,using read-only and configurable properties>> and <<lazy_configuration.adoc#sec:working_with_files_in_lazy_properties,lazy file properties>>.
+See also the chapter on <<lazy_configuration.adoc#lazy_configuration,lazy configuration>>, especially the sections about <<lazy_configuration.adoc#sec:lazy_properties,using read-only and configurable properties>> and <<lazy_configuration.adoc#sec:working_with_files_in_lazy_properties,lazy file properties>>.
 ====
 
 The incremental task action can then query for file changes for an input file parameter via `link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges]`.
@@ -196,7 +196,7 @@ However, there are many cases where Gradle is unable to determine which input fi
 * A non-incremental input file property has changed since the previous execution.
 * One or more output files have changed since the previous execution.
 
-In any of these cases, Gradle will consider all of the input files to be `added`.
+In any of these cases, Gradle will report all input files as `ADDED`.
 The link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges] method will return details for all files for the given input property.
 
 You can check if Gradle was able to determine the incremental changes to input files with link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges.html##org.gradle.work.InputChanges:incremental[InputChanges.isIncremental()].
@@ -299,7 +299,7 @@ include::{samplesPath}/userguide/tasks/incrementalTask/incrementalTaskChangedPro
 [[sec:storing_incremental_task_state]]
 === Storing incremental state for cached tasks
 
-Using Gradle's `InputChanges` is not the only way to create tasks that only works on changes since the last execution.
+Using Gradle's `InputChanges` is not the only way to create tasks that only work on changes since the last execution.
 Tools like the Kotlin compiler provide incrementality as a built-in feature.
 The way this is typically implemented is that the tool stores some analysis data about the state of the previous execution in some file.
 If such state files are <<build_cache.adoc#sec:task_output_caching_inputs,relocatable>>, then they can be declared as outputs of the task.

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -132,7 +132,9 @@ include::{samplesPath}/customPlugin/groovy/plugin/src/test/groovy/org/gradle/Gre
 [[incremental_tasks]]
 == Incremental tasks
 
-With Gradle, it's very simple to implement a task that is skipped when all of its inputs and outputs are up to date (see <<more_about_tasks.adoc#sec:up_to_date_checks,Incremental Builds>>). However, there are times when only a few input files have changed since the last execution, and you'd like to avoid reprocessing all of the unchanged inputs. This can be particularly useful for a transformer task, that converts input files to output files on a 1:1 basis.
+With Gradle, it's very simple to implement a task that is skipped when all of its inputs and outputs are up to date (see <<more_about_tasks.adoc#sec:up_to_date_checks,Incremental Builds>>).
+However, there are times when only a few input files have changed since the last execution, and you'd like to avoid reprocessing all of the unchanged inputs.
+This can be particularly useful for a transformer task, that converts input files to output files on a 1:1 basis.
 
 If you'd like to optimize your build so that only out-of-date input files are reprocessed, you can do so with an _incremental task_.
 

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -187,7 +187,7 @@ A task may only contain a single incremental task action.
 [[sec:which_inputs_are_considered_out_of_date]]
 === Which inputs are considered out of date?
 
-When Gradle has history of a previous task execution, and the only changes to the task execution context since that execution are to incremental input file properties, then Gradle is able to determine which input files need to be reprocessed by the task.
+When there is a previous execution of the task, and the only changes since that execution are to incremental input file properties, then Gradle is able to determine which input files need to be reprocessed by the task.
 In this case, the link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges] method returns details for all input files for the given property that were _added_, _modified_ or _removed_.
 
 However, there are many cases where Gradle is unable to determine which input files need to be reprocessed. Examples include:

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -134,15 +134,36 @@ include::{samplesPath}/customPlugin/groovy/plugin/src/test/groovy/org/gradle/Gre
 
 With Gradle, it's very simple to implement a task that is skipped when all of its inputs and outputs are up to date (see <<more_about_tasks.adoc#sec:up_to_date_checks,Incremental Builds>>). However, there are times when only a few input files have changed since the last execution, and you'd like to avoid reprocessing all of the unchanged inputs. This can be particularly useful for a transformer task, that converts input files to output files on a 1:1 basis.
 
-If you'd like to optimise your build so that only out-of-date inputs are processed, you can do so with an _incremental task_.
+If you'd like to optimize your build so that only out-of-date inputs are processed, you can do so with an _incremental task_.
 
+[NOTE]
+====
+There is the link:{javadocPath}/org/gradle/api/tasks/incremental/IncrementalTaskInputs.html[IncrementalTaskInputs] API, which is available in Gradle versions smaller than 5.4.
+The usage of this API is discouraged, since it does not allow querying individual input properties for changes.
+If you need to use the old API, have a look at the documentation in the link:https://docs.gradle.org/5.3.1/userguide/custom_tasks.html#incremental_tasks[userguide for Gradle 5.3.1].
+====
 
 [[sec:implementing_an_incremental_task]]
 === Implementing an incremental task
 
-For a task to process inputs incrementally, that task must contain an _incremental task action_. This is a task action method that contains a single link:{javadocPath}/org/gradle/api/tasks/incremental/IncrementalTaskInputs.html[IncrementalTaskInputs] parameter, which indicates to Gradle that the action will process the changed inputs only.
+For a task to process inputs incrementally, that task must contain an _incremental task action_.
+This is a task action method that contains a single link:{groovyDslPath}/org.gradle.work.InputChanges.html[InputChanges] parameter, which indicates to Gradle that the action will process the changed inputs only.
+Moreover, the task needs to declare at least one incremental file input property, by using either `@link:{javadocPath}/org/gradle/work/Incremental.html[Incremental]` or `@link:{javadocPath}/org/gradle/api/tasks/SkipWhenEmpty.html[SkipWhenEmpty]`.
 
-The incremental task action may supply an link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:outOfDate(org.gradle.api.Action)[IncrementalTaskInputs.outOfDate(org.gradle.api.Action)] action for processing any input file that is out-of-date, and a link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:removed(org.gradle.api.Action)[IncrementalTaskInputs.removed(org.gradle.api.Action)] action that executes for any input file that has been removed since the previous execution.
+[IMPORTANT]
+====
+For being able to query incremental changes for an input property, the getter of that property always needs to return the same value.
+The easiest way to accomplish this is to use `link:{javadocPath}/org/gradle/api/file/RegularFileProperty.html[RegularFileProperty]`, `link:{javadocPath}/org/gradle/api/file/DirectoryProperty.html[DirectoryProperty]` or `link:{javadocPath}/org/gradle/api/file/ConfigurableFileCollection.html[ConfigurableFileCollection]` as type of the property.
+See the chapter on <<lazy_configuration.adoc#lazy_configuration,lazy configuration>>, especially the sections about <<lazy_configuration.adoc#sec:lazy_properties,using read-only and configurable properties>> and <<lazy_configuration.adoc#sec:working_with_files_in_lazy_properties,lazy file properties>>.
+====
+
+The incremental task action can then query for file changes for an input file parameter via `link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges]`.
+The method returns an `Iterable` of `link:{javadocPath}/org/gradle/work/FileChange.html[FileChanges]`, which in turn can be queried for
+
+* the link:{javadocPath}/org/gradle/work/FileChange.html#getFile--[affected file],
+* the link:{javadocPath}/org/gradle/work/FileChange.html#getChangeType--[change type] (`ADDED`, `REMOVED` or `MODIFIED`),
+* the link:{javadocPath}/org/gradle/work/FileChange.html#getNormalizedPath--[normalized path] of the changed file,
+* the link:{javadocPath}/org/gradle/work/FileChange.html#getFileType--[file type] of the changed file.
 
 [[taskDefinition]]
 .Defining an incremental task action
@@ -153,7 +174,8 @@ include::sample[dir="userguide/tasks/incrementalTask/kotlin",files="build.gradle
 
 NOTE: The code for this example can be found at **`samples/userguide/tasks/incrementalTask`** in the ‘-all’ distribution of Gradle.
 
-If for some reason the task is not run incremental, e.g. by running with `--rerun-tasks`, only the outOfDate action is executed, even if there were deleted input files. You should consider handling this case at the beginning, as is done in the example above.
+If for some reason the task is executed non-incrementally, e.g. by running with `--rerun-tasks`, all files are reported as `ADDED`, no matter of the previous state.
+Gradle automatically removes the previous outputs, so the incremental task only needs to process the given files.
 
 For a simple transformer task like this, the task action simply needs to generate output files for any out-of-date inputs, and delete output files for any removed inputs.
 
@@ -162,7 +184,8 @@ A task may only contain a single incremental task action.
 [[sec:which_inputs_are_considered_out_of_date]]
 === Which inputs are considered out of date?
 
-When Gradle has history of a previous task execution, and the only changes to the task execution context since that execution are to input files, then Gradle is able to determine which input files need to be reprocessed by the task. In this case, the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:outOfDate(org.gradle.api.Action)[IncrementalTaskInputs.outOfDate(org.gradle.api.Action)] action will be executed for any input file that was _added_ or _modified_, and the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:removed(org.gradle.api.Action)[IncrementalTaskInputs.removed(org.gradle.api.Action)] action will be executed for any _removed_ input file.
+When Gradle has history of a previous task execution, and the only changes to the task execution context since that execution are to incremental input file properties, then Gradle is able to determine which input files need to be reprocessed by the task.
+In this case, the link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges] method returns details for all input files for the given property that were _added_, _modified_ or _removed_.
 
 However, there are many cases where Gradle is unable to determine which input files need to be reprocessed. Examples include:
 
@@ -170,18 +193,22 @@ However, there are many cases where Gradle is unable to determine which input fi
 * You are building with a different version of Gradle. Currently, Gradle does not use task history from a different version.
 * An `upToDateWhen` criteria added to the task returns `false`.
 * An input property has changed since the previous execution.
+* A non-incremental input file property has changed since the previous execution.
 * One or more output files have changed since the previous execution.
 
-In any of these cases, Gradle will consider all of the input files to be `outOfDate`. The link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:outOfDate(org.gradle.api.Action)[IncrementalTaskInputs.outOfDate(org.gradle.api.Action)] action will be executed for every input file, and the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:removed(org.gradle.api.Action)[IncrementalTaskInputs.removed(org.gradle.api.Action)] action will not be executed at all.
+In any of these cases, Gradle will consider all of the input files to be `added`.
+The link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges] method will return details for all files for the given input property.
 
-You can check if Gradle was able to determine the incremental changes to input files with link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:incremental[IncrementalTaskInputs.isIncremental()].
+You can check if Gradle was able to determine the incremental changes to input files with link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges.html##org.gradle.work.InputChanges:incremental[InputChanges.isIncremental()].
 
 [[sec:an_incremental_task_in_action]]
 === An incremental task in action
 
-Given the incremental task implementation <<#taskDefinition,above>>, we can explore the various change scenarios by example. Note that the various mutation tasks ('updateInputs', 'removeInput', etc) are only present for demonstration purposes: these would not normally be part of your build script.
+Given the incremental task implementation <<#taskDefinition,above>>, we can explore the various change scenarios by example.
+Note that the various mutation tasks ('updateInputs', 'removeInput', etc) are only present for demonstration purposes: these would not normally be part of your build script.
 
-First, consider the `IncrementalReverseTask` executed against a set of inputs for the first time. In this case, all inputs will be considered “out of date”:
+First, consider the `IncrementalReverseTask` executed against a set of inputs for the first time.
+In this case, all inputs will be considered added:
 
 .Running the incremental task for the first time
 ====
@@ -215,7 +242,7 @@ Naturally when the task is executed again with no changes, then the entire task 
 include::{samplesPath}/userguide/tasks/incrementalTask/incrementalTaskNoChange.out[]
 ----
 
-When an input file is modified in some way or a new input file is added, then re-executing the task results in those files being reported to link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:outOfDate(org.gradle.api.Action)[IncrementalTaskInputs.outOfDate(org.gradle.api.Action)]:
+When an input file is modified in some way or a new input file is added, then re-executing the task results in those files being returned by link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges]:
 
 .Running the incremental task with updated input files
 ====
@@ -229,7 +256,7 @@ include::sample[dir="userguide/tasks/incrementalTask/kotlin",files="build.gradle
 include::{samplesPath}/userguide/tasks/incrementalTask/incrementalTaskUpdatedInputs.out[]
 ----
 
-When an existing input file is removed, then re-executing the task results in that file being reported to link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:removed(org.gradle.api.Action)[IncrementalTaskInputs.removed(org.gradle.api.Action)]:
+When an existing input file is removed, then re-executing the task results in that file being returned by link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges] as `REMOVED`:
 
 .Running the incremental task with an input file removed
 ====
@@ -243,7 +270,8 @@ include::sample[dir="userguide/tasks/incrementalTask/kotlin",files="build.gradle
 include::{samplesPath}/userguide/tasks/incrementalTask/incrementalTaskRemovedInput.out[]
 ----
 
-When an output file is deleted (or modified), then Gradle is unable to determine which input files are out of date. In this case, _all_ input files are reported to the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:outOfDate(org.gradle.api.Action)[IncrementalTaskInputs.outOfDate(org.gradle.api.Action)] action, and no input files are reported to the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:removed(org.gradle.api.Action)[IncrementalTaskInputs.removed(org.gradle.api.Action)] action:
+When an output file is deleted (or modified), then Gradle is unable to determine which input files are out of date.
+In this case, details for _all_ input files for the given property are returned by link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges]:
 
 .Running the incremental task with an output file removed
 ====
@@ -257,7 +285,8 @@ include::sample[dir="userguide/tasks/incrementalTask/kotlin",files="build.gradle
 include::{samplesPath}/userguide/tasks/incrementalTask/incrementalTaskRemovedOutput.out[]
 ----
 
-When a task input property is modified, Gradle is unable to determine how this property impacted the task outputs, so all input files are assumed to be out of date. So similar to the changed output file example, _all_ input files are reported to the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:outOfDate(org.gradle.api.Action)[IncrementalTaskInputs.outOfDate(org.gradle.api.Action)] action, and no input files are reported to the link:{groovyDslPath}/org.gradle.api.tasks.incremental.IncrementalTaskInputs.html#org.gradle.api.tasks.incremental.IncrementalTaskInputs:removed(org.gradle.api.Action)[IncrementalTaskInputs.removed(org.gradle.api.Action)] action:
+When a task input property is modified, Gradle is unable to determine how this property impacted the task outputs, so the task is executed non-incrementally.
+So similar to the changed output file example, details for _all_ input files for the given property are returned by link:{groovyDslPath}/org.gradle.work.InputChanges.html#org.gradle.work.InputChanges:getFileChanges(org.gradle.api.file.FileCollection)[InputChanges.getFileChanges]:
 
 === Example: Running the incremental task with an input property changed
 
@@ -270,9 +299,15 @@ include::{samplesPath}/userguide/tasks/incrementalTask/incrementalTaskChangedPro
 [[sec:storing_incremental_task_state]]
 === Storing incremental state for cached tasks
 
-Using Gradle's `IncrementalTaskInputs` is not the only way to create tasks that only works on changes since the last execution. Tools like the Kotlin compiler provide incrementality as a built-in feature. The way this is typically implemented is that the tool stores some analysis data about the state of the previous execution in some file. If such state files are <<build_cache.adoc#sec:task_output_caching_inputs,relocatable>>, then they can be declared as outputs of the task. This way when the task's results are loaded from cache, the next execution can already use the analysis data loaded from cache, too.
+Using Gradle's `InputChanges` is not the only way to create tasks that only works on changes since the last execution.
+Tools like the Kotlin compiler provide incrementality as a built-in feature.
+The way this is typically implemented is that the tool stores some analysis data about the state of the previous execution in some file.
+If such state files are <<build_cache.adoc#sec:task_output_caching_inputs,relocatable>>, then they can be declared as outputs of the task.
+This way when the task's results are loaded from cache, the next execution can already use the analysis data loaded from cache, too.
 
-However, if the state files are non-relocatable, then they can't be shared via the build cache. Indeed, when the task is loaded from cache, any such state files must be cleaned up to prevent stale state to confuse the tool during the next execution. Gradle can ensure such stale files are removed if they are declared via `task.localState.register()` or a property is marked with the `@LocalState` annotation.
+However, if the state files are non-relocatable, then they can't be shared via the build cache.
+Indeed, when the task is loaded from cache, any such state files must be cleaned up to prevent stale state to confuse the tool during the next execution.
+Gradle can ensure such stale files are removed if they are declared via `task.localState.register()` or a property is marked with the `@LocalState` annotation.
 
 [[sec:declaring_and_using_command_line_options]]
 == Declaring and Using Command Line Options

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/groovy/build.gradle
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/groovy/build.gradle
@@ -41,44 +41,38 @@ task incrementalReverse(type: IncrementalReverseTask) {
 // end::reverse[]
 
 // tag::incremental-task[]
-class IncrementalReverseTask extends DefaultTask {
+abstract class IncrementalReverseTask extends DefaultTask {
+    @Incremental
+    @PathSensitive(PathSensitivity.NAME_ONLY)
     @InputDirectory
-    def File inputDir
+    abstract DirectoryProperty getInputDir()
 
     @OutputDirectory
-    def File outputDir
+    abstract DirectoryProperty getOutputDir()
 
     @Input
-    def inputProperty
+    abstract Property<String> getInputProperty()
 
     @TaskAction
-    void execute(IncrementalTaskInputs inputs) {
-        println inputs.incremental ? 'CHANGED inputs considered out of date'
-                                   : 'ALL inputs considered out of date'
-        // tag::handle-non-incremental-inputs[]
-        if (!inputs.incremental)
-            project.delete(outputDir.listFiles())
-        // end::handle-non-incremental-inputs[]
+    void execute(InputChanges inputChanges) {
+        println(inputChanges.incremental
+            ? 'Executing incrementally'
+            : 'Executing non-incrementally'
+        )
 
-        // tag::out-of-date-inputs[]
-        inputs.outOfDate { change ->
-            if (change.file.directory) return
+        // tag::process-file-changes[]
+        inputChanges.getFileChanges(inputDir).each { change ->
+            if (change.fileType == FileType.DIRECTORY) return
 
-            println "out of date: ${change.file.name}"
-            def targetFile = new File(outputDir, change.file.name)
-            targetFile.text = change.file.text.reverse()
+            println "${change.changeType}: ${change.normalizedPath}"
+            def targetFile = outputDir.file(change.normalizedPath).get().asFile
+            if (change.changeType == ChangeType.REMOVED) {
+                targetFile.delete()
+            } else {
+                targetFile.text = change.file.text.reverse()
+            }
         }
-        // end::out-of-date-inputs[]
-
-        // tag::removed-inputs[]
-        inputs.removed { change ->
-            if (change.file.directory) return
-
-            println "removed: ${change.file.name}"
-            def targetFile = new File(outputDir, change.file.name)
-            targetFile.delete()
-        }
-        // end::removed-inputs[]
+        // end::process-file-changes[]
     }
 }
 // end::incremental-task[]

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskChangedProperty.out
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskChangedProperty.out
@@ -1,4 +1,4 @@
-ALL inputs considered out of date
-out of date: 1.txt
-out of date: 2.txt
-out of date: 3.txt
+Executing non-incrementally
+ADDED: 1.txt
+ADDED: 2.txt
+ADDED: 3.txt

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskFirstRun.out
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskFirstRun.out
@@ -1,4 +1,4 @@
-ALL inputs considered out of date
-out of date: 1.txt
-out of date: 2.txt
-out of date: 3.txt
+Executing non-incrementally
+ADDED: 1.txt
+ADDED: 2.txt
+ADDED: 3.txt

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskRemovedInput.out
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskRemovedInput.out
@@ -1,2 +1,2 @@
-CHANGED inputs considered out of date
-removed: 3.txt
+Executing incrementally
+REMOVED: 3.txt

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskRemovedOutput.out
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskRemovedOutput.out
@@ -1,4 +1,4 @@
-ALL inputs considered out of date
-out of date: 1.txt
-out of date: 2.txt
-out of date: 3.txt
+Executing non-incrementally
+ADDED: 1.txt
+ADDED: 2.txt
+ADDED: 3.txt

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskUpdatedInputs.out
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/incrementalTaskUpdatedInputs.out
@@ -1,3 +1,3 @@
-CHANGED inputs considered out of date
-out of date: 1.txt
-out of date: 4.txt
+Executing incrementally
+MODIFIED: 1.txt
+ADDED: 4.txt

--- a/subprojects/docs/src/samples/userguide/tasks/incrementalTask/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/userguide/tasks/incrementalTask/kotlin/build.gradle.kts
@@ -34,54 +34,45 @@ tasks.register("removeOutput") {
 
 // tag::reverse[]
 tasks.register<IncrementalReverseTask>("incrementalReverse") {
-    inputDir = file("inputs")
-    outputDir = file("$buildDir/outputs")
-    inputProperty = project.properties["taskInputProperty"] as String? ?: "original"
+    inputDir.set(file("inputs"))
+    outputDir.set(file("$buildDir/outputs"))
+    inputProperty.set(project.properties["taskInputProperty"] as String? ?: "original")
 }
 // end::reverse[]
 
 // tag::incremental-task[]
-open class IncrementalReverseTask : DefaultTask() {
-    @InputDirectory
-    lateinit var inputDir: File
+abstract class IncrementalReverseTask : DefaultTask() {
+    @get:Incremental
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    @get:InputDirectory
+    abstract val inputDir: DirectoryProperty
 
-    @OutputDirectory
-    lateinit var outputDir: File
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
 
-    @Input
-    lateinit var inputProperty: String
+    @get:Input
+    abstract val inputProperty: Property<String>
 
     @TaskAction
-    fun execute(inputs: IncrementalTaskInputs) {
+    fun execute(inputChanges: InputChanges) {
         println(
-            if (inputs.isIncremental) "CHANGED inputs considered out of date"
-            else "ALL inputs considered out of date"
+            if (inputChanges.isIncremental) "Executing incrementally"
+            else "Executing non-incrementally"
         )
-        // tag::handle-non-incremental-inputs[]
-        if (!inputs.isIncremental) {
-            project.delete(outputDir.listFiles())
+
+        // tag::process-changed-inputs[]
+        inputChanges.getFileChanges(inputDir).forEach { change ->
+            if (change.fileType == FileType.DIRECTORY) return@forEach
+
+            println("${change.changeType}: ${change.normalizedPath}")
+            val targetFile = outputDir.file(change.normalizedPath).get().asFile
+            if (change.changeType == ChangeType.REMOVED) {
+                targetFile.delete()
+            } else {
+                targetFile.writeText(change.file.readText().reversed())
+            }
         }
-        // end::handle-non-incremental-inputs[]
-
-        // tag::out-of-date-inputs[]
-        inputs.outOfDate {
-            if (file.isDirectory) return@outOfDate
-
-            println("out of date: ${file.name}")
-            val targetFile = File(outputDir, file.name)
-            targetFile.writeText(file.readText().reversed())
-        }
-        // end::out-of-date-inputs[]
-
-        // tag::removed-inputs[]
-        inputs.removed {
-            if (file.isDirectory) return@removed
-
-            println("removed: ${file.name}")
-            val targetFile = File(outputDir, file.name)
-            targetFile.delete()
-        }
-        // end::removed-inputs[]
+        // end::process-changed-inputs[]
     }
 }
 // end::incremental-task[]

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/samples/UserGuideSamplesIntegrationTest.groovy
@@ -62,10 +62,10 @@ class UserGuideSamplesIntegrationTest {
     To update a sample test, change the *.sample.conf file
 
      You can run all samples tests with
-        ./gradlew :integtest:integTest --tests "UserGuideSamplesIntegrationTest"
+        ./gradlew :integtest:integTest --tests "org.gradle.integtests.samples.UserGuideSamplesIntegrationTest"
 
      To run a subset of samples, use a more fine-grained test filter like
-        ./gradlew :integtest:integTest --tests "UserGuideSamplesIntegrationTest.*native*"
+        ./gradlew :integtest:integTest --tests "org.gradle.integtests.samples.UserGuideSamplesIntegrationTest.*native*"
     */
 
     // NOTE: This weirdness is here because GradleSamplesRunner does not support JUnit @Rule, @After or @Before.


### PR DESCRIPTION
This PR updates the userguide section on how to implement incremental tasks using the new `InputChanges` API.