### PR TITLE
Visiting file collections, take 1

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/file/DefaultFileCollectionFactory.java
@@ -17,14 +17,13 @@
 package org.gradle.api.internal.file;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.gradle.api.Buildable;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.DefaultConfigurableFileCollection;
 import org.gradle.api.internal.file.collections.FileCollectionAdapter;
 import org.gradle.api.internal.file.collections.FileCollectionResolveContext;
+import org.gradle.api.internal.file.collections.ImmutableFileCollection;
 import org.gradle.api.internal.file.collections.MinimalFileSet;
-import org.gradle.api.internal.tasks.TaskDependencyInternal;
 import org.gradle.api.internal.tasks.TaskResolver;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.file.PathToFileResolver;
@@ -33,12 +32,11 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 public class DefaultFileCollectionFactory implements FileCollectionFactory {
-    public static final String DEFAULT_DISPLAY_NAME = "file collection";
+    private static final String DEFAULT_DISPLAY_NAME = "file collection";
+
     private final PathToFileResolver fileResolver;
-    @Nullable
     private final TaskResolver taskResolver;
 
     // Used by the Kotlin-dsl base plugin
@@ -84,7 +82,7 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
     @Override
     public FileCollectionInternal resolving(String displayName, List<?> files) {
         if (files.isEmpty()) {
-            return new EmptyFileCollection(displayName);
+            return empty(displayName);
         }
         return new ResolvingFileCollection(displayName, fileResolver, ImmutableList.copyOf(files));
     }
@@ -101,90 +99,32 @@ public class DefaultFileCollectionFactory implements FileCollectionFactory {
 
     @Override
     public FileCollectionInternal empty(String displayName) {
-        return new EmptyFileCollection(displayName);
+        return ImmutableFileCollection.named(displayName);
     }
 
     @Override
     public FileCollectionInternal empty() {
-        return empty(DEFAULT_DISPLAY_NAME);
+        return ImmutableFileCollection.of();
     }
 
     @Override
     public FileCollectionInternal fixed(File... files) {
-        return fixed(DEFAULT_DISPLAY_NAME, files);
+        return ImmutableFileCollection.of(files);
     }
 
     @Override
-    public FileCollectionInternal fixed(final String displayName, File... files) {
-        if (files.length == 0) {
-            return new EmptyFileCollection(displayName);
-        }
-        return new FixedFileCollection(displayName, ImmutableSet.copyOf(files));
+    public FileCollectionInternal fixed(String displayName, File... files) {
+        return ImmutableFileCollection.named(displayName, files);
     }
 
     @Override
     public FileCollectionInternal fixed(Collection<File> files) {
-        return fixed(DEFAULT_DISPLAY_NAME, files);
+        return ImmutableFileCollection.of(files);
     }
 
     @Override
     public FileCollectionInternal fixed(final String displayName, Collection<File> files) {
-        if (files.isEmpty()) {
-            return new EmptyFileCollection(displayName);
-        }
-        return new FixedFileCollection(displayName, ImmutableSet.copyOf(files));
-    }
-
-    private static final class EmptyFileCollection extends AbstractFileCollection {
-        private final String displayName;
-
-        public EmptyFileCollection(String displayName) {
-            this.displayName = displayName;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return displayName;
-        }
-
-        @Override
-        public TaskDependency getBuildDependencies() {
-            return TaskDependencyInternal.EMPTY;
-        }
-
-        @Override
-        public Set<File> getFiles() {
-            return ImmutableSet.of();
-        }
-
-        @Override
-        public void visitLeafCollections(FileCollectionLeafVisitor visitor) {
-        }
-    }
-
-    private static final class FixedFileCollection extends AbstractFileCollection {
-        private final String displayName;
-        private final ImmutableSet<File> files;
-
-        public FixedFileCollection(String displayName, ImmutableSet<File> files) {
-            this.displayName = displayName;
-            this.files = files;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return displayName;
-        }
-
-        @Override
-        public Set<File> getFiles() {
-            return files;
-        }
-
-        @Override
-        public TaskDependency getBuildDependencies() {
-            return TaskDependencyInternal.EMPTY;
-        }
+        return ImmutableFileCollection.named(displayName, files);
     }
 
     private static final class ResolvingFileCollection extends CompositeFileCollection {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -128,6 +128,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED;
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.BUILD_DEPENDENCIES_RESOLVED;
@@ -214,7 +215,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private AttributeContainerInternal configurationAttributes;
     private final DomainObjectContext domainObjectContext;
     private final ImmutableAttributesFactory attributesFactory;
-    private final FileCollection intrinsicFiles;
+    private final FileCollectionInternal intrinsicFiles;
 
     private final DisplayName displayName;
     private CollectionCallbackActionDecorator callbackActionDecorator;
@@ -465,6 +466,11 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     @Override
     public Iterator<File> iterator() {
         return intrinsicFiles.iterator();
+    }
+
+    @Override
+    public void visitContents(Consumer<File> visitor) {
+        intrinsicFiles.visitContents(visitor);
     }
 
     @Override

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -128,7 +128,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.function.Consumer;
 
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.ARTIFACTS_RESOLVED;
 import static org.gradle.api.internal.artifacts.configurations.ConfigurationInternal.InternalState.BUILD_DEPENDENCIES_RESOLVED;
@@ -469,8 +468,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     }
 
     @Override
-    public void visitContents(Consumer<File> visitor) {
-        intrinsicFiles.visitContents(visitor);
+    public boolean visitContents(CancellableVisitor<File> visitor) {
+        return intrinsicFiles.visitContents(visitor);
     }
 
     @Override

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/AbstractFileCollection.java
@@ -73,7 +73,7 @@ public abstract class AbstractFileCollection implements FileCollectionInternal {
 
     @Override
     public boolean visitContents(CancellableVisitor<File> visitor) {
-        for (File file : getFiles()) {
+        for (File file : this) {
             if (!visitor.accept(file)) {
                 return false;
             }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -38,7 +38,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Consumer;
 
 /**
  * A {@link org.gradle.api.file.FileCollection} that contains the union of zero or more file collections. Maintains file ordering.
@@ -85,10 +84,13 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
     }
 
     @Override
-    public void visitContents(Consumer<File> visitor) {
+    public boolean visitContents(CancellableVisitor<File> visitor) {
         for (FileCollectionInternal sourceCollection : getSourceCollections()) {
-            sourceCollection.visitContents(visitor);
+            if (!sourceCollection.visitContents(visitor)) {
+                return false;
+            }
         }
+        return true;
     }
 
     @Override

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/CompositeFileCollection.java
@@ -38,6 +38,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
 
 /**
  * A {@link org.gradle.api.file.FileCollection} that contains the union of zero or more file collections. Maintains file ordering.
@@ -80,6 +81,13 @@ public abstract class CompositeFileCollection extends AbstractFileCollection imp
                     builder.addAll(collection);
                 }
                 return builder.build();
+        }
+    }
+
+    @Override
+    public void visitContents(Consumer<File> visitor) {
+        for (FileCollectionInternal sourceCollection : getSourceCollections()) {
+            sourceCollection.visitContents(visitor);
         }
     }
 

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -20,7 +20,6 @@ package org.gradle.api.internal.file;
 import org.gradle.api.file.FileCollection;
 
 import java.io.File;
-import java.util.function.Consumer;
 
 public interface FileCollectionInternal extends FileCollection {
 
@@ -48,6 +47,19 @@ public interface FileCollectionInternal extends FileCollection {
     /**
      * Visits the contents of the collection.
      * Visits the same files as {@link #getFiles()}, but there is no guarantee that each file is visited only once.
+     * Stops visiting if visitor returns {@code false}.
+     *
+     * @return {@code true} if all elements were processed.
      */
-    void visitContents(Consumer<File> visitor);
+    boolean visitContents(CancellableVisitor<File> visitor);
+
+    interface CancellableVisitor<T> {
+        /**
+         * Visits the given object.
+         *
+         * @return {@code true} if visiting should continue with the next element,
+         * {@code false} if it should stop.
+         */
+        boolean accept(T file);
+    }
 }

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/FileCollectionInternal.java
@@ -19,6 +19,9 @@ package org.gradle.api.internal.file;
 
 import org.gradle.api.file.FileCollection;
 
+import java.io.File;
+import java.util.function.Consumer;
+
 public interface FileCollectionInternal extends FileCollection {
 
     /**
@@ -41,4 +44,10 @@ public interface FileCollectionInternal extends FileCollection {
      * <p>The implementation should call the most specific method on {@link FileCollectionLeafVisitor} that it is able to.</p>
      */
     void visitLeafCollections(FileCollectionLeafVisitor visitor);
+
+    /**
+     * Visits the contents of the collection.
+     * Visits the same files as {@link #getFiles()}, but there is no guarantee that each file is visited only once.
+     */
+    void visitContents(Consumer<File> visitor);
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.fingerprint.impl;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -44,7 +44,7 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
     @Override
     public CurrentFileCollectionFingerprint fingerprint(FileCollection files) {
         FileCollectionInternal fileCollection = (FileCollectionInternal) files;
-        ImmutableSet<FileSystemSnapshot> roots = fileSystemSnapshotter.snapshot(fileCollection);
+        ImmutableList<FileSystemSnapshot> roots = fileSystemSnapshotter.snapshot(fileCollection);
         return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy);
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/fingerprint/impl/AbstractFileCollectionFingerprinter.java
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.fingerprint.impl;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -26,8 +27,6 @@ import org.gradle.internal.fingerprint.FingerprintingStrategy;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotter;
-
-import java.util.List;
 
 /**
  * Responsible for calculating a {@link FileCollectionFingerprint} for a particular {@link FileCollection}.
@@ -45,7 +44,7 @@ public abstract class AbstractFileCollectionFingerprinter implements FileCollect
     @Override
     public CurrentFileCollectionFingerprint fingerprint(FileCollection files) {
         FileCollectionInternal fileCollection = (FileCollectionInternal) files;
-        List<FileSystemSnapshot> roots = fileSystemSnapshotter.snapshot(fileCollection);
+        ImmutableSet<FileSystemSnapshot> roots = fileSystemSnapshotter.snapshot(fileCollection);
         return DefaultCurrentFileCollectionFingerprint.from(roots, fingerprintingStrategy);
     }
 

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemSnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemSnapshotter.java
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.snapshot;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.internal.hash.HashCode;
 
@@ -51,5 +51,5 @@ public interface FileSystemSnapshotter {
     /**
      * Returns snapshots of the roots of a file collection.
      */
-    ImmutableSet<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection);
+    ImmutableList<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection);
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemSnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/FileSystemSnapshotter.java
@@ -16,13 +16,13 @@
 
 package org.gradle.internal.snapshot;
 
+import com.google.common.collect.ImmutableSet;
 import org.gradle.api.internal.file.FileCollectionInternal;
 import org.gradle.internal.hash.HashCode;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import java.io.File;
-import java.util.List;
 
 /**
  * Provides access to snapshots of the content and metadata of the file system.
@@ -51,5 +51,5 @@ public interface FileSystemSnapshotter {
     /**
      * Returns snapshots of the roots of a file collection.
      */
-    List<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection);
+    ImmutableSet<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection);
 }

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DefaultFileSystemSnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DefaultFileSystemSnapshotter.java
@@ -236,7 +236,10 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
 
         @Override
         public void visitCollection(FileCollectionInternal fileCollection) {
-            fileCollection.visitContents(root -> roots.add(snapshot(root)));
+            fileCollection.visitContents(root -> {
+                roots.add(snapshot(root));
+                return true;
+            });
         }
 
         @Override

--- a/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DefaultFileSystemSnapshotter.java
+++ b/subprojects/snapshots/src/main/java/org/gradle/internal/snapshot/impl/DefaultFileSystemSnapshotter.java
@@ -17,7 +17,7 @@
 package org.gradle.internal.snapshot.impl;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableList;
 import org.gradle.api.NonNullApi;
 import org.gradle.api.file.FileTreeElement;
 import org.gradle.api.file.FileVisitDetails;
@@ -120,7 +120,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
     }
 
     @Override
-    public ImmutableSet<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection) {
+    public ImmutableList<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection) {
         RootVisitingSnapshotBuilder visitor = new RootVisitingSnapshotBuilder();
         fileCollection.visitLeafCollections(visitor);
         return visitor.build();
@@ -232,7 +232,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
     }
 
     private class RootVisitingSnapshotBuilder implements FileCollectionLeafVisitor {
-        private final ImmutableSet.Builder<FileSystemSnapshot> roots = ImmutableSet.builder();
+        private final ImmutableList.Builder<FileSystemSnapshot> roots = ImmutableList.builder();
 
         @Override
         public void visitCollection(FileCollectionInternal fileCollection) {
@@ -252,7 +252,7 @@ public class DefaultFileSystemSnapshotter implements FileSystemSnapshotter {
             roots.add(snapshotDirectoryTree(root, patterns));
         }
 
-        public ImmutableSet<FileSystemSnapshot> build() {
+        public ImmutableList<FileSystemSnapshot> build() {
             return roots.build();
         }
     }

--- a/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/impl/TestFileSnapshotter.groovy
+++ b/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/impl/TestFileSnapshotter.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.internal.snapshot.impl
 
+import com.google.common.collect.ImmutableSet
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
@@ -44,7 +45,7 @@ class TestFileSnapshotter implements FileSystemSnapshotter {
     }
 
     @Override
-    List<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection) {
+    ImmutableSet<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection) {
         throw new UnsupportedOperationException()
     }
 }

--- a/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/impl/TestFileSnapshotter.groovy
+++ b/subprojects/snapshots/src/testFixtures/groovy/org/gradle/internal/snapshot/impl/TestFileSnapshotter.groovy
@@ -16,7 +16,7 @@
 
 package org.gradle.internal.snapshot.impl
 
-import com.google.common.collect.ImmutableSet
+import com.google.common.collect.ImmutableList
 import org.gradle.api.internal.file.FileCollectionInternal
 import org.gradle.internal.hash.HashCode
 import org.gradle.internal.hash.Hashing
@@ -45,7 +45,7 @@ class TestFileSnapshotter implements FileSystemSnapshotter {
     }
 
     @Override
-    ImmutableSet<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection) {
+    ImmutableList<FileSystemSnapshot> snapshot(FileCollectionInternal fileCollection) {
         throw new UnsupportedOperationException()
     }
 }


### PR DESCRIPTION
It is a common pattern in Gradle to have file collections nested into each other. When iterating these collections in many cases we use `getFiles()`, which constructs an expensive `Set` of `File` objects on several levels. This adds a lot of avoidable allocations, and in some cases the expensive de-duping achieved by putting the resolved files in a `Set` is also unnecessary.

This PR uses a cancellable visitor to iterate file collections in some cases.