### PR TITLE
Create NoOpPerformanceFlakinessAnalyzer if github token not found

### DIFF
--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzer.groovy
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzer.groovy
@@ -20,9 +20,7 @@ import groovy.transform.CompileStatic
 import groovy.transform.TypeChecked
 import groovy.transform.TypeCheckingMode
 import org.gradle.ci.common.model.FlakyTest
-import org.gradle.ci.github.DefaultGitHubIssuesClient
 import org.gradle.ci.github.GitHubIssuesClient
-import org.gradle.ci.tagging.flaky.GitHubKnownIssuesProvider
 import org.gradle.ci.tagging.flaky.KnownFlakyTestProvider
 import org.gradle.performance.results.ScenarioBuildResultData.ExecutionData
 import org.kohsuke.github.GHIssue
@@ -35,20 +33,14 @@ import static org.gradle.ci.github.GitHubIssuesClient.MESSAGE_PREFIX
 import static org.gradle.ci.github.GitHubIssuesClient.TEST_NAME_PREFIX
 
 @CompileStatic
-class PerformanceFlakinessAnalyzer {
-    static PerformanceFlakinessAnalyzer create() {
-        GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(System.getProperty("githubToken"))
-        KnownFlakyTestProvider provider = new GitHubKnownIssuesProvider(gitHubIssuesClient)
-        return new PerformanceFlakinessAnalyzer(gitHubIssuesClient, provider)
-    }
-
+class DefaultPerformanceFlakinessAnalyzer implements PerformanceFlakinessAnalyzer {
     static final String GITHUB_FIX_IT_LABEL = "fix-it"
     static final String GITHUB_IN_PERFORMANCE_LABEL = "in:performance"
     private final GitHubIssuesClient gitHubIssuesClient
     private final KnownFlakyTestProvider provider
     private List<FlakyTest> knownInvalidFailures
 
-    PerformanceFlakinessAnalyzer(GitHubIssuesClient gitHubIssuesClient, KnownFlakyTestProvider provider) {
+    DefaultPerformanceFlakinessAnalyzer(GitHubIssuesClient gitHubIssuesClient, KnownFlakyTestProvider provider) {
         this.gitHubIssuesClient = gitHubIssuesClient
         this.provider = provider
     }

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.performance.results;
+
+import org.apache.commons.lang3.StringUtils;
+import org.gradle.ci.common.model.FlakyTest;
+import org.gradle.ci.github.DefaultGitHubIssuesClient;
+import org.gradle.ci.github.GitHubIssuesClient;
+import org.gradle.ci.tagging.flaky.GitHubKnownIssuesProvider;
+import org.gradle.ci.tagging.flaky.KnownFlakyTestProvider;
+
+public interface PerformanceFlakinessAnalyzer {
+    static PerformanceFlakinessAnalyzer create() {
+        String githubToken = System.getProperty("githubToken");
+        if (StringUtils.isBlank(githubToken)) {
+            return NoOpPerformanceFlakinessAnalyzer.INSTANCE;
+        } else {
+            GitHubIssuesClient gitHubIssuesClient = new DefaultGitHubIssuesClient(githubToken);
+            KnownFlakyTestProvider provider = new GitHubKnownIssuesProvider(gitHubIssuesClient);
+            return new DefaultPerformanceFlakinessAnalyzer(gitHubIssuesClient, provider);
+        }
+    }
+
+    void report(ScenarioBuildResultData flakyScenario);
+
+    FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario);
+
+    enum NoOpPerformanceFlakinessAnalyzer implements PerformanceFlakinessAnalyzer {
+        INSTANCE;
+
+        @Override
+        public void report(ScenarioBuildResultData flakyScenario) {
+        }
+
+        @Override
+        public FlakyTest findKnownFlakyTest(ScenarioBuildResultData scenario) {
+            return null;
+        }
+    }
+}

--- a/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.java
+++ b/subprojects/internal-performance-testing/src/main/groovy/org/gradle/performance/results/PerformanceFlakinessAnalyzer.java
@@ -44,6 +44,7 @@ public interface PerformanceFlakinessAnalyzer {
 
         @Override
         public void report(ScenarioBuildResultData flakyScenario) {
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzerTest.groovy
+++ b/subprojects/internal-performance-testing/src/test/groovy/org/gradle/performance/results/DefaultPerformanceFlakinessAnalyzerTest.groovy
@@ -25,15 +25,15 @@ import spock.lang.Specification
 import spock.lang.Subject
 
 import static org.gradle.ci.github.GitHubIssuesClient.CI_TRACKED_FLAKINESS_LABEL
-import static org.gradle.performance.results.PerformanceFlakinessAnalyzer.GITHUB_FIX_IT_LABEL
-import static org.gradle.performance.results.PerformanceFlakinessAnalyzer.GITHUB_IN_PERFORMANCE_LABEL
+import static DefaultPerformanceFlakinessAnalyzer.GITHUB_FIX_IT_LABEL
+import static DefaultPerformanceFlakinessAnalyzer.GITHUB_IN_PERFORMANCE_LABEL
 
-class PerformanceFlakinessAnalyzerTest extends Specification {
+class DefaultPerformanceFlakinessAnalyzerTest extends Specification {
     GitHubIssuesClient issuesClient = Mock(GitHubIssuesClient)
     KnownFlakyTestProvider flakyTestProvider = Mock(KnownFlakyTestProvider)
 
     @Subject
-    PerformanceFlakinessAnalyzer reporter = new PerformanceFlakinessAnalyzer(issuesClient, flakyTestProvider)
+    DefaultPerformanceFlakinessAnalyzer reporter = new DefaultPerformanceFlakinessAnalyzer(issuesClient, flakyTestProvider)
 
     ScenarioBuildResultData scenario = new ScenarioBuildResultData(
         scenarioName: 'myScenario',


### PR DESCRIPTION
### Context

In https://github.com/gradle/gradle/pull/8997 we query GitHub API for known flakiness issues. However sometimes `githubToken` is not set - in this case we shouldn't let the build fail.

This PR fixes the issue by creating a `NoOpPerformanceFlakinessAnalyzer` when `githubToken` is not set.