### PR TITLE
Add a build operation for immediate artifact transforms

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -578,7 +578,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                     attributesFactory),
                                 attributesSchema,
                                 attributesFactory,
-                                transformationNodeRegistry
+                                transformationNodeRegistry,
+                                buildOperationExecutor
                             ),
                             moduleIdentifierFactory,
                             buildOperationExecutor,

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelector.java
@@ -30,6 +30,7 @@ import org.gradle.internal.component.AmbiguousVariantSelectionException;
 import org.gradle.internal.component.NoMatchingVariantSelectionException;
 import org.gradle.internal.component.VariantSelectionException;
 import org.gradle.internal.component.model.AttributeMatcher;
+import org.gradle.internal.operations.BuildOperationExecutor;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -46,6 +47,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
     private final ImmutableAttributes requested;
     private final boolean ignoreWhenNoMatches;
     private final ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver;
+    private final BuildOperationExecutor buildOperationExecutor;
 
     AttributeMatchingVariantSelector(
         ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
@@ -54,7 +56,8 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         TransformationNodeRegistry transformationNodeRegistry,
         AttributeContainerInternal requested,
         boolean ignoreWhenNoMatches,
-        ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver
+        ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver,
+        BuildOperationExecutor buildOperationExecutor
     ) {
         this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
         this.schema = schema;
@@ -63,6 +66,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
         this.requested = requested.asImmutable();
         this.ignoreWhenNoMatches = ignoreWhenNoMatches;
         this.dependenciesResolver = dependenciesResolver;
+        this.buildOperationExecutor = buildOperationExecutor;
     }
 
     @Override
@@ -109,7 +113,7 @@ class AttributeMatchingVariantSelector implements VariantSelector {
             ResolvedArtifactSet artifacts = result.getLeft().getArtifacts();
             AttributeContainerInternal attributes = result.getRight().attributes;
             Transformation transformation = result.getRight().transformation;
-            return new ConsumerProvidedResolvedVariant(producer.getComponentId(), artifacts, attributes, transformation, dependenciesResolver, transformationNodeRegistry);
+            return new ConsumerProvidedResolvedVariant(producer.getComponentId(), artifacts, attributes, transformation, dependenciesResolver, transformationNodeRegistry, buildOperationExecutor);
         }
 
         if (!candidates.isEmpty()) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransforms.java
