### PR TITLE
Add transform build operation

### DIFF
--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -364,7 +364,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                     ArtifactTransformListener artifactTransformListener,
                                                     FileCollectionFactory fileCollectionFactory,
                                                     ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
-                                                    ProjectFinder projectFinder
+                                                    ProjectFinder projectFinder,
+                                                    BuildOperationExecutor buildOperationExecutor
         ) {
             return new DefaultTransformerInvoker(
                 workExecutor,
@@ -373,7 +374,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 transformationWorkspaceProvider,
                 fileCollectionFactory,
                 classLoaderHierarchyHasher,
-                projectFinder
+                projectFinder,
+                buildOperationExecutor
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -50,7 +50,6 @@ import org.gradle.internal.fingerprint.OutputNormalizer;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
-import org.gradle.internal.operations.BuildOperationCategory;
 import org.gradle.internal.operations.BuildOperationContext;
 import org.gradle.internal.operations.BuildOperationDescriptor;
 import org.gradle.internal.operations.BuildOperationExecutor;
@@ -188,8 +187,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
             public BuildOperationDescriptor.Builder description() {
                 String displayName = transformer.getDisplayName() + " " + inputArtifact.getName();
                 return BuildOperationDescriptor.displayName(displayName)
-                    .progressDisplayName(displayName)
-                    .operationType(BuildOperationCategory.UNCATEGORIZED);
+                    .progressDisplayName(displayName);
             }
         }));
     }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvoker.java
@@ -50,6 +50,11 @@ import org.gradle.internal.fingerprint.OutputNormalizer;
 import org.gradle.internal.hash.HashCode;
 import org.gradle.internal.hash.Hasher;
 import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.operations.BuildOperationCategory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.CallableBuildOperation;
 import org.gradle.internal.snapshot.FileSystemLocationSnapshot;
 import org.gradle.internal.snapshot.FileSystemSnapshotter;
 import org.gradle.internal.snapshot.ValueSnapshot;
@@ -86,6 +91,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
     private final FileCollectionFactory fileCollectionFactory;
     private final ClassLoaderHierarchyHasher classLoaderHierarchyHasher;
     private final ProjectFinder projectFinder;
+    private final BuildOperationExecutor buildOperationExecutor;
 
     public DefaultTransformerInvoker(WorkExecutor<IncrementalContext, CachingResult> workExecutor,
                                      FileSystemSnapshotter fileSystemSnapshotter,
@@ -93,7 +99,9 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
                                      CachingTransformationWorkspaceProvider immutableTransformationWorkspaceProvider,
                                      FileCollectionFactory fileCollectionFactory,
                                      ClassLoaderHierarchyHasher classLoaderHierarchyHasher,
-                                     ProjectFinder projectFinder) {
+                                     ProjectFinder projectFinder,
+                                     BuildOperationExecutor buildOperationExecutor
+    ) {
         this.workExecutor = workExecutor;
         this.fileSystemSnapshotter = fileSystemSnapshotter;
         this.artifactTransformListener = artifactTransformListener;
@@ -101,6 +109,7 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         this.fileCollectionFactory = fileCollectionFactory;
         this.classLoaderHierarchyHasher = classLoaderHierarchyHasher;
         this.projectFinder = projectFinder;
+        this.buildOperationExecutor = buildOperationExecutor;
     }
 
     @Override
