### PR TITLE
Pass Github token to flakiness detection build

### DIFF
--- a/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
+++ b/.teamcity/Gradle_Check/configurations/PerformanceTestCoordinator.kt
@@ -54,7 +54,6 @@ class PerformanceTestCoordinator(model: CIBuildModel, type: PerformanceTestType,
             val rerunnerParameters = listOf(
                     "-PteamCityBuildId=%teamcity.build.id%",
                     "-PonlyPreviousFailedTestClasses=true",
-                    "-PgithubToken=%github.ci.oauth.token%",
                     "-Dscan.tag.RERUN_TESTS")
             runner("GRADLE_RERUNNER", "tagBuild distributed${type.taskId}s", rerunnerParameters.joinToString(" "), ExecutionMode.RUN_ON_FAILURE)
         } else {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -261,7 +261,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
 enum class PerformanceTestType(val taskId: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "", val hasRerunner: Boolean = true) {
     test("PerformanceTest", 420, "defaults"),
     experiment("PerformanceExperiment", 420, "defaults"),
-    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit", "-PgithubToken=%github.ci.oauth.token%", hasRerunner = false),
+    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit", hasRerunner = false),
     historical("FullPerformanceTest", 2280, "2.14.1,3.5.1,4.0,last", "--checks none", hasRerunner = false);
 
     fun asId(model: CIBuildModel): String {

--- a/.teamcity/Gradle_Check/model/CIBuildModel.kt
+++ b/.teamcity/Gradle_Check/model/CIBuildModel.kt
@@ -261,7 +261,7 @@ enum class TestType(val unitTests: Boolean = true, val functionalTests: Boolean 
 enum class PerformanceTestType(val taskId: String, val timeout: Int, val defaultBaselines: String = "", val extraParameters: String = "", val hasRerunner: Boolean = true) {
     test("PerformanceTest", 420, "defaults"),
     experiment("PerformanceExperiment", 420, "defaults"),
-    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit", hasRerunner = false),
+    flakinessDetection("FlakinessDetection", 420, "flakiness-detection-commit", "-PgithubToken=%github.ci.oauth.token%", hasRerunner = false),
     historical("FullPerformanceTest", 2280, "2.14.1,3.5.1,4.0,last", "--checks none", hasRerunner = false);
 
     fun asId(model: CIBuildModel): String {

--- a/.teamcity/common/performance-test-extensions.kt
+++ b/.teamcity/common/performance-test-extensions.kt
@@ -48,6 +48,6 @@ fun performanceTestCommandLine(task: String, baselines: String, extraParameters:
 )
 
 fun distributedPerformanceTestParameters(workerId: String = "Gradle_Check_IndividualPerformanceScenarioWorkersLinux") = listOf(
-        "-Porg.gradle.performance.buildTypeId=${workerId} -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%"
+        "-Porg.gradle.performance.buildTypeId=${workerId} -Porg.gradle.performance.workerTestTaskName=fullPerformanceTest -Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id% -PgithubToken=%github.ci.oauth.token%"
 )
 

--- a/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
+++ b/.teamcityTest/Gradle_Check_Tests/PerformanceTestBuildTypeTest.kt
@@ -77,6 +77,7 @@ class PerformanceTestBuildTypeTest {
                 "-Porg.gradle.performance.buildTypeId=Gradle_Check_IndividualPerformanceScenarioWorkersLinux",
                 "-Porg.gradle.performance.workerTestTaskName=fullPerformanceTest",
                 "-Porg.gradle.performance.coordinatorBuildId=%teamcity.build.id%",
+                "-PgithubToken=%github.ci.oauth.token%",
                 "\"-Dscan.tag.PerformanceTest\"",
                 "--build-cache",
                 "\"-Dgradle.cache.remote.url=%gradle.cache.remote.url%\"",
@@ -95,7 +96,6 @@ class PerformanceTestBuildTypeTest {
                         + expectedRunnerParams
                         + "-PteamCityBuildId=%teamcity.build.id%"
                         + "-PonlyPreviousFailedTestClasses=true"
-                        + "-PgithubToken=%github.ci.oauth.token%"
                         + "-Dscan.tag.RERUN_TESTS"
                         ).joinToString(" "),
                 performanceTest.getGradleStep("GRADLE_RERUNNER").gradleParams


### PR DESCRIPTION
The build to determine performance test flakiness wants to open Github
issues as well.

This is the current failure: https://builds.gradle.org/viewLog.html?buildId=21649701&tab=buildResultsDiv&buildTypeId=Gradle_Check_PerformanceFlakinessDetectionCoordinator