### PR TITLE
Mark known flaky performance test in report

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -44,8 +44,8 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
 
     protected void generatePerformanceReport() {
         generateResultsJson()
-        def out = new ByteArrayOutputStream()
 
+        project.delete(reportDir)
         project.javaexec(new Action<JavaExecSpec>() {
             void execute(JavaExecSpec spec) {
                 spec.setMain(reportGeneratorClass)
@@ -54,12 +54,8 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
                 spec.systemProperty("org.gradle.performance.execution.channel", channel)
                 spec.systemProperty("githubToken", project.findProperty("githubToken"))
                 spec.setClasspath(ReportGenerationPerformanceTest.this.getClasspath())
-                spec.standardOutput = out
-                spec.errorOutput = out
             }
         })
-
-        println("Exec output: ${out}")
     }
 
     protected void generateResultsJson() {

--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/ReportGenerationPerformanceTest.groovy
@@ -44,8 +44,8 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
 
     protected void generatePerformanceReport() {
         generateResultsJson()
+        def out = new ByteArrayOutputStream()
 
-        project.delete(reportDir)
         project.javaexec(new Action<JavaExecSpec>() {
             void execute(JavaExecSpec spec) {
                 spec.setMain(reportGeneratorClass)
@@ -54,8 +54,12 @@ abstract class ReportGenerationPerformanceTest extends PerformanceTest {
                 spec.systemProperty("org.gradle.performance.execution.channel", channel)
                 spec.systemProperty("githubToken", project.findProperty("githubToken"))
                 spec.setClasspath(ReportGenerationPerformanceTest.this.getClasspath())
+                spec.standardOutput = out
+                spec.errorOutput = out
             }
         })
+
+        println("Exec output: ${out}")
     }
 
     protected void generateResultsJson() {

--- a/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/results/BuildScanReportGenerator.java
+++ b/subprojects/build-scan-performance/src/testFixtures/groovy/org/gradle/performance/results/BuildScanReportGenerator.java
@@ -17,7 +17,7 @@
 package org.gradle.performance.results;
 
 public class BuildScanReportGenerator extends AbstractReportGenerator<BuildScanResultsStore> {
-    public static void main(String[] args) throws Exception {
-        getGenerator(BuildScanReportGenerator.class).generateReport(args);
+    public static void main(String[] args) {
+        new BuildScanReportGenerator().generateReport(args);
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractReportGenerator.java
@@ -31,12 +31,12 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
         File outputDirectory = new File(args[0]);
         File resultJson = new File(args[1]);
         String projectName = args[2];
-        generate(outputDirectory, resultJson, projectName);
+        generate(PerformanceFlakinessAnalyzer.create(), outputDirectory, resultJson, projectName);
     }
 
-    protected void generate(File outputDirectory, File resultJson, String projectName) {
+    protected void generate(PerformanceFlakinessAnalyzer flakinessAnalyzer, File outputDirectory, File resultJson, String projectName) {
         try (ResultsStore store = getResultsStore()) {
-            renderIndexPage(store, resultJson, outputDirectory);
+            renderIndexPage(flakinessAnalyzer, store, resultJson, outputDirectory);
 
             for (String testName : store.getTestNames()) {
                 PerformanceTestHistory testResults = store.getTestResults(testName, 500, 90, ResultsStoreHelper.determineChannel());
@@ -55,8 +55,8 @@ public abstract class AbstractReportGenerator<R extends ResultsStore> {
         }
     }
 
-    protected void renderIndexPage(ResultsStore store, File resultJson, File outputDirectory) throws IOException {
-        new FileRenderer().render(store, new IndexPageGenerator(store, resultJson), new File(outputDirectory, "index.html"));
+    protected void renderIndexPage(PerformanceFlakinessAnalyzer flakinessAnalyzer, ResultsStore store, File resultJson, File outputDirectory) throws IOException {
+        new FileRenderer().render(store, new IndexPageGenerator(flakinessAnalyzer, store, resultJson), new File(outputDirectory, "index.html"));
     }
 
     protected void renderScenarioPage(String projectName, File outputDirectory, PerformanceTestHistory testResults) throws IOException {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractReportGenerator.java
@@ -26,9 +26,6 @@ import java.lang.reflect.Type;
 import java.net.URL;
 
 public abstract class AbstractReportGenerator<R extends ResultsStore> {
-    protected static <G extends AbstractReportGenerator> G getGenerator(Class<G> generatorClass) throws Exception {
-        return generatorClass.getConstructor().newInstance();
-    }
 
     protected void generateReport(String... args) {
         File outputDirectory = new File(args[0]);

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractTablePageGenerator.java
@@ -310,7 +310,8 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
         REGRESSED("REGRESSED", "badge badge-danger", "Regression confidence > 99% despite retries."),
         IMPROVED("IMPROVED", "badge badge-success", "Improvement confidence > 90%, rebaseline it to keep this improvement! :-)"),
         UNKNOWN("UNKNOWN", "badge badge-dark", "The status is unknown, may be it's cancelled?"),
-        FLAKY("FLAKY", "badge badge-warning", "The scenario's difference confidence > 95% even when running identical code."),
+        FLAKY("FLAKY", "badge badge-danger", "The scenario's difference confidence > 95% even when running identical code."),
+        KNOWN_FLAKY("KNOWN-FLAKY", "badge badge-danger", "The scenario was marked as flaky in gradle-private issue tracker recently."),
         UNTAGGED("UNTAGGED", null, null);
 
         private String name;

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractTablePageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/AbstractTablePageGenerator.java
@@ -44,10 +44,12 @@ public abstract class AbstractTablePageGenerator extends HtmlPageGenerator<Resul
     protected static final int PERFORMANCE_DATE_RETRIEVE_DAYS = 2;
     protected final Set<ScenarioBuildResultData> scenarios;
     protected final ResultsStore resultsStore;
+    protected final PerformanceFlakinessAnalyzer flakinessAnalyzer;
     protected final String commitId = Git.current().getCommitId();
 
-    public AbstractTablePageGenerator(ResultsStore resultsStore, File resultJson) {
+    public AbstractTablePageGenerator(PerformanceFlakinessAnalyzer flakinessAnalyzer, ResultsStore resultsStore, File resultJson) {
         this.resultsStore = resultsStore;
+        this.flakinessAnalyzer = flakinessAnalyzer;
         this.scenarios = readBuildResultData(resultJson);
     }
 

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultReportGenerator.java
@@ -17,7 +17,7 @@
 package org.gradle.performance.results;
 
 public class DefaultReportGenerator extends AbstractReportGenerator<AllResultsStore> {
-    public static void main(String[] args) throws Exception {
-        getGenerator(DefaultReportGenerator.class).generateReport(args);
+    public static void main(String[] args) {
+        new DefaultReportGenerator().generateReport(args);
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIndexPageGenerator.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
 import static org.gradle.performance.results.ScenarioBuildResultData.FLAKINESS_DETECTION_THRESHOLD;
+import static org.gradle.performance.results.Tag.FixedTag.FLAKY;
 
 public class FlakinessIndexPageGenerator extends AbstractTablePageGenerator {
     public static final int MOST_RECENT_EXECUTIONS = 9;
@@ -100,7 +101,7 @@ public class FlakinessIndexPageGenerator extends AbstractTablePageGenerator {
 
             @Override
             protected Set<Tag> determineTags(ScenarioBuildResultData scenario) {
-                return isFlaky(scenario) ? Sets.newHashSet(Tag.FLAKY) : Collections.emptySet();
+                return isFlaky(scenario) ? Sets.newHashSet(FLAKY) : Collections.emptySet();
             }
 
             @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIndexPageGenerator.java
@@ -42,8 +42,11 @@ public class FlakinessIndexPageGenerator extends AbstractTablePageGenerator {
             .thenComparing(comparing(ScenarioBuildResultData::getDifferencePercentage).reversed())
             .thenComparing(ScenarioBuildResultData::getScenarioName);
 
+    private final PerformanceFlakinessAnalyzer flakinessAnalyzer;
+
     public FlakinessIndexPageGenerator(ResultsStore resultsStore, File resultJson) {
         super(resultsStore, resultJson);
+        this.flakinessAnalyzer = PerformanceFlakinessAnalyzer.create();
     }
 
     @Override
@@ -111,7 +114,7 @@ public class FlakinessIndexPageGenerator extends AbstractTablePageGenerator {
     }
 
     public void reportToIssueTracker() {
-        scenarios.stream().filter(FlakinessIndexPageGenerator::isFlaky).forEach(PerformanceFlakinessAnalyzer.getInstance()::report);
+        scenarios.stream().filter(FlakinessIndexPageGenerator::isFlaky).forEach(flakinessAnalyzer::report);
     }
 
     private static boolean isFlaky(ScenarioBuildResultData scenario) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessIndexPageGenerator.java
@@ -42,11 +42,9 @@ public class FlakinessIndexPageGenerator extends AbstractTablePageGenerator {
             .thenComparing(comparing(ScenarioBuildResultData::getDifferencePercentage).reversed())
             .thenComparing(ScenarioBuildResultData::getScenarioName);
 
-    private final PerformanceFlakinessAnalyzer flakinessAnalyzer;
 
-    public FlakinessIndexPageGenerator(ResultsStore resultsStore, File resultJson) {
-        super(resultsStore, resultJson);
-        this.flakinessAnalyzer = PerformanceFlakinessAnalyzer.create();
+    public FlakinessIndexPageGenerator(PerformanceFlakinessAnalyzer flakinessAnalyzer, ResultsStore resultsStore, File resultJson) {
+        super(flakinessAnalyzer, resultsStore, resultJson);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
@@ -16,9 +16,6 @@
 
 package org.gradle.performance.results;
 
-import org.gradle.ci.github.DefaultGitHubIssuesClient;
-import org.gradle.ci.github.GitHubIssuesClient;
-
 import java.io.File;
 import java.io.IOException;
 
@@ -29,8 +26,7 @@ public class FlakinessReportGenerator extends AbstractReportGenerator<CrossVersi
 
     @Override
     protected void renderIndexPage(ResultsStore store, File resultJson, File outputDirectory) throws IOException {
-        GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(System.getProperty("githubToken"));
-        FlakinessIndexPageGenerator reporter = new FlakinessIndexPageGenerator(store, resultJson, gitHubIssuesClient);
+        FlakinessIndexPageGenerator reporter = new FlakinessIndexPageGenerator(store, resultJson);
         new FileRenderer().render(store, reporter, new File(outputDirectory, "index.html"));
 
         reporter.reportToIssueTracker();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
@@ -20,8 +20,8 @@ import java.io.File;
 import java.io.IOException;
 
 public class FlakinessReportGenerator extends AbstractReportGenerator<CrossVersionResultsStore> {
-    public static void main(String[] args) throws Exception {
-        getGenerator(FlakinessReportGenerator.class).generateReport(args);
+    public static void main(String[] args) {
+        new FlakinessReportGenerator().generateReport(args);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessReportGenerator.java
@@ -25,8 +25,8 @@ public class FlakinessReportGenerator extends AbstractReportGenerator<CrossVersi
     }
 
     @Override
-    protected void renderIndexPage(ResultsStore store, File resultJson, File outputDirectory) throws IOException {
-        FlakinessIndexPageGenerator reporter = new FlakinessIndexPageGenerator(store, resultJson);
+    protected void renderIndexPage(PerformanceFlakinessAnalyzer flakinessAnalyzer, ResultsStore store, File resultJson, File outputDirectory) throws IOException {
+        FlakinessIndexPageGenerator reporter = new FlakinessIndexPageGenerator(flakinessAnalyzer, store, resultJson);
         new FileRenderer().render(store, reporter, new File(outputDirectory, "index.html"));
 
         reporter.reportToIssueTracker();

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -35,6 +35,7 @@ import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.FAIL
 import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.FLAKY;
 import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.FROM_CACHE;
 import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.IMPROVED;
+import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.KNOWN_FLAKY;
 import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.NEARLY_FAILED;
 import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.REGRESSED;
 import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.UNKNOWN;
@@ -185,9 +186,13 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
                 if (scenario.isFromCache()) {
                     result.add(FROM_CACHE);
                 }
+
                 if (isFlaky(scenario)) {
                     result.add(FLAKY);
+                } else if (PerformanceFlakinessAnalyzer.getInstance().findKnownFlakyTest(scenario) != null) {
+                    result.add(KNOWN_FLAKY);
                 }
+
                 if (scenario.isUnknown()) {
                     result.add(UNKNOWN);
                 } else if (scenario.isBuildFailed()) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -57,8 +57,11 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
         .thenComparing(comparing(ScenarioBuildResultData::getDifferencePercentage).reversed())
         .thenComparing(ScenarioBuildResultData::getScenarioName);
 
+    private final PerformanceFlakinessAnalyzer flakinessAnalyzer;
+
     public IndexPageGenerator(ResultsStore resultsStore, File resultJson) {
         super(resultsStore, resultJson);
+        this.flakinessAnalyzer = PerformanceFlakinessAnalyzer.create();
     }
 
     @Override
@@ -213,7 +216,7 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
             }
 
             private void markKnownFlakyTestIfFound(ScenarioBuildResultData scenario, Set<Tag> result) {
-                FlakyTest flakyTest = PerformanceFlakinessAnalyzer.getInstance().findKnownFlakyTest(scenario);
+                FlakyTest flakyTest = flakinessAnalyzer.findKnownFlakyTest(scenario);
                 if (flakyTest != null) {
                     result.add(new Tag.KnownFlakyTag(flakyTest));
                 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -17,6 +17,7 @@
 package org.gradle.performance.results;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.gradle.ci.common.model.FlakyTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,18 +32,17 @@ import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.FAILED;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.FLAKY;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.FROM_CACHE;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.IMPROVED;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.KNOWN_FLAKY;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.NEARLY_FAILED;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.REGRESSED;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.UNKNOWN;
-import static org.gradle.performance.results.AbstractTablePageGenerator.Tag.UNTAGGED;
 import static org.gradle.performance.results.ScenarioBuildResultData.ExecutionData;
 import static org.gradle.performance.results.ScenarioBuildResultData.STATUS_SUCCESS;
 import static org.gradle.performance.results.ScenarioBuildResultData.STATUS_UNKNOWN;
+import static org.gradle.performance.results.Tag.FixedTag.FAILED;
+import static org.gradle.performance.results.Tag.FixedTag.FLAKY;
+import static org.gradle.performance.results.Tag.FixedTag.FROM_CACHE;
+import static org.gradle.performance.results.Tag.FixedTag.IMPROVED;
+import static org.gradle.performance.results.Tag.FixedTag.NEARLY_FAILED;
+import static org.gradle.performance.results.Tag.FixedTag.REGRESSED;
+import static org.gradle.performance.results.Tag.FixedTag.UNKNOWN;
+import static org.gradle.performance.results.Tag.FixedTag.UNTAGGED;
 
 public class IndexPageGenerator extends AbstractTablePageGenerator {
     private static final int DEFAULT_RETRY_COUNT = 3;
@@ -189,8 +189,11 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
 
                 if (isFlaky(scenario)) {
                     result.add(FLAKY);
-                } else if (PerformanceFlakinessAnalyzer.getInstance().findKnownFlakyTest(scenario) != null) {
-                    result.add(KNOWN_FLAKY);
+                } else {
+                    FlakyTest flakyTest = PerformanceFlakinessAnalyzer.getInstance().findKnownFlakyTest(scenario);
+                    if (flakyTest != null) {
+                        result.add(new Tag.KnownFlakyTag(flakyTest));
+                    }
                 }
 
                 if (scenario.isUnknown()) {

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -189,12 +189,10 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
 
                 if (isFlaky(scenario)) {
                     result.add(FLAKY);
-                } else {
-                    FlakyTest flakyTest = PerformanceFlakinessAnalyzer.getInstance().findKnownFlakyTest(scenario);
-                    if (flakyTest != null) {
-                        result.add(new Tag.KnownFlakyTag(flakyTest));
-                    }
                 }
+
+                markKnownFlakyTestIfFound(scenario, result);
+
 
                 if (scenario.isUnknown()) {
                     result.add(UNKNOWN);
@@ -212,6 +210,13 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
                     result.add(UNTAGGED);
                 }
                 return result;
+            }
+
+            private void markKnownFlakyTestIfFound(ScenarioBuildResultData scenario, Set<Tag> result) {
+                FlakyTest flakyTest = PerformanceFlakinessAnalyzer.getInstance().findKnownFlakyTest(scenario);
+                if (flakyTest != null) {
+                    result.add(new Tag.KnownFlakyTag(flakyTest));
+                }
             }
 
             @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/IndexPageGenerator.java
@@ -57,11 +57,8 @@ public class IndexPageGenerator extends AbstractTablePageGenerator {
         .thenComparing(comparing(ScenarioBuildResultData::getDifferencePercentage).reversed())
         .thenComparing(ScenarioBuildResultData::getScenarioName);
 
-    private final PerformanceFlakinessAnalyzer flakinessAnalyzer;
-
-    public IndexPageGenerator(ResultsStore resultsStore, File resultJson) {
-        super(resultsStore, resultJson);
-        this.flakinessAnalyzer = PerformanceFlakinessAnalyzer.create();
+    public IndexPageGenerator(PerformanceFlakinessAnalyzer flakinessAnalyzer, ResultsStore resultsStore, File resultJson) {
+        super(flakinessAnalyzer, resultsStore, resultJson);
     }
 
     @Override

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
@@ -115,11 +115,11 @@ ${MESSAGE_PREFIX}$message
     }
 
 
-    private boolean issueClosed(FlakyTest flakyTest) {
+    private static boolean issueClosed(FlakyTest flakyTest) {
         return flakyTest.issue.state == GHIssueState.CLOSED
     }
 
-    private boolean hasFixItLabel(FlakyTest flakyTest) {
+    private static boolean hasFixItLabel(FlakyTest flakyTest) {
         return flakyTest.issue.getLabels().collect { it.name }.contains(GITHUB_FIX_IT_LABEL)
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
@@ -28,6 +28,7 @@ import org.gradle.performance.results.ScenarioBuildResultData.ExecutionData
 import org.kohsuke.github.GHIssue
 import org.kohsuke.github.GHIssueState
 
+import static org.apache.commons.lang3.StringUtils.isNoneBlank
 import static org.gradle.ci.github.GitHubIssuesClient.CI_TRACKED_FLAKINESS_LABEL
 import static org.gradle.ci.github.GitHubIssuesClient.FROM_BOT_PREFIX
 import static org.gradle.ci.github.GitHubIssuesClient.MESSAGE_PREFIX
@@ -73,11 +74,7 @@ class PerformanceFlakinessAnalyzer {
     }
 
     FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario) {
-        FlakyTest f = provider.knownInvalidFailures.find { scenario.flakyIssueTestName.contains(it.name) }
-        if (f != null) {
-            println "issue number: ${f.issue.number}"
-        }
-        return f
+        return provider.knownInvalidFailures.find { isNoneBlank(it.name) && scenario.flakyIssueTestName.contains(it.name) }
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
@@ -36,15 +36,11 @@ import static org.gradle.ci.github.GitHubIssuesClient.TEST_NAME_PREFIX
 
 @CompileStatic
 class PerformanceFlakinessAnalyzer {
-    private static PerformanceFlakinessAnalyzer instance
 
-    static PerformanceFlakinessAnalyzer getInstance() {
-        if (instance == null) {
-            GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(System.getProperty("githubToken"))
-            KnownFlakyTestProvider provider = new GitHubKnownIssuesProvider(gitHubIssuesClient)
-            instance = new PerformanceFlakinessAnalyzer(gitHubIssuesClient, provider)
-        }
-        return instance
+    static PerformanceFlakinessAnalyzer create() {
+        GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(System.getProperty("githubToken"))
+        KnownFlakyTestProvider provider = new GitHubKnownIssuesProvider(gitHubIssuesClient)
+        return new PerformanceFlakinessAnalyzer(gitHubIssuesClient, provider)
     }
 
     static final String GITHUB_FIX_IT_LABEL = "fix-it"

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
@@ -73,7 +73,11 @@ class PerformanceFlakinessAnalyzer {
     }
 
     FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario) {
-        return provider.knownInvalidFailures.find { scenario.flakyIssueTestName.contains(it.name) }
+        FlakyTest f = provider.knownInvalidFailures.find { scenario.flakyIssueTestName.contains(it.name) }
+        if (f != null) {
+            println "issue number: ${f.issue.number}"
+        }
+        return f
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.groovy
@@ -36,7 +36,6 @@ import static org.gradle.ci.github.GitHubIssuesClient.TEST_NAME_PREFIX
 
 @CompileStatic
 class PerformanceFlakinessAnalyzer {
-
     static PerformanceFlakinessAnalyzer create() {
         GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(System.getProperty("githubToken"))
         KnownFlakyTestProvider provider = new GitHubKnownIssuesProvider(gitHubIssuesClient)

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Tag.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Tag.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import org.gradle.ci.common.model.FlakyTest;
+
+import static org.gradle.performance.results.Tag.FixedTag.KNOWN_FLAKY;
+import static org.gradle.performance.results.Tag.FixedTag.UNTAGGED;
+
+public interface Tag {
+    String getName();
+
+    String getClassAttr();
+
+    String getTitle();
+
+    String getUrl();
+
+    default boolean isValid() {
+        return this != UNTAGGED;
+    }
+
+    enum FixedTag implements Tag {
+        FROM_CACHE("FROM-CACHE", "badge badge-info", "The test is not really executed - its results are fetched from build cache."),
+        FAILED("FAILED", "badge badge-danger", "Regression confidence > 99% despite retries."),
+        NEARLY_FAILED("NEARLY-FAILED", "badge badge-warning", "Regression confidence > 90%, we're going to fail soon."),
+        REGRESSED("REGRESSED", "badge badge-danger", "Regression confidence > 99% despite retries."),
+        IMPROVED("IMPROVED", "badge badge-success", "Improvement confidence > 90%, rebaseline it to keep this improvement! :-)"),
+        UNKNOWN("UNKNOWN", "badge badge-dark", "The status is unknown, may be it's cancelled?"),
+        FLAKY("FLAKY", "badge badge-danger", "The scenario's difference confidence > 95% even when running identical code."),
+        KNOWN_FLAKY("KNOWN-FLAKY", "badge badge-danger", "The scenario was marked as flaky in gradle-private issue tracker recently."),
+        UNTAGGED("UNTAGGED", null, null);
+
+        private String name;
+        private String classAttr;
+        private String title;
+
+        FixedTag(String name, String classAttr, String title) {
+            this.name = name;
+            this.classAttr = classAttr;
+            this.title = title;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getClassAttr() {
+            return classAttr;
+        }
+
+        @Override
+        public String getTitle() {
+            return title;
+        }
+
+        @Override
+        public String getUrl() {
+            return null;
+        }
+    }
+
+    class KnownFlakyTag implements Tag {
+        private String url;
+
+        public KnownFlakyTag(FlakyTest flakyTest) {
+            this.url = flakyTest.getIssue().getHtmlUrl().toString();
+        }
+
+        @Override
+        public String getName() {
+            return KNOWN_FLAKY.name;
+        }
+
+        @Override
+        public String getClassAttr() {
+            return KNOWN_FLAKY.classAttr;
+        }
+
+        @Override
+        public String getTitle() {
+            return KNOWN_FLAKY.title;
+        }
+
+        @Override
+        public String getUrl() {
+            return url;
+        }
+    }
+}

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/IndexPageGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/IndexPageGeneratorTest.groovy
@@ -33,7 +33,7 @@ class IndexPageGeneratorTest extends ResultSpecification {
 
     def setup() {
         resultsJson << '[]'
-        generator = new IndexPageGenerator(mockStore, resultsJson)
+        generator = new IndexPageGenerator(Mock(PerformanceFlakinessAnalyzer), mockStore, resultsJson)
     }
 
     def 'can sort scenarios correctly'() {

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzerTest.groovy
@@ -25,14 +25,15 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 import static org.gradle.ci.github.GitHubIssuesClient.CI_TRACKED_FLAKINESS_LABEL
-import static org.gradle.performance.results.FlakinessIssueReporter.GITHUB_FIX_IT_LABEL
+import static org.gradle.performance.results.PerformanceFlakinessAnalyzer.GITHUB_FIX_IT_LABEL
+import static org.gradle.performance.results.PerformanceFlakinessAnalyzer.GITHUB_IN_PERFORMANCE_LABEL
 
-class FlakinessIssueReporterTest extends Specification {
+class PerformanceFlakinessAnalyzerTest extends Specification {
     GitHubIssuesClient issuesClient = Mock(GitHubIssuesClient)
     KnownFlakyTestProvider flakyTestProvider = Mock(KnownFlakyTestProvider)
 
     @Subject
-    FlakinessIssueReporter reporter = new FlakinessIssueReporter(issuesClient, flakyTestProvider)
+    PerformanceFlakinessAnalyzer reporter = new PerformanceFlakinessAnalyzer(issuesClient, flakyTestProvider)
 
     ScenarioBuildResultData scenario = new ScenarioBuildResultData(
         scenarioName: 'myScenario',
@@ -91,7 +92,7 @@ TEST_NAME: my.AwesomeClass.myScenario
 
 MESSAGE: we're slower than
 """
-            , [CI_TRACKED_FLAKINESS_LABEL]) >> issue
+            , [CI_TRACKED_FLAKINESS_LABEL, GITHUB_IN_PERFORMANCE_LABEL]) >> issue
         1 * issue.comment("""
 FROM-BOT
 

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/ReportGeneratorTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/ReportGeneratorTest.groovy
@@ -49,7 +49,7 @@ class ReportGeneratorTest extends ResultSpecification {
         store.report(result2)
 
         when:
-        generator.generate(reportDir, resultsJson, 'testProject')
+        generator.generate(Mock(PerformanceFlakinessAnalyzer), reportDir, resultsJson, 'testProject')
 
         then:
         reportDir.file("index.html").isFile()


### PR DESCRIPTION
### Context

This closes https://github.com/gradle/gradle-private/issues/1735

We want to mark the known performance test scenarios in the report even when they pass. This can give us insights of how the scenarios work previously. In this way, we can easily know, "this scenario fails, ah, it's marked as flaky", or, "this scenario is improved, but hold on, it's marked as flaky, let's not rebaseline it".