@@ -113,65 +122,76 @@ public class DefaultTransformerInvoker implements TransformerInvoker {
         FileCollectionFingerprinter inputArtifactFingerprinter = fingerprinterRegistry.getFingerprinter(transformer.getInputArtifactNormalizer());
         String normalizedInputPath = inputArtifactFingerprinter.normalizePath(inputArtifactSnapshot);
         TransformationWorkspaceIdentity identity = getTransformationIdentity(producerProject, inputArtifactSnapshot, normalizedInputPath, transformer, dependenciesFingerprint);
-        return workspaceProvider.withWorkspace(identity, (identityString, workspace) -> {
-            return fireTransformListeners(transformer, subject, () -> {
-                String transformIdentity = "transform/" + identityString;
-                ExecutionHistoryStore executionHistoryStore = workspaceProvider.getExecutionHistoryStore();
-                FileCollectionFingerprinter outputFingerprinter = fingerprinterRegistry.getFingerprinter(OutputNormalizer.class);
+        return workspaceProvider.withWorkspace(identity, (identityString, workspace) -> buildOperationExecutor.call(new CallableBuildOperation<Try<ImmutableList<File>>>() {
+            @Override
+            public Try<ImmutableList<File>> call(BuildOperationContext context) {
+                return fireTransformListeners(transformer, subject, () -> {
+                    String transformIdentity = "transform/" + identityString;
+                    ExecutionHistoryStore executionHistoryStore = workspaceProvider.getExecutionHistoryStore();
+                    FileCollectionFingerprinter outputFingerprinter = fingerprinterRegistry.getFingerprinter(OutputNormalizer.class);
 
-                Optional<AfterPreviousExecutionState> afterPreviousExecutionState = executionHistoryStore.load(transformIdentity);
+                    Optional<AfterPreviousExecutionState> afterPreviousExecutionState = executionHistoryStore.load(transformIdentity);
 
-                ImplementationSnapshot implementationSnapshot = ImplementationSnapshot.of(transformer.getImplementationClass(), classLoaderHierarchyHasher);
-                CurrentFileCollectionFingerprint inputArtifactFingerprint = inputArtifactFingerprinter.fingerprint(ImmutableList.of(inputArtifactSnapshot));
-                ImmutableSortedMap<String, ValueSnapshot> inputFingerprints = snapshotInputs(transformer);
-                ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsBeforeExecution = snapshotOutputs(outputFingerprinter, fileCollectionFactory, workspace);
-                ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints = createInputFileFingerprints(inputArtifactFingerprint, dependenciesFingerprint);
-                BeforeExecutionState beforeExecutionState = new DefaultBeforeExecutionState(
-                    implementationSnapshot,
-                    ImmutableList.of(),
-                    inputFingerprints,
-                    inputFileFingerprints,
-                    outputsBeforeExecution
-                );
+                    ImplementationSnapshot implementationSnapshot = ImplementationSnapshot.of(transformer.getImplementationClass(), classLoaderHierarchyHasher);
+                    CurrentFileCollectionFingerprint inputArtifactFingerprint = inputArtifactFingerprinter.fingerprint(ImmutableList.of(inputArtifactSnapshot));
+                    ImmutableSortedMap<String, ValueSnapshot> inputFingerprints = snapshotInputs(transformer);
+                    ImmutableSortedMap<String, CurrentFileCollectionFingerprint> outputsBeforeExecution = snapshotOutputs(outputFingerprinter, fileCollectionFactory, workspace);
+                    ImmutableSortedMap<String, CurrentFileCollectionFingerprint> inputFileFingerprints = createInputFileFingerprints(inputArtifactFingerprint, dependenciesFingerprint);
+                    BeforeExecutionState beforeExecutionState = new DefaultBeforeExecutionState(
+                        implementationSnapshot,
+                        ImmutableList.of(),
+                        inputFingerprints,
+                        inputFileFingerprints,
+                        outputsBeforeExecution
+                    );
 
-                TransformerExecution execution = new TransformerExecution(
-                    transformer,
-                    workspace,
-                    transformIdentity,
-                    executionHistoryStore,
-                    fileCollectionFactory,
-                    inputArtifact,
-                    dependencies,
-                    outputFingerprinter
-                );
+                    TransformerExecution execution = new TransformerExecution(
+                        transformer,
+                        workspace,
+                        transformIdentity,
+                        executionHistoryStore,
+                        fileCollectionFactory,
+                        inputArtifact,
+                        dependencies,
+                        outputFingerprinter
+                    );
 
-                CachingResult outcome = workExecutor.execute(new IncrementalContext() {
-                    @Override
-                    public UnitOfWork getWork() {
-                        return execution;
-                    }
+                    CachingResult outcome = workExecutor.execute(new IncrementalContext() {
+                        @Override
+                        public UnitOfWork getWork() {
+                            return execution;
+                        }
 
-                    @Override
-                    public Optional<String> getRebuildReason() {
-                        return Optional.empty();
-                    }
+                        @Override
+                        public Optional<String> getRebuildReason() {
+                            return Optional.empty();
+                        }
 
-                    @Override
-                    public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
-                        return afterPreviousExecutionState;
-                    }
+                        @Override
+                        public Optional<AfterPreviousExecutionState> getAfterPreviousExecutionState() {
+                            return afterPreviousExecutionState;
+                        }
 
-                    @Override
-                    public Optional<BeforeExecutionState> getBeforeExecutionState() {
-                        return Optional.of(beforeExecutionState);
-                    }
+                        @Override
+                        public Optional<BeforeExecutionState> getBeforeExecutionState() {
+                            return Optional.of(beforeExecutionState);
+                        }
+                    });
+
+                    return outcome.getOutcome()
+                        .map(outcome1 -> execution.loadResultsFile())
+                        .mapFailure(failure -> new TransformException(String.format("Execution failed for %s.", execution.getDisplayName()), failure));
                 });
+            }
 
-                return outcome.getOutcome()
-                    .map(outcome1 -> execution.loadResultsFile())
-                    .mapFailure(failure -> new TransformException(String.format("Execution failed for %s.", execution.getDisplayName()), failure));
-            });
-        });
+            @Override
+            public BuildOperationDescriptor.Builder description() {
+                String displayName = transformer.getDisplayName() + " " + inputArtifact.getName();
+                return BuildOperationDescriptor.displayName(displayName)
+                    .progressDisplayName(displayName)
+                    .operationType(BuildOperationCategory.UNCATEGORIZED);
+            }
+        }));
     }
 
     private TransformationWorkspaceIdentity getTransformationIdentity(@Nullable ProjectInternal project, FileSystemLocationSnapshot inputArtifactSnapshot, String inputArtifactPath, Transformer transformer, CurrentFileCollectionFingerprint dependenciesFingerprint) {

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/transform/DefaultTransformerInvokerTest.groovy
@@ -40,6 +40,8 @@ import org.gradle.internal.fingerprint.impl.AbsolutePathFileCollectionFingerprin
 import org.gradle.internal.fingerprint.impl.DefaultFileCollectionFingerprinterRegistry
 import org.gradle.internal.fingerprint.impl.OutputFileCollectionFingerprinter
 import org.gradle.internal.hash.HashCode
+import org.gradle.internal.operations.BuildOperationExecutor
+import org.gradle.internal.operations.CallableBuildOperation
 import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.snapshot.impl.DefaultFileSystemMirror
 import org.gradle.internal.snapshot.impl.DefaultFileSystemSnapshotter
@@ -89,6 +91,12 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         fingerprint(_ as FileCollectionFingerprinter) >> { FileCollectionFingerprinter fingerprinter -> fingerprinter.empty() }
     }
 
+    def buildOperationExecutor = Stub(BuildOperationExecutor) {
+        call(_) >> { CallableBuildOperation op ->
+            op.call(null)
+        }
+    }
+
     def invoker = new DefaultTransformerInvoker(
         workExecutorTestFixture.workExecutor,
         fileSystemSnapshotter,
@@ -96,7 +104,8 @@ class DefaultTransformerInvokerTest extends AbstractProjectBuilderSpec {
         transformationWorkspaceProvider,
         fileCollectionFactory,
         classloaderHasher,
-        projectFinder
+        projectFinder,
+        buildOperationExecutor
     )
 
     private static class TestTransformer implements Transformer {


### PR DESCRIPTION
So the user sees when the transform actually needs to do something.
The operation is added after we determine the workspace, so we only
show the operation once per build and transform workspace.

Here is an asciinema recording showing the build operations in action: [![asciicast](https://asciinema.org/a/241547.svg)](https://asciinema.org/a/241547)