### PR TITLE
Dependency locking improvements

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -314,6 +314,140 @@ task copyFiles(type: Copy) {
 
     }
 
+    def "fails when a force overwrites a locked version"() {
+        given:
+        mavenRepo.module('org', 'test', '1.0').publish()
+        mavenRepo.module('org', 'test', '1.1').publish()
+
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'])
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf {
+        resolutionStrategy {
+            force 'org:test:1.0'
+        }
+    }
+}
+
+dependencies {
+    lockedConf 'org:test:[1.0,2.0)'
+}
+
+task resolve {
+    doLast {
+        println configurations.lockedConf.files
+    }
+}
+"""
+
+        when:
+        fails 'resolve'
+
+        then:
+        failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
+    }
+
+    def "fails when a substitute overwrites a locked version"() {
+        given:
+        mavenRepo.module('org', 'test', '1.0').publish()
+        mavenRepo.module('org', 'test', '1.1').publish()
+
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'])
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf {
+        resolutionStrategy.dependencySubstitution {
+            substitute module('org:test') with module('org:test:1.0')
+        }
+    }
+}
+
+dependencies {
+    lockedConf 'org:test:[1.0,2.0)'
+}
+
+task resolve {
+    doLast {
+        println configurations.lockedConf.files
+    }
+}
+"""
+
+        when:
+        fails 'resolve'
+
+        then:
+        failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
+    }
+
+    def "fails when a useTarget overwrites a locked version"() {
+        given:
+        mavenRepo.module('org', 'test', '1.0').publish()
+        mavenRepo.module('org', 'test', '1.1').publish()
+
+        lockfileFixture.createLockfile('lockedConf', ['org:test:1.1'])
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+configurations {
+    lockedConf {
+        resolutionStrategy.eachDependency { details ->
+            if (details.requested.group == 'org' && details.requested.name == 'test') {
+                details.useVersion '1.0'
+            }
+        }
+    }
+}
+
+dependencies {
+    lockedConf 'org:test:[1.0,2.0)'
+}
+
+task resolve {
+    doLast {
+        println configurations.lockedConf.files
+    }
+}
+"""
+
+        when:
+        fails 'resolve'
+
+        then:
+        failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
+    }
+
     @ToBeImplemented
     def "avoids HTTP requests for dynamic version when lock exists"() {
         def module1 = mavenHttpRepo.module('org', 'foo', '1.0').publish()

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -448,6 +448,49 @@ task resolve {
         failureHasCause("Did not resolve 'org:test:1.1' which has been forced / substituted to a different version: '1.0'")
     }
 
+    def "ignores the lock entry that matches a composite"() {
+        given:
+        lockfileFixture.createLockfile('lockedConf', ['org:composite:1.1'])
+
+        file("composite/settings.gradle") << """
+rootProject.name = 'composite'
+"""
+        file("composite/build.gradle") << """
+apply plugin: 'java'
+group = 'org'
+version = '1.1'
+"""
+
+        buildFile << """
+dependencyLocking {
+    lockAllConfigurations()
+}
+
+repositories {
+    maven {
+        name 'repo'
+        url '${mavenRepo.uri}'
+    }
+}
+
+configurations {
+    lockedConf
+}
+
+dependencies {
+    lockedConf 'org:composite:1.1'
+}
+
+task resolve {
+    doLast {
+        println configurations.lockedConf.files
+    }
+}
+"""
+        expect:
+        succeeds 'resolve', '--include-build', 'composite'
+    }
+
     @ToBeImplemented
     def "avoids HTTP requests for dynamic version when lock exists"() {
         def module1 = mavenHttpRepo.module('org', 'foo', '1.0').publish()

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -521,8 +521,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
             return instantiator.newInstance(DefaultDependencyLockingHandler.class, configurationContainer);
         }
 
-        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context) {
-            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context);
+        DependencyLockingProvider createDependencyLockingProvider(Instantiator instantiator, FileResolver fileResolver, StartParameter startParameter, DomainObjectContext context, GlobalDependencyResolutionRules globalDependencyResolutionRules) {
+            return instantiator.newInstance(DefaultDependencyLockingProvider.class, fileResolver, startParameter, context, globalDependencyResolutionRules.getDependencySubstitutionRules());
         }
 
         DependencyConstraintHandler createDependencyConstraintHandler(Instantiator instantiator, ConfigurationContainerInternal configurationContainer, DependencyFactory dependencyFactory, ComponentMetadataHandler componentMetadataHandler) {


### PR DESCRIPTION
* A force or substitution was not detected by dependency locking and would allow a user to have a graph result that differed from the lock state. With this PR, such differences are now properly reported and will fail resolution when identified.
* When globabl composite substitutions are declared, they will also filter out lock entries. This means that a binary dependency substituted with a project dependency will no longer be part of the live lock state