### PR TITLE
Use `-fPIC` for C++ static library with Swift 4.1+ tool chain

### DIFF
--- a/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationCppInteroperabilityIntegrationTest.groovy
+++ b/subprojects/language-native/src/integTest/groovy/org/gradle/language/swift/SwiftApplicationCppInteroperabilityIntegrationTest.groovy
@@ -26,10 +26,8 @@ import org.gradle.nativeplatform.fixtures.app.SwiftAppWithDep
 import org.gradle.nativeplatform.fixtures.app.SwiftGreeterUsingCppFunction
 import org.gradle.nativeplatform.fixtures.app.SwiftMainWithCppDep
 import org.gradle.nativeplatform.fixtures.app.SwiftSum
-import spock.lang.Ignore
 import spock.lang.Unroll
 
-@Ignore
 class SwiftApplicationCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest {
     @Unroll
     def "can compile and link against a #linkage.toLowerCase() c++ library"() {

--- a/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestCppInteroperabilityIntegrationTest.groovy
+++ b/subprojects/testing-native/src/integTest/groovy/org/gradle/nativeplatform/test/xctest/SwiftXCTestCppInteroperabilityIntegrationTest.groovy
@@ -21,10 +21,8 @@ import org.gradle.nativeplatform.fixtures.app.CppGreeterFunction
 import org.gradle.nativeplatform.fixtures.app.SwiftLibTest
 import org.gradle.nativeplatform.fixtures.app.SwiftLibWithCppDep
 import org.gradle.nativeplatform.fixtures.app.SwiftLibWithCppDepXCTest
-import spock.lang.Ignore
 import spock.lang.Unroll
 
-@Ignore
 class SwiftXCTestCppInteroperabilityIntegrationTest extends AbstractSwiftMixedLanguageIntegrationTest implements XCTestExecutionResult {
     def setup() {
         buildFile << """


### PR DESCRIPTION
### Context
See https://github.com/gradle/gradle-native-private/issues/246

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Ffix-swift-failures)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
