### PR TITLE
Dissallow `@Incremental` on fields

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/work/Incremental.java
+++ b/subprojects/core-api/src/main/java/org/gradle/work/Incremental.java
@@ -35,7 +35,7 @@ import java.lang.annotation.Target;
  */
 @Incubating
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD})
 @Documented
 public @interface Incremental {
 }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -196,13 +196,20 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         buildFile << """
 
             class MyTask extends DefaultTask {
-                @Incremental
-                @InputDirectory
                 File inputOne
+                File inputTwo
 
                 @Incremental
                 @InputDirectory
-                File inputTwo
+                File getInputOne() {
+                    inputOne
+                }
+
+                @Incremental
+                @InputDirectory
+                File getInputTwo() {
+                    inputTwo
+                }
 
                 @OutputDirectory
                 File outputDirectory


### PR DESCRIPTION
The newly introduced annotation should be used like this:
```
abstract class MyClass {
   @Incremental @InputDirectory
   abstract DirectoryProperty getInputDir()
}
```

That means it makes no sense to allow `FIELD` as a target.