### PR TITLE
Fix DistributedPerformanceTest

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/DistributedPerformanceTest.groovy
@@ -32,8 +32,6 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.testing.TestListener
 import org.gradle.api.tasks.testing.TestOutputListener
@@ -49,7 +47,6 @@ import javax.inject.Inject
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
 import java.util.zip.ZipInputStream
-
 /**
  * Runs each performance test scenario in a dedicated TeamCity job.
  *
@@ -87,7 +84,6 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
     int repeat = 1
 
     @OutputFile
-    @PathSensitive(PathSensitivity.RELATIVE)
     File scenarioList
 
     private RESTClient client
@@ -269,7 +265,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
     }
 
     @TypeChecked(TypeCheckingMode.SKIP)
-    private String findLastChangeIdInJson(Map responseJson) {
+    private static String findLastChangeIdInJson(Map responseJson) {
         responseJson?.lastChanges?.change?.get(0)?.id
     }
 
@@ -356,7 +352,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
         }
     }
 
-    private void rethrowIfNonRecoverable(HttpResponseException e) {
+    private static void rethrowIfNonRecoverable(HttpResponseException e) {
         if (e.statusCode != 404) {
             throw e
         }
@@ -409,7 +405,7 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
         return testSuite
     }
 
-    JUnitTestSuite parseXmlsInZip(InputStream inputStream) {
+    private static JUnitTestSuite parseXmlsInZip(InputStream inputStream) {
         List<JUnitTestSuite> parsedXmls = []
         new ZipInputStream(inputStream).withStream { zipInput ->
             def entry
@@ -434,8 +430,8 @@ class DistributedPerformanceTest extends ReportGenerationPerformanceTest {
     private RESTClient createClient() {
         client = new RESTClient("$teamCityUrl/httpAuth/app/rest/9.1")
         client.auth.basic(teamCityUsername, teamCityPassword)
-        client.headers['Origin'] = teamCityUrl
-        client.headers['Accept'] = ContentType.JSON.toString()
+        client.headers.putAt('Origin', teamCityUrl)
+        client.headers.putAt('Accept', ContentType.JSON.toString())
         client
     }
 


### PR DESCRIPTION
Remove illegal `@PathSensitivity` annotation from an `@OutputFile` property, and some other fine tuning.

Without this change the  https://github.com/gradle/gradle/pull/8933 fails to run `GradleBuildPerformanceTest.help on the gradle build comparing the build`, as the improved validation chokes on the invalid annotation.