### PR TITLE
Fix Gradle Module Metadata marker disappearing

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/xml/XmlTransformer.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/xml/XmlTransformer.java
@@ -15,6 +15,7 @@
  */
 package org.gradle.internal.xml;
 
+import com.google.common.collect.Lists;
 import groovy.lang.Closure;
 import groovy.util.IndentPrinter;
 import groovy.util.Node;
@@ -56,10 +57,15 @@ import java.util.List;
 
 public class XmlTransformer implements Transformer<String, String> {
     private final List<Action<? super XmlProvider>> actions = new ArrayList<Action<? super XmlProvider>>();
+    private final List<Action<? super XmlProvider>> finalizers = Lists.newArrayListWithExpectedSize(2);
     private String indentation = "  ";
 
     public void addAction(Action<? super XmlProvider> provider) {
         actions.add(provider);
+    }
+
+    public void addFinalizer(Action<? super XmlProvider> provider) {
+        finalizers.add(provider);
     }
 
     public void setIndentation(String indentation) {
@@ -144,6 +150,7 @@ public class XmlTransformer implements Transformer<String, String> {
 
     private XmlProviderImpl doTransform(XmlProviderImpl provider) {
         provider.apply(actions);
+        provider.apply(finalizers);
         return provider;
     }
 

--- a/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publish/maven/internal/tasks/MavenPomFileGenerator.java
@@ -107,7 +107,7 @@ public class MavenPomFileGenerator {
         model.setArtifactId(identity.getArtifactId().get());
         model.setVersion(identity.getVersion().get());
         if (gradleMetadataMarker) {
-            withXml(ADD_GRADLE_METADATA_MARKER);
+            xmlTransformer.addFinalizer(ADD_GRADLE_METADATA_MARKER);
         }
     }
 


### PR DESCRIPTION

### Context

This commit fixes an issue where using `withXml` would
erase the Gradle Module Metadata marker from generated
POM or IVY files.

This is fixed by having the marker being a finalizer,
rather than an initial step.