@@ -19,28 +19,41 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.internal.operations.BuildOperationExecutor;
 
 public class DefaultArtifactTransforms implements ArtifactTransforms {
     private final ConsumerProvidedVariantFinder consumerProvidedVariantFinder;
     private final AttributesSchemaInternal schema;
     private final ImmutableAttributesFactory attributesFactory;
     private final TransformationNodeRegistry transformationNodeRegistry;
+    private final BuildOperationExecutor buildOperationExecutor;
 
     public DefaultArtifactTransforms(
         ConsumerProvidedVariantFinder consumerProvidedVariantFinder,
         AttributesSchemaInternal schema,
         ImmutableAttributesFactory attributesFactory,
-        TransformationNodeRegistry transformationNodeRegistry
+        TransformationNodeRegistry transformationNodeRegistry,
+        BuildOperationExecutor buildOperationExecutor
     ) {
         this.consumerProvidedVariantFinder = consumerProvidedVariantFinder;
         this.schema = schema;
         this.attributesFactory = attributesFactory;
         this.transformationNodeRegistry = transformationNodeRegistry;
+        this.buildOperationExecutor = buildOperationExecutor;
     }
 
     @Override
     public VariantSelector variantSelector(AttributeContainerInternal consumerAttributes, boolean allowNoMatchingVariants, ExtraExecutionGraphDependenciesResolverFactory dependenciesResolver) {
-        return new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, schema, attributesFactory, transformationNodeRegistry, consumerAttributes.asImmutable(), allowNoMatchingVariants, dependenciesResolver);
+        return new AttributeMatchingVariantSelector(
+            consumerProvidedVariantFinder,
+            schema,
+            attributesFactory,
+            transformationNodeRegistry,
+            consumerAttributes.asImmutable(),
+            allowNoMatchingVariants,
+            dependenciesResolver,
+            buildOperationExecutor
+        );
     }
 
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationOperation.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformationOperation.java
@@ -43,7 +43,7 @@ class TransformationOperation implements TransformationResult, RunnableBuildOper
 
     @Override
     public BuildOperationDescriptor.Builder description() {
-        String displayName = "Transform " + subject.getDisplayName() + " with " + transformation.getDisplayName();
+        String displayName = "Transforming";
         return BuildOperationDescriptor.displayName(displayName)
             .progressDisplayName(displayName)
             .operationType(BuildOperationCategory.UNCATEGORIZED);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListener.java
@@ -19,6 +19,7 @@ package org.gradle.api.internal.artifacts.transform;
 import org.gradle.api.artifacts.component.ComponentArtifactIdentifier;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvedArtifactSet;
+import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationQueue;
 import org.gradle.internal.operations.RunnableBuildOperation;
 
@@ -31,6 +32,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
     private final Map<File, TransformationResult> fileResults;
     private final ExecutionGraphDependenciesResolver dependenciesResolver;
     private final TransformationNodeRegistry transformationNodeRegistry;
+    private final BuildOperationExecutor buildOperationExecutor;
     private final BuildOperationQueue<RunnableBuildOperation> actions;
     private final ResolvedArtifactSet.AsyncArtifactListener delegate;
     private final Transformation transformation;
@@ -42,7 +44,8 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
         Map<ComponentArtifactIdentifier, TransformationResult> artifactResults,
         Map<File, TransformationResult> fileResults,
         ExecutionGraphDependenciesResolver dependenciesResolver,
-        TransformationNodeRegistry transformationNodeRegistry
+        TransformationNodeRegistry transformationNodeRegistry,
+        BuildOperationExecutor buildOperationExecutor
     ) {
         this.artifactResults = artifactResults;
         this.actions = actions;
@@ -51,6 +54,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
         this.fileResults = fileResults;
         this.dependenciesResolver = dependenciesResolver;
         this.transformationNodeRegistry = transformationNodeRegistry;
+        this.buildOperationExecutor = buildOperationExecutor;
     }
 
     @Override
@@ -74,7 +78,7 @@ class TransformingAsyncArtifactListener implements ResolvedArtifactSet.AsyncArti
             // If it has been downloaded earlier, then there is a high chance that the transformed artifact is already in a Gradle user home workspace and up-to-date.
             // Using the BuildOperationQueue here to only realize that the result of the transformation is up-to-date in the Gradle user home workspace has a performance impact,
             // so we are executing the up-to-date transform operation in place.
-            operation.run(null);
+            buildOperationExecutor.run(operation);
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/AttributeMatchingVariantSelectorSpec.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.internal.tasks.TaskDependencyResolveContext
 import org.gradle.internal.Describables
 import org.gradle.internal.component.AmbiguousVariantSelectionException
 import org.gradle.internal.component.model.AttributeMatcher
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.util.AttributeTestUtil
 import spock.lang.Specification
 
@@ -48,6 +49,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         getAttributes() >> variantAttributes
         asDescribable() >> Describables.of("mock resolved variant")
     }
+    def buildOperationExecutor = Mock(BuildOperationExecutor)
     def variantSet = Mock(ResolvedVariantSet) {
         asDescribable() >> Describables.of("mock producer")
         getVariants() >> [variant]
@@ -56,7 +58,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
     def 'direct match on variant means no finder interaction'() {
         given:
         def resolvedArtifactSet = Mock(ResolvedArtifactSet)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(variantSet)
@@ -74,7 +76,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
             asDescribable() >> Describables.of('other mocked variant')
             getAttributes() >> otherVariantAttributes
         }
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(variantSet)
@@ -108,7 +110,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
 
     def 'selecting a transform results in added DefaultTransformationDependency'() {
         given:
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(variantSet)
@@ -154,7 +156,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         }
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -206,7 +208,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         }
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -258,7 +260,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         }
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -315,7 +317,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
         def transform3 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -376,7 +378,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
         def transform3 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(multiVariantSet)
