### PR TITLE
docs: Fix parenthesis in Jacoco plugin configuration example

### DIFF
--- a/subprojects/docs/src/docs/userguide/jacoco_plugin.adoc
+++ b/subprojects/docs/src/docs/userguide/jacoco_plugin.adoc
@@ -130,7 +130,7 @@ test {
 [.multi-language-text.lang-kotlin]
 ----
 tasks.getByName<Test>("test") {
-    extensions.configure<JacocoTaskExtension::class) {
+    extensions.configure(JacocoTaskExtension::class) {
         isEnabled = true
         destinationFile = file("$buildDir/jacoco/$name.exec")
         includes = listOf()


### PR DESCRIPTION
### Context

It's a typo fix in an example.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
