### PR TITLE
Fix Guava performance regression

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -54,7 +54,7 @@ libraries.fastutil =            [coordinates: 'it.unimi.dsi:fastutil', version: 
 libraries.gcs =                 [coordinates: 'com.google.apis:google-api-services-storage', version: 'v1-rev136-1.25.0']
 libraries.groovy =              [coordinates: 'org.gradle.groovy:groovy-all', version: gradleGroovyVersion, because: 'emulating the Groovy 2.4-style groovy-all.jar, see https://github.com/gradle/gradle-groovy-all']
 libraries.gson =                [coordinates: 'com.google.code.gson:gson', version: '2.8.5']
-libraries.guava =               [coordinates: 'com.google.guava:guava', version: '27.1-android', because: 'JRE variant introduces regression - https://github.com/google/guava/issues/3223']
+libraries.guava =               [coordinates: 'com.google.guava:guava', version: '27.1-jre']
 libraries.inject =              [coordinates: 'javax.inject:javax.inject', version: '1']
 libraries.ivy =                 [coordinates: 'org.apache.ivy:ivy', version: '2.3.0',
                                  because: '2.4.0 contains a breaking change in DefaultModuleDescriptor.getExtraInfo(), cf. https://issues.apache.org/jira/browse/IVY-1457']

--- a/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/AstUtils.java
+++ b/subprojects/base-services-groovy/src/main/java/org/gradle/groovy/scripts/internal/AstUtils.java
@@ -201,8 +201,15 @@ public abstract class AstUtils {
     @Nullable
     public static ScriptBlock detectScriptBlock(Statement statement, final Collection<String> names) {
         return detectScriptBlock(statement, new Predicate<ScriptBlock>() {
+            @Override
             public boolean apply(ScriptBlock input) {
                 return names.contains(input.getName());
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ScriptBlock input) {
+                return apply(input);
             }
         });
     }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/Actions.java
@@ -37,6 +37,12 @@ public abstract class Actions {
         public boolean apply(@Nullable Action<?> input) {
             return input != DO_NOTHING;
         }
+
+        @Override
+        // Added for Java 6 source compatibility
+        public boolean test(@Nullable Action<?> input) {
+            return apply(input);
+        }
     };
 
     /**

--- a/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/work/DefaultWorkerLeaseService.java
@@ -16,7 +16,6 @@
 
 package org.gradle.internal.work;
 
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import org.gradle.api.Action;
@@ -44,7 +43,6 @@ import org.gradle.util.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -204,12 +202,12 @@ public class DefaultWorkerLeaseService implements WorkerLeaseService, Parallelis
     }
 
     private boolean containsProjectLocks(Iterable<? extends ResourceLock> locks) {
-        return Iterables.any(locks, new Predicate<ResourceLock>() {
-            @Override
-            public boolean apply(@Nullable ResourceLock lock) {
-                return lock instanceof ProjectLock;
+        for (ResourceLock lock : locks) {
+            if (lock instanceof ProjectLock) {
+                return true;
             }
-        });
+        }
+        return false;
     }
 
     private Iterable<? extends ResourceLock> locksNotHeld(final Iterable<? extends ResourceLock> locks) {

--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractTaskOutputPackagingBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractTaskOutputPackagingBenchmark.java
@@ -106,7 +106,7 @@ public abstract class AbstractTaskOutputPackagingBenchmark {
 
     private static ImmutableList<DataSource> createInputFiles(int fileCount, int minFileSize, int maxFileSize, DataAccessor accessor) throws IOException {
         Random random = new Random(1234L);
-        ImmutableList.Builder<DataSource> inputs = ImmutableList.builder();
+        ImmutableList.Builder<DataSource> inputs = ImmutableList.builderWithExpectedSize(fileCount);
         for (int idx = 0; idx < fileCount; idx++) {
             String name = "input-" + idx + ".bin";
             int fileSize = minFileSize + random.nextInt(maxFileSize - minFileSize);

--- a/subprojects/core-api/src/main/java/org/gradle/model/internal/type/ModelType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/model/internal/type/ModelType.java
@@ -18,10 +18,10 @@ package org.gradle.model.internal.type;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
-import javax.annotation.concurrent.ThreadSafe;
 import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -136,7 +136,7 @@ public abstract class ModelType<T> {
     public List<ModelType<?>> getTypeVariables() {
         if (isParameterized()) {
             TypeWrapper[] typeArguments = ((ParameterizedTypeWrapper) wrapper).getActualTypeArguments();
-            ImmutableList.Builder<ModelType<?>> builder = ImmutableList.builder();
+            ImmutableList.Builder<ModelType<?>> builder = ImmutableList.builderWithExpectedSize(typeArguments.length);
             for (TypeWrapper typeArgument : typeArguments) {
                 builder.add(Simple.typed(typeArgument));
             }

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -232,7 +232,7 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
 
         expect:
         fails("myTask")
-        failureHasCause("Multiple entries with same key: ${file('input').absolutePath}=inputTwo and ${file('input').absolutePath}=inputOne")
+        failureHasCause("Multiple entries with same value: ${file('input').absolutePath}=inputTwo and ${file('input').absolutePath}=inputOne")
     }
 
     def "two incremental file properties can point to the same file"() {

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/IncrementalInputsIntegrationTest.groovy
@@ -232,7 +232,8 @@ class IncrementalInputsIntegrationTest extends AbstractIncrementalTasksIntegrati
 
         expect:
         fails("myTask")
-        failureHasCause("Multiple entries with same value: ${file('input').absolutePath}=inputTwo and ${file('input').absolutePath}=inputOne")
+        def inputFilePath = file('input').absolutePath
+        failureHasCause("Multiple entries with same value: inputTwo=$inputFilePath and inputOne=$inputFilePath")
     }
 
     def "two incremental file properties can point to the same file"() {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceFilter.java
@@ -30,7 +30,7 @@ public class IgnoringResourceFilter implements ResourceFilter {
 
     public IgnoringResourceFilter(ImmutableSet<String> ignores) {
         this.ignores = ignores;
-        ImmutableSet.Builder<PathMatcher> builder = ImmutableSet.builder();
+        ImmutableSet.Builder<PathMatcher> builder = ImmutableSet.builderWithExpectedSize(ignores.size());
         for (String ignore : ignores) {
             PathMatcher matcher = PatternMatcherFactory.compile(true, ignore);
             builder.add(matcher);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginContainer.java
@@ -103,8 +103,15 @@ public class DefaultPluginContainer extends DefaultPluginCollection<Plugin> impl
     private Plugin doFindPlugin(String id) {
         for (final PluginManagerInternal.PluginWithId pluginWithId : pluginManager.pluginsForId(id)) {
             Plugin plugin = Iterables.tryFind(DefaultPluginContainer.this, new Predicate<Plugin>() {
+                @Override
                 public boolean apply(Plugin plugin) {
                     return pluginWithId.clazz.equals(plugin.getClass());
+                }
+
+                @Override
+                // Added for Java 6 source compatibility
+                public boolean test(Plugin input) {
+                    return apply(input);
                 }
             }).orNull();
 

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
@@ -105,7 +105,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         if (taskActions.isEmpty()) {
             return ImmutableList.of();
         }
-        ImmutableList.Builder<ImplementationSnapshot> actionImplementations = ImmutableList.builder();
+        ImmutableList.Builder<ImplementationSnapshot> actionImplementations = ImmutableList.builderWithExpectedSize(taskActions.size());
         for (InputChangesAwareTaskAction taskAction : taskActions) {
             actionImplementations.add(taskAction.getActionImplementation(classLoaderHierarchyHasher));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/DefaultTaskProperties.java
@@ -125,6 +125,12 @@ public class DefaultTaskProperties implements TaskProperties {
             public boolean apply(InputFilePropertySpec property) {
                 return property.isSkipWhenEmpty();
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable InputFilePropertySpec input) {
+                return apply(input);
+            }
         });
         this.outputFiles = new CompositeFileCollection() {
             @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InspectionSchemeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InspectionSchemeFactory.java
@@ -37,7 +37,7 @@ public class InspectionSchemeFactory {
     private final CrossBuildInMemoryCacheFactory cacheFactory;
 
     public InspectionSchemeFactory(List<? extends PropertyAnnotationHandler> allKnownPropertyHandlers, List<? extends TypeAnnotationHandler> allKnownTypeHandlers, CrossBuildInMemoryCacheFactory cacheFactory) {
-        ImmutableMap.Builder<Class<? extends Annotation>, PropertyAnnotationHandler> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<Class<? extends Annotation>, PropertyAnnotationHandler> builder = ImmutableMap.builderWithExpectedSize(allKnownPropertyHandlers.size());
         for (PropertyAnnotationHandler handler : allKnownPropertyHandlers) {
             builder.put(handler.getAnnotationType(), handler);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -68,7 +68,7 @@ public class WriteProperties extends DefaultTask {
      */
     @Input
     public Map<String, String> getProperties() {
-        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(properties.size() + deferredProperties.size());
         propertiesBuilder.putAll(properties);
         try {
             for (Map.Entry<String, Callable<String>> e : deferredProperties.entrySet()) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -400,6 +400,12 @@ public class DefaultExecutionPlan implements ExecutionPlan {
             public boolean apply(Node input) {
                 return visitingNodes.containsEntry(input, nodeWithVisitingSegment.visitingSegment);
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable Node input) {
+                return apply(input);
+            }
         });
     }
 
@@ -437,6 +443,12 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                     @SuppressWarnings("NullableProblems")
                     public boolean apply(NodeInVisitingSegment nodeInVisitingSegment) {
                         return nodeInVisitingSegment.node.equals(dependsOnTask);
+                    }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(@Nullable NodeInVisitingSegment input) {
+                        return apply(input);
                     }
                 });
             }

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -541,7 +541,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
 
     @Override
     public Set<Task> getFilteredTasks() {
-        ImmutableSet.Builder<Task> builder = ImmutableSet.builder();
+        ImmutableSet.Builder<Task> builder = ImmutableSet.builderWithExpectedSize(filteredNodes.size());
         for (Node filteredNode : filteredNodes) {
             if (filteredNode instanceof LocalTaskNode) {
                 builder.add(((LocalTaskNode) filteredNode).getTask());
@@ -661,7 +661,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                                     FileParameterUtils.resolveOutputFilePropertySpecs(task.toString(), propertyName, value, filePropertyType, fileCollectionFactory, new Consumer<OutputFilePropertySpec>() {
                                         @Override
                                         public void accept(OutputFilePropertySpec outputFilePropertySpec) {
-                                            mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, outputFilePropertySpec.getPropertyFiles()));
+                                            mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, outputFilePropertySpec.getPropertyFiles().getFiles()));
                                         }
                                     });
                                 }
