### PR TITLE
Validate types for injection annotations

### DIFF
--- a/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
+++ b/buildSrc/subprojects/binary-compatibility/src/main/groovy/org/gradle/binarycompatibility/rules/SinceAnnotationMissingRule.java
@@ -18,6 +18,7 @@ package org.gradle.binarycompatibility.rules;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.body.AnnotationDeclaration;
+import com.github.javaparser.ast.body.AnnotationMemberDeclaration;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
@@ -68,6 +69,13 @@ public class SinceAnnotationMissingRule extends AbstractGradleViolationRule {
                         return new Object();
                     }
                     return super.visit(annotationDeclaration, arg);
+                }
+                @Override
+                public Object visit(AnnotationMemberDeclaration annotationMemberDeclaration, Void arg) {
+                    if (matchesNameAndContainsAnnotation(annotationMemberDeclaration.getName().asString(), method.getName(), annotationMemberDeclaration)) {
+                        return new Object();
+                    }
+                    return super.visit(annotationMemberDeclaration, arg);
                 }
                 @Override
                 public Object visit(EnumDeclaration enumDeclaration, Void arg) {

--- a/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/artifacts/transform/InputArtifact.java
@@ -17,6 +17,7 @@
 package org.gradle.api.artifacts.transform;
 
 import org.gradle.api.Incubating;
+import org.gradle.api.file.FileSystemLocation;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.reflect.InjectionPointQualifier;
 
@@ -40,6 +41,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 @Documented
-@InjectionPointQualifier(supportedTypes = { File.class, Provider.class })
+@InjectionPointQualifier(supportedTypes = { File.class }, supportedProviderTypes = { FileSystemLocation.class })
 public @interface InputArtifact {
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/reflect/InjectionPointQualifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/reflect/InjectionPointQualifier.java
@@ -37,4 +37,5 @@ import java.lang.annotation.Target;
 @Documented
 public @interface InjectionPointQualifier {
     Class<?>[] supportedTypes() default {};
+    Class<?>[] supportedProviderTypes() default {};
 }

--- a/subprojects/core-api/src/main/java/org/gradle/api/reflect/InjectionPointQualifier.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/reflect/InjectionPointQualifier.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 /**
  * The annotated annotation can be used to inject elements of the supported types.
  *
- * <p>If no {@code supportedTypes} are supplied, all types are supported.</p>
+ * <p>If both {@link #supportedTypes()} and {@link #supportedProviderTypes()} are empty, all types are supported.</p>
  *
  * @since 5.3
  */
@@ -36,6 +36,17 @@ import java.lang.annotation.Target;
 @Target({ElementType.ANNOTATION_TYPE})
 @Documented
 public @interface InjectionPointQualifier {
+    /**
+     * The types which are supported for injection.
+     */
     Class<?>[] supportedTypes() default {};
+
+    /**
+     * The types of {@link org.gradle.api.provider.Provider}s supported for injection.
+     * <br>
+     * If e.g. {@link org.gradle.api.file.FileSystemLocation} is in the list, then this annotation can be used for injecting {@link org.gradle.api.provider.Provider}&lt;{@link org.gradle.api.file.FileSystemLocation}&gt;.
+     *
+     * @since 5.5
+     */
     Class<?>[] supportedProviderTypes() default {};
 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -696,7 +696,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project")
-        failure.assertHasCause("Cannot register artifact transform MakeGreen with parameters null")
+        failure.assertHasCause("Cannot register artifact transform MakeGreen (from: {color=blue}, to: {color=green})")
         failure.assertHasCause("Cannot use @InputArtifact annotation on property MakeGreen.getInput() of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider<org.gradle.api.file.FileSystemLocation>.")
 
         where:
@@ -733,7 +733,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project")
-        failure.assertHasCause("Cannot register artifact transform MakeGreen with parameters null")
+        failure.assertHasCause("Cannot register artifact transform MakeGreen (from: {color=blue}, to: {color=green})")
         failure.assertHasCause("Cannot use @InputArtifactDependencies annotation on property MakeGreen.getDependencies() of type ${propertyType.name}. Allowed property types: org.gradle.api.file.FileCollection.")
 
         where:

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -668,7 +668,7 @@ abstract class MakeGreen extends ArtifactTransform {
     @Unroll
     def "transform cannot use @InputArtifact to receive #propertyType"() {
         settingsFile << """
-            include 'a', 'b', 'c'
+            include 'a', 'b'
         """
         setupBuildWithColorTransformAction()
         def typeName = propertyType instanceof Class ? propertyType.name : propertyType.toString()
@@ -695,7 +695,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         fails(":a:resolve")
 
         then:
-        if (configurationTime) {
+        if (expectFailureDuringConfigurationTime) {
             failure.assertHasDescription("A problem occurred evaluating root project")
             failure.assertHasCause("Cannot register artifact transform MakeGreen with parameters null")
             failure.assertHasCause("Cannot use @InputArtifact annotation on property MakeGreen.getInput() of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider.")
@@ -706,7 +706,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         }
 
         where:
-        propertyType                                   | configurationTime
+        propertyType                                   | expectFailureDuringConfigurationTime
         FileCollection                                 | true
         new TypeToken<Provider<File>>() {}.getType()   | false
         new TypeToken<Provider<String>>() {}.getType() | false
@@ -715,7 +715,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
     @Unroll
     def "transform cannot use @InputArtifactDependencies to receive #propertyType"() {
         settingsFile << """
-            include 'a', 'b', 'c'
+            include 'a', 'b'
         """
         setupBuildWithColorTransformAction()
         buildFile << """
@@ -746,9 +746,9 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         failure.assertHasCause("Cannot use @InputArtifactDependencies annotation on property MakeGreen.getDependencies() of type ${propertyType.name}. Allowed property types: org.gradle.api.file.FileCollection.")
 
         where:
-        annotation                | propertyType                                   | configurationTime
-        InputArtifactDependencies | File                                           | true
-        InputArtifactDependencies | String                                         | true
+        annotation                | propertyType
+        InputArtifactDependencies | File
+        InputArtifactDependencies | String
     }
 
     def "transform cannot use @Inject to receive input file"() {

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -695,21 +695,12 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
         fails(":a:resolve")
 
         then:
-        if (expectFailureDuringConfigurationTime) {
-            failure.assertHasDescription("A problem occurred evaluating root project")
-            failure.assertHasCause("Cannot register artifact transform MakeGreen with parameters null")
-            failure.assertHasCause("Cannot use @InputArtifact annotation on property MakeGreen.getInput() of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider.")
-        } else {
-            failure.assertHasDescription("Execution failed for task ':a:resolve'.")
-            failure.assertHasCause("Execution failed for MakeGreen: ${file('b/build/b.jar')}.")
-            failure.assertHasCause("Cannot use @InputArtifact annotation on property of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider<org.gradle.api.file.FileSystemLocation>.")
-        }
+        failure.assertHasDescription("A problem occurred evaluating root project")
+        failure.assertHasCause("Cannot register artifact transform MakeGreen with parameters null")
+        failure.assertHasCause("Cannot use @InputArtifact annotation on property MakeGreen.getInput() of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider<org.gradle.api.file.FileSystemLocation>.")
 
         where:
-        propertyType                                   | expectFailureDuringConfigurationTime
-        FileCollection                                 | true
-        new TypeToken<Provider<File>>() {}.getType()   | false
-        new TypeToken<Provider<String>>() {}.getType() | false
+        propertyType << [FileCollection, new TypeToken<Provider<File>>() {}.getType(), new TypeToken<Provider<String>>() {}.getType()]
     }
 
     @Unroll

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/transform/ArtifactTransformValuesInjectionIntegrationTest.groovy
@@ -696,7 +696,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project")
-        failure.assertHasCause("Cannot register artifact transform MakeGreen (from: {color=blue}, to: {color=green})")
+        failure.assertHasCause("Cannot register artifact transform MakeGreen (from {color=blue} to {color=green})")
         failure.assertHasCause("Cannot use @InputArtifact annotation on property MakeGreen.getInput() of type ${typeName}. Allowed property types: java.io.File, org.gradle.api.provider.Provider<org.gradle.api.file.FileSystemLocation>.")
 
         where:
@@ -733,7 +733,7 @@ abstract class MakeGreen implements TransformAction<TransformParameters.None> {
 
         then:
         failure.assertHasDescription("A problem occurred evaluating root project")
-        failure.assertHasCause("Cannot register artifact transform MakeGreen (from: {color=blue}, to: {color=green})")
+        failure.assertHasCause("Cannot register artifact transform MakeGreen (from {color=blue} to {color=green})")
         failure.assertHasCause("Cannot use @InputArtifactDependencies annotation on property MakeGreen.getDependencies() of type ${propertyType.name}. Allowed property types: org.gradle.api.file.FileCollection.")
 
         where:

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -351,7 +351,17 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
         public Object get(Type serviceType, Class<? extends Annotation> annotatedWith) throws UnknownServiceException, ServiceLookupException {
             Object result = find(serviceType, annotatedWith);
             if (result == null) {
-                throw new UnknownServiceException(serviceType, "No service of type " + serviceType + " available.");
+                String allowedTypes = injectionPoints.stream()
+                    .filter(injectionPoint -> injectionPoint.getAnnotation() == annotatedWith)
+                    .map(injectionPoint -> injectionPoint.getInjectedType().getTypeName())
+                    .sorted()
+                    .collect(Collectors.joining(", "));
+                throw new UnknownServiceException(serviceType, String.format(
+                    "Cannot use @%s annotation on property of type %s. Allowed property types: %s.",
+                    annotatedWith.getSimpleName(),
+                    serviceType,
+                    allowedTypes
+                ));
             }
             return result;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformer.java
@@ -351,17 +351,7 @@ public class DefaultTransformer extends AbstractTransformer<TransformAction> {
         public Object get(Type serviceType, Class<? extends Annotation> annotatedWith) throws UnknownServiceException, ServiceLookupException {
             Object result = find(serviceType, annotatedWith);
             if (result == null) {
-                String allowedTypes = injectionPoints.stream()
-                    .filter(injectionPoint -> injectionPoint.getAnnotation() == annotatedWith)
-                    .map(injectionPoint -> injectionPoint.getInjectedType().getTypeName())
-                    .sorted()
-                    .collect(Collectors.joining(", "));
-                throw new UnknownServiceException(serviceType, String.format(
-                    "Cannot use @%s annotation on property of type %s. Allowed property types: %s.",
-                    annotatedWith.getSimpleName(),
-                    serviceType,
-                    allowedTypes
-                ));
+                throw new UnknownServiceException(serviceType, "No service of type " + serviceType + " available.");
             }
             return result;
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -99,7 +99,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
             ArtifactTransformRegistration finalizedRegistration = registrationFactory.create(registration.from.asImmutable(), registration.to.asImmutable(), actionType, parameterObject);
             transforms.add(finalizedRegistration);
         } catch (Exception e) {
-            throw new VariantTransformConfigurationException(String.format("Cannot register artifact transform %s with parameters %s", ModelType.of(actionType).getDisplayName(), parameterObject), e);
+            throw new VariantTransformConfigurationException(String.format("Cannot register artifact transform %s (from: %s, to: %s)", ModelType.of(actionType).getDisplayName(), registration.from, registration.to), e);
         }
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultVariantTransformRegistry.java
@@ -99,7 +99,7 @@ public class DefaultVariantTransformRegistry implements VariantTransformRegistry
             ArtifactTransformRegistration finalizedRegistration = registrationFactory.create(registration.from.asImmutable(), registration.to.asImmutable(), actionType, parameterObject);
             transforms.add(finalizedRegistration);
         } catch (Exception e) {
-            throw new VariantTransformConfigurationException(String.format("Cannot register artifact transform %s (from: %s, to: %s)", ModelType.of(actionType).getDisplayName(), registration.from, registration.to), e);
+            throw new VariantTransformConfigurationException(String.format("Cannot register artifact transform %s (from %s to %s)", ModelType.of(actionType).getDisplayName(), registration.from, registration.to), e);
         }
     }
 


### PR DESCRIPTION
This gives a better error message for artifact transforms which
attach `@InputArtifact` or the `@ArtifactDependencies` to a property
of the wrong type.
