### PR TITLE
Show detailed executions for performance test

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessScenarioPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/FlakinessScenarioPageGenerator.java
@@ -16,23 +16,10 @@
 
 package org.gradle.performance.results;
 
-import com.google.common.collect.ImmutableMap;
-import groovy.json.JsonOutput;
-import org.gradle.performance.util.Git;
-
 import java.io.IOException;
 import java.io.Writer;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-public class FlakinessScenarioPageGenerator extends HtmlPageGenerator<PerformanceTestHistory> {
-    private final String commitId = Git.current().getCommitId();
-    private final AtomicInteger counter = new AtomicInteger(0);
-
+public class FlakinessScenarioPageGenerator extends HtmlPageGenerator<PerformanceTestHistory> implements PerformanceExecutionGraphRenderer {
     @Override
     public int getDepth() {
         return 1;
@@ -40,7 +27,6 @@ public class FlakinessScenarioPageGenerator extends HtmlPageGenerator<Performanc
 
     @Override
     public void render(PerformanceTestHistory history, Writer writer) throws IOException {
-        List<Graph> graphs = getGraphs(history);
         // @formatter:off
         new MetricsHtml(writer) {{
             html();
@@ -50,112 +36,11 @@ public class FlakinessScenarioPageGenerator extends HtmlPageGenerator<Performanc
                 end();
                 body();
                     h2().text("Flaky report for " + history.getDisplayName()).end();
-                    div().id("flot-placeholder").end();
-                    graphs.forEach(this::renderGraph);
+                    getGraphs(history).forEach(graph -> graph.render(this));
                 end();
             end();
         }
-
-        private void renderGraph(Graph graph) {
-            h3().text(graph.title).end();
-            div().id(graph.id).classAttr("chart").end();
-            script().raw(String.format("$.plot('#%s', %s, %s)", graph.id, graph.getData(), graph.getOptions())).end();
-        }
         };
         // @formatter:on
-    }
-
-    private List<Graph> getGraphs(PerformanceTestHistory history) {
-        return history.getExecutions()
-            .stream()
-            .filter(this::sameCommit)
-            .filter(this::hasTwoDataLines)
-            .map(this::toGraph)
-            .collect(Collectors.toList());
-    }
-
-    private boolean hasTwoDataLines(PerformanceTestExecution execution) {
-        return execution.getScenarios().size() > 1;
-    }
-
-    private boolean hasData(MeasuredOperationList measuredOperations) {
-        return !measuredOperations.getTotalTime().isEmpty();
-    }
-
-    private Graph toGraph(PerformanceTestExecution execution) {
-        int index = counter.incrementAndGet();
-        String id = "execution_" + index;
-        String title = "Execution " + index;
-
-        Line baseline = new Line(execution.getScenarios().stream().filter(this::hasData).findFirst().orElse(new MeasuredOperationList()));
-        Line current = new Line(execution.getScenarios().get(execution.getScenarios().size() - 1));
-
-        return new Graph(id, title, baseline, current);
-    }
-
-    private boolean sameCommit(PerformanceTestExecution execution) {
-        return execution.getVcsCommits().contains(commitId);
-    }
-
-    private static class Graph {
-        String id;
-        String title;
-        List<Line> data;
-
-        public Graph(String id, String title, Line... lines) {
-            this.id = id;
-            this.title = title;
-            this.data = Arrays.asList(lines);
-        }
-
-        String getData() {
-            return JsonOutput.toJson(data);
-        }
-
-        String getOptions() {
-            List<List<Object>> ticks = IntStream.range(0, data.get(0).data.size())
-                .mapToObj(index -> Arrays.<Object>asList(index, index))
-                .collect(Collectors.toList());
-            return JsonOutput.toJson(ImmutableMap.of("xaxis", ImmutableMap.of("ticks", ticks)));
-        }
-    }
-
-    private static class Line {
-        private static final Map<String, Object> SHOW_TRUE = ImmutableMap.of("show", true);
-        private static final Map<String, Object> SHOW_FALSE = ImmutableMap.of("show", false);
-        String label;
-        List<List<Number>> data;
-
-        public Line(MeasuredOperationList measuredOperations) {
-            List<Double> points = measuredOperations.getTotalTime().asDoubleList();
-            this.label = measuredOperations.getName();
-            this.data = IntStream.range(0, points.size())
-                .mapToObj(index -> Arrays.<Number>asList(index, points.get(index)))
-                .collect(Collectors.toList());
-        }
-
-        public String getLabel() {
-            return label;
-        }
-
-        public List<List<Number>> getData() {
-            return data;
-        }
-
-        public boolean getStack() {
-            return false;
-        }
-
-        public Map getBars() {
-            return SHOW_FALSE;
-        }
-
-        public Map getLines() {
-            return SHOW_TRUE;
-        }
-
-        public Map getPoints() {
-            return SHOW_TRUE;
-        }
     }
 }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Graph.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Graph.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import com.google.common.collect.ImmutableMap;
+import groovy.json.JsonOutput;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Graph {
+    String id;
+    String title;
+    List<Line> data;
+
+    public Graph(String id, String title, Line... lines) {
+        this.id = id;
+        this.title = title;
+        this.data = Arrays.asList(lines);
+    }
+
+    String getData() {
+        return JsonOutput.toJson(data);
+    }
+
+    String getOptions() {
+        List<List<Object>> ticks = IntStream.range(0, data.get(0).data.size())
+            .mapToObj(index -> Arrays.<Object>asList(index, index))
+            .collect(Collectors.toList());
+        return JsonOutput.toJson(ImmutableMap.of("xaxis", ImmutableMap.of("ticks", ticks)));
+    }
+
+    void render(HtmlPageGenerator.MetricsHtml html) {
+        html.h3().text(title).end();
+        html.div().id(id).classAttr("chart").end();
+        html.script().raw(String.format("$.plot('#%s', %s, %s)", id, getData(), getOptions())).end();
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Line.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/Line.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class Line {
+    private static final Map<String, Object> SHOW_TRUE = ImmutableMap.of("show", true);
+    private static final Map<String, Object> SHOW_FALSE = ImmutableMap.of("show", false);
+    String label;
+    List<List<Number>> data;
+
+    public Line(MeasuredOperationList measuredOperations) {
+        List<Double> points = measuredOperations.getTotalTime().asDoubleList();
+        this.label = measuredOperations.getName();
+        this.data = IntStream.range(0, points.size())
+            .mapToObj(index -> Arrays.<Number>asList(index, points.get(index)))
+            .collect(Collectors.toList());
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public List<List<Number>> getData() {
+        return data;
+    }
+
+    public boolean getStack() {
+        return false;
+    }
+
+    public Map getBars() {
+        return SHOW_FALSE;
+    }
+
+    public Map getLines() {
+        return SHOW_TRUE;
+    }
+
+    public Map getPoints() {
+        return SHOW_TRUE;
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import org.gradle.performance.util.Git;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static java.util.stream.Collectors.toList;
+
+public interface PerformanceExecutionGraphRenderer {
+    default List<Graph> getGraphs(PerformanceTestHistory history) {
+        List<PerformanceTestExecution> executions = history.getExecutions()
+            .stream()
+            .filter(this::sameCommit)
+            .filter(this::hasTwoDataLines)
+            .collect(toList());
+        return IntStream.range(0, executions.size()).mapToObj(i -> toGraph(executions.get(i), i + 1)).collect(toList());
+    }
+
+    default boolean hasTwoDataLines(PerformanceTestExecution execution) {
+        return execution.getScenarios().size() > 1;
+    }
+
+    default boolean hasData(MeasuredOperationList measuredOperations) {
+        return !measuredOperations.getTotalTime().isEmpty();
+    }
+
+    default Graph toGraph(PerformanceTestExecution execution, int index) {
+        String id = "execution_" + index;
+        String title = "Execution " + index;
+
+        Line baseline = new Line(execution.getScenarios().stream().filter(this::hasData).findFirst().orElse(new MeasuredOperationList()));
+        Line current = new Line(execution.getScenarios().get(execution.getScenarios().size() - 1));
+
+        return new Graph(id, title, baseline, current);
+    }
+
+    default boolean sameCommit(PerformanceTestExecution execution) {
+        return execution.getVcsCommits().contains(Git.current().getCommitId());
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceExecutionGraphRenderer.java
@@ -43,7 +43,7 @@ public interface PerformanceExecutionGraphRenderer {
 
     default Graph toGraph(PerformanceTestExecution execution, int index) {
         String id = "execution_" + index;
-        String title = "Execution " + index;
+        String title = "Execution " + index + "(ms)";
 
         Line baseline = new Line(execution.getScenarios().stream().filter(this::hasData).findFirst().orElse(new MeasuredOperationList()));
         Line current = new Line(execution.getScenarios().get(execution.getScenarios().size() - 1));

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/TestPageGenerator.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Sets;
 import com.googlecode.jatl.Html;
 import groovy.json.JsonOutput;
 import org.apache.commons.lang.StringUtils;
+import org.gradle.performance.util.Git;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -31,7 +32,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Set;
 
-public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory> {
+public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory> implements PerformanceExecutionGraphRenderer {
     private final String projectName;
 
     public TestPageGenerator(String projectName) {
@@ -206,6 +207,13 @@ public class TestPageGenerator extends HtmlPageGenerator<PerformanceTestHistory>
                 script();
                     raw("performanceTests.createPerformanceGraph('" + urlEncode(testHistory.getId()) + ".json', " + JsonOutput.toJson(charts) + ")");
                 end();
+
+                renderExecutions();
+            }
+
+            private void renderExecutions() {
+                h3().text("Executions for commit " + Git.current().getCommitId()).end();
+                getGraphs(testHistory).forEach(graph -> graph.render(this));
             }
         };
     }


### PR DESCRIPTION
### Context

This fixes https://github.com/gradle/gradle-private/issues/2069

We want to see the detailed execution information (i.e. fluctuations, stablities) in the graph. This PR extracts the code in flakiness report and applies them to normal performance scenario graph:

https://builds.gradle.org/viewLog.html?buildId=21884785&buildTypeId=Gradle_Check_PerformanceTestCoordinator&tab=report_project944_Performance&branch_Gradle_Check_Stage_ReadyforMerge=blindpirate%2Fshow-executions

https://builds.gradle.org/repository/download/Gradle_Check_PerformanceTestCoordinator/21884785:id/report-performance-performance-tests.zip%21/report/tests/resolves-dependencies-from-external-repository-%28parallel%29.html