### PR TITLE
Define size of immutable builders where possible

### DIFF
--- a/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractTaskOutputPackagingBenchmark.java
+++ b/subprojects/build-cache/src/jmh/java/org/gradle/caching/internal/tasks/AbstractTaskOutputPackagingBenchmark.java
@@ -106,7 +106,7 @@ public abstract class AbstractTaskOutputPackagingBenchmark {
 
     private static ImmutableList<DataSource> createInputFiles(int fileCount, int minFileSize, int maxFileSize, DataAccessor accessor) throws IOException {
         Random random = new Random(1234L);
-        ImmutableList.Builder<DataSource> inputs = ImmutableList.builder();
+        ImmutableList.Builder<DataSource> inputs = ImmutableList.builderWithExpectedSize(fileCount);
         for (int idx = 0; idx < fileCount; idx++) {
             String name = "input-" + idx + ".bin";
             int fileSize = minFileSize + random.nextInt(maxFileSize - minFileSize);

--- a/subprojects/core-api/src/main/java/org/gradle/model/internal/type/ModelType.java
+++ b/subprojects/core-api/src/main/java/org/gradle/model/internal/type/ModelType.java
@@ -18,10 +18,10 @@ package org.gradle.model.internal.type;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
-import javax.annotation.concurrent.ThreadSafe;
 import org.gradle.internal.Cast;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -136,7 +136,7 @@ public abstract class ModelType<T> {
     public List<ModelType<?>> getTypeVariables() {
         if (isParameterized()) {
             TypeWrapper[] typeArguments = ((ParameterizedTypeWrapper) wrapper).getActualTypeArguments();
-            ImmutableList.Builder<ModelType<?>> builder = ImmutableList.builder();
+            ImmutableList.Builder<ModelType<?>> builder = ImmutableList.builderWithExpectedSize(typeArguments.length);
             for (TypeWrapper typeArgument : typeArguments) {
                 builder.add(Simple.typed(typeArgument));
             }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceFilter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/changedetection/state/IgnoringResourceFilter.java
@@ -30,7 +30,7 @@ public class IgnoringResourceFilter implements ResourceFilter {
 
     public IgnoringResourceFilter(ImmutableSet<String> ignores) {
         this.ignores = ignores;
-        ImmutableSet.Builder<PathMatcher> builder = ImmutableSet.builder();
+        ImmutableSet.Builder<PathMatcher> builder = ImmutableSet.builderWithExpectedSize(ignores.size());
         for (String ignore : ignores) {
             PathMatcher matcher = PatternMatcherFactory.compile(true, ignore);
             builder.add(matcher);

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ResolveBeforeExecutionStateTaskExecuter.java
@@ -105,7 +105,7 @@ public class ResolveBeforeExecutionStateTaskExecuter implements TaskExecuter {
         if (taskActions.isEmpty()) {
             return ImmutableList.of();
         }
-        ImmutableList.Builder<ImplementationSnapshot> actionImplementations = ImmutableList.builder();
+        ImmutableList.Builder<ImplementationSnapshot> actionImplementations = ImmutableList.builderWithExpectedSize(taskActions.size());
         for (InputChangesAwareTaskAction taskAction : taskActions) {
             actionImplementations.add(taskAction.getActionImplementation(classLoaderHierarchyHasher));
         }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InspectionSchemeFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/properties/InspectionSchemeFactory.java
@@ -37,7 +37,7 @@ public class InspectionSchemeFactory {
     private final CrossBuildInMemoryCacheFactory cacheFactory;
 
     public InspectionSchemeFactory(List<? extends PropertyAnnotationHandler> allKnownPropertyHandlers, List<? extends TypeAnnotationHandler> allKnownTypeHandlers, CrossBuildInMemoryCacheFactory cacheFactory) {
-        ImmutableMap.Builder<Class<? extends Annotation>, PropertyAnnotationHandler> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<Class<? extends Annotation>, PropertyAnnotationHandler> builder = ImmutableMap.builderWithExpectedSize(allKnownPropertyHandlers.size());
         for (PropertyAnnotationHandler handler : allKnownPropertyHandlers) {
             builder.put(handler.getAnnotationType(), handler);
         }

--- a/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
+++ b/subprojects/core/src/main/java/org/gradle/api/tasks/WriteProperties.java
@@ -68,7 +68,7 @@ public class WriteProperties extends DefaultTask {
      */
     @Input
     public Map<String, String> getProperties() {
-        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(properties.size() + deferredProperties.size());
         propertiesBuilder.putAll(properties);
         try {
             for (Map.Entry<String, Callable<String>> e : deferredProperties.entrySet()) {

--- a/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/plan/DefaultExecutionPlan.java
@@ -529,7 +529,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
 
     @Override
     public Set<Task> getFilteredTasks() {
-        ImmutableSet.Builder<Task> builder = ImmutableSet.builder();
+        ImmutableSet.Builder<Task> builder = ImmutableSet.builderWithExpectedSize(filteredNodes.size());
         for (Node filteredNode : filteredNodes) {
             if (filteredNode instanceof LocalTaskNode) {
                 builder.add(((LocalTaskNode) filteredNode).getTask());
@@ -649,7 +649,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                                     FileParameterUtils.resolveOutputFilePropertySpecs(task.toString(), propertyName, value, filePropertyType, fileCollectionFactory, new Consumer<OutputFilePropertySpec>() {
                                         @Override
                                         public void accept(OutputFilePropertySpec outputFilePropertySpec) {
-                                            mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, outputFilePropertySpec.getPropertyFiles()));
+                                            mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, outputFilePropertySpec.getPropertyFiles().getFiles()));
                                         }
                                     });
                                 }
@@ -663,7 +663,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                         withDeadlockHandling(taskNode, "a local state property", "local state properties", new Runnable() {
                             @Override
                             public void run() {
-                                mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value)));
+                                mutations.outputPaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value).getFiles()));
                             }
                         });
                         mutations.hasLocalState = true;
@@ -674,7 +674,7 @@ public class DefaultExecutionPlan implements ExecutionPlan {
                         withDeadlockHandling(taskNode, "a destroyable", "destroyables", new Runnable() {
                             @Override
                             public void run() {
-                                mutations.destroyablePaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value)));
+                                mutations.destroyablePaths.addAll(canonicalizedPaths(canonicalizedFileCache, resolver.resolveFiles(value).getFiles()));
                             }
                         });
                     }
@@ -741,8 +741,8 @@ public class DefaultExecutionPlan implements ExecutionPlan {
         return !doesDestroyNotYetConsumedOutputOfAnotherNode(node, candidateNodeDestroyables);
     }
 
-    private static ImmutableSet<String> canonicalizedPaths(final Map<File, String> cache, Iterable<File> files) {
-        ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+    private static ImmutableSet<String> canonicalizedPaths(final Map<File, String> cache, Set<File> files) {
+        ImmutableSet.Builder<String> builder = ImmutableSet.builderWithExpectedSize(files.size());
         for (File file : files) {
             builder.add(canonicalizePath(file, cache));
         }

--- a/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/taskgraph/DefaultTaskExecutionGraph.java
@@ -293,8 +293,9 @@ public class DefaultTaskExecutionGraph implements TaskExecutionGraphInternal {
     public Set<Task> getDependencies(Task task) {
         ensurePopulated();
         Node node = executionPlan.getNode(task);
-        ImmutableSet.Builder<Task> builder = ImmutableSet.builder();
-        for (Node dependencyNode : node.getDependencySuccessors()) {
+        Set<Node> dependencySuccessors = node.getDependencySuccessors();
+        ImmutableSet.Builder<Task> builder = ImmutableSet.builderWithExpectedSize(dependencySuccessors.size());
+        for (Node dependencyNode : dependencySuccessors) {
             if (dependencyNode instanceof TaskNode) {
                 builder.add(((TaskNode) dependencyNode).getTask());
             }

--- a/subprojects/core/src/main/java/org/gradle/initialization/GradleApiSpecAggregator.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/GradleApiSpecAggregator.java
@@ -56,10 +56,10 @@ class GradleApiSpecAggregator {
     }
 
     private Spec mergeSpecsOf(List<Class<? extends GradleApiSpecProvider>> providers) {
-        final ImmutableSet.Builder<Class<?>> exportedClasses = ImmutableSet.builder();
-        final ImmutableSet.Builder<String> exportedPackages = ImmutableSet.builder();
-        final ImmutableSet.Builder<String> exportedResources = ImmutableSet.builder();
-        final ImmutableSet.Builder<String> exportedResourcePrefixes = ImmutableSet.builder();
+        final ImmutableSet.Builder<Class<?>> exportedClasses = ImmutableSet.builderWithExpectedSize(providers.size());
+        final ImmutableSet.Builder<String> exportedPackages = ImmutableSet.builderWithExpectedSize(providers.size());
+        final ImmutableSet.Builder<String> exportedResources = ImmutableSet.builderWithExpectedSize(providers.size());
+        final ImmutableSet.Builder<String> exportedResourcePrefixes = ImmutableSet.builderWithExpectedSize(providers.size());
         for (Class<? extends GradleApiSpecProvider> provider : providers) {
             Spec spec = specFrom(provider);
             exportedClasses.addAll(spec.getExportedClasses());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/SuppliedComponentMetadataSerializer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/modulecache/SuppliedComponentMetadataSerializer.java
@@ -78,8 +78,8 @@ public class SuppliedComponentMetadataSerializer extends AbstractSerializer<Comp
 
     private List<String> readStatusScheme(Decoder decoder) throws IOException {
         int size = decoder.readSmallInt();
-        ImmutableList.Builder<String> scheme = ImmutableList.builder();
-        for (int i=0; i<size; i++) {
+        ImmutableList.Builder<String> scheme = ImmutableList.builderWithExpectedSize(size);
+        for (int i = 0; i < size; i++) {
             scheme.add(decoder.readString());
         }
         return scheme.build();

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractIvyDependencyDescriptorFactory.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/moduleconverter/dependencies/AbstractIvyDependencyDescriptorFactory.java
@@ -49,7 +49,7 @@ public abstract class AbstractIvyDependencyDescriptorFactory implements IvyDepen
     }
 
     protected ImmutableList<IvyArtifactName> convertArtifacts(Set<DependencyArtifact> dependencyArtifacts) {
-        ImmutableList.Builder<IvyArtifactName> names = ImmutableList.builder();
+        ImmutableList.Builder<IvyArtifactName> names = ImmutableList.builderWithExpectedSize(dependencyArtifacts.size());
         for (DependencyArtifact dependencyArtifact : dependencyArtifacts) {
             DefaultIvyArtifactName name = new DefaultIvyArtifactName(dependencyArtifact.getName(), dependencyArtifact.getType(), getExtension(dependencyArtifact), dependencyArtifact.getClassifier());
             names.add(name);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/artifact/DefaultArtifactSet.java
@@ -72,12 +72,13 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
     }
 
     public static ArtifactSet multipleVariants(ComponentIdentifier componentIdentifier, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, Set<? extends VariantResolveMetadata> variants, AttributesSchemaInternal schema, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry, ImmutableAttributes selectionAttributes) {
-        if (variants.size() == 1) {
+        int variantCount = variants.size();
+        if (variantCount == 1) {
             VariantResolveMetadata variantMetadata = variants.iterator().next();
             ResolvedVariant resolvedVariant = toResolvedVariant(variantMetadata, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             return new SingleVariantArtifactSet(componentIdentifier, schema, resolvedVariant, selectionAttributes);
         }
-        ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builder();
+        ImmutableSet.Builder<ResolvedVariant> result = ImmutableSet.builderWithExpectedSize(variantCount);
         for (VariantResolveMetadata variant : variants) {
             ResolvedVariant resolvedVariant = toResolvedVariant(variant, ownerId, moduleSource, exclusions, artifactResolver, allResolvedArtifacts, artifactTypeRegistry);
             result.add(resolvedVariant);
@@ -93,7 +94,7 @@ public abstract class DefaultArtifactSet implements ArtifactSet, ResolvedVariant
 
     private static ResolvedVariant toResolvedVariant(VariantResolveMetadata variant, ModuleVersionIdentifier ownerId, ModuleSource moduleSource, ModuleExclusion exclusions, ArtifactResolver artifactResolver, Map<ComponentArtifactIdentifier, ResolvableArtifact> allResolvedArtifacts, ArtifactTypeRegistry artifactTypeRegistry) {
         List<? extends ComponentArtifactMetadata> artifacts = variant.getArtifacts();
-        ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builder();
+        ImmutableSet.Builder<ResolvableArtifact> resolvedArtifacts = ImmutableSet.builderWithExpectedSize(artifacts.size());
 
         // Apply any artifact type mappings to the attributes of the variant
         ImmutableAttributes attributes = artifactTypeRegistry.mapAttributesFor(variant);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/ModuleExclusions.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/excludes/ModuleExclusions.java
@@ -99,7 +99,7 @@ public class ModuleExclusions {
         if (exclusion != null) {
             return exclusion;
         }
-        ImmutableSet.Builder<AbstractModuleExclusion> exclusions = ImmutableSet.builder();
+        ImmutableSet.Builder<AbstractModuleExclusion> exclusions = ImmutableSet.builderWithExpectedSize(excludes.size());
         for (ExcludeMetadata exclude : excludes) {
             exclusions.add(forExclude(exclude));
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/oldresult/ResolutionFailureCollector.java
@@ -78,7 +78,7 @@ public class ResolutionFailureCollector implements DependencyGraphVisitor {
         if (extraFailures.isEmpty() && failuresByRevisionId.isEmpty()) {
             return ImmutableSet.of();
         }
-        ImmutableSet.Builder<UnresolvedDependency> builder = ImmutableSet.builder();
+        ImmutableSet.Builder<UnresolvedDependency> builder = ImmutableSet.builderWithExpectedSize(extraFailures.size() + failuresByRevisionId.size());
         builder.addAll(extraFailures);
         for (Map.Entry<ComponentSelector, BrokenDependency> entry : failuresByRevisionId.entrySet()) {
             Collection<List<ComponentIdentifier>> paths = DependencyGraphPathResolver.calculatePaths(entry.getValue().requiredBy, root);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -301,8 +301,8 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         private ImmutableList<File> loadResultsFile() {
             Path transformerResultsPath = workspace.getResultsFile().toPath();
             try {
-                ImmutableList.Builder<File> builder = ImmutableList.builder();
                 List<String> paths = Files.readAllLines(transformerResultsPath, StandardCharsets.UTF_8);
+                ImmutableList.Builder<File> builder = ImmutableList.builderWithExpectedSize(paths.size());
                 for (String path : paths) {
                     if (path.startsWith(OUTPUT_FILE_PATH_PREFIX)) {
                         builder.add(new File(workspace.getOutputDirectory(), path.substring(2)));

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultMutableIvyModuleResolveMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/ivy/DefaultMutableIvyModuleResolveMetadata.java
@@ -68,7 +68,7 @@ public class DefaultMutableIvyModuleResolveMetadata extends AbstractMutableModul
     }
 
     private static ImmutableMap<String, Configuration> toMap(Collection<Configuration> configurations) {
-        ImmutableMap.Builder<String, Configuration> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Configuration> builder = ImmutableMap.builderWithExpectedSize(configurations.size());
         for (Configuration configuration : configurations) {
             builder.put(configuration.getName(), configuration);
         }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/external/model/maven/RealisedMavenModuleResolveMetadataSerializationHelper.java
@@ -67,7 +67,7 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
     public ModuleComponentResolveMetadata readMetadata(Decoder decoder, DefaultMavenModuleResolveMetadata resolveMetadata, Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {
         Map<String, List<GradleDependencyMetadata>> variantToDependencies = readVariantDependencies(decoder);
         ImmutableList<? extends ComponentVariant> variants = resolveMetadata.getVariants();
-        ImmutableList.Builder<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> builder = ImmutableList.builder();
+        ImmutableList.Builder<AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl> builder = ImmutableList.builderWithExpectedSize(variants.size());
         for (ComponentVariant variant: variants) {
             builder.add(new AbstractRealisedModuleComponentResolveMetadata.ImmutableRealisedVariantImpl(resolveMetadata.getId(), variant.getName(), variant.getAttributes().asImmutable(), variant.getDependencies(), variant.getDependencyConstraints(),
                 variant.getFiles(), ImmutableCapabilities.of(variant.getCapabilities().getCapabilities()), variantToDependencies.get(variant.getName())));
@@ -148,11 +148,11 @@ public class RealisedMavenModuleResolveMetadataSerializationHelper extends Abstr
     }
 
     private ImmutableList<ModuleDependencyMetadata> readDependencies(Decoder decoder, DefaultMavenModuleResolveMetadata metadata, RealisedConfigurationMetadata configurationMetadata, Map<Integer, MavenDependencyDescriptor> deduplicationDependencyCache) throws IOException {
-        ImmutableList.Builder<ModuleDependencyMetadata> builder = ImmutableList.builder();
         int dependenciesCount = decoder.readSmallInt();
         if (dependenciesCount == 0) {
             return ImmutableList.of();
         }
+        ImmutableList.Builder<ModuleDependencyMetadata> builder = ImmutableList.builderWithExpectedSize(dependenciesCount);
         for (int j = 0; j < dependenciesCount; j++) {
             byte dependencyType = decoder.readByte();
             boolean force = false;

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/local/model/DefaultLocalComponentMetadata.java
@@ -146,11 +146,12 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
     @Override
     public void addVariant(String configuration, OutgoingVariant variant) {
         List<LocalComponentArtifactMetadata> artifacts;
-        if (variant.getArtifacts().isEmpty()) {
+        Set<? extends PublishArtifact> variantArtifacts = variant.getArtifacts();
+        if (variantArtifacts.isEmpty()) {
             artifacts = ImmutableList.of();
         } else {
-            ImmutableList.Builder<LocalComponentArtifactMetadata> builder = ImmutableList.builder();
-            for (PublishArtifact artifact : variant.getArtifacts()) {
+            ImmutableList.Builder<LocalComponentArtifactMetadata> builder = ImmutableList.builderWithExpectedSize(variantArtifacts.size());
+            for (PublishArtifact artifact : variantArtifacts) {
                 builder.add(new PublishArtifactLocalArtifactMetadata(componentId, artifact));
             }
             artifacts = builder.build();
@@ -411,7 +412,7 @@ public class DefaultLocalComponentMetadata implements LocalComponentMetadata, Bu
                 if (attributeValue.isPresent() && attributeValue.get().getName().equals(Category.ENFORCED_PLATFORM)) {
                     // need to wrap all dependencies to force them
                     ImmutableList<LocalOriginDependencyMetadata> rawDependencies = result.build();
-                    result = ImmutableList.builder();
+                    result = ImmutableList.builderWithExpectedSize(rawDependencies.size());
                     for (LocalOriginDependencyMetadata rawDependency : rawDependencies) {
                         result.add(rawDependency.forced());
                     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/internal/component/model/MultipleCandidateMatcher.java
@@ -317,13 +317,14 @@ class MultipleCandidateMatcher<T extends HasAttributes> {
     }
 
     private List<T> getCandidates(BitSet liveSet) {
-        if (liveSet.cardinality() == 0) {
-            return Collections.emptyList();
+        int cardinality = liveSet.cardinality();
+        if (cardinality == 0) {
+            return ImmutableList.of();
         }
-        if (liveSet.cardinality() == 1) {
-            return Collections.singletonList(this.candidates.get(liveSet.nextSetBit(0)));
+        if (cardinality == 1) {
+            return ImmutableList.of(this.candidates.get(liveSet.nextSetBit(0)));
         }
-        ImmutableList.Builder<T> builder = ImmutableList.builder();
+        ImmutableList.Builder<T> builder = ImmutableList.builderWithExpectedSize(cardinality);
         for (int c = liveSet.nextSetBit(0); c >= 0; c = liveSet.nextSetBit(c + 1)) {
             builder.add(this.candidates.get(c));
         }

--- a/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializer.java
+++ b/subprojects/execution/src/main/java/org/gradle/internal/execution/history/impl/DefaultPreviousExecutionStateSerializer.java
@@ -53,7 +53,7 @@ public class DefaultPreviousExecutionStateSerializer extends AbstractSerializer<
 
         // We can't use an immutable list here because some hashes can be null
         int taskActionsCount = decoder.readSmallInt();
-        ImmutableList.Builder<ImplementationSnapshot> taskActionImplementationsBuilder = ImmutableList.builder();
+        ImmutableList.Builder<ImplementationSnapshot> taskActionImplementationsBuilder = ImmutableList.builderWithExpectedSize(taskActionsCount);
         for (int j = 0; j < taskActionsCount; j++) {
             ImplementationSnapshot actionImpl = implementationSnapshotSerializer.read(decoder);
             taskActionImplementationsBuilder.add(actionImpl);

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassDependentsAccumulator.java
@@ -19,11 +19,9 @@ package org.gradle.api.internal.tasks.compile.incremental.deps;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import it.unimi.dsi.fastutil.ints.IntSet;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -73,9 +71,9 @@ public class ClassDependentsAccumulator {
     @VisibleForTesting
     Map<String, DependentsSet> getDependentsMap() {
         if (dependenciesToAll.isEmpty() && dependents.isEmpty()) {
-            return Collections.emptyMap();
+            return ImmutableMap.of();
         }
-        ImmutableMap.Builder<String, DependentsSet> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<String, DependentsSet> builder = ImmutableMap.builderWithExpectedSize(dependenciesToAll.size() + dependents.size());
         for (String s : dependenciesToAll) {
             builder.put(s, DependentsSet.dependencyToAll());
         }
@@ -101,13 +99,5 @@ public class ClassDependentsAccumulator {
 
     public ClassSetAnalysisData getAnalysis() {
         return new ClassSetAnalysisData(ImmutableSet.copyOf(seenClasses), getDependentsMap(), getClassesToConstants(), fullRebuildCause);
-    }
-
-    private static <K, V> Map<K, Set<V>> asMap(Multimap<K, V> multimap) {
-        ImmutableMap.Builder<K, Set<V>> builder = ImmutableMap.builder();
-        for (K key : multimap.keySet()) {
-            builder.put(key, ImmutableSet.copyOf(multimap.get(key)));
-        }
-        return builder.build();
     }
 }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/incremental/deps/ClassSetAnalysisData.java
@@ -92,13 +92,13 @@ public class ClassSetAnalysisData {
             Map<Integer, String> classNameMap = new HashMap<Integer, String>();
 
             int count = decoder.readSmallInt();
-            ImmutableSet.Builder<String> classes = ImmutableSet.builder();
+            ImmutableSet.Builder<String> classes = ImmutableSet.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 classes.add(readClassName(decoder, classNameMap));
             }
 
             count = decoder.readSmallInt();
-            ImmutableMap.Builder<String, DependentsSet> dependentsBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, DependentsSet> dependentsBuilder = ImmutableMap.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 String className = readClassName(decoder, classNameMap);
                 DependentsSet dependents = readDependentsSet(decoder, classNameMap);
@@ -106,7 +106,7 @@ public class ClassSetAnalysisData {
             }
 
             count = decoder.readSmallInt();
-            ImmutableMap.Builder<String, IntSet> classesToConstantsBuilder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, IntSet> classesToConstantsBuilder = ImmutableMap.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 String className = readClassName(decoder, classNameMap);
                 IntSet constants = IntSetSerializer.INSTANCE.read(decoder);
@@ -146,7 +146,7 @@ public class ClassSetAnalysisData {
                 return DependentsSet.dependencyToAll(decoder.readNullableString());
             }
             int count = decoder.readSmallInt();
-            ImmutableSet.Builder<String> builder = ImmutableSet.builder();
+            ImmutableSet.Builder<String> builder = ImmutableSet.builderWithExpectedSize(count);
             for (int i = 0; i < count; i++) {
                 builder.add(readClassName(decoder, classNameMap));
             }

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/processing/AnnotationProcessorDetector.java
@@ -193,7 +193,7 @@ public class AnnotationProcessorDetector {
             if (processorNames.isEmpty()) {
                 return Collections.emptyList();
             }
-            ImmutableList.Builder<AnnotationProcessorDeclaration> processors = ImmutableList.builder();
+            ImmutableList.Builder<AnnotationProcessorDeclaration> processors = ImmutableList.builderWithExpectedSize(processorNames.size());
             for (String name : processorNames) {
                 IncrementalAnnotationProcessorType type = processorTypes.get(name);
                 type = type != null ? type : IncrementalAnnotationProcessorType.UNKNOWN;

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializer.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/CompilationStateSerializer.java
@@ -41,13 +41,13 @@ public class CompilationStateSerializer implements Serializer<CompilationState> 
         // Deduplicates the include file states, as these are often shared between source files
         Map<Integer, IncludeFileEdge> ids = new HashMap<Integer, IncludeFileEdge>();
         int sourceFileCount = decoder.readSmallInt();
-        ImmutableMap.Builder<File, SourceFileState> builder = ImmutableMap.builder();
+        ImmutableMap.Builder<File, SourceFileState> builder = ImmutableMap.builderWithExpectedSize(sourceFileCount);
         for (int i = 0; i < sourceFileCount; i++) {
             File sourceFile = fileSerializer.read(decoder);
             HashCode sourceHashCode = hashSerializer.read(decoder);
             boolean isUnresolved = decoder.readBoolean();
             int includeFileCount = decoder.readSmallInt();
-            ImmutableSet.Builder<IncludeFileEdge> includeFileStateBuilder = ImmutableSet.builder();
+            ImmutableSet.Builder<IncludeFileEdge> includeFileStateBuilder = ImmutableSet.builderWithExpectedSize(includeFileCount);
             for (int j = 0; j < includeFileCount; j++) {
                 int id = decoder.readSmallInt();
                 IncludeFileEdge includeFileState = ids.get(id);

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultIncrementalCompilerBuilder.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/DefaultIncrementalCompilerBuilder.java
@@ -119,7 +119,7 @@ public class DefaultIncrementalCompilerBuilder implements IncrementalCompilerBui
         }
 
         private IncludeDirectives directivesForMacros(Map<String, String> macros) {
-            ImmutableList.Builder<Macro> builder = ImmutableList.builder();
+            ImmutableList.Builder<Macro> builder = ImmutableList.builderWithExpectedSize(macros.size());
             for (Map.Entry<String, String> entry : macros.entrySet()) {
                 Expression expression = RegexBackedCSourceParser.parseExpression(entry.getValue());
                 builder.add(new MacroWithSimpleExpression(entry.getKey(), expression.getType(), expression.getValue()));

--- a/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/nativeplatform/internal/incremental/IncrementalNativeCompiler.java
@@ -69,7 +69,7 @@ public class IncrementalNativeCompiler<T extends NativeCompileSpec> implements C
         // For source files that do include the precompiled header, we mark them as a "source file for pch"
         // The native compiler then adds the appropriate compiler arguments for those source files that can use PCH
         if (spec.getPreCompiledHeader() != null) {
-            ImmutableList.Builder<File> sourceFiles = ImmutableList.builder();
+            ImmutableList.Builder<File> sourceFiles = ImmutableList.builderWithExpectedSize(spec.getSourceFiles().size());
             for (File sourceFile : spec.getSourceFiles()) {
                 SourceFileState state = incrementalCompilation.getFinalState().getState(sourceFile);
                 final HashCode hash = state.getHash();

--- a/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
+++ b/subprojects/messaging/src/main/java/org/gradle/internal/serialize/BaseSerializerFactory.java
@@ -141,7 +141,7 @@ public class BaseSerializerFactory {
     private static class StringMapSerializer extends AbstractSerializer<Map<String, String>> {
         public Map<String, String> read(Decoder decoder) throws Exception {
             int pairs = decoder.readSmallInt();
-            ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+            ImmutableMap.Builder<String, String> builder = ImmutableMap.builderWithExpectedSize(pairs);
             for (int i = 0; i < pairs; ++i) {
                 builder.put(decoder.readString(), decoder.readString());
             }

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultDependencySpecContainer.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/internal/DefaultDependencySpecContainer.java
@@ -17,7 +17,11 @@
 package org.gradle.platform.base.internal;
 
 import com.google.common.collect.ImmutableSet;
-import org.gradle.platform.base.*;
+import org.gradle.platform.base.DependencySpec;
+import org.gradle.platform.base.DependencySpecBuilder;
+import org.gradle.platform.base.DependencySpecContainer;
+import org.gradle.platform.base.ModuleDependencySpecBuilder;
+import org.gradle.platform.base.ProjectDependencySpecBuilder;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -77,7 +81,7 @@ public class DefaultDependencySpecContainer implements DependencySpecContainer {
     }
 
     private Set<DependencySpec> dependencySpecSet() {
-        ImmutableSet.Builder<DependencySpec> specs = ImmutableSet.builder();
+        ImmutableSet.Builder<DependencySpec> specs = ImmutableSet.builderWithExpectedSize(builders.size());
         for (DependencySpecBuilder specBuilder : builders) {
             specs.add(specBuilder.build());
         }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/resolve/DefaultVariantsMetaData.java
@@ -51,11 +51,13 @@ public class DefaultVariantsMetaData implements VariantsMetaData {
 
     public static VariantsMetaData extractFrom(BinarySpec binarySpec, ModelSchema<?> binarySpecSchema) {
         Map<String, Object> variants = Maps.newLinkedHashMap();
-        ImmutableMap.Builder<String, ModelType<?>> dimensionTypesBuilder = ImmutableMap.builder();
+        ImmutableMap<String, ModelType<?>> dimensionTypes;
         if (binarySpecSchema instanceof StructSchema) {
             VariantAspect variantAspect = ((StructSchema<?>) binarySpecSchema).getAspect(VariantAspect.class);
             if (variantAspect != null) {
-                for (ModelProperty<?> property : variantAspect.getDimensions()) {
+                Set<ModelProperty<?>> dimensions = variantAspect.getDimensions();
+                ImmutableMap.Builder<String, ModelType<?>> dimensionTypesBuilder = ImmutableMap.builderWithExpectedSize(dimensions.size());
+                for (ModelProperty<?> property : dimensions) {
                     // note: it's not the role of this class to validate that the annotation is properly used, that
                     // is to say only on a getter returning String or a Named instance, so we trust the result of
                     // the call
@@ -63,9 +65,14 @@ public class DefaultVariantsMetaData implements VariantsMetaData {
                     variants.put(property.getName(), value);
                     dimensionTypesBuilder.put(property.getName(), property.getType());
                 }
+                dimensionTypes = dimensionTypesBuilder.build();
+            } else {
+                dimensionTypes = ImmutableMap.of();
             }
+        } else {
+            dimensionTypes = ImmutableMap.of();
         }
-        return new DefaultVariantsMetaData(Collections.unmodifiableMap(variants), dimensionTypesBuilder.build());
+        return new DefaultVariantsMetaData(Collections.unmodifiableMap(variants), dimensionTypes);
     }
 
     @Override

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/tasks/ValidateTaskProperties.java
@@ -213,7 +213,7 @@ public class ValidateTaskProperties extends ConventionTask implements Verificati
     }
 
     private static List<String> toProblemMessages(Map<String, Boolean> problems) {
-        ImmutableList.Builder<String> builder = ImmutableList.builder();
+        ImmutableList.Builder<String> builder = ImmutableList.builderWithExpectedSize(problems.size());
         for (Map.Entry<String, Boolean> entry : problems.entrySet()) {
             String problem = entry.getKey();
             Boolean error = entry.getValue();

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/SnapshotSerializer.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/SnapshotSerializer.java
@@ -87,7 +87,7 @@ public class SnapshotSerializer extends AbstractSerializer<ValueSnapshot> {
                 return new ListValueSnapshot(listElements);
             case SET_SNAPSHOT:
                 size = decoder.readSmallInt();
-                ImmutableSet.Builder<ValueSnapshot> setBuilder = ImmutableSet.builder();
+                ImmutableSet.Builder<ValueSnapshot> setBuilder = ImmutableSet.builderWithExpectedSize(size);
                 for (int i = 0; i < size; i++) {
                     setBuilder.add(read(decoder));
                 }


### PR DESCRIPTION
This makes it possible to avoid unnecessary re-allocations when the number of elements is known up-front.

Fixes #9036.