### PR TITLE
Fix ConcurrentModificationException in NodeState

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -308,9 +308,9 @@ class EdgeState implements DependencyGraphEdge {
         });
     }
 
-    void maybeDecreaseHardEdgeCount() {
+    void maybeDecreaseHardEdgeCount(NodeState removalSource) {
         if (!isConstraint) {
-            selector.getTargetModule().decreaseHardEdgeCount();
+            selector.getTargetModule().decreaseHardEdgeCount(removalSource);
         }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -339,14 +339,14 @@ class ModuleResolveState implements CandidateModule {
         return platformState != null && !platformState.getParticipatingModules().isEmpty();
     }
 
-    void decreaseHardEdgeCount() {
+    void decreaseHardEdgeCount(NodeState removalSource) {
         pendingDependencies.decreaseHardEdgeCount();
         if (pendingDependencies.isPending()) {
             // Back to being a pending dependency
             // Clear remaining incoming edges, as they must be all from constraints
             if (selected != null) {
                 for (NodeState node : selected.getNodes()) {
-                    node.clearConstraintEdges(pendingDependencies);
+                    node.clearConstraintEdges(pendingDependencies, removalSource);
                 }
             }
         }


### PR DESCRIPTION
When removing outgoing edges, there was a code path trying to remove
elements from the same collection that is being cleared initially.
This commit fixes that condition by not attempting to do so, knowing
that the edges to be removed will be as part of the external iteration.