### PR TITLE
Fix Ivy versionMapping and silence dependency version compatibility warnings when used

### DIFF
--- a/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/integtests/publish/ivy/IvyPublishResolvedVersionsJavaIntegTest.groovy
@@ -53,6 +53,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
         run "publish"
 
         then:
+        javaLibrary.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             dependency("org.test:foo:1.0") {
@@ -69,6 +70,10 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
             }
             noMoreDependencies()
         }
+
+        and:
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('compile', "org.test:foo:1.0")
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('runtime', 'org.test:bar:1.1', "org.test:foo:1.1")
 
         and:
         resolveArtifacts(javaLibrary) {
@@ -128,6 +133,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
         run "publish"
 
         then:
+        javaLibrary.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             dependency("org.test:foo:1.0") {
@@ -144,6 +150,10 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
             }
             noMoreDependencies()
         }
+
+        and:
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('compile', "org.test:foo:1.0")
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('runtime', 'org.test:bar:1.1', "org.test:foo:1.1")
 
         and:
         resolveArtifacts(javaLibrary) {
@@ -210,6 +220,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
         run "publish"
 
         then:
+        javaLibrary.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             dependency("org.test:foo:1.0") {
@@ -226,6 +237,10 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
             }
             noMoreDependencies()
         }
+
+        and:
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('compile', "org.test:foo:1.0")
+        javaLibrary.parsedIvy.assertConfigurationDependsOn('runtime', 'org.test:bar:1.1')
 
         and:
         resolveArtifacts(javaLibrary) {
@@ -296,6 +311,7 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
         run "publish"
 
         then:
+        javaLibrary.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             constraint("org.test:bar:1.1") {
@@ -311,6 +327,13 @@ class IvyPublishResolvedVersionsJavaIntegTest extends AbstractIvyPublishIntegTes
             assert it.org == 'org.test'
             assert it.module == 'foo'
             assert it.revision == '1.0'
+            assert it.conf == 'compile->default'
+        }
+        dependencies.get("org.test:bar:1.1").with {
+            assert it.org == 'org.test'
+            assert it.module == 'bar'
+            assert it.revision == '1.1'
+            assert it.conf == 'runtime->default'
         }
         javaLibrary.parsedModuleMetadata.variant("runtimeElements") {
             constraint("org.test:bar:1.1") {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/DefaultIvyDependency.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.artifacts.ExternalDependency;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,6 +34,7 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
     private final boolean transitive;
     private final List<DependencyArtifact> artifacts = new ArrayList<DependencyArtifact>();
     private final List<ExcludeRule> excludeRules = new ArrayList<ExcludeRule>();
+    private final ImmutableAttributes attributes;
 
     public DefaultIvyDependency(String organisation, String module, String revision, String confMapping, boolean transitive) {
         this.organisation = organisation;
@@ -40,6 +42,7 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
         this.revision = Strings.nullToEmpty(revision);
         this.confMapping = confMapping;
         this.transitive = transitive;
+        this.attributes = ImmutableAttributes.EMPTY;
     }
 
     public DefaultIvyDependency(String organisation, String module, String revision, String confMapping, boolean transitive, Collection<DependencyArtifact> artifacts) {
@@ -52,8 +55,15 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
         this.excludeRules.addAll(excludeRules);
     }
 
-    public DefaultIvyDependency(ExternalDependency dependency, String confMapping) {
-        this(dependency.getGroup(), dependency.getName(), dependency.getVersion(), confMapping, dependency.isTransitive(), dependency.getArtifacts(), dependency.getExcludeRules());
+    public DefaultIvyDependency(ExternalDependency dependency, String confMapping, ImmutableAttributes attributes) {
+        this.organisation = dependency.getGroup();
+        this.module = dependency.getName();
+        this.revision = Strings.nullToEmpty(dependency.getVersion());
+        this.confMapping = confMapping;
+        this.transitive = dependency.isTransitive();
+        this.artifacts.addAll(dependency.getArtifacts());
+        this.excludeRules.addAll(dependency.getExcludeRules());
+        this.attributes = attributes;
     }
 
     public String getOrganisation() {
@@ -82,5 +92,10 @@ public class DefaultIvyDependency implements IvyDependencyInternal {
 
     public Iterable<ExcludeRule> getExcludeRules() {
         return excludeRules;
+    }
+
+    @Override
+    public ImmutableAttributes getAttributes() {
+        return attributes;
     }
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/IvyDependencyInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/dependency/IvyDependencyInternal.java
@@ -18,10 +18,13 @@ package org.gradle.api.publish.ivy.internal.dependency;
 
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
+import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.publish.ivy.IvyDependency;
 
 public interface IvyDependencyInternal extends IvyDependency {
     Iterable<DependencyArtifact> getArtifacts();
 
     Iterable<ExcludeRule> getExcludeRules();
+
+    ImmutableAttributes getAttributes();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpec.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyModuleDescriptorSpec.java
@@ -22,6 +22,7 @@ import org.gradle.api.XmlProvider;
 import org.gradle.api.internal.UserCodeAction;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor;
 import org.gradle.api.publish.ivy.IvyConfiguration;
@@ -147,6 +148,11 @@ public class DefaultIvyModuleDescriptorSpec implements IvyModuleDescriptorSpecIn
     @Override
     public IvyModuleDescriptorDescription getDescription() {
         return description;
+    }
+
+    @Override
+    public VersionMappingStrategyInternal getVersionMappingStrategy() {
+        return ivyPublication.getVersionMappingStrategy();
     }
 
     @Override

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -134,6 +134,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
     private Set<IvyExcludeRule> globalExcludes = new LinkedHashSet<IvyExcludeRule>();
     private boolean populated;
     private boolean artifactsOverridden;
+    private boolean versionMappingInUse = false;
 
     public DefaultIvyPublication(
         String name, Instantiator instantiator, ObjectFactory objectFactory, IvyPublicationIdentity publicationIdentity, NotationParser<Object, IvyArtifact> ivyArtifactNotationParser,
@@ -281,7 +282,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                         if (PlatformSupport.isTargettingPlatform(dependency)) {
                             publicationWarningsCollector.addUnsupported(String.format("%s:%s:%s declared as platform", dependency.getGroup(), dependency.getName(), dependency.getVersion()));
                         }
-                        if (externalDependency.getVersion() == null) {
+                        if (!versionMappingInUse && externalDependency.getVersion() == null) {
                             publicationWarningsCollector.addUnsupported(String.format("%s:%s declared without version", externalDependency.getGroup(), externalDependency.getName()));
                         }
                         addExternalDependency(externalDependency, confMapping, ((AttributeContainerInternal) usageContext.getAttributes()).asImmutable());
@@ -535,6 +536,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
 
     @Override
     public void versionMapping(Action<? super VersionMappingStrategy> configureAction) {
+        this.versionMappingInUse = true;
         configureAction.execute(versionMappingStrategy);
     }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublication.java
@@ -42,6 +42,7 @@ import org.gradle.api.internal.FeaturePreviews;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.artifacts.dsl.dependencies.PlatformSupport;
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.ProjectDependencyPublicationResolver;
+import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.internal.component.IvyPublishingAwareContext;
@@ -283,7 +284,7 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                         if (externalDependency.getVersion() == null) {
                             publicationWarningsCollector.addUnsupported(String.format("%s:%s declared without version", externalDependency.getGroup(), externalDependency.getName()));
                         }
-                        addExternalDependency(externalDependency, confMapping);
+                        addExternalDependency(externalDependency, confMapping, ((AttributeContainerInternal) usageContext.getAttributes()).asImmutable());
                     }
                 }
             }
@@ -327,8 +328,8 @@ public class DefaultIvyPublication implements IvyPublicationInternal {
                 identifier.getGroup(), identifier.getName(), identifier.getVersion(), confMapping, dependency.isTransitive(), Collections.<DependencyArtifact>emptyList(), dependency.getExcludeRules()));
     }
 
-    private void addExternalDependency(ExternalDependency dependency, String confMapping) {
-        ivyDependencies.add(new DefaultIvyDependency(dependency, confMapping));
+    private void addExternalDependency(ExternalDependency dependency, String confMapping, ImmutableAttributes attributes) {
+        ivyDependencies.add(new DefaultIvyDependency(dependency, confMapping, attributes));
     }
 
     public void configurations(Action<? super IvyConfigurationContainer> config) {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyModuleDescriptorSpecInternal.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publication/IvyModuleDescriptorSpecInternal.java
@@ -18,6 +18,7 @@ package org.gradle.api.publish.ivy.internal.publication;
 
 import org.gradle.api.Action;
 import org.gradle.api.XmlProvider;
+import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyModuleDescriptorAuthor;
 import org.gradle.api.publish.ivy.IvyConfiguration;
@@ -50,6 +51,8 @@ public interface IvyModuleDescriptorSpecInternal extends IvyModuleDescriptorSpec
     List<IvyModuleDescriptorLicense> getLicenses();
 
     IvyModuleDescriptorDescription getDescription();
+
+    VersionMappingStrategyInternal getVersionMappingStrategy();
 
     boolean writeGradleMetadataMarker();
 }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/plugins/IvyPublishPlugin.java
@@ -131,7 +131,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
             @Override
             public void execute(IvyPublicationInternal publication) {
                 final String publicationName = publication.getName();
-                createGenerateIvyDescriptorTask(tasks, publicationName, publication, buildDir);
+                createGenerateIvyDescriptorTask(tasks, publicationName, publication, buildDir, project);
                 createGenerateMetadataTask(project, tasks, publication, publications, buildDir);
                 createPublishTaskForEachRepository(tasks, publication, publicationName, repositories);
             }
@@ -164,7 +164,7 @@ public class IvyPublishPlugin implements Plugin<Project> {
         tasks.named(publishAllToSingleRepoTaskName(repository), publish -> publish.dependsOn(publishTaskName));
     }
 
-    private void createGenerateIvyDescriptorTask(TaskContainer tasks, final String publicationName, final IvyPublicationInternal publication, @Path("buildDir") final DirectoryProperty buildDir) {
+    private void createGenerateIvyDescriptorTask(TaskContainer tasks, final String publicationName, final IvyPublicationInternal publication, @Path("buildDir") final DirectoryProperty buildDir, final Project project) {
         final String descriptorTaskName = "generateDescriptorFileFor" + capitalize(publicationName) + "Publication";
 
         TaskProvider<GenerateIvyDescriptor> generatorTask = tasks.register(descriptorTaskName, GenerateIvyDescriptor.class, new Action<GenerateIvyDescriptor>() {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/tasks/GenerateIvyDescriptor.java
@@ -105,7 +105,9 @@ public class GenerateIvyDescriptor extends DefaultTask {
     public void doGenerate() {
         IvyModuleDescriptorSpecInternal descriptorInternal = toIvyModuleDescriptorInternal(getDescriptor());
 
-        IvyDescriptorFileGenerator ivyGenerator = new IvyDescriptorFileGenerator(descriptorInternal.getProjectIdentity(), descriptorInternal.writeGradleMetadataMarker());
+        IvyDescriptorFileGenerator ivyGenerator = new IvyDescriptorFileGenerator(descriptorInternal.getProjectIdentity(),
+                                                                                 descriptorInternal.writeGradleMetadataMarker(),
+                                                                                 descriptorInternal.getVersionMappingStrategy());
         ivyGenerator.setStatus(descriptorInternal.getStatus());
         ivyGenerator.setBranch(descriptorInternal.getBranch());
         ivyGenerator.setExtraInfo(descriptorInternal.getExtraInfo().asMap());

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publication/DefaultIvyPublicationTest.groovy
@@ -416,6 +416,7 @@ class DefaultIvyPublicationTest extends Specification {
             getName() >> 'runtime'
             getArtifacts() >> artifacts
             getDependencies() >> dependencies
+            getAttributes() >> ImmutableAttributes.EMPTY
         }
         def component = Stub(SoftwareComponentInternal) {
             getUsages() >> [usage]

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGeneratorTest.groovy
@@ -21,6 +21,8 @@ import org.gradle.api.XmlProvider
 import org.gradle.api.artifacts.DependencyArtifact
 import org.gradle.api.artifacts.ExcludeRule
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser
+import org.gradle.api.publish.internal.versionmapping.VariantVersionMappingStrategyInternal
+import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal
 import org.gradle.api.publish.ivy.internal.artifact.FileBasedIvyArtifact
 import org.gradle.api.publish.ivy.internal.dependency.DefaultIvyDependency
 import org.gradle.api.publish.ivy.internal.publication.DefaultIvyConfiguration
@@ -42,8 +44,12 @@ class IvyDescriptorFileGeneratorTest extends Specification {
     @Rule
     TestNameTestDirectoryProvider testDirectoryProvider = new TestNameTestDirectoryProvider()
 
+    VersionMappingStrategyInternal versionMappingStrategy = Mock() {
+        findStrategyForVariant(_) >> Mock(VariantVersionMappingStrategyInternal)
+    }
+
     def projectIdentity = new DefaultIvyPublicationIdentity("my-org", "my-name", "my-version")
-    IvyDescriptorFileGenerator generator = new IvyDescriptorFileGenerator(projectIdentity, false)
+    IvyDescriptorFileGenerator generator = new IvyDescriptorFileGenerator(projectIdentity, false, versionMappingStrategy)
 
     def "writes correct prologue and schema declarations"() {
         expect:
@@ -55,7 +61,7 @@ class IvyDescriptorFileGeneratorTest extends Specification {
 
     def "writes Gradle metadata marker"() {
         given:
-        generator = new IvyDescriptorFileGenerator(projectIdentity, markerPresent)
+        generator = new IvyDescriptorFileGenerator(projectIdentity, markerPresent, versionMappingStrategy)
 
         expect:
         ivyFile.text.contains(MetaDataParser.GRADLE_METADATA_MARKER) == markerPresent
@@ -84,7 +90,7 @@ class IvyDescriptorFileGeneratorTest extends Specification {
     def "encodes coordinates for XML and unicode"() {
         when:
         def projectIdentity = new DefaultIvyPublicationIdentity('org-ぴ₦ガき∆ç√∫', 'module-<tag attrib="value"/>-markup', 'version-&"')
-        generator = new IvyDescriptorFileGenerator(projectIdentity, false)
+        generator = new IvyDescriptorFileGenerator(projectIdentity, false, null)
 
 
         then:

--- a/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
+++ b/subprojects/ivy/src/test/groovy/org/gradle/api/publish/ivy/internal/publisher/ValidatingIvyPublisherTest.groovy
@@ -209,7 +209,7 @@ class ValidatingIvyPublisherTest extends Specification {
     def "reports and fails with invalid descriptor file (marker = #marker)"() {
         given:
         def identity = new DefaultIvyPublicationIdentity("the-group", "the-artifact", "the-version")
-        IvyDescriptorFileGenerator ivyFileGenerator = new IvyDescriptorFileGenerator(identity, marker)
+        IvyDescriptorFileGenerator ivyFileGenerator = new IvyDescriptorFileGenerator(identity, marker, null)
         def artifact = new FileBasedIvyArtifact(new File("foo.txt"), identity)
         artifact.setConf("unknown")
         ivyFileGenerator.addArtifact(artifact)
@@ -366,7 +366,7 @@ class ValidatingIvyPublisherTest extends Specification {
 
     class TestIvyDescriptorFileGenerator extends IvyDescriptorFileGenerator {
         TestIvyDescriptorFileGenerator(IvyPublicationIdentity projectIdentity) {
-            super(projectIdentity, false)
+            super(projectIdentity, false, null)
         }
 
         TestIvyDescriptorFileGenerator withBranch(String branch) {

--- a/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
+++ b/subprojects/maven/src/integTest/groovy/org/gradle/api/publish/maven/MavenPublishResolvedVersionsJavaIntegTest.groovy
@@ -55,6 +55,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         run "publish"
 
         then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             dependency("org.test:foo:1.0") {
@@ -73,23 +74,33 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         }
 
         and:
+        javaLibrary.parsedPom.scopes.compile.assertDependsOn('org.test:foo:1.0')
+        javaLibrary.parsedPom.scopes.runtime.assertDependsOn('org.test:bar:1.1')
+
+        and:
         resolveArtifacts(javaLibrary) {
-            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                // With Maven, can't have different versions for a dependency between compile and runtime
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
         }
 
         and:
         resolveApiArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveRuntimeArtifacts(javaLibrary) {
-            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
         }
 
         where:
@@ -130,6 +141,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         run "publish"
 
         then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             dependency("org.test:foo:1.0") {
@@ -148,23 +160,34 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         }
 
         and:
+        javaLibrary.parsedPom.scopes.compile.assertDependsOn('org.test:foo:1.0')
+        javaLibrary.parsedPom.scopes.runtime.assertDependsOn('org.test:bar:1.1')
+
+        and:
         resolveArtifacts(javaLibrary) {
-            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                // With Maven, can't have different versions for a dependency between compile and runtime
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
         }
 
         and:
         resolveApiArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveRuntimeArtifacts(javaLibrary) {
-            expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            withModuleMetadata {
+                expectFiles "bar-1.1.jar", "foo-1.1.jar", "publishTest-1.9.jar"
+            }
+            withoutModuleMetadata {
+                // With Maven, can't have different versions for a dependency between compile and runtime
+                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
+            }
         }
 
         where:
@@ -212,6 +235,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         run "publish"
 
         then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             dependency("org.test:foo:1.0") {
@@ -230,33 +254,22 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         }
 
         and:
+        javaLibrary.parsedPom.scopes.compile.assertDependsOn('org.test:foo:1.0')
+        javaLibrary.parsedPom.scopes.runtime.assertDependsOn('org.test:bar:1.1')
+
+        and:
         resolveArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveApiArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveRuntimeArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         where:
@@ -298,6 +311,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         run "publish"
 
         then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             constraint("org.test:bar:1.1") {
@@ -329,33 +343,22 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         }
 
         and:
+        javaLibrary.parsedPom.scopes.compile.assertDependsOn('org.test:foo:1.0')
+        javaLibrary.parsedPom.scopes.runtime.assertDependsOn('org.test:bar:1.1')
+
+        and:
         resolveArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveApiArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveRuntimeArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "bar-1.1.jar", "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         where:
@@ -395,6 +398,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         run "publish"
 
         then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             constraint("org.test:bar:[1.0, 2.0[") {
@@ -424,32 +428,17 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
 
         and:
         resolveArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveApiArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
         and:
         resolveRuntimeArtifacts(javaLibrary) {
-            withModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
-            withoutModuleMetadata {
-                expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
-            }
+            expectFiles "foo-1.0.jar", "publishTest-1.9.jar"
         }
 
     }
@@ -486,6 +475,7 @@ class MavenPublishResolvedVersionsJavaIntegTest extends AbstractMavenPublishInte
         run "publish"
 
         then:
+        javaLibrary.mavenModule.removeGradleMetadataRedirection()
         javaLibrary.assertPublished()
         javaLibrary.parsedModuleMetadata.variant("apiElements") {
             constraint("org.test:bar:1.0") {


### PR DESCRIPTION
* While the `versionMapping` feature was added for the Gradle metadata linked to an Ivy
publication, it was missed for the Ivy xml itself.
This commit corrects that, relying on the usage context attributes to
map the Ivy dependency to the requested resolved configuration.
* When using `versionMapping`, the publication warnings on incompatible
versions make little sense since all notations will be replaced by the
resolved version.

