### PR TITLE
Use Java 8-compatible variant of Guava

### DIFF
--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api("com.google.guava:guava:27.1-jre")
+    api("com.google.guava:guava:26.0-jre")
     api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
 
     implementation(project(":buildPlatform"))

--- a/buildSrc/subprojects/build/build.gradle.kts
+++ b/buildSrc/subprojects/build/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    api("com.google.guava:guava:26.0-jre")
+    api("com.google.guava:guava:27.1-jre")
     api("org.asciidoctor:asciidoctor-gradle-plugin:1.5.10")
 
     implementation(project(":buildPlatform"))

--- a/buildSrc/subprojects/packaging/packaging.gradle.kts
+++ b/buildSrc/subprojects/packaging/packaging.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":configuration"))
     implementation(project(":build"))
     implementation(project(":kotlinDsl"))
-    implementation("com.google.guava:guava:27.1-jre")
+    implementation("com.google.guava:guava:26.0-jre")
     implementation("org.ow2.asm:asm:6.0")
     implementation("org.ow2.asm:asm-commons:6.0")
     implementation("com.google.code.gson:gson:2.7")

--- a/buildSrc/subprojects/packaging/packaging.gradle.kts
+++ b/buildSrc/subprojects/packaging/packaging.gradle.kts
@@ -2,7 +2,7 @@ dependencies {
     implementation(project(":configuration"))
     implementation(project(":build"))
     implementation(project(":kotlinDsl"))
-    implementation("com.google.guava:guava:26.0-jre")
+    implementation("com.google.guava:guava:27.1-jre")
     implementation("org.ow2.asm:asm:6.0")
     implementation("org.ow2.asm:asm-commons:6.0")
     implementation("com.google.code.gson:gson:2.7")

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ libraries.fastutil =            [coordinates: 'it.unimi.dsi:fastutil', version: 
 libraries.gcs =                 [coordinates: 'com.google.apis:google-api-services-storage', version: 'v1-rev136-1.25.0']
 libraries.groovy =              [coordinates: 'org.gradle.groovy:groovy-all', version: gradleGroovyVersion, because: 'emulating the Groovy 2.4-style groovy-all.jar, see https://github.com/gradle/gradle-groovy-all']
 libraries.gson =                [coordinates: 'com.google.code.gson:gson', version: '2.8.5']
-libraries.guava =               [coordinates: 'com.google.guava:guava', version: '26.0-android', because: 'android variant is compatible with JDK 7']
+libraries.guava =               [coordinates: 'com.google.guava:guava', version: '26.0-jre']
 libraries.inject =              [coordinates: 'javax.inject:javax.inject', version: '1']
 libraries.ivy =                 [coordinates: 'org.apache.ivy:ivy', version: '2.3.0',
                                  because: '2.4.0 contains a breaking change in DefaultModuleDescriptor.getExtraInfo(), cf. https://issues.apache.org/jira/browse/IVY-1457']

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ libraries.fastutil =            [coordinates: 'it.unimi.dsi:fastutil', version: 
 libraries.gcs =                 [coordinates: 'com.google.apis:google-api-services-storage', version: 'v1-rev136-1.25.0']
 libraries.groovy =              [coordinates: 'org.gradle.groovy:groovy-all', version: gradleGroovyVersion, because: 'emulating the Groovy 2.4-style groovy-all.jar, see https://github.com/gradle/gradle-groovy-all']
 libraries.gson =                [coordinates: 'com.google.code.gson:gson', version: '2.8.5']
-libraries.guava =               [coordinates: 'com.google.guava:guava', version: '27.1-jre']
+libraries.guava =               [coordinates: 'com.google.guava:guava', version: '26.0-jre']
 libraries.inject =              [coordinates: 'javax.inject:javax.inject', version: '1']
 libraries.ivy =                 [coordinates: 'org.apache.ivy:ivy', version: '2.3.0',
                                  because: '2.4.0 contains a breaking change in DefaultModuleDescriptor.getExtraInfo(), cf. https://issues.apache.org/jira/browse/IVY-1457']

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ libraries.fastutil =            [coordinates: 'it.unimi.dsi:fastutil', version: 
 libraries.gcs =                 [coordinates: 'com.google.apis:google-api-services-storage', version: 'v1-rev136-1.25.0']
 libraries.groovy =              [coordinates: 'org.gradle.groovy:groovy-all', version: gradleGroovyVersion, because: 'emulating the Groovy 2.4-style groovy-all.jar, see https://github.com/gradle/gradle-groovy-all']
 libraries.gson =                [coordinates: 'com.google.code.gson:gson', version: '2.8.5']
-libraries.guava =               [coordinates: 'com.google.guava:guava', version: '26.0-jre']
+libraries.guava =               [coordinates: 'com.google.guava:guava', version: '27.1-jre']
 libraries.inject =              [coordinates: 'javax.inject:javax.inject', version: '1']
 libraries.ivy =                 [coordinates: 'org.apache.ivy:ivy', version: '2.3.0',
                                  because: '2.4.0 contains a breaking change in DefaultModuleDescriptor.getExtraInfo(), cf. https://issues.apache.org/jira/browse/IVY-1457']

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/AstUtils.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/AstUtils.java
@@ -201,8 +201,15 @@ public abstract class AstUtils {
     @Nullable
     public static ScriptBlock detectScriptBlock(Statement statement, final Collection<String> names) {
         return detectScriptBlock(statement, new Predicate<ScriptBlock>() {
+            @Override
             public boolean apply(ScriptBlock input) {
                 return names.contains(input.getName());
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ScriptBlock input) {
+                return apply(input);
             }
         });
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
@@ -37,6 +37,12 @@ public abstract class Actions {
         public boolean apply(@Nullable Action<?> input) {
             return input != DO_NOTHING;
         }
+
+        @Override
+        // Added for Java 6 source compatibility
+        public boolean test(@Nullable Action<?> input) {
+            return apply(input);
+        }
     };
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.work;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
@@ -44,7 +43,6 @@ import org.gradle.util.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -204,12 +202,12 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     }
 
     private boolean containsProjectLocks(Iterable<? extends ResourceLock> locks) {
-        return Iterables.any(locks, new Predicate<ResourceLock>() {
-            @Override
-            public boolean apply(@Nullable ResourceLock lock) {
-                return lock instanceof ProjectLock;
+        for (ResourceLock lock : locks) {
+            if (lock instanceof ProjectLock) {
+                return true;
             }
-        });
+        }
+        return false;
     }
 
     private Iterable<? extends ResourceLock> locksNotHeld(final Iterable<? extends ResourceLock> locks) {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -232,7 +232,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
 
         expect:
         fails("myTask")
-        failureHasCause("Multiple entries with same key: ${file('input').absolutePath}=inputTwo and ${file('input').absolutePath}=inputOne")
+        failureHasCause("Multiple entries with same value: ${file('input').absolutePath}=inputTwo and ${file('input').absolutePath}=inputOne")
     }
 
     def "two incremental file properties can point to the same file"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -229,10 +229,11 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
         """
 
         file("input").createDir()
+        def inputPath = file('input').absolutePath
 
         expect:
         fails("myTask")
-        failureHasCause("Multiple entries with same value: ${file('input').absolutePath}=inputTwo and ${file('input').absolutePath}=inputOne")
+        failureHasCause("Multiple entries with same value: inputTwo=$inputPath and inputOne=$inputPath")
     }
 
     def "two incremental file properties can point to the same file"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -103,8 +103,15 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
     private Plugin doFindPlugin(String id) {
         for (final PluginManagerInternal.PluginWithId pluginWithId : pluginManager.pluginsForId(id)) {
             Plugin plugin = Iterables.tryFind(DefaultPluginContainer.this, new Predicate<Plugin>() {
+                @Override
                 public boolean apply(Plugin plugin) {
                     return pluginWithId.clazz.equals(plugin.getClass());
+                }
+
+                @Override
+                // Added for Java 6 source compatibility
+                public boolean test(Plugin input) {
+                    return apply(input);
                 }
             }).orNull();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -125,6 +125,12 @@ public class DefaultTaskProperties implements TaskProperties {
             public boolean apply(InputFilePropertySpec property) {
                 return property.isSkipWhenEmpty();
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable InputFilePropertySpec input) {
+                return apply(input);
+            }
         });
         this.outputFiles = new CompositeFileCollection() {
             @Override

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -400,6 +400,12 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             public boolean apply(Node input) {
                 return visitingNodes.containsEntry(input, nodeWithVisitingSegment.visitingSegment);
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable Node input) {
+                return apply(input);
+            }
         });
     }
 
@@ -437,6 +443,12 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                     @SuppressWarnings("NullableProblems")
                     public boolean apply(NodeInVisitingSegment nodeInVisitingSegment) {
                         return nodeInVisitingSegment.node.equals(dependsOnTask);
+                    }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(@Nullable NodeInVisitingSegment input) {
+                        return apply(input);
                     }
                 });
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchPointsRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchPointsRegistry.java
@@ -121,6 +121,12 @@ class WatchPointsRegistry {
                 public boolean apply(File input) {
                     return inCombinedRootsOrAncestorOfAnyRoot(input, roots, unfiltered);
                 }
+
+                @Override
+                // Added for Java 6 source compatibility
+                public boolean test(File input) {
+                    return apply(input);
+                }
             });
         }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -173,6 +173,12 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
                     public boolean apply(Record input) {
                         return detailsType.isInstance(input.descriptor.getDetails());
                     }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(Record input) {
+                        return apply(input);
+                    }
                 })
                 .transform(new Function<Record, TypedRecord<D, R>>() {
                     @Override

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsGraphRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsGraphRenderer.java
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependenc
 import org.gradle.internal.graph.GraphRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.Info;
@@ -126,6 +127,12 @@ public class DependentComponentsGraphRenderer {
                 return !hideNonBuildable && !hideTestSuite;
             }
             return false;
+        }
+
+        @Override
+        // Added for Java 6 source compatibility
+        public boolean test(@Nullable RenderableDependency input) {
+            return apply(input);
         }
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsRenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsRenderableDependency.java
@@ -54,6 +54,12 @@ public class DependentComponentsRenderableDependency extends AbstractRenderableD
                 public boolean apply(BinarySpec binarySpec) {
                     return binarySpec.isBuildable();
                 }
+
+                @Override
+                // Added for Java 6 source compatibility
+                public boolean test(BinarySpec input) {
+                    return apply(input);
+                }
             });
         }
         boolean testSuite = false;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/internal/ModelNodeRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/internal/ModelNodeRenderer.java
@@ -34,7 +34,9 @@ import org.gradle.reporting.ReportRenderer;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Description;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Identifier;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Normal;
 
 public class ModelNodeRenderer extends ReportRenderer<ModelNode, TextReportBuilder> {
 
@@ -167,6 +169,12 @@ public class ModelNodeRenderer extends ReportRenderer<ModelNode, TextReportBuild
             @Override
             public boolean apply(ModelRuleDescriptor input) {
                 return !input.equals(model.getDescriptor());
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ModelRuleDescriptor input) {
+                return apply(input);
             }
         });
         return ImmutableSet.copyOf(filtered);

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -47,7 +47,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-io-2.6.jar' : 'f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513',
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'groovy-all-1.0-2.5.4.jar' : '704d3307616c57234871c4db3a355c3e81ea975db8dac8ee6c9264b91c74d2b7',
-            'guava-26.0-android.jar' : '1d044ebb866ef08b7d04e998b4260c9b52fab6e6d6b68d207859486bb3686cd5',
+            'guava-26.0-jre.jar' : 'a0e9cabad665bc20bcd2b01f108e5fc03f756e13aea80abaadb9f407033bea2c',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',
             'jcl-over-slf4j-1.7.25.jar' : '5e938457e79efcbfb3ab64bc29c43ec6c3b95fffcda3c155f4a86cc320c11e14',

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -15,8 +15,7 @@
  */
 package org.gradle.api.internal.file;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterators;
+import com.google.common.collect.AbstractIterator;
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.file.FileCollection;
@@ -32,7 +31,6 @@ import org.gradle.api.tasks.TaskDependency;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.GUtil;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -190,12 +188,6 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public FileCollection filter(final Spec<? super File> filterSpec) {
-        final Predicate<File> predicate = new Predicate<File>() {
-            @Override
-            public boolean apply(@Nullable File input) {
-                return filterSpec.isSatisfiedBy(input);
-            }
-        };
         return new AbstractFileCollection() {
             @Override
             public String getDisplayName() {
@@ -214,12 +206,24 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
             @Override
             public boolean contains(File file) {
-                return AbstractFileCollection.this.contains(file) && predicate.apply(file);
+                return AbstractFileCollection.this.contains(file) && filterSpec.isSatisfiedBy(file);
             }
 
             @Override
             public Iterator<File> iterator() {
-                return Iterators.filter(AbstractFileCollection.this.iterator(), predicate);
+                final Iterator<File> delegate = AbstractFileCollection.this.iterator();
+                return new AbstractIterator<File>() {
+                    @Override
+                    protected File computeNext() {
+                        while (delegate.hasNext()) {
+                            File element = delegate.next();
+                            if (filterSpec.isSatisfiedBy(element)) {
+                                return element;
+                            }
+                        }
+                        return endOfData();
+                    }
+                };
             }
         };
     }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AntFileCollectionMatchingTaskBuilder.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AntFileCollectionMatchingTaskBuilder.java
@@ -20,10 +20,10 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import groovy.lang.Closure;
-import org.gradle.internal.metaobject.BeanDynamicObject;
-import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.tasks.AntBuilderAware;
+import org.gradle.internal.metaobject.BeanDynamicObject;
+import org.gradle.internal.metaobject.DynamicObject;
 
 import java.util.Collections;
 
@@ -45,6 +45,12 @@ public class AntFileCollectionMatchingTaskBuilder implements AntBuilderAware {
                             @Override
                             public boolean apply(DirectoryFileTree input) {
                                 return input.getDir().exists();
+                            }
+
+                            @Override
+                            // Added for Java 6 source compatibility
+                            public boolean test(DirectoryFileTree input) {
+                                return apply(input);
                             }
                         })
         );

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -44,6 +44,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.VersionNumber;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -162,6 +163,12 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                             @Override
                             public boolean apply(File file) {
                                 return hasExtension(file, ".java");
+                            }
+
+                            @Override
+                            // Added for Java 6 source compatibility
+                            public boolean test(@Nullable File input) {
+                                return apply(input);
                             }
                         }));
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -70,6 +71,12 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                     }
                 }
                 return false;
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable File input) {
+                return apply(input);
             }
         });
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -60,6 +60,12 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
             public boolean apply(@Nullable File input) {
                 return hasExtension(input, ".java");
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable File input) {
+                return apply(input);
+            }
         });
 
         spec.setSourceFiles(ImmutableSet.copyOf(javaOnly));

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassRelevancyFilter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassRelevancyFilter.java
@@ -41,9 +41,16 @@ class ClassRelevancyFilter implements Predicate<String> {
         this.excludedClassName = excludedClassName;
     }
 
+    @Override
     public boolean apply(String className) {
         return !className.startsWith("java.")
             && !excludedClassName.equals(className)
             && !PRIMITIVES.contains(className);
+    }
+
+    @Override
+    // Added for Java 6 source compatibility
+    public boolean test(String input) {
+        return apply(input);
     }
 }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
@@ -89,7 +89,19 @@ public class LocalLibraryDependencyResolver implements DependencyToComponentIdRe
                     public boolean apply(Binary input) {
                         return binaryType.isAssignableFrom(input.getClass());
                     }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(Binary input) {
+                        return apply(input);
+                    }
                 });
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(VariantComponent input) {
+                return apply(input);
             }
         };
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMap.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMap.java
@@ -109,6 +109,12 @@ public class DomainObjectCollectionBackedModelMap<T> extends ModelMapGroovyView<
         public boolean apply(@Nullable T input) {
             return namer.determineName(input).equals(name);
         }
+
+        @Override
+        // Added for Java 6 source compatibility
+        public boolean test(@Nullable T input) {
+            return apply(input);
+        }
     }
 
     private static class ToName<T> implements Function<T, String> {

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/registry/ModelMapBasedRule.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/registry/ModelMapBasedRule.java
@@ -46,6 +46,12 @@ public abstract class ModelMapBasedRule<T, C> extends AbstractMethodRuleAction<C
             public boolean apply(ModelReference<?> element) {
                 return element.getType().equals(baseType);
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ModelReference<?> input) {
+                return apply(input);
+            }
         });
     }
 
@@ -54,6 +60,12 @@ public abstract class ModelMapBasedRule<T, C> extends AbstractMethodRuleAction<C
             @Override
             public boolean apply(ModelReference<?> element) {
                 return !element.getType().equals(baseType);
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ModelReference<?> input) {
+                return apply(input);
             }
         });
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
@@ -45,6 +45,12 @@ public class DefaultVariantsMetaData implements VariantsMetaData {
             public boolean apply(Map.Entry<String, Object> input) {
                 return input.getValue()!=null;
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(Map.Entry<String, Object> input) {
+                return apply(input);
+            }
         }).keySet());
         this.variantAxisTypes = variantAxisTypes;
     }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
@@ -102,8 +102,15 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
         return Iterables.any(
                 classOutputProviders.get(id),
                 new Predicate<DelegateProvider>() {
+                    @Override
                     public boolean apply(DelegateProvider delegateProvider) {
                         return delegateProvider.provider.hasOutput(delegateProvider.id, destination);
+                    }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(DelegateProvider input) {
+                        return apply(input);
                     }
                 });
     }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
@@ -30,7 +30,7 @@ class ToolingApiClasspathIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.classpath.size() == 2
         resolve.classpath.any {it.name ==~ /slf4j-api-.*\.jar/}
-        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 1.86 * 1024 * 1024
+        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 2.05 * 1024 * 1024
 
         cleanup:
         resolver.stop()


### PR DESCRIPTION
There doesn't seem to be a need for the Java 7-compatible variant (`-android`) of Guava.

This enables the use of immutable `Collector`s to be used with the Java 8 stream APIs.