@@ -675,7 +675,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                         withDeadlockHandling(taskNode, "a local state property", "local state properties", new Runnable() {
                             @Override
                             public void run() {
-                                mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value)));
+                                mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value).getFiles()));
                             }
                         });
                         mutations.hasLocalState = true;
@@ -686,7 +686,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                         withDeadlockHandling(taskNode, "a destroyable", "destroyables", new Runnable() {
                             @Override
                             public void run() {
-                                mutations.destroyablePaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value)));
+                                mutations.destroyablePaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value).getFiles()));
                             }
                         });
                     }
@@ -753,8 +753,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         return !doesDestroyNotYetConsumedOutputOfAnotherNode(node, candidateNodeDestroyables);
     }
 
-    private static ImmutableSet<String> canonicalizedPaths(final Map<File, String> cache, Iterable<File> files) {
-        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+    private static ImmutableSet<String> canonicalizedPaths(final Map<File, String> cache, Set<File> files) {
+        ImmutableSet.Builder<String> builder = ImmutableSet.builderWithExpectedSize(files.size());
         for (File file : files) {
             builder.add(canonicalizePath(file, cache));
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -293,8 +293,9 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     public Set<Task> getDependencies(Task task) {
         ensurePopulated();
         Node node = executionPlan.getNode(task);
-        ImmutableSet.Builder<Task> builder = ImmutableSet.builder();
-        for (Node dependencyNode : node.getDependencySuccessors()) {
+        Set<Node> dependencySuccessors = node.getDependencySuccessors();
+        ImmutableSet.Builder<Task> builder = ImmutableSet.builderWithExpectedSize(dependencySuccessors.size());
+        for (Node dependencyNode : dependencySuccessors) {
             if (dependencyNode instanceof TaskNode) {
                 builder.add(((TaskNode) dependencyNode).getTask());
             }

--- a/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchPointsRegistry.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/filewatch/jdk7/WatchPointsRegistry.java
@@ -121,6 +121,12 @@ class WatchPointsRegistry {
                 public boolean apply(File input) {
                     return inCombinedRootsOrAncestorOfAnyRoot(input, roots, unfiltered);
                 }
+
+                @Override
+                // Added for Java 6 source compatibility
+                public boolean test(File input) {
+                    return apply(input);
+                }
             });
         }
 

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/internal/operations/TestBuildOperationExecutor.java
@@ -173,6 +173,12 @@ public class TestBuildOperationExecutor implements BuildOperationExecutor {
                     public boolean apply(Record input) {
                         return detailsType.isInstance(input.descriptor.getDetails());
                     }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(Record input) {
+                        return apply(input);
+                    }
                 })
                 .transform(new Function<Record, TypedRecord<D, R>>() {
                     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/SuppliedComponentMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/SuppliedComponentMetadataSerializer.java
@@ -78,8 +78,8 @@ public class SuppliedComponentMetadataSerializer extends AbstractSerializer<Comp
 
     private List<String> readStatusScheme(Decoder decoder) throws IOException {
         int size = decoder.readSmallInt();
-        ImmutableList.Builder<String> scheme = ImmutableList.builder();
-        for (int i=0; i<size; i++) {
+        ImmutableList.Builder<String> scheme = ImmutableList.builderWithExpectedSize(size);
+        for (int i = 0; i < size; i++) {
             scheme.add(decoder.readString());
         }
         return scheme.build();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractIvyDependencyDescriptorFactory.java
@@ -49,7 +49,7 @@ public abstract class AbstractIvyDependencyDescriptorFactory implements IvyDepen
     }
 
     protected ImmutableList<IvyArtifactName> convertArtifacts(Set<DependencyArtifact> dependencyArtifacts) {
-        ImmutableList.Builder<IvyArtifactName> names = ImmutableList.builder();
+        ImmutableList.Builder<IvyArtifactName> names = ImmutableList.builderWithExpectedSize(dependencyArtifacts.size());
         for (DependencyArtifact dependencyArtifact : dependencyArtifacts) {
             DefaultIvyArtifactName name = new DefaultIvyArtifactName(dependencyArtifact.getName(), dependencyArtifact.getType(), getExtension(dependencyArtifact), dependencyArtifact.getClassifier());
             names.add(name);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -72,12 +72,13 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     }
 
     public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
-        if (variants.size() == 1) {
+        int variantCount = variants.size();
+        if (variantCount == 1) {
             VariantResolveMetadata variantMetadata = variants.iterator().next();
             ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
         }
-        ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builder();
+        ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builderWithExpectedSize(variantCount);
         for (VariantResolveMetadata variant : variants) {
             ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             result.add(resolvedVariant);
@@ -93,7 +94,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
 
     private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry) {
         List<? extends ComponentArtifactMetadata> artifacts = variant.getArtifacts();
-        ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
+        ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builderWithExpectedSize(artifacts.size());
 
         // Apply any artifact type mappings to the attributes of the variant
         ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/ModuleExclusions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/ModuleExclusions.java
@@ -99,7 +99,7 @@ public class ModuleExclusions {
         if (exclusion != null) {
             return exclusion;
         }
-        ImmutableSet.Builder<AbstractModuleExclusion> exclusions = ImmutableSet.builder();
+        ImmutableSet.Builder<AbstractModuleExclusion> exclusions = ImmutableSet.builderWithExpectedSize(excludes.size());
         for (ExcludeMetadata exclude : excludes) {
             exclusions.add(forExclude(exclude));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
@@ -78,7 +78,7 @@ public class ResolutionFailureCollector implements DependencyGraphVisitor {
         if (extraFailures.isEmpty() && failuresByRevisionId.isEmpty()) {
             return ImmutableSet.of();
         }
-        ImmutableSet.Builder<UnresolvedDependency> builder = ImmutableSet.builder();
+        ImmutableSet.Builder<UnresolvedDependency> builder = ImmutableSet.builderWithExpectedSize(extraFailures.size() + failuresByRevisionId.size());
         builder.addAll(extraFailures);
         for (Map.Entry<ComponentSelector, BrokenDependency> entry : failuresByRevisionId.entrySet()) {
             Collection<List<ComponentIdentifier>> paths = DependencyGraphPathResolver.calculatePaths(entry.getValue().requiredBy, root);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -301,8 +301,8 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         private ImmutableList<File> loadResultsFile() {
             Path transformerResultsPath = workspace.getResultsFile().toPath();
             try {
-                ImmutableList.Builder<File> builder = ImmutableList.builder();
                 List<String> paths = Files.readAllLines(transformerResultsPath, StandardCharsets.UTF_8);
+                ImmutableList.Builder<File> builder = ImmutableList.builderWithExpectedSize(paths.size());
                 for (String path : paths) {
                     if (path.startsWith(OUTPUT_FILE_PATH_PREFIX)) {
                         builder.add(new File(workspace.getOutputDirectory(), path.substring(2)));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultMutableIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultMutableIvyModuleResolveMetadata.java
@@ -68,7 +68,7 @@ public class DefaultMutableIvyModuleResolveMetadata extends AbstractMutableModul
     }
 
     private static ImmutableMap<String, Configuration> toMap(Collection<Configuration> configurations) {
-        ImmutableMap.Builder<String, Configuration> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Configuration> builder = ImmutableMap.builderWithExpectedSize(configurations.size());
         for (Configuration configuration : configurations) {
             builder.put(configuration.getName(), configuration);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
@@ -67,7 +67,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
     public ModuleComponentResolveMetadata readMetadata(Decoder decoder, DefaultMavenModuleResolveMetadata resolveMetadata, Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {
         Map<String, List<GradleDependencyMetadata>> variantToDependencies = readVariantDependencies(decoder);
         ImmutableList<? extends ComponentVariant> variants = resolveMetadata.getVariants();
-        ImmutableList.Builder<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> builder = ImmutableList.builder();
+        ImmutableList.Builder<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> builder = ImmutableList.builderWithExpectedSize(variants.size());
         for (ComponentVariant variant: variants) {
             builder.add(new AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl(resolveMetadata.getId(), variant.getName(), variant.getAttributes().asImmutable(), variant.getDependencies(), variant.getDependencyConstraints(),
                 variant.getFiles(), ImmutableCapabilities.of(variant.getCapabilities().getCapabilities()), variantToDependencies.get(variant.getName())));
@@ -148,11 +148,11 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
     }
 
     private ImmutableList<ModuleDependencyMetadata> readDependencies(Decoder decoder, DefaultMavenModuleResolveMetadata metadata, RealisedConfigurationMetadata configurationMetadata, Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {
-        ImmutableList.Builder<ModuleDependencyMetadata> builder = ImmutableList.builder();
         int dependenciesCount = decoder.readSmallInt();
         if (dependenciesCount == 0) {
             return ImmutableList.of();
         }
+        ImmutableList.Builder<ModuleDependencyMetadata> builder = ImmutableList.builderWithExpectedSize(dependenciesCount);
         for (int j = 0; j < dependenciesCount; j++) {
             byte dependencyType = decoder.readByte();
             boolean force = false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -146,11 +146,12 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     @Override
     public void addVariant(String configuration, OutgoingVariant variant) {
         List<LocalComponentArtifactMetadata> artifacts;
-        if (variant.getArtifacts().isEmpty()) {
+        Set<? extends PublishArtifact> variantArtifacts = variant.getArtifacts();
+        if (variantArtifacts.isEmpty()) {
             artifacts = ImmutableList.of();
         } else {
-            ImmutableList.Builder<LocalComponentArtifactMetadata> builder = ImmutableList.builder();
-            for (PublishArtifact artifact : variant.getArtifacts()) {
+            ImmutableList.Builder<LocalComponentArtifactMetadata> builder = ImmutableList.builderWithExpectedSize(variantArtifacts.size());
+            for (PublishArtifact artifact : variantArtifacts) {
                 builder.add(new PublishArtifactLocalArtifactMetadata(componentId, artifact));
             }
             artifacts = builder.build();
@@ -411,7 +412,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                 if (attributeValue.isPresent() && attributeValue.get().getName().equals(Category.ENFORCED_PLATFORM)) {
                     // need to wrap all dependencies to force them
                     ImmutableList<LocalOriginDependencyMetadata> rawDependencies = result.build();
-                    result = ImmutableList.builder();
+                    result = ImmutableList.builderWithExpectedSize(rawDependencies.size());
                     for (LocalOriginDependencyMetadata rawDependency : rawDependencies) {
                         result.add(rawDependency.forced());
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -317,13 +317,14 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
     }
 
     private List<T> getCandidates(BitSet liveSet) {
-        if (liveSet.cardinality() == 0) {
-            return Collections.emptyList();
+        int cardinality = liveSet.cardinality();
+        if (cardinality == 0) {
+            return ImmutableList.of();
         }
-        if (liveSet.cardinality() == 1) {
-            return Collections.singletonList(this.candidates.get(liveSet.nextSetBit(0)));
+        if (cardinality == 1) {
+            return ImmutableList.of(this.candidates.get(liveSet.nextSetBit(0)));
         }
-        ImmutableList.Builder<T> builder = ImmutableList.builder();
+        ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(cardinality);
         for (int c = liveSet.nextSetBit(0); c >= 0; c = liveSet.nextSetBit(c + 1)) {
             builder.add(this.candidates.get(c));
         }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsGraphRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsGraphRenderer.java
@@ -24,6 +24,7 @@ import org.gradle.api.tasks.diagnostics.internal.graph.nodes.RenderableDependenc
 import org.gradle.internal.graph.GraphRenderer;
 import org.gradle.internal.logging.text.StyledTextOutput;
 
+import javax.annotation.Nullable;
 import java.util.Set;
 
 import static org.gradle.internal.logging.text.StyledTextOutput.Style.Info;
@@ -126,6 +127,12 @@ public class DependentComponentsGraphRenderer {
                 return !hideNonBuildable && !hideTestSuite;
             }
             return false;
+        }
+
+        @Override
+        // Added for Java 6 source compatibility
+        public boolean test(@Nullable RenderableDependency input) {
+            return apply(input);
         }
     }
 }

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsRenderableDependency.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/dependents/internal/DependentComponentsRenderableDependency.java
@@ -54,6 +54,12 @@ public class DependentComponentsRenderableDependency extends AbstractRenderableD
                 public boolean apply(BinarySpec binarySpec) {
                     return binarySpec.isBuildable();
                 }
+
+                @Override
+                // Added for Java 6 source compatibility
+                public boolean test(BinarySpec input) {
+                    return apply(input);
+                }
             });
         }
         boolean testSuite = false;

--- a/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/internal/ModelNodeRenderer.java
+++ b/subprojects/diagnostics/src/main/java/org/gradle/api/reporting/model/internal/ModelNodeRenderer.java
@@ -34,7 +34,9 @@ import org.gradle.reporting.ReportRenderer;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static org.gradle.internal.logging.text.StyledTextOutput.Style.*;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Description;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Identifier;
+import static org.gradle.internal.logging.text.StyledTextOutput.Style.Normal;
 
 public class ModelNodeRenderer extends ReportRenderer<ModelNode, TextReportBuilder> {
 
@@ -167,6 +169,12 @@ public class ModelNodeRenderer extends ReportRenderer<ModelNode, TextReportBuild
             @Override
             public boolean apply(ModelRuleDescriptor input) {
                 return !input.equals(model.getDescriptor());
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ModelRuleDescriptor input) {
+                return apply(input);
             }
         });
         return ImmutableSet.copyOf(filtered);

--- a/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
+++ b/subprojects/distributions/src/integTest/groovy/org/gradle/DistributionIntegritySpec.groovy
@@ -48,7 +48,7 @@ class DistributionIntegritySpec extends DistributionIntegrationSpec {
             'commons-lang-2.6.jar' : '50f11b09f877c294d56f24463f47d28f929cf5044f648661c0f0cfbae9a2f49c',
             'failureaccess-1.0.1.jar' : 'a171ee4c734dd2da837e4b16be9df4661afab72a41adaf31eb84dfdaf936ca26',
             'groovy-all-1.0-2.5.4.jar' : '704d3307616c57234871c4db3a355c3e81ea975db8dac8ee6c9264b91c74d2b7',
-            'guava-27.1-android.jar' : '686404f2d1d4d221911f96bd627ff60dac2226a5dfa6fb8ba517073eb97ec0ef',
+            'guava-27.1-jre.jar' : '4a5aa70cc968a4d137e599ad37553e5cfeed2265e8c193476d7119036c536fe7',
             'jansi-1.17.1.jar' : 'b2234bfb0d8f245562d64ed9325df6b907093f4daa702c9082d4796db2a2d894',
             'javax.inject-1.jar' : '91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',
             'jcl-over-slf4j-1.7.25.jar' : '5e938457e79efcbfb3ab64bc29c43ec6c3b95fffcda3c155f4a86cc320c11e14',

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializer.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializer.java
@@ -53,7 +53,7 @@ public class DefaultPreviousExecutionStateSerializer extends AbstractSerializer<
 
         // We can't use an immutable list here because some hashes can be null
         int taskActionsCount = decoder.readSmallInt();
-        ImmutableList.Builder<ImplementationSnapshot> taskActionImplementationsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<ImplementationSnapshot> taskActionImplementationsBuilder = ImmutableList.builderWithExpectedSize(taskActionsCount);
         for (int j = 0; j < taskActionsCount; j++) {
             ImplementationSnapshot actionImpl = implementationSnapshotSerializer.read(decoder);
             taskActionImplementationsBuilder.add(actionImpl);

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -15,8 +15,7 @@
  */
 package org.gradle.api.internal.file;
 
-import com.google.common.base.Predicate;
-import com.google.common.collect.Iterators;
+import com.google.common.collect.AbstractIterator;
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.gradle.api.file.FileCollection;
@@ -32,7 +31,6 @@ import org.gradle.api.tasks.TaskDependency;
 import org.gradle.util.CollectionUtils;
 import org.gradle.util.GUtil;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -190,12 +188,6 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public FileCollection filter(final Spec<? super File> filterSpec) {
-        final Predicate<File> predicate = new Predicate<File>() {
-            @Override
-            public boolean apply(@Nullable File input) {
-                return filterSpec.isSatisfiedBy(input);
-            }
-        };
         return new AbstractFileCollection() {
             @Override
             public String getDisplayName() {
@@ -214,12 +206,24 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
             @Override
             public boolean contains(File file) {
-                return AbstractFileCollection.this.contains(file) && predicate.apply(file);
+                return AbstractFileCollection.this.contains(file) && filterSpec.isSatisfiedBy(file);
             }
 
             @Override
             public Iterator<File> iterator() {
-                return Iterators.filter(AbstractFileCollection.this.iterator(), predicate);
+                final Iterator<File> delegate = AbstractFileCollection.this.iterator();
+                return new AbstractIterator<File>() {
+                    @Override
+                    protected File computeNext() {
+                        while (delegate.hasNext()) {
+                            File element = delegate.next();
+                            if (filterSpec.isSatisfiedBy(element)) {
+                                return element;
+                            }
+                        }
+                        return endOfData();
+                    }
+                };
             }
         };
     }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AntFileCollectionMatchingTaskBuilder.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AntFileCollectionMatchingTaskBuilder.java
@@ -20,10 +20,10 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import groovy.lang.Closure;
-import org.gradle.internal.metaobject.BeanDynamicObject;
-import org.gradle.internal.metaobject.DynamicObject;
 import org.gradle.api.internal.file.collections.DirectoryFileTree;
 import org.gradle.api.tasks.AntBuilderAware;
+import org.gradle.internal.metaobject.BeanDynamicObject;
+import org.gradle.internal.metaobject.DynamicObject;
 
 import java.util.Collections;
 
@@ -45,6 +45,12 @@ public class AntFileCollectionMatchingTaskBuilder implements AntBuilderAware {
                             @Override
                             public boolean apply(DirectoryFileTree input) {
                                 return input.getDir().exists();
+                            }
+
+                            @Override
+                            // Added for Java 6 source compatibility
+                            public boolean test(DirectoryFileTree input) {
+                                return apply(input);
                             }
                         })
         );

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/ApiGroovyCompiler.java
@@ -44,6 +44,7 @@ import org.gradle.internal.concurrent.CompositeStoppable;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.VersionNumber;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Serializable;
 import java.lang.reflect.Method;
@@ -162,6 +163,12 @@ public class ApiGroovyCompiler implements org.gradle.language.base.internal.comp
                             @Override
                             public boolean apply(File file) {
                                 return hasExtension(file, ".java");
+                            }
+
+                            @Override
+                            // Added for Java 6 source compatibility
+                            public boolean test(@Nullable File input) {
+                                return apply(input);
                             }
                         }));
 

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingGroovyCompiler.java
@@ -28,6 +28,7 @@ import org.gradle.api.tasks.WorkResults;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.util.CollectionUtils;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.util.List;
 
@@ -70,6 +71,12 @@ public class NormalizingGroovyCompiler implements Compiler<GroovyJavaJointCompil
                     }
                 }
                 return false;
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable File input) {
+                return apply(input);
             }
         });
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/NormalizingJavaCompiler.java
@@ -60,6 +60,12 @@ public class NormalizingJavaCompiler implements Compiler<JavaCompileSpec> {
             public boolean apply(@Nullable File input) {
                 return hasExtension(input, ".java");
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(@Nullable File input) {
+                return apply(input);
+            }
         });
 
         spec.setSourceFiles(ImmutableSet.copyOf(javaOnly));

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassRelevancyFilter.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/asm/ClassRelevancyFilter.java
@@ -41,9 +41,16 @@ class ClassRelevancyFilter implements Predicate<String> {
         this.excludedClassName = excludedClassName;
     }
 
+    @Override
     public boolean apply(String className) {
         return !className.startsWith("java.")
             && !excludedClassName.equals(className)
             && !PRIMITIVES.contains(className);
+    }
+
+    @Override
+    // Added for Java 6 source compatibility
+    public boolean test(String input) {
+        return apply(input);
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -19,11 +19,9 @@ package org.gradle.api.internal.tasks.compile.incremental.deps;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntSet;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -73,9 +71,9 @@ public class ClassDependentsAccumulator {
     @VisibleForTesting
     Map<String, DependentsSet> getDependentsMap() {
         if (dependenciesToAll.isEmpty() && dependents.isEmpty()) {
-            return Collections.emptyMap();
+            return ImmutableMap.of();
         }
-        ImmutableMap.Builder<String, DependentsSet> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, DependentsSet> builder = ImmutableMap.builderWithExpectedSize(dependenciesToAll.size() + dependents.size());
         for (String s : dependenciesToAll) {
             builder.put(s, DependentsSet.dependencyToAll());
         }
@@ -101,13 +99,5 @@ public class ClassDependentsAccumulator {
 
     public ClassSetAnalysisData getAnalysis() {
         return new ClassSetAnalysisData(ImmutableSet.copyOf(seenClasses), getDependentsMap(), getClassesToConstants(), fullRebuildCause);
-    }
-
-    private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {
-        ImmutableMap.Builder<K, Set<V>> builder = ImmutableMap.builder();
-        for (K key : multimap.keySet()) {
-            builder.put(key, ImmutableSet.copyOf(multimap.get(key)));
-        }
-        return builder.build();
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -92,13 +92,13 @@ public class ClassSetAnalysisData {
             Map<Integer, String> classNameMap = new HashMap<Integer, String>();
 
             int count = decoder.readSmallInt();
-            ImmutableSet.Builder<String> classes = ImmutableSet.builder();
+            ImmutableSet.Builder<String> classes = ImmutableSet.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 classes.add(readClassName(decoder, classNameMap));
             }
 
             count = decoder.readSmallInt();
-            ImmutableMap.Builder<String, DependentsSet> dependentsBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, DependentsSet> dependentsBuilder = ImmutableMap.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 String className = readClassName(decoder, classNameMap);
                 DependentsSet dependents = readDependentsSet(decoder, classNameMap);
@@ -106,7 +106,7 @@ public class ClassSetAnalysisData {
             }
 
             count = decoder.readSmallInt();
-            ImmutableMap.Builder<String, IntSet> classesToConstantsBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, IntSet> classesToConstantsBuilder = ImmutableMap.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 String className = readClassName(decoder, classNameMap);
                 IntSet constants = IntSetSerializer.INSTANCE.read(decoder);
@@ -146,7 +146,7 @@ public class ClassSetAnalysisData {
                 return DependentsSet.dependencyToAll(decoder.readNullableString());
             }
             int count = decoder.readSmallInt();
-            ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+            ImmutableSet.Builder<String> builder = ImmutableSet.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 builder.add(readClassName(decoder, classNameMap));
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
@@ -193,7 +193,7 @@ public class AnnotationProcessorDetector {
             if (processorNames.isEmpty()) {
                 return Collections.emptyList();
             }
-            ImmutableList.Builder<AnnotationProcessorDeclaration> processors = ImmutableList.builder();
+            ImmutableList.Builder<AnnotationProcessorDeclaration> processors = ImmutableList.builderWithExpectedSize(processorNames.size());
             for (String name : processorNames) {
                 IncrementalAnnotationProcessorType type = processorTypes.get(name);
                 type = type != null ? type : IncrementalAnnotationProcessorType.UNKNOWN;

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializer.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializer.java
@@ -41,13 +41,13 @@ public class CompilationStateSerializer implements Serializer<CompilationState> 
         // Deduplicates the include file states, as these are often shared between source files
         Map<Integer, IncludeFileEdge> ids = new HashMap<Integer, IncludeFileEdge>();
         int sourceFileCount = decoder.readSmallInt();
-        ImmutableMap.Builder<File, SourceFileState> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<File, SourceFileState> builder = ImmutableMap.builderWithExpectedSize(sourceFileCount);
         for (int i = 0; i < sourceFileCount; i++) {
             File sourceFile = fileSerializer.read(decoder);
             HashCode sourceHashCode = hashSerializer.read(decoder);
             boolean isUnresolved = decoder.readBoolean();
             int includeFileCount = decoder.readSmallInt();
-            ImmutableSet.Builder<IncludeFileEdge> includeFileStateBuilder = ImmutableSet.builder();
+            ImmutableSet.Builder<IncludeFileEdge> includeFileStateBuilder = ImmutableSet.builderWithExpectedSize(includeFileCount);
             for (int j = 0; j < includeFileCount; j++) {
                 int id = decoder.readSmallInt();
                 IncludeFileEdge includeFileState = ids.get(id);

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultIncrementalCompilerBuilder.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultIncrementalCompilerBuilder.java
@@ -119,7 +119,7 @@ public class DefaultIncrementalCompilerBuilder implements IncrementalCompilerBui
         }
 
         private IncludeDirectives directivesForMacros(Map<String, String> macros) {
-            ImmutableList.Builder<Macro> builder = ImmutableList.builder();
+            ImmutableList.Builder<Macro> builder = ImmutableList.builderWithExpectedSize(macros.size());
             for (Map.Entry<String, String> entry : macros.entrySet()) {
                 Expression expression = RegexBackedCSourceParser.parseExpression(entry.getValue());
                 builder.add(new MacroWithSimpleExpression(entry.getKey(), expression.getType(), expression.getValue()));

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -69,7 +69,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
         // For source files that do include the precompiled header, we mark them as a "source file for pch"
         // The native compiler then adds the appropriate compiler arguments for those source files that can use PCH
         if (spec.getPreCompiledHeader() != null) {
-            ImmutableList.Builder<File> sourceFiles = ImmutableList.builder();
+            ImmutableList.Builder<File> sourceFiles = ImmutableList.builderWithExpectedSize(spec.getSourceFiles().size());
             for (File sourceFile : spec.getSourceFiles()) {
                 SourceFileState state = incrementalCompilation.getFinalState().getState(sourceFile);
                 final HashCode hash = state.getHash();

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -141,7 +141,7 @@ public class BaseSerializerFactory {
     private static class StringMapSerializer extends AbstractSerializer<Map<String, String>> {
         public Map<String, String> read(Decoder decoder) throws Exception {
             int pairs = decoder.readSmallInt();
-            ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.builderWithExpectedSize(pairs);
             for (int i = 0; i < pairs; ++i) {
                 builder.put(decoder.readString(), decoder.readString());
             }

--- a/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/api/internal/resolve/LocalLibraryDependencyResolver.java
@@ -89,7 +89,19 @@ public class LocalLibraryDependencyResolver implements DependencyToComponentIdRe
                     public boolean apply(Binary input) {
                         return binaryType.isAssignableFrom(input.getClass());
                     }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(Binary input) {
+                        return apply(input);
+                    }
                 });
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(VariantComponent input) {
+                return apply(input);
             }
         };
     }

--- a/subprojects/platform-base/src/main/java/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMap.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/model/internal/core/DomainObjectCollectionBackedModelMap.java
@@ -109,6 +109,12 @@ public class DomainObjectCollectionBackedModelMap<T> extends ModelMapGroovyView<
         public boolean apply(@Nullable T input) {
             return namer.determineName(input).equals(name);
         }
+
+        @Override
+        // Added for Java 6 source compatibility
+        public boolean test(@Nullable T input) {
+            return apply(input);
+        }
     }
 
     private static class ToName<T> implements Function<T, String> {

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultDependencySpecContainer.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultDependencySpecContainer.java
@@ -17,7 +17,11 @@
 package org.gradle.platform.base.internal;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.platform.base.*;
+import org.gradle.platform.base.DependencySpec;
+import org.gradle.platform.base.DependencySpecBuilder;
+import org.gradle.platform.base.DependencySpecContainer;
+import org.gradle.platform.base.ModuleDependencySpecBuilder;
+import org.gradle.platform.base.ProjectDependencySpecBuilder;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -77,7 +81,7 @@ public class DefaultDependencySpecContainer implements DependencySpecContainer {
     }
 
     private Set<DependencySpec> dependencySpecSet() {
-        ImmutableSet.Builder<DependencySpec> specs = ImmutableSet.builder();
+        ImmutableSet.Builder<DependencySpec> specs = ImmutableSet.builderWithExpectedSize(builders.size());
         for (DependencySpecBuilder specBuilder : builders) {
             specs.add(specBuilder.build());
         }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/registry/ModelMapBasedRule.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/registry/ModelMapBasedRule.java
@@ -46,6 +46,12 @@ public abstract class ModelMapBasedRule<T, C> extends AbstractMethodRuleAction<C
             public boolean apply(ModelReference<?> element) {
                 return element.getType().equals(baseType);
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ModelReference<?> input) {
+                return apply(input);
+            }
         });
     }
 
@@ -54,6 +60,12 @@ public abstract class ModelMapBasedRule<T, C> extends AbstractMethodRuleAction<C
             @Override
             public boolean apply(ModelReference<?> element) {
                 return !element.getType().equals(baseType);
+            }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(ModelReference<?> input) {
+                return apply(input);
             }
         });
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
@@ -45,6 +45,12 @@ public class DefaultVariantsMetaData implements VariantsMetaData {
             public boolean apply(Map.Entry<String, Object> input) {
                 return input.getValue()!=null;
             }
+
+            @Override
+            // Added for Java 6 source compatibility
+            public boolean test(Map.Entry<String, Object> input) {
+                return apply(input);
+            }
         }).keySet());
         this.variantAxisTypes = variantAxisTypes;
     }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
@@ -57,11 +57,13 @@ public class DefaultVariantsMetaData implements VariantsMetaData {
 
     public static VariantsMetaData extractFrom(BinarySpec binarySpec, ModelSchema<?> binarySpecSchema) {
         Map<String, Object> variants = Maps.newLinkedHashMap();
-        ImmutableMap.Builder<String, ModelType<?>> dimensionTypesBuilder = ImmutableMap.builder();
+        ImmutableMap<String, ModelType<?>> dimensionTypes;
         if (binarySpecSchema instanceof StructSchema) {
             VariantAspect variantAspect = ((StructSchema<?>) binarySpecSchema).getAspect(VariantAspect.class);
             if (variantAspect != null) {
-                for (ModelProperty<?> property : variantAspect.getDimensions()) {
+                Set<ModelProperty<?>> dimensions = variantAspect.getDimensions();
+                ImmutableMap.Builder<String, ModelType<?>> dimensionTypesBuilder = ImmutableMap.builderWithExpectedSize(dimensions.size());
+                for (ModelProperty<?> property : dimensions) {
                     // note: it's not the role of this class to validate that the annotation is properly used, that
                     // is to say only on a getter returning String or a Named instance, so we trust the result of
                     // the call
@@ -69,9 +71,14 @@ public class DefaultVariantsMetaData implements VariantsMetaData {
                     variants.put(property.getName(), value);
                     dimensionTypesBuilder.put(property.getName(), property.getType());
                 }
+                dimensionTypes = dimensionTypesBuilder.build();
+            } else {
+                dimensionTypes = ImmutableMap.of();
             }
+        } else {
+            dimensionTypes = ImmutableMap.of();
         }
-        return new DefaultVariantsMetaData(Collections.unmodifiableMap(variants), dimensionTypesBuilder.build());
+        return new DefaultVariantsMetaData(Collections.unmodifiableMap(variants), dimensionTypes);
     }
 
     @Override

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -213,7 +213,7 @@ public class ValidateTaskProperties extends ConventionTask implements Verificati
     }
 
     private static List<String> toProblemMessages(Map<String, Boolean> problems) {
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(problems.size());
         for (Map.Entry<String, Boolean> entry : problems.entrySet()) {
             String problem = entry.getKey();
             Boolean error = entry.getValue();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/SnapshotSerializer.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/SnapshotSerializer.java
@@ -87,7 +87,7 @@ public class SnapshotSerializer extends AbstractSerializer<ValueSnapshot> {
                 return new ListValueSnapshot(listElements);
             case SET_SNAPSHOT:
                 size = decoder.readSmallInt();
-                ImmutableSet.Builder<ValueSnapshot> setBuilder = ImmutableSet.builder();
+                ImmutableSet.Builder<ValueSnapshot> setBuilder = ImmutableSet.builderWithExpectedSize(size);
                 for (int i = 0; i < size; i++) {
                     setBuilder.add(read(decoder));
                 }

--- a/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
+++ b/subprojects/testing-base/src/main/java/org/gradle/api/internal/tasks/testing/junit/result/AggregateTestResultsProvider.java
@@ -102,8 +102,15 @@ public class AggregateTestResultsProvider implements TestResultsProvider {
         return Iterables.any(
                 classOutputProviders.get(id),
                 new Predicate<DelegateProvider>() {
+                    @Override
                     public boolean apply(DelegateProvider delegateProvider) {
                         return delegateProvider.provider.hasOutput(delegateProvider.id, destination);
+                    }
+
+                    @Override
+                    // Added for Java 6 source compatibility
+                    public boolean test(DelegateProvider input) {
+                        return apply(input);
                     }
                 });
     }

--- a/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
+++ b/subprojects/tooling-api/src/integTest/groovy/org/gradle/integtests/tooling/ToolingApiClasspathIntegrationTest.groovy
@@ -30,7 +30,7 @@ class ToolingApiClasspathIntegrationTest extends AbstractIntegrationSpec {
         then:
         resolve.classpath.size() == 2
         resolve.classpath.any {it.name ==~ /slf4j-api-.*\.jar/}
-        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 1.86 * 1024 * 1024
+        resolve.classpath.find { it.name ==~ /gradle-tooling-api.*\.jar/ }.size() < 2.05 * 1024 * 1024
 
         cleanup:
         resolver.stop()


### PR DESCRIPTION
Since 24.1, Guava included a change that made ImmutableSet.Builder with unspecified expected size allocate a lot more memory for many items. We haven't bumped into this problem before, because we used the Android variant of Guava that somehow didn't contain the regressing change.

With moving to the Java 8 variant (see #8991) we now have to deal with this problem.

See https://github.com/google/guava/issues/3223 and https://github.com/google/guava/commit/a98632ee83a6c4c93f4b31820437f68ddde041dd#diff-439cf531381acbc7a3a95b99000d22ca for more details.