### PR TITLE
Fix selection of target configuration with Ivy+constraints

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/attributes/DependenciesAttributesIntegrationTest.groovy
@@ -199,8 +199,7 @@ class DependenciesAttributesIntegrationTest extends AbstractModuleDependencyReso
         fails 'checkDeps'
 
         then:
-        failure.assertHasCause("""Module 'org:test' has been rejected:
-   Cannot select module with conflict on capability 'org:test:1.0' also provided by [org:test:1.0(api), org:test:1.0(runtime)]""")
+        failure.assertHasCause("""Inconsistency between attributes of a constraint and a dependency, on attribute 'custom' : dependency requires 'c1' while constraint required 'c2'""")
     }
 
     @RequiredFeatures(

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -66,12 +66,6 @@ class ModuleResolveState implements CandidateModule {
     private ComponentState selected;
     private ImmutableAttributes mergedConstraintAttributes = ImmutableAttributes.EMPTY;
 
-    // This field caches an arbitrary edge attributes, used when computing the attributes
-    // of selection of a constraint, in order to make sure we choose a "variant of the constraint"
-    // which is compatible with edges. In theory we shouldn't select a variant for constraints, but
-    // since they are represented as node states, it's required
-    private ImmutableAttributes nonConstraintAttributes = null;
-
     private AttributeMergingException attributeMergingError;
     private VirtualPlatformState platformState;
     private boolean overriddenSelection;
@@ -285,7 +279,6 @@ class ModuleResolveState implements CandidateModule {
     void removeSelector(SelectorState selector) {
         selectors.remove(selector);
         mergedConstraintAttributes = ImmutableAttributes.EMPTY;
-        nonConstraintAttributes = null;
         for (SelectorState selectorState : selectors) {
             mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selectorState);
         }
@@ -299,7 +292,7 @@ class ModuleResolveState implements CandidateModule {
         return unattachedDependencies;
     }
 
-    ImmutableAttributes mergedConstraintsAttributes(AttributeContainer append) {
+    ImmutableAttributes mergedConstraintsAttributes(AttributeContainer append) throws AttributeMergingException {
         if (attributeMergingError != null) {
             throw new IllegalStateException(IncompatibleDependencyAttributesMessageBuilder.buildMergeErrorMessage(this, attributeMergingError));
         }
@@ -307,28 +300,17 @@ class ModuleResolveState implements CandidateModule {
         if (mergedConstraintAttributes.isEmpty()) {
             return attributes;
         }
-        return attributesFactory.concat(mergedConstraintAttributes, attributes);
-    }
-
-    ImmutableAttributes mergeConstraintAttributesWithHardDependencyAttributes(ImmutableAttributes constraintAttributes) {
-        if (nonConstraintAttributes != null) {
-            return attributesFactory.concat(nonConstraintAttributes, constraintAttributes);
-        }
-        return constraintAttributes;
+        return attributesFactory.safeConcat(mergedConstraintAttributes.asImmutable(), attributes);
     }
 
     private ImmutableAttributes appendAttributes(ImmutableAttributes dependencyAttributes, SelectorState selectorState) {
         try {
             DependencyMetadata dependencyMetadata = selectorState.getDependencyMetadata();
             boolean constraint = dependencyMetadata.isConstraint();
-            if (nonConstraintAttributes == null && !constraint) {
-                nonConstraintAttributes = ((AttributeContainerInternal) selectorState.getRequested().getAttributes()).asImmutable();
-            } else {
-                if (constraint) {
-                    ComponentSelector selector = dependencyMetadata.getSelector();
-                    ImmutableAttributes attributes = ((AttributeContainerInternal) selector.getAttributes()).asImmutable();
-                    dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
-                }
+            if (constraint) {
+                ComponentSelector selector = dependencyMetadata.getSelector();
+                ImmutableAttributes attributes = ((AttributeContainerInternal) selector.getAttributes()).asImmutable();
+                dependencyAttributes = attributesFactory.safeConcat(attributes, dependencyAttributes);
             }
         } catch (AttributeMergingException e) {
             attributeMergingError = e;


### PR DESCRIPTION
### Context

This commit fixes an edge case when a dependency doesn't
use variant awareness, but rather an explicit target
configuration. In particular in the case of Ivy, the fact
of adding a constraint made the build fail with an error
stating that no matching configuration could be selected,
with the list of configurations and their attributes, but
no required attribute.

This case happened when the target module didn't provide
a "default" configuration.

Now we avoid selecting a configuration for constraint edges,
unless they are well known cases (virtual platforms). This
should have a positive impact on performance too.

