### PR TITLE
More improvements for incremental task documentation

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.api.Task.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.api.Task.xml
@@ -35,6 +35,9 @@
                 <td>outputs</td>
             </tr>
             <tr>
+                <td>localState</td>
+            </tr>
+            <tr>
                 <td>destroyables</td>
             </tr>
             <tr>

--- a/subprojects/docs/src/docs/userguide/custom_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_tasks.adoc
@@ -331,7 +331,7 @@ This way when the task's results are loaded from cache, the next execution can a
 
 However, if the state files are non-relocatable, then they can't be shared via the build cache.
 Indeed, when the task is loaded from cache, any such state files must be cleaned up to prevent stale state from confusing the tool during the next execution.
-Gradle can ensure such stale files are removed if they are declared via `task.localState.register()` or if a property is marked with the `@LocalState` annotation.
+Gradle can ensure such stale files are removed if they are declared via `link:{javadocPath}/org/gradle/api/tasks/TaskLocalState.html#register-java.lang.Object++...++-[task.localState.register()]` or if a property is marked with the `@link:{javadocPath}/org/gradle/api/tasks/LocalState.html[LocalState]` annotation.
 
 [[sec:declaring_and_using_command_line_options]]
 == Declaring and Using Command Line Options

--- a/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
+++ b/subprojects/docs/src/docs/userguide/more_about_tasks.adoc
@@ -649,7 +649,11 @@ Using a file tree turns <<build_cache.adoc#sec:task_output_caching, caching>> of
 
 | [#skip-when-empty]`@link:{javadocPath}/org/gradle/api/tasks/SkipWhenEmpty.html[SkipWhenEmpty]`
 | `File`+++*+++
-| Used with `@InputFiles` or `@InputDirectory` to tell Gradle to skip the task if the corresponding files or directory are empty, along with all other input files declared with this annotation. Tasks that have been skipped due to all of their input files that were declared with this annotation being empty will result in a distinct “no source” outcome. For example, `NO-SOURCE` will be emitted in the console output.
+| Used with `@InputFiles` or `@InputDirectory` to tell Gradle to skip the task if the corresponding files or directory are empty, along with all other input files declared with this annotation. Tasks that have been skipped due to all of their input files that were declared with this annotation being empty will result in a distinct “no source” outcome. For example, `NO-SOURCE` will be emitted in the console output. Implies `<<#incremental,@Incremental>>`.
+
+| [#incremental]`@link:{javadocPath}/org/gradle/work/Incremental.html[Incremental]`
+| `Provider<FileSystemLocation>` or `FileCollection`
+| Used with `@InputFiles` or `@InputDirectory` to instruct Gradle to track changes to the annotated file property, so the changes can be queried via `@link:{groovyDslPath}/org.gradle.work.InputChanges.html[InputChanges.getFileChanges()]`. Required for <<custom_tasks.adoc#incremental_tasks,incremental tasks>>.
 
 | `@link:{javadocPath}/org/gradle/api/tasks/Optional.html[Optional]`
 | Any type


### PR DESCRIPTION
- Add `@Incremental` in the input/output annotation table
- Expose `localState` in the DSL docs
- Add some links to local state in `custom_tasks.adoc`