@@ -437,7 +439,7 @@ class AttributeMatchingVariantSelectorSpec extends Specification {
         def transform1 = Mock(Transformation)
         def transform2 = Mock(Transformation)
         def transform3 = Mock(Transformation)
-        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory)
+        def selector = new AttributeMatchingVariantSelector(consumerProvidedVariantFinder, attributesSchema, attributesFactory, transformationNodeRegistry, requestedAttributes, false, dependenciesResolverFactory, buildOperationExecutor)
 
         when:
         def result = selector.select(multiVariantSet)

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultArtifactTransformsTest.groovy
@@ -35,6 +35,7 @@ import org.gradle.internal.component.AmbiguousVariantSelectionException
 import org.gradle.internal.component.NoMatchingVariantSelectionException
 import org.gradle.internal.component.local.model.ComponentFileArtifactIdentifier
 import org.gradle.internal.component.model.AttributeMatcher
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationQueue
 import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.internal.operations.TestBuildOperationExecutor
@@ -51,7 +52,8 @@ class DefaultArtifactTransformsTest extends Specification {
     def attributeMatcher = Mock(AttributeMatcher)
     def dependenciesResolver = Stub(ExtraExecutionGraphDependenciesResolverFactory)
     def transformationNodeRegistry = Mock(TransformationNodeRegistry)
-    def transforms = new DefaultArtifactTransforms(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformationNodeRegistry)
+    def buildOperationExecutor = Mock(BuildOperationExecutor)
+    def transforms = new DefaultArtifactTransforms(matchingCache, consumerSchema, AttributeTestUtil.attributesFactory(), transformationNodeRegistry, buildOperationExecutor)
 
     def "selects producer variant with requested attributes"() {
         def variant1 = resolvedVariant()
@@ -176,6 +178,9 @@ class DefaultArtifactTransformsTest extends Specification {
         _ * transformation.getDisplayName() >> "transform"
         _ * transformation.requiresDependencies() >> false
         _ * transformationNodeRegistry.getIfExecuted(_, _) >> Optional.empty()
+        _ * buildOperationExecutor.run(_) >> { RunnableBuildOperation operation ->
+            operation.run(null)
+        }
 
         1 * transformation.transform({ it.files == [sourceArtifactFile]}, _ as ExecutionGraphDependenciesResolver, _) >> Try.successful(TransformationSubject.initial(sourceArtifactId, sourceArtifactFile).createSubjectFromResult(ImmutableList.of(outFile1, outFile2)))
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/TransformingAsyncArtifactListenerTest.groovy
@@ -22,14 +22,17 @@ import org.gradle.api.artifacts.component.ComponentArtifactIdentifier
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.artifact.ResolvableArtifact
 import org.gradle.internal.Try
 import org.gradle.internal.operations.BuildOperation
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationQueue
+import org.gradle.internal.operations.RunnableBuildOperation
 import org.gradle.testing.internal.util.Specification
 
 class TransformingAsyncArtifactListenerTest extends Specification {
     def transformation = Mock(Transformation)
     def operationQueue = Mock(BuildOperationQueue)
+    def buildOperationExecutor = Mock(BuildOperationExecutor)
     def transformationNodeRegistry = Mock(TransformationNodeRegistry)
-    def listener  = new TransformingAsyncArtifactListener(transformation, null, operationQueue, Maps.newHashMap(), Maps.newHashMap(), Mock(ExecutionGraphDependenciesResolver), transformationNodeRegistry)
+    def listener  = new TransformingAsyncArtifactListener(transformation, null, operationQueue, Maps.newHashMap(), Maps.newHashMap(), Mock(ExecutionGraphDependenciesResolver), transformationNodeRegistry, buildOperationExecutor)
     def file = new File("foo")
     def artifactFile = new File("foo-artifact")
     def artifactId = Stub(ComponentArtifactIdentifier)
@@ -53,6 +56,9 @@ class TransformingAsyncArtifactListenerTest extends Specification {
 
         then:
         1 * transformationNodeRegistry.getIfExecuted(artifactId, transformation) >> Optional.empty()
+        1 * buildOperationExecutor.run(_) >> { RunnableBuildOperation operation ->
+            operation.run(null)
+        }
         1 * transformation.transform({ it.files == [artifactFile] }, _ as ExecutionGraphDependenciesResolver, _)
     }
 


### PR DESCRIPTION
So the user knows what is going on. This change shows the artifact transform running as part of dependency resolution. It also allows seeing the transforms in the chrome trace generated by `gradle-profiler`.