### PR TITLE
Maven publish should retry publication on transient remote errors

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifier.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.transport;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.conn.HttpHostConnectException;
+import org.gradle.internal.exceptions.DefaultMultiCauseException;
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
+
+import java.net.SocketTimeoutException;
+import java.util.List;
+
+public class NetworkingIssueVerifier {
+
+    /**
+     * Determines if an error should cause a retry. We will currently retry:
+     * <ul>
+     * <li>on a network timeout</li>
+     * <li>on a server error (return code 5xx)</li>
+     * <li>on rate limiting</li>
+     * </ul>
+     */
+    public static <E extends Throwable> boolean isLikelyTransientNetworkingIssue(E failure) {
+        if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
+            return true;
+        }
+        if (failure instanceof DefaultMultiCauseException) {
+            List<? extends Throwable> causes = ((DefaultMultiCauseException) failure).getCauses();
+            for (Throwable cause : causes) {
+                if (isLikelyTransientNetworkingIssue(cause)) {
+                    return true;
+                }
+            }
+        }
+        if (failure instanceof HttpErrorStatusCodeException) {
+            HttpErrorStatusCodeException httpError = (HttpErrorStatusCodeException) failure;
+            return httpError.isServerError() || isTransientClientError(httpError.getStatusCode());
+        }
+        Throwable cause = failure.getCause();
+        if (cause != null && cause != failure) {
+            return isLikelyTransientNetworkingIssue(cause);
+        }
+        return false;
+    }
+
+    private static boolean isTransientClientError(int statusCode) {
+        return statusCode == HttpStatus.SC_REQUEST_TIMEOUT ||
+            statusCode == 429; // Too many requests (not available through HttpStatus.XXX)
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/repositories/transport/NetworkingIssueVerifierTest.groovy
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.repositories.transport
+
+import org.apache.http.conn.HttpHostConnectException
+import org.gradle.internal.exceptions.DefaultMultiCauseException
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Subject(NetworkingIssueVerifier)
+class NetworkingIssueVerifierTest extends Specification {
+
+    @Unroll("'#description' is likely transient network issue")
+    def "verifies if an exception is a related to transient network issue"() {
+        expect:
+        NetworkingIssueVerifier.isLikelyTransientNetworkingIssue(failure)
+
+        where:
+        description                                                 | failure
+        "SocketTimeoutException"                                    | new SocketTimeoutException()
+        "HttpHostConnectException"                                  | new HttpHostConnectException(new IOException("something went wrong"), null, null)
+        "DefaultMultiCauseException"                                | new DefaultMultiCauseException("something went wrong", new SocketTimeoutException())
+        "HttpErrorStatusCodeException with server error"            | new HttpErrorStatusCodeException("something", "something", 503, "something")
+        "HttpErrorStatusCodeException with transient client error"  | new HttpErrorStatusCodeException("something", "something", 429, "something")
+        "RuntimeException with a likely network exception as cause" | new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/DefaultMavenDeployRetrier.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/DefaultMavenDeployRetrier.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publication.maven.internal.action;
+
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.maven.artifact.ant.RemoteRepository;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.aether.deployment.DeploymentException;
+
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Callable;
+
+public class DefaultMavenDeployRetrier implements MavenDeployRetrier {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultMavenDeployRetrier.class);
+    private final RemoteRepository remoteRepository;
+    private final Callable operation;
+    private final int maxDeployAttempts;
+    private final int initialBackOff;
+
+    public DefaultMavenDeployRetrier(Callable operation, RemoteRepository remoteRepository, int maxDeployAttempts, int initialBackOff) {
+        this.operation = operation;
+        this.maxDeployAttempts = maxDeployAttempts;
+        this.initialBackOff = initialBackOff;
+        assert maxDeployAttempts > 0;
+        assert initialBackOff > 0;
+        this.remoteRepository = remoteRepository;
+    }
+
+
+    public void deployWithRetry() throws DeploymentException {
+        int backoff = initialBackOff;
+        int retries = 0;
+        while (retries < maxDeployAttempts) {
+            retries++;
+            Throwable failure;
+            try {
+                operation.call();
+                if (retries > 1) {
+                    LOGGER.info("Successfully deployed resource after {} retries", retries - 1);
+                }
+                break;
+            } catch (Exception throwable) {
+                failure = throwable;
+            }
+            if (!isLikelyTransientNetworkingIssue(failure) || retries == maxDeployAttempts) {
+                throw new DeploymentException("Could not deploy to remote repository | " + failure.getMessage(), failure);
+            } else {
+                LOGGER.info("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", remoteRepository, backoff, maxDeployAttempts - retries, failure);
+                try {
+                    Thread.sleep(backoff);
+                    backoff *= 2;
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+        }
+    }
+
+    private static boolean isLikelyTransientNetworkingIssue(Throwable failure) {
+        if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
+            return true;
+        }
+        if (failure instanceof HttpErrorStatusCodeException) {
+            HttpErrorStatusCodeException httpError = (HttpErrorStatusCodeException) failure;
+            return httpError.isServerError();
+        }
+        Throwable cause = failure.getCause();
+        if (cause != null && cause != failure) {
+            return isLikelyTransientNetworkingIssue(cause);
+        }
+        return false;
+    }
+}

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
@@ -15,12 +15,9 @@
  */
 package org.gradle.api.publication.maven.internal.action;
 
-import org.apache.http.conn.HttpHostConnectException;
 import org.apache.maven.artifact.ant.RemoteRepository;
 import org.gradle.api.GradleException;
 import org.gradle.api.publish.maven.internal.publisher.MavenProjectIdentity;
-import org.gradle.internal.UncheckedException;
-import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonatype.aether.RepositorySystem;
@@ -33,10 +30,8 @@ import org.sonatype.aether.repository.Proxy;
 import org.sonatype.aether.util.repository.DefaultProxySelector;
 
 import java.io.File;
-import java.net.SocketTimeoutException;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.Callable;
 
 public class MavenDeployAction extends AbstractMavenPublishAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenDeployAction.class);
@@ -79,38 +74,15 @@ public class MavenDeployAction extends AbstractMavenPublishAction {
 
         LOGGER.info("Deploying to {}", gradleRepo.getUrl());
 
-        deployWithRetry(() -> { repositorySystem.deploy(session, request); return null; }, maxDeployAttempts, initialBackOff);
-    }
+        MavenDeployRetrier deployRetrier = new MavenDeployRetrier(
+            () -> { repositorySystem.deploy(session, request); return null; },
+            maxDeployAttempts,
+            initialBackOff,
+            remoteRepository
+        );
 
-    private void deployWithRetry(Callable operation, int maxDeployAttempts, int backoff) throws DeploymentException {
-        int retries = 0;
-        while (retries < maxDeployAttempts) {
-            retries++;
-            Throwable failure;
-            try {
-                operation.call();
-                if (retries > 1) {
-                    LOGGER.info("Successfully deployed resource after {} retries", retries - 1);
-                }
-                break;
-            } catch (Exception throwable) {
-                failure = throwable;
-            }
-            boolean doNotRetry = !isLikelyTransientNetworkingIssue(failure);
-            if (doNotRetry || retries == maxDeployAttempts) {
-                throw new DeploymentException("Could not deploy to remote repository | " + failure.getMessage(), failure);
-            } else {
-                LOGGER.info("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", remoteRepository, backoff, maxDeployAttempts - retries, failure);
-                try {
-                    Thread.sleep(backoff);
-                    backoff *= 2;
-                } catch (InterruptedException e) {
-                    throw UncheckedException.throwAsUncheckedException(e);
-                }
-            }
-        }
+        deployRetrier.deployWithRetry();
     }
-
 
     private org.sonatype.aether.repository.RemoteRepository createRepository(RemoteRepository gradleRepo) {
         org.sonatype.aether.repository.RemoteRepository repo = new org.sonatype.aether.repository.RemoteRepository("remote", gradleRepo.getLayout(), gradleRepo.getUrl());
@@ -131,18 +103,4 @@ public class MavenDeployAction extends AbstractMavenPublishAction {
         return repo;
     }
 
-    private static boolean isLikelyTransientNetworkingIssue(Throwable failure) {
-        if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
-            return true;
-        }
-        if (failure instanceof HttpErrorStatusCodeException) {
-            HttpErrorStatusCodeException httpError = (HttpErrorStatusCodeException) failure;
-            return httpError.isServerError();
-        }
-        Throwable cause = failure.getCause();
-        if (cause != null && cause != failure) {
-            return isLikelyTransientNetworkingIssue(cause);
-        }
-        return false;
-    }
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
@@ -35,9 +35,9 @@ import java.util.List;
 
 public class MavenDeployAction extends AbstractMavenPublishAction {
     private static final Logger LOGGER = LoggerFactory.getLogger(MavenDeployAction.class);
+
     private final static String MAX_DEPLOY_ATTEMPTS = "org.gradle.internal.remote.repository.deploy.max.attempts";
     private final static String INITIAL_BACKOFF_MS = "org.gradle.internal.remote.repository.deploy.initial.backoff";
-
     private RemoteRepository remoteRepository;
     private RemoteRepository remoteSnapshotRepository;
     private final int maxDeployAttempts;
@@ -74,11 +74,11 @@ public class MavenDeployAction extends AbstractMavenPublishAction {
 
         LOGGER.info("Deploying to {}", gradleRepo.getUrl());
 
-        MavenDeployRetrier deployRetrier = new MavenDeployRetrier(
+        DefaultMavenDeployRetrier deployRetrier = new DefaultMavenDeployRetrier(
             () -> { repositorySystem.deploy(session, request); return null; },
+            remoteRepository,
             maxDeployAttempts,
-            initialBackOff,
-            remoteRepository
+            initialBackOff
         );
 
         deployRetrier.deployWithRetry();

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployAction.java
@@ -75,7 +75,10 @@ public class MavenDeployAction extends AbstractMavenPublishAction {
         LOGGER.info("Deploying to {}", gradleRepo.getUrl());
 
         DefaultMavenDeployRetrier deployRetrier = new DefaultMavenDeployRetrier(
-            () -> { repositorySystem.deploy(session, request); return null; },
+            () -> {
+                repositorySystem.deploy(session, request);
+                return null;
+                },
             remoteRepository,
             maxDeployAttempts,
             initialBackOff

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployRetrier.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployRetrier.java
@@ -16,73 +16,8 @@
 
 package org.gradle.api.publication.maven.internal.action;
 
-import org.apache.http.conn.HttpHostConnectException;
-import org.apache.maven.artifact.ant.RemoteRepository;
-import org.gradle.internal.UncheckedException;
-import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonatype.aether.deployment.DeploymentException;
 
-import java.net.SocketTimeoutException;
-import java.util.concurrent.Callable;
-
-public class MavenDeployRetrier {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MavenDeployRetrier.class);
-    private final RemoteRepository remoteRepository;
-    private final Callable operation;
-    private final int maxDeployAttempts;
-    private final int initialBackOff;
-
-    public MavenDeployRetrier(Callable operation, int maxDeployAttempts, int initialBackOff, RemoteRepository remoteRepository) {
-        this.operation = operation;
-        this.maxDeployAttempts = maxDeployAttempts;
-        this.initialBackOff = initialBackOff;
-        this.remoteRepository = remoteRepository;
-    }
-
-    public void deployWithRetry() throws DeploymentException {
-        int backoff = initialBackOff;
-        int retries = 0;
-        while (retries < maxDeployAttempts) {
-            retries++;
-            Throwable failure;
-            try {
-                operation.call();
-                if (retries > 1) {
-                    LOGGER.info("Successfully deployed resource after {} retries", retries - 1);
-                }
-                break;
-            } catch (Exception throwable) {
-                failure = throwable;
-            }
-            boolean doNotRetry = !isLikelyTransientNetworkingIssue(failure);
-            if (doNotRetry || retries == maxDeployAttempts) {
-                throw new DeploymentException("Could not deploy to remote repository | " + failure.getMessage(), failure);
-            } else {
-                LOGGER.info("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", remoteRepository, backoff, maxDeployAttempts - retries, failure);
-                try {
-                    Thread.sleep(backoff);
-                    backoff *= 2;
-                } catch (InterruptedException e) {
-                    throw UncheckedException.throwAsUncheckedException(e);
-                }
-            }
-        }
-    }
-
-    private static boolean isLikelyTransientNetworkingIssue(Throwable failure) {
-        if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
-            return true;
-        }
-        if (failure instanceof HttpErrorStatusCodeException) {
-            HttpErrorStatusCodeException httpError = (HttpErrorStatusCodeException) failure;
-            return httpError.isServerError();
-        }
-        Throwable cause = failure.getCause();
-        if (cause != null && cause != failure) {
-            return isLikelyTransientNetworkingIssue(cause);
-        }
-        return false;
-    }
+interface MavenDeployRetrier {
+    void deployWithRetry() throws DeploymentException;
 }

--- a/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployRetrier.java
+++ b/subprojects/maven/src/main/java/org/gradle/api/publication/maven/internal/action/MavenDeployRetrier.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publication.maven.internal.action;
+
+import org.apache.http.conn.HttpHostConnectException;
+import org.apache.maven.artifact.ant.RemoteRepository;
+import org.gradle.internal.UncheckedException;
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonatype.aether.deployment.DeploymentException;
+
+import java.net.SocketTimeoutException;
+import java.util.concurrent.Callable;
+
+public class MavenDeployRetrier {
+    private static final Logger LOGGER = LoggerFactory.getLogger(MavenDeployRetrier.class);
+    private final RemoteRepository remoteRepository;
+    private final Callable operation;
+    private final int maxDeployAttempts;
+    private final int initialBackOff;
+
+    public MavenDeployRetrier(Callable operation, int maxDeployAttempts, int initialBackOff, RemoteRepository remoteRepository) {
+        this.operation = operation;
+        this.maxDeployAttempts = maxDeployAttempts;
+        this.initialBackOff = initialBackOff;
+        this.remoteRepository = remoteRepository;
+    }
+
+    public void deployWithRetry() throws DeploymentException {
+        int backoff = initialBackOff;
+        int retries = 0;
+        while (retries < maxDeployAttempts) {
+            retries++;
+            Throwable failure;
+            try {
+                operation.call();
+                if (retries > 1) {
+                    LOGGER.info("Successfully deployed resource after {} retries", retries - 1);
+                }
+                break;
+            } catch (Exception throwable) {
+                failure = throwable;
+            }
+            boolean doNotRetry = !isLikelyTransientNetworkingIssue(failure);
+            if (doNotRetry || retries == maxDeployAttempts) {
+                throw new DeploymentException("Could not deploy to remote repository | " + failure.getMessage(), failure);
+            } else {
+                LOGGER.info("Error while accessing remote repository {}. Waiting {}ms before next retry. {} retries left", remoteRepository, backoff, maxDeployAttempts - retries, failure);
+                try {
+                    Thread.sleep(backoff);
+                    backoff *= 2;
+                } catch (InterruptedException e) {
+                    throw UncheckedException.throwAsUncheckedException(e);
+                }
+            }
+        }
+    }
+
+    private static boolean isLikelyTransientNetworkingIssue(Throwable failure) {
+        if (failure instanceof SocketTimeoutException || failure instanceof HttpHostConnectException) {
+            return true;
+        }
+        if (failure instanceof HttpErrorStatusCodeException) {
+            HttpErrorStatusCodeException httpError = (HttpErrorStatusCodeException) failure;
+            return httpError.isServerError();
+        }
+        Throwable cause = failure.getCause();
+        if (cause != null && cause != failure) {
+            return isLikelyTransientNetworkingIssue(cause);
+        }
+        return false;
+    }
+}

--- a/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/action/DefaultMavenDeployRetrierTest.groovy
+++ b/subprojects/maven/src/test/groovy/org/gradle/api/publication/maven/internal/action/DefaultMavenDeployRetrierTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.publication.maven.internal.action
+
+import org.apache.http.conn.HttpHostConnectException
+import org.apache.maven.artifact.ant.RemoteRepository
+import org.gradle.internal.resource.transport.http.HttpErrorStatusCodeException
+import org.gradle.testing.internal.util.Specification
+import org.sonatype.aether.deployment.DeploymentException
+import spock.lang.Unroll
+
+import java.util.concurrent.Callable
+
+@Unroll
+class DefaultMavenDeployRetrierTest extends Specification {
+
+    def 'retries operation if transient network issue - #ex'() {
+        when:
+        int retried = 0
+        Callable operation = {
+            retried++
+            throw ex
+        }
+        DefaultMavenDeployRetrier defaultMavenDeployRetrier = new DefaultMavenDeployRetrier(operation, Mock(RemoteRepository), 3, 1)
+        defaultMavenDeployRetrier.deployWithRetry()
+
+        then:
+        retried == 3
+        thrown(DeploymentException)
+
+        where:
+        ex << [
+            new SocketTimeoutException("something went wrong"),
+            new HttpHostConnectException(new IOException("something went wrong"), null, null),
+            new HttpErrorStatusCodeException("something", "something", 503, "something"),
+            new RuntimeException("with cause", new SocketTimeoutException("something went wrong"))
+        ]
+    }
+
+    def 'does not retry operation if not transient network issue - #ex'() {
+        when:
+        int retried = 0
+        Callable operation = {
+            retried++
+            throw ex
+        }
+        DefaultMavenDeployRetrier defaultMavenDeployRetrier = new DefaultMavenDeployRetrier(operation, Mock(RemoteRepository), 3, 1)
+        defaultMavenDeployRetrier.deployWithRetry()
+
+        then:
+        retried == 1
+        thrown(DeploymentException)
+
+        where:
+        ex << [
+            new RuntimeException("non network issue"),
+            new HttpErrorStatusCodeException("something", "something", 400, "something")
+        ]
+    }
+}


### PR DESCRIPTION
Hi @ljacomet 

This is for https://github.com/gradle/gradle/issues/8992

Still unsure how to do this for Ivy. Would this be part of `ExternalResourceResolver?

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
