### PR TITLE
Let console report sub-second durations in milliseconds

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
@@ -49,7 +49,7 @@ public class TimeFormatting {
         if (elapsedTimeInMs > MILLIS_PER_MINUTE) {
             result.append((elapsedTimeInMs % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE).append("m ");
         }
-        if (elapsedTimeInMs > MILLIS_PER_SECOND) {
+        if (elapsedTimeInMs >= MILLIS_PER_SECOND) {
             result.append((elapsedTimeInMs % MILLIS_PER_MINUTE) / 1000).append("s");
         } else {
             result.append(elapsedTimeInMs).append("ms");

--- a/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/time/TimeFormatting.java
@@ -49,7 +49,11 @@ public class TimeFormatting {
         if (elapsedTimeInMs > MILLIS_PER_MINUTE) {
             result.append((elapsedTimeInMs % MILLIS_PER_HOUR) / MILLIS_PER_MINUTE).append("m ");
         }
-        result.append((elapsedTimeInMs % MILLIS_PER_MINUTE) / 1000).append("s");
+        if (elapsedTimeInMs > MILLIS_PER_SECOND) {
+            result.append((elapsedTimeInMs % MILLIS_PER_MINUTE) / 1000).append("s");
+        } else {
+            result.append(elapsedTimeInMs).append("ms");
+        }
         return result.toString();
     }
 

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/time/TimeFormattingTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/time/TimeFormattingTest.groovy
@@ -62,14 +62,15 @@ class TimeFormattingTest extends Specification {
         result == output
 
         where:
-        lowerBoundInclusive | upperBoundExclusive | input            | output
-        "None"              | "10 seconds"        | seconds(4.21345) | "4s"
-        "10 seconds"        | "1 minute"          | seconds(42.1234) | "42s"
-        "1 minute"          | "10 minutes"        | minutes(4.21234) | "4m 12s"
-        "10 minutes"        | "1 hour"            | minutes(42.1234) | "42m 7s"
-        "1 hour"            | "10 hours"          | hours(4.2123456) | "4h 12m 44s"
-        "10 hours"          | "100 hours"         | hours(42.123456) | "42h 7m 24s"
-        "100 hours"         | "None"              | hours(421.23456) | "421h 14m 4s"
+        lowerBoundInclusive | upperBoundExclusive | input             | output
+        "None"              | "1 second"          | seconds(0.421345) | "421ms"
+        "1 second"          | "10 seconds"        | seconds(4.21345)  | "4s"
+        "10 seconds"        | "1 minute"          | seconds(42.1234)  | "42s"
+        "1 minute"          | "10 minutes"        | minutes(4.21234)  | "4m 12s"
+        "10 minutes"        | "1 hour"            | minutes(42.1234)  | "42m 7s"
+        "1 hour"            | "10 hours"          | hours(4.2123456)  | "4h 12m 44s"
+        "10 hours"          | "100 hours"         | hours(42.123456)  | "42h 7m 24s"
+        "100 hours"         | "None"              | hours(421.23456)  | "421h 14m 4s"
     }
 
     private static long hours(double value) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/internal/scan/eob/BuildScanEndOfBuildNotifierIntegrationTest.groovy
@@ -47,7 +47,7 @@ class BuildScanEndOfBuildNotifierIntegrationTest extends AbstractIntegrationSpec
         output.matches("""(?s).*
 build finished
 
-BUILD SUCCESSFUL in \\d+s
+BUILD SUCCESSFUL in \\d+m?s
 1 actionable task: 1 executed
 failure is null: true
 \$""")
@@ -81,7 +81,7 @@ failure message: Execution failed for task ':t'.
 
 FAILURE: Build failed with an exception.
 .*
-BUILD FAILED in \\d+s
+BUILD FAILED in \\d+m?s
 notified
 \$""")
     }

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/executer/OutputScrapingExecutionResult.java
@@ -45,7 +45,7 @@ public class OutputScrapingExecutionResult implements ExecutionResult {
     //for example: ':hey' or ':a SKIPPED' or ':foo:bar:baz UP-TO-DATE' but not ':a FOO'
     private static final Pattern TASK_PATTERN = Pattern.compile("(> Task )?(:\\S+?(:\\S+?)*)((\\s+SKIPPED)|(\\s+UP-TO-DATE)|(\\s+FROM-CACHE)|(\\s+NO-SOURCE)|(\\s+FAILED)|(\\s*))");
 
-    private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("BUILD (SUCCESSFUL|FAILED) in( \\d+[smh])+");
+    private static final Pattern BUILD_RESULT_PATTERN = Pattern.compile("BUILD (SUCCESSFUL|FAILED) in( \\d+m?[smh])+");
 
     private final LogContent output;
     private final LogContent error;

--- a/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleBuildResultFunctionalTest.groovy
+++ b/subprojects/logging/src/integTest/groovy/org/gradle/internal/logging/console/taskgrouping/AbstractConsoleBuildResultFunctionalTest.groovy
@@ -46,7 +46,7 @@ abstract class AbstractConsoleBuildResultFunctionalTest extends AbstractConsoleG
         then:
         result.formattedOutput.contains(buildSuccessful.output)
         result.plainTextOutput.matches """(?s).*
-BUILD SUCCESSFUL in \\d+s
+BUILD SUCCESSFUL in \\d+m?s
 2 actionable tasks: 2 executed
 .*"""
 
@@ -56,7 +56,7 @@ BUILD SUCCESSFUL in \\d+s
         then:
         result.formattedOutput.contains(buildSuccessful.output)
         result.plainTextOutput.matches """(?s).*
-BUILD SUCCESSFUL in \\d+s
+BUILD SUCCESSFUL in \\d+m?s
 2 actionable tasks: 1 executed, 1 up-to-date
 .*"""
     }
@@ -91,7 +91,7 @@ BUILD SUCCESSFUL in \\d+s
         then:
         result.plainTextOutput.matches """(?s).*build finished
 
-BUILD SUCCESSFUL in \\d+s
+BUILD SUCCESSFUL in \\d+m?s
 1 actionable task: 1 executed
 .*"""
     }

--- a/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
+++ b/subprojects/logging/src/test/groovy/org/gradle/internal/logging/console/BuildStatusRendererTest.groovy
@@ -55,7 +55,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == "<-------------> 0% INITIALIZING [0s]"
+        statusBar.display == "<-------------> 0% INITIALIZING [0ms]"
 
         when:
         currentTimeMs += 1000
@@ -75,7 +75,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% INITIALIZING [0s]'
+        statusBar.display == '<-------------> 0% INITIALIZING [0ms]'
 
         when:
         renderer.onOutput(complete(1, 'WAITING'))
@@ -94,7 +94,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% INITIALIZING [0s]'
+        statusBar.display == '<-------------> 0% INITIALIZING [0ms]'
 
         when:
         renderer.onOutput(complete(1))
@@ -118,21 +118,21 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% CONFIGURING [0s]'
+        statusBar.display == '<-------------> 0% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(event3)
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% CONFIGURING [0s]'
+        statusBar.display == '<-------------> 0% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(complete(3))
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<===----------> 25% CONFIGURING [0s]'
+        statusBar.display == '<===----------> 25% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(event4)
@@ -143,7 +143,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=========----> 75% CONFIGURING [0s]'
+        statusBar.display == '<=========----> 75% CONFIGURING [0ms]'
     }
 
     def "formats configuration phase with nested builds"() {
@@ -160,21 +160,21 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% CONFIGURING [0s]'
+        statusBar.display == '<-------------> 0% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(event4)
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% CONFIGURING [0s]'
+        statusBar.display == '<-------------> 0% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(complete(4))
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=------------> 10% CONFIGURING [0s]'
+        statusBar.display == '<=------------> 10% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(complete(3))
@@ -182,7 +182,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=------------> 10% CONFIGURING [0s]'
+        statusBar.display == '<=------------> 10% CONFIGURING [0ms]'
     }
 
     def "formats execution phase"() {
@@ -197,28 +197,28 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% EXECUTING [0s]'
+        statusBar.display == '<-------------> 0% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(event3)
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% EXECUTING [0s]'
+        statusBar.display == '<-------------> 0% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(complete(3))
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<===----------> 25% EXECUTING [0s]'
+        statusBar.display == '<===----------> 25% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(complete(2))
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<===----------> 25% EXECUTING [0s]'
+        statusBar.display == '<===----------> 25% EXECUTING [0ms]'
     }
 
     def "formats execution phase with nested builds"() {
@@ -235,21 +235,21 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% EXECUTING [0s]'
+        statusBar.display == '<-------------> 0% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(event4)
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% EXECUTING [0s]'
+        statusBar.display == '<-------------> 0% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(complete(4))
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=------------> 10% EXECUTING [0s]'
+        statusBar.display == '<=------------> 10% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(complete(3))
@@ -257,7 +257,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=------------> 10% EXECUTING [0s]'
+        statusBar.display == '<=------------> 10% EXECUTING [0ms]'
     }
 
     def "configuration phase runs until task graph execution"() {
@@ -274,7 +274,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% CONFIGURING [0s]'
+        statusBar.display == '<-------------> 0% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(event3)
@@ -283,14 +283,14 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=============> 100% CONFIGURING [0s]'
+        statusBar.display == '<=============> 100% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(event4)
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<=============> 100% CONFIGURING [0s]'
+        statusBar.display == '<=============> 100% CONFIGURING [0ms]'
 
         when:
         renderer.onOutput(complete(4))
@@ -298,7 +298,7 @@ class BuildStatusRendererTest extends OutputSpecification {
         renderer.onOutput(updateNow())
 
         then:
-        statusBar.display == '<-------------> 0% EXECUTING [0s]'
+        statusBar.display == '<-------------> 0% EXECUTING [0ms]'
 
         when:
         renderer.onOutput(complete(5))

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/m8/ToolingApiLoggingCrossVersionSpec.groovy
@@ -168,7 +168,7 @@ project.logger.debug("debug logging");
         // Must replace both build result formats for cross compat
         return output
             .replaceFirst(/Support for .* was deprecated.*\n/,'')
-            .replaceFirst(/ in [.\d]+s/, " in 0s")
+            .replaceFirst(/ in [.\d]+m?s/, " in 0ms")
             .replaceFirst("Total time: .+ secs", "Total time: 0 secs")
     }
 


### PR DESCRIPTION
instead of reporting `0s`.
