### PR TITLE
Update gradle metadata spec link

### DIFF
--- a/subprojects/dependency-management/preview-features.adoc
+++ b/subprojects/dependency-management/preview-features.adoc
@@ -4,7 +4,7 @@
 
 In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a new module metadata format, that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
 
-The new metadata format is still under active development. The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md[here]. Currently there are the following issues with enabling it in Gradle 4.x:
+The new metadata format is still under active development. The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md[here]. Currently there are the following issues with enabling it in Gradle 4.x:
 
 - We do not yet guarantee backward or forward compatibility for the metadata file format. Thus, resolution may change when upgrading Gradle, if a metadata file is published with an old format.
 - An additional request is required for Maven and Ivy repositories to check for the new metadata file.


### PR DESCRIPTION
This fixes a link to the gradle metadata spec.

### Context

This page shows up in some google searches for gradle metadata, and then I found that this link on the page was broken.

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
