### PR TITLE
Update dependency management preview feature documentation

### DIFF
--- a/subprojects/dependency-management/preview-features.adoc
+++ b/subprojects/dependency-management/preview-features.adoc
@@ -2,24 +2,33 @@
 
 ## New Gradle `.module` metadata format
 
-In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a new module metadata format, that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
+In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle defines a new module metadata format, that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
 
-The new metadata format is still under active development. The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md[here]. Currently there are the following issues with enabling it in Gradle 4.x:
-
-- We do not yet guarantee backward or forward compatibility for the metadata file format. Thus, resolution may change when upgrading Gradle, if a metadata file is published with an old format.
-- An additional request is required for Maven and Ivy repositories to check for the new metadata file.
+The new metadata format reached a stable 1.0 with Gradle 5.3.
+The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md[here].
+Publishing Gradle Module Metadata to public repositories is now possible as Gradle will support format 1.0 going forward.
 
 [NOTE]
 Activate this feature in Gradle 4.6+ by adding `enableFeaturePreview("GRADLE_METADATA")` in _settings.gradle(.kts)_.
 
 ### Publishing `.module` metadata files
 
-If this feature preview is activated, the _maven-publish_ and _ivy-publish_ plugins automatically publish a `.module` file in addition to the `pom`/`ivy.xml` metadata file. If these modules are consumed by Gradle, _dependency constraints_ and _version constraints_, for examples strict versions, are preserved. By still publishing the traditional metadata formats, compatibility with Maven and Ivy is still ensured as much as possible.
+If this feature preview is activated, the _maven-publish_ and _ivy-publish_ plugins automatically publish a `.module` file in addition to the `pom`/`ivy.xml` metadata file.
+If these modules are consumed by Gradle, all dependency management features that are published will be honored.
+There is no loss of information since no mapping to a less expressive format is required.
+By still publishing the traditional metadata formats, compatibility with Maven and Ivy is still ensured as much as possible.
 
-The `.module` files are used to automatically publish the `api` and `runtime` variants of  Java libraries. These variants are honoured during dependency resolution. Additional publishing features will be added in the future which will allow for the publication of additional variants.
+The `.module` files are used to automatically publish the `api` and `runtime` variants of  Java libraries.
+These variants are honoured during dependency resolution.
+Additional publishing features will be added in the future which will allow for the publication of additional variants.
 
 ### Consuming `.module` metadata files
 
-If this feature preview is activated, Gradle automatically searches for a `.module` file for each dependency in a Maven or Ivy repository. If the file is found, it is preferred over the `pom`/`ivy.xml` file.
+Any Gradle module metadata published with Gradle 5.3 and above will be consumed automatically by Gradle.
+This is possible by the creation of a marker in the regular Ivy or Maven metadata files that tell Gradle there is a matching module file.
 
-If a `.module` file is found, _dependency constraints_ and _version constraints_ of the dependency are consumed from that file and are honored during dependency resolution.
+If this feature preview is activated, Gradle automatically and always searches for a `.module` file for each dependency in a Maven or Ivy repository.
+If the file is found, it is preferred over the `pom`/`ivy.xml` file.
+Unless you plan on publishing Gradle Module Metadata, you should not enable the feature if the only goal is consumption, as this is transparently covered.
+
+If a `.module` file is found, the full expressiveness of the Gradle feature set is preserved and honored during resolution.

--- a/subprojects/dependency-management/preview-features.adoc
+++ b/subprojects/dependency-management/preview-features.adoc
@@ -4,7 +4,7 @@
 
 In order to provide rich support for variant-aware dependency management and dependency constraints, Gradle 5.0 will define a new module metadata format, that can be used in conjunction with Ivy descriptor and Maven POM files in existing repositories.
 
-The new metadata format is still under active development. The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-specification.md[here]. Currently there are the following issues with enabling it in Gradle 4.x:
+The new metadata format is still under active development. The latest version of the specification can be found https://github.com/gradle/gradle/blob/master/subprojects/docs/src/docs/design/gradle-module-metadata-1.0-specification.md[here]. Currently there are the following issues with enabling it in Gradle 4.x:
 
 - We do not yet guarantee backward or forward compatibility for the metadata file format. Thus, resolution may change when upgrading Gradle, if a metadata file is published with an old format.
 - An additional request is required for Maven and Ivy repositories to check for the new metadata file.

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -7,6 +7,7 @@ We would like to thank the following community contributors to this release of G
 Include only their name, impactful features should be called out separately below.
  [Some person](https://github.com/some-person)
 -->
+[Ben Asher](https://github.com/benasher44)
 
 <!-- 
 ## 1


### PR DESCRIPTION
A number of things changed with the release of Gradle Module Metadata
1.0.
This document was lacking an update following these changes.