### PR TITLE
IvyDescriptorFileGenerator: add revConstraint if using resolved dependencies

### DIFF
--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptor.groovy
@@ -75,6 +75,7 @@ class IvyDescriptor {
                     org: dep.@org,
                     module: dep.@name,
                     revision: dep.@rev,
+                    revisionConstraint: dep.@revConstraint,
                     conf: dep.@conf,
                     transitive: dep.@transitive
             )

--- a/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
+++ b/subprojects/internal-integ-testing/src/main/groovy/org/gradle/test/fixtures/ivy/IvyDescriptorDependency.groovy
@@ -20,6 +20,7 @@ class IvyDescriptorDependency {
     String org
     String module
     String revision
+    String revisionConstraint
     String conf
     String transitive
     Collection<IvyDescriptorDependencyExclusion> exclusions = []

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -825,7 +825,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         javaLibrary.assertPublished()
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
         javaLibrary.parsedIvy.assertDependsOn("commons-collections:commons-collections:${expectedVersion}@runtime")
-        javaLibrary.parsedIvy.dependencies["commons-collections:commons-collections:3.2.2"].revisionConstraint == requestedVersion
+        javaLibrary.parsedIvy.dependencies["commons-collections:commons-collections:${expectedVersion}"].revisionConstraint == requestedVersion
 
         and:
         javaLibrary.parsedModuleMetadata.variant('apiElements') {
@@ -850,6 +850,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         requestedVersion | expectedVersion
         "3.2.+"          | "3.2.2"
         "[2.1.0,4.0.0)"  | "3.2.2"
+        "latest.release" | "20040616"
     }
 
 

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -734,7 +734,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
             ${jcenterRepository()}
 
             dependencies {
-                implementation "commons-collections:commons-collections"
+                implementation "commons-collections:commons-collections:3.2.+"
                 constraints {
                     implementation "commons-collections:commons-collections:3.2.2"
                 }
@@ -764,6 +764,7 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         javaLibrary.assertPublished()
         javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
         javaLibrary.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@runtime")
+        javaLibrary.parsedIvy.dependencies["commons-collections:commons-collections:3.2.2"].revisionConstraint == "3.2.+"
 
         and:
         javaLibrary.parsedModuleMetadata.variant('apiElements') {

--- a/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
+++ b/subprojects/ivy/src/integTest/groovy/org/gradle/api/publish/ivy/IvyPublishJavaIntegTest.groovy
@@ -786,6 +786,62 @@ class IvyPublishJavaIntegTest extends AbstractIvyPublishIntegTest {
         }
     }
 
+    def "can publish java-library with dependencies with version using versionMapping and not adding revConstraints"() {
+        requiresExternalDependencies = true
+        given:
+        createBuildScripts("""
+
+            ${jcenterRepository()}
+
+            dependencies {
+                implementation "commons-collections:commons-collections:3.2.2"
+            }
+
+            publishing {
+                publications {
+                    ivy(IvyPublication) {
+                        from components.java
+                        versionMapping {
+                            usage('java-runtime') {
+                                fromResolutionResult()
+                            }
+                        }
+                    }
+                }
+            }
+""")
+
+        when:
+        succeeds "publish"
+
+        then:
+        javaLibrary.removeGradleMetadataRedirection()
+        outputDoesNotContain(DefaultIvyPublication.UNSUPPORTED_FEATURE)
+        outputDoesNotContain('commons-collections:commons-collections declared without version')
+        javaLibrary.assertPublished()
+        javaLibrary.parsedIvy.configurations.keySet() == ["compile", "runtime", "default"] as Set
+        javaLibrary.parsedIvy.assertDependsOn("commons-collections:commons-collections:3.2.2@runtime")
+        !javaLibrary.parsedIvy.dependencies["commons-collections:commons-collections:3.2.2"].revisionConstraint
+
+        and:
+        javaLibrary.parsedModuleMetadata.variant('apiElements') {
+            noMoreDependencies()
+        }
+
+        javaLibrary.parsedModuleMetadata.variant('runtimeElements') {
+            dependency('commons-collections:commons-collections:3.2.2') {
+                noMoreExcludes()
+            }
+            noMoreDependencies()
+        }
+
+        and:
+        resolveArtifacts(javaLibrary) {
+            expectFiles 'commons-collections-3.2.2.jar', 'publishTest-1.9.jar'
+        }
+    }
+
+
     def "can publish java-library with rejected versions"() {
         requiresExternalDependencies = true
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -24,6 +24,7 @@ import org.gradle.api.XmlProvider;
 import org.gradle.api.artifacts.DependencyArtifact;
 import org.gradle.api.artifacts.ExcludeRule;
 import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.parser.MetaDataParser;
+import org.gradle.api.internal.artifacts.ivyservice.ivyresolve.strategy.VersionRangeSelector;
 import org.gradle.api.publish.internal.versionmapping.VersionMappingStrategyInternal;
 import org.gradle.api.publish.ivy.IvyArtifact;
 import org.gradle.api.publish.ivy.IvyConfiguration;
@@ -263,7 +264,7 @@ public class IvyDescriptorFileGenerator {
                     .attribute("rev", resolvedVersion != null ? resolvedVersion : dependency.getRevision())
                     .attribute("conf", dependency.getConfMapping());
 
-            if(resolvedVersion != null && !resolvedVersion.equals(dependency.getRevision())) {
+            if(resolvedVersion != null && isDynamicVersion(dependency.getRevision())) {
                 xmlWriter.attribute("revConstraint", dependency.getRevision());
             }
 
@@ -283,6 +284,10 @@ public class IvyDescriptorFileGenerator {
             writeGlobalExclude(excludeRule, xmlWriter);
         }
         xmlWriter.endElement();
+    }
+
+    private boolean isDynamicVersion(String version) {
+        return VersionRangeSelector.ALL_RANGE.matcher(version).matches() || version.endsWith("+");
     }
 
     private void writeDependencyExclude(ExcludeRule excludeRule, OptionalAttributeXmlWriter xmlWriter) throws IOException {

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -263,7 +263,7 @@ public class IvyDescriptorFileGenerator {
                     .attribute("rev", resolvedVersion != null ? resolvedVersion : dependency.getRevision())
                     .attribute("conf", dependency.getConfMapping());
 
-            if(resolvedVersion != null) {
+            if(resolvedVersion != null && !resolvedVersion.equals(dependency.getRevision())) {
                 xmlWriter.attribute("revConstraint", dependency.getRevision());
             }
 

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -263,6 +263,10 @@ public class IvyDescriptorFileGenerator {
                     .attribute("rev", resolvedVersion != null ? resolvedVersion : dependency.getRevision())
                     .attribute("conf", dependency.getConfMapping());
 
+            if(resolvedVersion != null) {
+                xmlWriter.attribute("revConstraint", dependency.getRevision());
+            }
+
             if (!dependency.isTransitive()) {
                 xmlWriter.attribute("transitive", "false");
             }

--- a/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
+++ b/subprojects/ivy/src/main/java/org/gradle/api/publish/ivy/internal/publisher/IvyDescriptorFileGenerator.java
@@ -287,7 +287,7 @@ public class IvyDescriptorFileGenerator {
     }
 
     private boolean isDynamicVersion(String version) {
-        return VersionRangeSelector.ALL_RANGE.matcher(version).matches() || version.endsWith("+");
+        return VersionRangeSelector.ALL_RANGE.matcher(version).matches() || version.endsWith("+") || version.startsWith("latest.");
     }
 
     private void writeDependencyExclude(ExcludeRule excludeRule, OptionalAttributeXmlWriter xmlWriter) throws IOException {


### PR DESCRIPTION
Hi @ljacomet @melix , this is for  https://github.com/gradle/gradle/issues/9120 

Given a set of dependencies, for example:

```
dependencies {
                compile 'test.resolved:d:[1.0.0, 2.0.0['
            }
```

And `IvyPublication` using `versionMapping`:

```
 project.publishing {
                publications {
                    withType(IvyPublication) {

                        versionMapping {
                            allVariants {
                                fromResolutionResult()
                            }
                        }
                    }
                }
            }
```

It would be ideal if we could have requested version (`[1.0.0, 2.0.0[`)  as `revConstraint`

Currently, `IvyDescriptorFileGenerator` only writes `rev` as part of the XML.

We already do this in our nebula publishing plugin but we would like to migrate to core gradle feature for this. (https://github.com/nebula-plugins/nebula-publishing-plugin/blob/master/src/main/groovy/nebula/plugin/publishing/ivy/IvyResolvedDependenciesPlugin.groovy#L96)


Wondering if this could be part of 5.4.1 

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [x] Recognize contributor in release notes
