### PR TITLE
improve gradle 5 compatibility

### DIFF
--- a/subprojects/docs/src/samples/signing/maven-publish/groovy/build.gradle
+++ b/subprojects/docs/src/samples/signing/maven-publish/groovy/build.gradle
@@ -27,8 +27,10 @@ publishing {
 // end::pom-customization[]
             artifactId = 'my-library'
             from components.java
-            artifact sourcesJar
-            artifact javadocJar
+            afterEvaluate {
+                artifact sourcesJar
+                artifact javadocJar
+            }
 // tag::versions-resolved[]
             versionMapping {
                 usage('java-api') {


### PR DESCRIPTION
gradle 5 does no longer allow eager created artifacts to be specified in the publishing configuration. 
Since this sample file is shown in the official `maven-publish` documentation, it would be nice
to show a working version there.
The given example currently fails with 
```
 Could not get unknown property 'sourcesJar' for object of type org.gradle.api.publish.maven.internal.publication.DefaultMavenPublication.
```

### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
