### PR TITLE
Bump the timeout for continuous tests

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/integtests/fixtures/AbstractContinuousIntegrationTest.groovy
@@ -32,13 +32,12 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 import static org.gradle.integtests.fixtures.RetryConditions.onBuildTimeout
-import static org.gradle.util.TestPrecondition.PULL_REQUEST_BUILD
 import static spock.lang.Retry.Mode.SETUP_FEATURE_CLEANUP
 
 @Retry(condition = { onBuildTimeout(instance, failure) }, mode = SETUP_FEATURE_CLEANUP, count = 2)
 abstract class AbstractContinuousIntegrationTest extends AbstractIntegrationSpec {
 
-    private static final int WAIT_FOR_WATCHING_TIMEOUT_SECONDS = PULL_REQUEST_BUILD.fulfilled ? 60 : 30
+    private static final int WAIT_FOR_WATCHING_TIMEOUT_SECONDS = 60
     private static final int WAIT_FOR_SHUTDOWN_TIMEOUT_SECONDS = 20
     private static final boolean OS_IS_WINDOWS = OperatingSystem.current().isWindows()
     private static final String CHANGE_DETECTED_OUTPUT = "Change detected, executing build..."


### PR DESCRIPTION
CI history shows that we were breaking often enough the 30 seconds
barrier so changing the value to be always 60 seconds.