### PR TITLE
Add OpenBSD as a detectable operating system

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/os/OperatingSystem.java
@@ -33,6 +33,7 @@ public abstract class OperatingSystem {
     public static final Solaris SOLARIS = new Solaris();
     public static final Linux LINUX = new Linux();
     public static final FreeBSD FREE_BSD = new FreeBSD();
+    public static final OpenBSD OPEN_BSD = new OpenBSD();
     public static final Unix UNIX = new Unix();
     private static OperatingSystem currentOs;
     private final String toStringValue;
@@ -69,6 +70,8 @@ public abstract class OperatingSystem {
             return LINUX;
         } else if (osName.contains("freebsd")) {
             return FREE_BSD;
+        } else if (osName.contains("openbsd")) {
+            return OPEN_BSD;
         } else {
             // Not strictly true
             return UNIX;
@@ -102,6 +105,14 @@ public abstract class OperatingSystem {
     }
 
     public boolean isLinux() {
+        return false;
+    }
+
+    public boolean isFreeBSD() {
+        return false;
+    }
+
+    public boolean isOpenBSD() {
         return false;
     }
 
@@ -406,6 +417,9 @@ public abstract class OperatingSystem {
     }
 
     static class FreeBSD extends Unix {
+    }
+
+    static class OpenBSD extends Unix {
     }
 
     static class Solaris extends Unix {

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/os/OperatingSystemTest.groovy
@@ -201,6 +201,13 @@ class OperatingSystemTest extends Specification {
         OperatingSystem.current() instanceof OperatingSystem.FreeBSD
     }
 
+    def "uses os.name property to determine if openbsd"() {
+        System.properties['os.name'] = 'OpenBSD'
+
+        expect:
+        OperatingSystem.current() instanceof OperatingSystem.OpenBSD
+    }
+
     def "uses default implementation for other os"() {
         System.properties['os.name'] = 'unknown'
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/OperatingSystem.java
@@ -93,4 +93,10 @@ public interface OperatingSystem extends Named {
      */
     @Internal
     boolean isFreeBSD();
+
+    /**
+     * Is it OpenBSD?
+     */
+    @Internal
+    boolean isOpenBSD();
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/DefaultOperatingSystem.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/platform/internal/DefaultOperatingSystem.java
@@ -97,6 +97,11 @@ public class DefaultOperatingSystem implements OperatingSystemInternal {
     }
 
     @Override
+    public boolean isOpenBSD() {
+        return internalOs == OperatingSystem.OPEN_BSD;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/platform/internal/DefaultOperatingSystemTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/platform/internal/DefaultOperatingSystemTest.groovy
@@ -44,6 +44,7 @@ class DefaultOperatingSystemTest extends Specification {
         "sunos"   | OperatingSystem.SOLARIS
         "solaris" | OperatingSystem.SOLARIS
         "freebsd" | OperatingSystem.FREE_BSD
+        "openbsd" | OperatingSystem.OPEN_BSD
     }
 
     def "can create arbitrary operating system"() {


### PR DESCRIPTION
### Context
I'm trying to port an open source Java project to OpenBSD, but it requires OpenBSD detection support in gradle to determine what host OS it's running on, and thus which native binaries to use for certain operations. These changes make that possible.
### Contributor Checklist
- [X] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [X] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [X] Check ["Allo- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
Couldn't find integration tests for the existing OS detection logic, but maybe I'm oblivious?
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
Couldn't find unit tests for the existing OS detection logic, but maybe I'm oblivious?
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
Also couldn't find :/
- [X] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`w edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
Existing tests worked fine.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
