### PR TITLE
Introduce VersionMapping support for IvyPublication

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/AbstractIvyPublishIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/AbstractIvyPublishIntegTest.groovy
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.publish.ivy
+
+import org.gradle.integtests.fixtures.AbstractIntegrationSpec
+import org.gradle.integtests.fixtures.FeaturePreviewsFixture
+import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.test.fixtures.ArtifactResolutionExpectationSpec
+import org.gradle.test.fixtures.GradleMetadataAwarePublishingSpec
+import org.gradle.test.fixtures.ModuleArtifact
+import org.gradle.test.fixtures.SingleArtifactResolutionResultSpec
+import org.gradle.test.fixtures.ivy.IvyFileModule
+import org.gradle.test.fixtures.ivy.IvyJavaModule
+import org.gradle.test.fixtures.ivy.IvyModule
+
+
+abstract class AbstractIvyPublishIntegTest extends AbstractIntegrationSpec implements GradleMetadataAwarePublishingSpec {
+
+    def setup() {
+        prepare()
+    }
+
+    protected static IvyJavaModule javaLibrary(IvyFileModule ivyFileModule) {
+        return new IvyJavaModule(ivyFileModule)
+    }
+
+    void resolveArtifacts(Object dependencyNotation, @DelegatesTo(value = IvyArtifactResolutionExpectation, strategy = Closure.DELEGATE_FIRST) Closure<?> expectationSpec) {
+        IvyArtifactResolutionExpectation expectation = new IvyArtifactResolutionExpectation(dependencyNotation)
+        expectation.dependency = convertDependencyNotation(dependencyNotation)
+        expectationSpec.resolveStrategy = Closure.DELEGATE_FIRST
+        expectationSpec.delegate = expectation
+        expectationSpec()
+
+        expectation.validate()
+
+    }
+
+    void resolveApiArtifacts(IvyModule module, @DelegatesTo(value = IvyArtifactResolutionExpectation, strategy = Closure.DELEGATE_FIRST) Closure<?> expectationSpec) {
+        resolveArtifacts(module) {
+            variant = 'JAVA_API'
+            expectationSpec.delegate = delegate
+            expectationSpec()
+        }
+    }
+
+    void resolveRuntimeArtifacts(IvyModule module, @DelegatesTo(value = IvyArtifactResolutionExpectation, strategy = Closure.DELEGATE_FIRST) Closure<?> expectationSpec) {
+        resolveArtifacts(module) {
+            variant = 'JAVA_RUNTIME'
+            expectationSpec.delegate = delegate
+            expectationSpec()
+        }
+    }
+
+    private def doResolveArtifacts(ResolveParams params) {
+        // Replace the existing buildfile with one for resolving the published module
+        settingsFile.text = "rootProject.name = 'resolve'"
+        FeaturePreviewsFixture.enableGradleMetadata(settingsFile)
+        def attributes = params.variant == null ?
+            "" :
+            """ 
+    attributes {
+        attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.${params.variant}))
+    }
+"""
+        String extraArtifacts = ""
+        if (params.additionalArtifacts) {
+            String artifacts = params.additionalArtifacts.collect {
+                def tokens = it.ivyTokens
+                """
+                    artifact {
+                        name = '${sq(tokens.artifact)}'
+                        classifier = '${sq(tokens.classifier)}'
+                        type = '${sq(tokens.type)}'
+                    }"""
+            }.join('\n')
+            extraArtifacts = """
+                {
+                    transitive = false
+                    $artifacts
+                }
+            """
+        }
+
+        String dependencyNotation = params.dependency
+        if (params.classifier) {
+            dependencyNotation = "${dependencyNotation}, classifier: '${sq(params.classifier)}'"
+        }
+        if (params.ext) {
+            dependencyNotation = "${dependencyNotation}, ext: '${sq(params.ext)}'"
+        }
+
+        def optional = params.optionalFeatureCapabilities.collect {
+            "resolve($dependencyNotation) { capabilities { requireCapability('$it') } }"
+        }.join('\n')
+        buildFile.text = """import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport
+
+            apply plugin: 'java-base' // to get the standard Java library derivation strategy
+            configurations {
+                resolve {
+                    ${attributes}
+                }
+            }
+            repositories {
+                ivy { 
+                    url "${ivyRepo.uri}"
+                }
+            }
+
+            dependencies {
+               attributesSchema { 
+                getMatchingStrategy(Category.CATEGORY_ATTRIBUTE)
+                   .disambiguationRules
+                   .add(PlatformSupport.PreferRegularPlatform)
+               }
+               resolve($dependencyNotation) $extraArtifacts
+               $optional
+            }
+
+            task resolveArtifacts(type: Sync) {
+                outputs.upToDateWhen { false }
+                from configurations.resolve
+                into "artifacts"
+            }
+
+"""
+
+        if (params.expectFailure) {
+            fails("resolveArtifacts")
+            return failure
+        }
+        run("resolveArtifacts")
+        def artifactsList = file("artifacts").exists() ? file("artifacts").list() : []
+        return artifactsList.sort()
+    }
+
+    static class ResolveParams {
+        IvyModule module
+        String dependency
+        List<? extends ModuleArtifact> additionalArtifacts
+
+        String classifier
+        String ext
+        String variant
+        boolean resolveModuleMetadata = GradleMetadataResolveRunner.isExperimentalResolveBehaviorEnabled()
+        boolean expectFailure
+
+        List<String> optionalFeatureCapabilities = []
+    }
+
+    class IvyArtifactResolutionExpectation extends ResolveParams implements ArtifactResolutionExpectationSpec<IvyModule> {
+
+        IvyArtifactResolutionExpectation(Object dependencyNotation) {
+            if (dependencyNotation instanceof IvyModule) {
+                module = dependencyNotation
+            }
+            createSpecs()
+        }
+
+        IvyModule getModule() {
+            super.module
+        }
+
+        void validate() {
+            singleValidation(true, withModuleMetadataSpec)
+            singleValidation(false, withoutModuleMetadataSpec)
+        }
+
+        void singleValidation(boolean withModuleMetadata, SingleArtifactResolutionResultSpec expectationSpec) {
+            ResolveParams params = new ResolveParams(
+                module: module,
+                dependency: dependency,
+                classifier: classifier,
+                ext: ext,
+                additionalArtifacts: additionalArtifacts?.asImmutable(),
+                variant: variant,
+                resolveModuleMetadata: withModuleMetadata,
+                expectFailure: !expectationSpec.expectSuccess,
+                optionalFeatureCapabilities: optionalFeatureCapabilities,
+            )
+            println "Checking ${additionalArtifacts?'additional artifacts':'artifacts'} when resolving ${withModuleMetadata?'with':'without'} Gradle module metadata"
+            def resolutionResult = doResolveArtifacts(params)
+            expectationSpec.with {
+                if (expectSuccess) {
+                    assert resolutionResult == expectedFileNames
+                } else {
+                    failureExpectations.each {
+                        it.resolveStrategy = Closure.DELEGATE_FIRST
+                        it.delegate = resolutionResult
+                        it()
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.publish.ivy
+
+import org.gradle.test.fixtures.ivy.IvyJavaModule
+import spock.lang.Unroll
+
+class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTest  {
+    IvyJavaModule javaLibrary = javaLibrary(ivyRepo.module("org.gradle.test", "publishTest", "1.9"))
+
+    @Unroll("can publish java-library with dependencies (#apiMapping, #runtimeMapping)")
+    def "can publish java-library with dependencies (runtime last)"() {
+        given:
+        javaLibrary(ivyRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "foo", "1.1")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.1")).withModuleMetadata().publish()
+
+        createBuildScripts("""
+            dependencies {
+                api "org.test:foo:[1.0,1.0]"
+                runtimeOnly "org.test:bar:+"
+                runtimeOnly "org.test:foo:+"
+            }
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        versionMapping {
+                            $apiMapping
+                            $runtimeMapping
+                        }
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.assertPublished()
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            dependency("org.test:foo:1.0") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            dependency("org.test:foo:1.1") {
+                exists()
+            }
+            dependency("org.test:bar:1.1") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+
+        and:
+        resolveArtifacts(javaLibrary) {
+            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+        }
+
+        and:
+        resolveApiArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        and:
+        resolveRuntimeArtifacts(javaLibrary) {
+            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+        }
+
+        where:
+        [apiMapping, runtimeMapping] << ([
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)"), apiJarsUsingUsage(), apiJarsUsingUsage("fromResolutionOf('compileClasspath')"), apiJarsUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)"), runtimeJarsUsingUsage(), runtimeJarsUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeJarsUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+        ].combinations() + [[allVariants(), noop()]])
+    }
+
+    @Unroll("can publish java-library with dependencies (#runtimeMapping, #apiMapping)")
+    def "can publish java-library with dependencies (runtime first)"() {
+        given:
+        javaLibrary(ivyRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "foo", "1.1")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.1")).withModuleMetadata().publish()
+
+        createBuildScripts("""
+            dependencies {
+                api "org.test:foo:[1.0,1.0]"
+                runtimeOnly "org.test:bar:+"
+                runtimeOnly "org.test:foo:+"
+            }
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        versionMapping {
+                            $runtimeMapping
+                            $apiMapping
+                        }
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.assertPublished()
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            dependency("org.test:foo:1.0") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            dependency("org.test:foo:1.1") {
+                exists()
+            }
+            dependency("org.test:bar:1.1") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+
+        and:
+        resolveArtifacts(javaLibrary) {
+            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+        }
+
+        and:
+        resolveApiArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        and:
+        resolveRuntimeArtifacts(javaLibrary) {
+            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+        }
+
+        where:
+        [apiMapping, runtimeMapping] << ([
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')"), apiUsingUsage("fromResolutionOf(project.configurations.compileClasspath)"), apiJarsUsingUsage(), apiJarsUsingUsage("fromResolutionOf('compileClasspath')"), apiJarsUsingUsage("fromResolutionOf(project.configurations.compileClasspath)")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)"), runtimeJarsUsingUsage(), runtimeJarsUsingUsage("fromResolutionOf('runtimeClasspath')"), runtimeJarsUsingUsage("fromResolutionOf(project.configurations.runtimeClasspath)")],
+        ].combinations() + [[allVariants(), noop()]])
+    }
+
+    /**
+     * This use case corresponds to the cases where the published versions should be different
+     * from the versions published using the default configurations (compileClasspath, runtimeClasspath).
+     * This can be the case if there are multiple compile classpath and one should be preferred for publication,
+     * or when the component is not a Java library and we don't have a default.
+     */
+    @Unroll("can publish resolved versions from a different configuration (#config)")
+    def "can publish resolved versions from a different configuration"() {
+        given:
+        javaLibrary(ivyRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.1")).withModuleMetadata().publish()
+
+        createBuildScripts("""
+            configurations {
+                extra.extendsFrom(api)
+            }
+            dependencies {
+                api "org.test:foo:1.0"
+                implementation "org.test:bar:1.0"
+                extra "org.test:bar:1.1"
+            }
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        versionMapping {
+                            ${runtimeUsingUsage(config)}
+                        }
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.assertPublished()
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            dependency("org.test:foo:1.0") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            dependency("org.test:foo:1.0") {
+                exists()
+            }
+            dependency("org.test:bar:1.1") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+
+        and:
+        resolveArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        and:
+        resolveApiArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        and:
+        resolveRuntimeArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        where:
+        config << [
+            "fromResolutionOf('extra')",
+            "fromResolutionOf(project.configurations.extra)"
+        ]
+    }
+
+    @Unroll("can publish resolved versions from dependency constraints (#apiMapping, #runtimeMapping)")
+    def "can publish resolved versions from dependency constraints"() {
+        javaLibrary(ivyRepo.module("org.test", "foo", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.0")).withModuleMetadata().publish()
+        javaLibrary(ivyRepo.module("org.test", "bar", "1.1")).withModuleMetadata().publish()
+
+        given:
+        createBuildScripts("""
+            dependencies {
+                constraints {
+                    api "org.test:bar:+"
+                }
+                api "org.test:foo:1.0"
+                implementation "org.test:bar"
+            }
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        versionMapping {
+                            $apiMapping
+                            $runtimeMapping
+                        }
+                    }
+                }
+            }
+""")
+
+        when:
+        run "publish"
+
+        then:
+        javaLibrary.assertPublished()
+        javaLibrary.parsedModuleMetadata.variant("apiElements") {
+            constraint("org.test:bar:1.1") {
+                exists()
+            }
+            dependency("org.test:foo:1.0") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+        def dependencies = javaLibrary.parsedIvy.dependencies
+        dependencies.get("org.test:foo:1.0").with {
+            assert it.org == 'org.test'
+            assert it.module == 'foo'
+            assert it.revision == '1.0'
+        }
+        javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
+            constraint("org.test:bar:1.1") {
+                exists()
+            }
+            dependency("org.test:foo:1.0") {
+                exists()
+            }
+            dependency("org.test:bar:1.1") {
+                exists()
+            }
+            noMoreDependencies()
+        }
+
+        and:
+        resolveArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        and:
+        resolveApiArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        and:
+        resolveRuntimeArtifacts(javaLibrary) {
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
+        }
+
+        where:
+        [apiMapping, runtimeMapping] << ([
+            [apiUsingUsage(), apiUsingUsage("fromResolutionOf('compileClasspath')")],
+            [runtimeUsingUsage(), runtimeUsingUsage("fromResolutionOf('runtimeClasspath')")]
+        ].combinations() + [[allVariants(), noop()]])
+    }
+
+    private static String allVariants() {
+        " allVariants { fromResolutionResult() } "
+    }
+
+    private static String noop() { "" }
+
+    private static String apiUsingUsage(String config = "fromResolutionResult()") {
+        """ usage("java-api") { $config } """
+    }
+
+    private static String apiJarsUsingUsage(String config = "fromResolutionResult()") {
+        """ usage("java-api-jars") { $config } """
+    }
+
+    private static String runtimeJarsUsingUsage(String config = "fromResolutionResult()") {
+        """ usage("java-runtime-jars") { $config } """
+    }
+
+    private static String runtimeUsingUsage(String config = "fromResolutionResult()") {
+        """ usage("java-runtime") { $config } """
+    }
+
+    private void createBuildScripts(def append) {
+        settingsFile << "rootProject.name = 'publishTest' "
+
+        buildFile << """
+            apply plugin: 'ivy-publish'
+            apply plugin: 'java-library'
+
+            repositories {
+                // use for resolving
+                ivy { url "${ivyRepo.uri}" }
+            }
+            
+            publishing {
+                repositories {
+                    // used for publishing
+                    ivy { url "${ivyRepo.uri}" }
+                }
+            }
+
+            group = 'org.gradle.test'
+            version = '1.9'
+
+$append
+"""
+
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/IvyPublication.java
@@ -17,8 +17,10 @@
 package org.gradle.api.publish.ivy;
 
 import org.gradle.api.Action;
+import org.gradle.api.Incubating;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.publish.Publication;
+import org.gradle.api.publish.VersionMappingStrategy;
 import org.gradle.internal.HasInternalProtocol;
 
 /**
@@ -330,5 +332,34 @@ public interface IvyPublication extends Publication {
      * Sets the revision for this publication.
      */
     void setRevision(String revision);
+
+    /**
+     * Configures the version mapping strategy.
+     *
+     * For example, to use resolved versions for runtime dependencies:
+     * <pre class='autoTested'>
+     * apply plugin: "java"
+     * apply plugin: "ivy-publish"
+     *
+     * publishing {
+     *   publications {
+     *     maven(IvyPublication) {
+     *       from components.java
+     *       versionMapping {
+     *         usage('java-runtime'){
+     *           fromResolutionResult()
+     *         }
+     *       }
+     *     }
+     *   }
+     * }
+     * </pre>
+     *
+     * @param configureAction the configuration
+     *
+     * @since 5.4
+     */
+    @Incubating
+    void versionMapping(Action<? super VersionMappingStrategy> configureAction);
 
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -53,6 +53,7 @@ import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.publish.VersionMappingStrategy;
 import org.gradle.api.publish.internal.CompositePublicationArtifactSet;
 import org.gradle.api.publish.internal.DefaultPublicationArtifactSet;
 import org.gradle.api.publish.internal.PublicationArtifactSet;
@@ -122,6 +123,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private final DefaultIvyDependencySet ivyDependencies;
     private final ProjectDependencyPublicationResolver projectDependencyResolver;
     private final ImmutableAttributesFactory immutableAttributesFactory;
+    private final VersionMappingStrategyInternal versionMappingStrategy;
     private final FeaturePreviews featurePreviews;
     private IvyArtifact ivyDescriptorArtifact;
     private Task moduleDescriptorGenerator;
@@ -136,12 +138,13 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
         String name, Instantiator instantiator, ObjectFactory objectFactory, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
         ProjectDependencyPublicationResolver projectDependencyResolver, FileCollectionFactory fileCollectionFactory,
         ImmutableAttributesFactory immutableAttributesFactory, FeaturePreviews featurePreviews,
-        CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        CollectionCallbackActionDecorator collectionCallbackActionDecorator, VersionMappingStrategyInternal versionMappingStrategy) {
         this.name = name;
         this.publicationIdentity = publicationIdentity;
         this.projectDependencyResolver = projectDependencyResolver;
         this.configurations = instantiator.newInstance(DefaultIvyConfigurationContainer.class, instantiator, collectionCallbackActionDecorator);
         this.immutableAttributesFactory = immutableAttributesFactory;
+        this.versionMappingStrategy = versionMappingStrategy;
         this.featurePreviews = featurePreviews;
         this.mainArtifacts = instantiator.newInstance(DefaultIvyArtifactSet.class, name, ivyArtifactNotationParser, fileCollectionFactory, collectionCallbackActionDecorator);
         this.metadataArtifacts = new DefaultPublicationArtifactSet<IvyArtifact>(IvyArtifact.class, "metadata artifacts for " + name, fileCollectionFactory, collectionCallbackActionDecorator);
@@ -530,9 +533,14 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     }
 
     @Override
+    public void versionMapping(Action<? super VersionMappingStrategy> configureAction) {
+        configureAction.execute(versionMappingStrategy);
+    }
+
+    @Override
     @Nullable
     public VersionMappingStrategyInternal getVersionMappingStrategy() {
-        return null;
+        return versionMappingStrategy;
     }
 
     @Override

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVariantVersionMappingStrategy.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVariantVersionMappingStrategy.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.ivy.internal.versionmapping;
+
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal;
+
+import java.util.Set;
+
+public class DefaultVariantVersionMappingStrategy implements VariantVersionMappingStrategyInternal {
+    private final ConfigurationContainer configurations;
+    private boolean usePublishedVersions;
+    private Configuration targetConfiguration;
+
+    DefaultVariantVersionMappingStrategy(ConfigurationContainer configurations) {
+        this.configurations = configurations;
+    }
+
+    @Override
+    public void fromResolutionResult() {
+        usePublishedVersions = true;
+    }
+
+    @Override
+    public void fromResolutionOf(Configuration configuration) {
+        usePublishedVersions = true;
+        targetConfiguration = configuration;
+    }
+
+    @Override
+    public void fromResolutionOf(String configurationName) {
+        fromResolutionOf(configurations.getByName(configurationName));
+    }
+
+    @Override
+    public String maybeResolveVersion(String group, String module) {
+        if (usePublishedVersions && targetConfiguration != null) {
+            Set<? extends ResolvedComponentResult> resolvedComponentResults = targetConfiguration.getIncoming().getResolutionResult().getAllComponents();
+            for (ResolvedComponentResult selected : resolvedComponentResults) {
+                ModuleVersionIdentifier moduleVersion = selected.getModuleVersion();
+                if (moduleVersion != null && group.equals(moduleVersion.getGroup()) && module.equals(moduleVersion.getName())) {
+                    return moduleVersion.getVersion();
+                }
+            }
+        }
+        return null;
+    }
+
+    public void setTargetConfiguration(Configuration target) {
+        targetConfiguration = target;
+    }
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/versionmapping/DefaultVersionMappingStrategy.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.api.publish.ivy.internal.versionmapping;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import org.gradle.api.Action;
+import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.attributes.Attribute;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
+import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.publish.VariantVersionMappingStrategy;
+import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal;
+import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
+import org.gradle.internal.component.model.AttributeMatcher;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class DefaultVersionMappingStrategy implements VersionMappingStrategyInternal {
+    private final ObjectFactory objectFactory;
+    private final ConfigurationContainer configurations;
+    private final AttributesSchemaInternal schema;
+    private final ImmutableAttributesFactory attributesFactory;
+    private final List<Action<? super VariantVersionMappingStrategy>> mappingsForAllVariants = Lists.newArrayListWithExpectedSize(2);
+    private final Map<ImmutableAttributes, String> defaultConfigurations = Maps.newHashMap();
+    private final Multimap<ImmutableAttributes, Action<? super VariantVersionMappingStrategy>> attributeBasedMappings = ArrayListMultimap.create();
+
+    public DefaultVersionMappingStrategy(ObjectFactory objectFactory,
+                                         ConfigurationContainer configurations,
+                                         AttributesSchemaInternal schema,
+                                         ImmutableAttributesFactory attributesFactory) {
+        this.objectFactory = objectFactory;
+        this.configurations = configurations;
+        this.schema = schema;
+        this.attributesFactory = attributesFactory;
+    }
+
+    @Override
+    public void allVariants(Action<? super VariantVersionMappingStrategy> action) {
+        mappingsForAllVariants.add(action);
+    }
+
+    @Override
+    public <T> void variant(Attribute<T> attribute, T attributeValue, Action<? super VariantVersionMappingStrategy> action) {
+        attributeBasedMappings.put(attributesFactory.of(attribute, attributeValue), action);
+    }
+
+    @Override
+    public void usage(String usage, Action<? super VariantVersionMappingStrategy> action) {
+        variant(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage), action);
+    }
+
+    @Override
+    public void defaultResolutionConfiguration(String usage, String defaultConfiguration) {
+        defaultConfigurations.put(attributesFactory.of(Usage.USAGE_ATTRIBUTE, objectFactory.named(Usage.class, usage)), defaultConfiguration);
+    }
+
+    @Override
+    public VariantVersionMappingStrategyInternal findStrategyForVariant(ImmutableAttributes variantAttributes) {
+        DefaultVariantVersionMappingStrategy strategy = createDefaultMappingStrategy(variantAttributes);
+        // Apply strategies for "all variants"
+        for (Action<? super VariantVersionMappingStrategy> action : mappingsForAllVariants) {
+            action.execute(strategy);
+        }
+
+        // Then use attribute specific mapping
+        if (!attributeBasedMappings.isEmpty()) {
+            AttributeMatcher matcher = schema.matcher();
+            Set<ImmutableAttributes> candidates = attributeBasedMappings.keySet();
+            List<ImmutableAttributes> matches = matcher.matches(candidates, variantAttributes);
+            if (matches.size() == 1) {
+                Collection<Action<? super VariantVersionMappingStrategy>> actions = attributeBasedMappings.get(matches.get(0));
+                for (Action<? super VariantVersionMappingStrategy> action : actions) {
+                    action.execute(strategy);
+                }
+            } else if (matches.size() > 1) {
+                throw new InvalidUserCodeException("Unable to find a suitable version mapping strategy for " + variantAttributes);
+            }
+        }
+        return strategy;
+    }
+
+    private DefaultVariantVersionMappingStrategy createDefaultMappingStrategy(ImmutableAttributes variantAttributes) {
+        DefaultVariantVersionMappingStrategy strategy = new DefaultVariantVersionMappingStrategy(configurations);
+        if (!defaultConfigurations.isEmpty()) {
+            // First need to populate the default variant version mapping strategy with the default values
+            // provided by plugins
+            AttributeMatcher matcher = schema.matcher();
+            Set<ImmutableAttributes> candidates = defaultConfigurations.keySet();
+            List<ImmutableAttributes> matches = matcher.matches(candidates, variantAttributes);
+            for (ImmutableAttributes match : matches) {
+                strategy.setTargetConfiguration(configurations.getByName(defaultConfigurations.get(match)));
+            }
+        }
+        return strategy;
+    }
+
+}

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -22,18 +22,25 @@ import org.gradle.api.NamedDomainObjectList;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.artifacts.repositories.IvyArtifactRepository;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
+import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.ExtensionContainer;
+import org.gradle.api.plugins.JavaPlatformPlugin;
+import org.gradle.api.plugins.PluginManager;
 import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyPublication;
 import org.gradle.api.publish.ivy.internal.artifact.IvyArtifactNotationParserFactory;
@@ -41,10 +48,13 @@ import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublication;
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyPublicationIdentity;
 import org.gradle.api.publish.ivy.internal.publication.IvyPublicationInternal;
 import org.gradle.api.publish.ivy.internal.publisher.IvyPublicationIdentity;
+import org.gradle.api.publish.ivy.internal.versionmapping.DefaultVersionMappingStrategy;
 import org.gradle.api.publish.ivy.tasks.GenerateIvyDescriptor;
 import org.gradle.api.publish.ivy.tasks.PublishToIvyRepository;
 import org.gradle.api.publish.plugins.PublishingPlugin;
 import org.gradle.api.publish.tasks.GenerateModuleMetadata;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.internal.reflect.Instantiator;
@@ -94,7 +104,15 @@ public class IvyPublishPlugin implements Plugin<Project> {
         project.getExtensions().configure(PublishingExtension.class, new Action<PublishingExtension>() {
             @Override
             public void execute(PublishingExtension extension) {
-                extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider, instantiator, objectFactory, fileResolver, collectionCallbackActionDecorator));
+                extension.getPublications().registerFactory(IvyPublication.class, new IvyPublicationFactory(dependencyMetaDataProvider,
+                    instantiator,
+                    objectFactory,
+                    fileResolver,
+                    collectionCallbackActionDecorator,
+                    project.getConfigurations(),
+                    project.getPluginManager(),
+                    project.getExtensions(),
+                    (AttributesSchemaInternal) project.getDependencies().getAttributesSchema()));
                 createTasksLater(project, extension, project.getLayout().getBuildDirectory());
             }
         });
@@ -185,25 +203,55 @@ public class IvyPublishPlugin implements Plugin<Project> {
         private final ObjectFactory objectFactory;
         private final FileResolver fileResolver;
         private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
+        private final ConfigurationContainer configurations;
+        private final PluginManager plugins;
+        private final ExtensionContainer extensionContainer;
+        private final AttributesSchemaInternal attributesSchema;
 
         private IvyPublicationFactory(DependencyMetaDataProvider dependencyMetaDataProvider, Instantiator instantiator, ObjectFactory objectFactory, FileResolver fileResolver,
-                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator, ConfigurationContainer configurations,
+                                      PluginManager plugins, ExtensionContainer extensionContainer,
+                                      AttributesSchemaInternal attributesSchema) {
             this.dependencyMetaDataProvider = dependencyMetaDataProvider;
             this.instantiator = instantiator;
             this.objectFactory = objectFactory;
             this.fileResolver = fileResolver;
             this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+            this.configurations = configurations;
+            this.plugins = plugins;
+            this.extensionContainer = extensionContainer;
+            this.attributesSchema = attributesSchema;
         }
 
         public IvyPublication create(String name) {
             Module module = dependencyMetaDataProvider.getModule();
             IvyPublicationIdentity publicationIdentity = new DefaultIvyPublicationIdentity(module);
             NotationParser<Object, IvyArtifact> notationParser = new IvyArtifactNotationParserFactory(instantiator, fileResolver, publicationIdentity).create();
+            VersionMappingStrategyInternal versionMappingStrategy = instantiator.newInstance(DefaultVersionMappingStrategy.class,
+                objectFactory,
+                configurations,
+                attributesSchema,
+                immutableAttributesFactory);
+            configureDefaultConfigurationsUsedWhenMappingToResolvedVersions(versionMappingStrategy);
+
             return instantiator.newInstance(
                 DefaultIvyPublication.class,
                 name, instantiator, objectFactory, publicationIdentity, notationParser, projectDependencyResolver, fileCollectionFactory, immutableAttributesFactory, featurePreviews,
-                collectionCallbackActionDecorator
+                collectionCallbackActionDecorator, versionMappingStrategy
             );
+        }
+
+        private void configureDefaultConfigurationsUsedWhenMappingToResolvedVersions(VersionMappingStrategyInternal versionMappingStrategy) {
+            plugins.withPlugin("org.gradle.java", plugin -> {
+                SourceSet mainSourceSet = extensionContainer.getByType(SourceSetContainer.class).getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                // setup the default configurations used when mapping to resolved versions
+                versionMappingStrategy.defaultResolutionConfiguration(Usage.JAVA_API, mainSourceSet.getCompileClasspathConfigurationName());
+                versionMappingStrategy.defaultResolutionConfiguration(Usage.JAVA_RUNTIME, mainSourceSet.getRuntimeClasspathConfigurationName());
+            });
+            plugins.withPlugin("org.gradle.java-platform", plugin -> {
+                versionMappingStrategy.defaultResolutionConfiguration(Usage.JAVA_API, JavaPlatformPlugin.CLASSPATH_CONFIGURATION_NAME);
+                versionMappingStrategy.defaultResolutionConfiguration(Usage.JAVA_RUNTIME, JavaPlatformPlugin.CLASSPATH_CONFIGURATION_NAME);
+            });
         }
     }
 

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -36,6 +36,7 @@ import org.gradle.api.internal.component.SoftwareComponentInternal
 import org.gradle.api.internal.component.UsageContext
 import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.publish.internal.PublicationInternal
+import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.api.publish.ivy.IvyArtifact
 import org.gradle.api.tasks.TaskOutputs
 import org.gradle.internal.typeconversion.NotationParser
@@ -288,7 +289,8 @@ class DefaultIvyPublicationTest extends Specification {
             TestFiles.fileCollectionFactory(),
             attributesFactory,
             featurePreviews,
-            CollectionCallbackActionDecorator.NOOP
+            CollectionCallbackActionDecorator.NOOP,
+            Mock(VersionMappingStrategyInternal)
         )
         publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
 
@@ -373,7 +375,8 @@ class DefaultIvyPublicationTest extends Specification {
             TestFiles.fileCollectionFactory(),
             attributesFactory,
             featurePreviews,
-            CollectionCallbackActionDecorator.NOOP
+            CollectionCallbackActionDecorator.NOOP,
+            Mock(VersionMappingStrategyInternal)
         )
         publication.setIvyDescriptorGenerator(createArtifactGenerator(ivyDescriptorFile))
         publication.setModuleDescriptorGenerator(createArtifactGenerator(moduleDescriptorFile))


### PR DESCRIPTION
### Context
This is for https://github.com/gradle/gradle/issues/8948

Similar to MavenPublication, it would be nice if IvyPublication supports versionMapping.

Example:

```
publishing {
  publications {
    ivy(IvyPublication) {
      from components.java
      versionMapping {
        usage('java-runtime'){
          fromResolutionResult()
        }
      }
    }
  }
}
```

Note: I basically followed the same implementation pattern from Maven and made adjustments to be Ivy. While there might be opportunities to consolidate things like `DefaultVariantVersionMappingStrategy` or `DefaultVersionMappingStrategy`, I decided to keep them duplicated because things could change in the future and having to make adjustments for maven could impact ivy or viceversa.


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
