### PR TITLE
Fix integration tests which don't use repo mirrors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformIntegrationTest.groovy
@@ -24,6 +24,7 @@ import org.hamcrest.Matcher
 import spock.lang.Issue
 import spock.lang.Unroll
 
+import static org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 import static org.gradle.util.Matchers.matchesRegexp
 
 class ArtifactTransformIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -137,7 +138,7 @@ $fileSizer
 
                     classpath 'org.apache.commons:commons-math3:3.6.1'
                 }
-                repositories { jcenter() }
+                ${jcenterRepository()} 
                 println(
                     configurations.classpath.incoming.artifactView {
                             attributes.attribute(artifactType, "size")

--- a/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/configuration/ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest.groovy
+++ b/subprojects/integ-test/src/integTest/groovy/org/gradle/integtests/configuration/ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest.groovy
@@ -343,13 +343,9 @@ class ExecuteDomainObjectCollectionCallbackBuildOperationTypeIntegrationTest ext
         """
         buildFile << """
             buildscript {
-                repositories {
-                    mavenCentral()
-                }
+                ${mavenCentralRepository()}
             }
-            repositories {
-                mavenCentral()
-            }
+            ${mavenCentralRepository()}
         """
 
         when:

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/GradleKotlinDslIntegrationTest.kt
@@ -18,21 +18,19 @@ package org.gradle.kotlin.dsl.integration
 
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
-
-import org.gradle.test.fixtures.file.LeaksFileHandles
-
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 import org.gradle.kotlin.dsl.embeddedKotlinVersion
 import org.gradle.kotlin.dsl.fixtures.DeepThought
 import org.gradle.kotlin.dsl.fixtures.LightThought
 import org.gradle.kotlin.dsl.fixtures.ZeroThought
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
 import org.gradle.kotlin.dsl.support.normaliseLineSeparators
-
+import org.gradle.test.fixtures.dsl.GradleDsl
+import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.hamcrest.CoreMatchers.allOf
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-
 import org.junit.Assert.assertNotEquals
 import org.junit.Test
 
@@ -404,7 +402,7 @@ class GradleKotlinDslIntegrationTest : AbstractPluginIntegrationTest() {
 
         withSettings("""
             buildscript {
-                repositories { jcenter() }
+                ${jcenterRepository(GradleDsl.KOTLIN)}
                 dependencies {
                     classpath("org.apache.commons:commons-lang3:3.6")
                 }

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/PrecompiledScriptPluginIntegrationTest.kt
@@ -1,6 +1,8 @@
 package org.gradle.kotlin.dsl.integration
 
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 import org.gradle.kotlin.dsl.fixtures.normalisedPath
+import org.gradle.test.fixtures.dsl.GradleDsl
 import org.gradle.test.fixtures.file.LeaksFileHandles
 import org.hamcrest.CoreMatchers.containsString
 import org.junit.Assert.assertFalse
@@ -62,7 +64,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
         """)
         withBuildScriptIn(firstLocation, """
             plugins { `kotlin-dsl` }
-            repositories { jcenter() }
+            ${jcenterRepository(GradleDsl.KOTLIN)}
         """)
 
         withFile("$firstLocation/src/main/kotlin/plugin-without-package.gradle.kts")
@@ -109,7 +111,7 @@ class PrecompiledScriptPluginIntegrationTest : AbstractPluginIntegrationTest() {
 
         withBuildScript("""
             plugins { `kotlin-dsl` }
-            repositories { jcenter() }
+            ${jcenterRepository(GradleDsl.KOTLIN)}
         """)
 
         val fooScript = withFile("src/main/kotlin/foo.gradle.kts", "")

--- a/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
+++ b/subprojects/kotlin-dsl-integ-tests/src/integTest/kotlin/org/gradle/kotlin/dsl/integration/ProjectSchemaAccessorsIntegrationTest.kt
@@ -16,9 +16,11 @@
 
 package org.gradle.kotlin.dsl.integration
 
+import org.gradle.integtests.fixtures.RepoScriptBlockUtil.jcenterRepository
 import org.gradle.kotlin.dsl.fixtures.FoldersDsl
 import org.gradle.kotlin.dsl.fixtures.FoldersDslExpression
 import org.gradle.kotlin.dsl.fixtures.containsMultiLineString
+import org.gradle.test.fixtures.dsl.GradleDsl
 
 import org.gradle.test.fixtures.file.LeaksFileHandles
 
@@ -568,7 +570,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
                 compile("org.apache.commons:commons-io:1.3.2")
             }
 
-            repositories { jcenter() }
+            ${jcenterRepository(GradleDsl.KOTLIN)}
         """)
 
         withBuildScriptIn("c", """
@@ -586,7 +588,7 @@ class ProjectSchemaAccessorsIntegrationTest : AbstractPluginIntegrationTest() {
                 }
             }
 
-            repositories { jcenter() }
+            ${jcenterRepository(GradleDsl.KOTLIN)}
 
             configurations.compileClasspath.files.forEach {
                 println(org.gradle.util.TextUtil.normaliseFileSeparators(it.path))


### PR DESCRIPTION
### Context

We observed some flakiness caused by not using repository mirrors: https://github.com/gradle/gradle-private/issues/2049

This PR identifies some integration tests which don't use mirrors and fixes them. It would be great if we can detect such cases earlier.