### PR TITLE
Fix performance test project generator tasks

### DIFF
--- a/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
+++ b/buildSrc/subprojects/performance/src/main/groovy/org/gradle/testing/performance/generator/tasks/AbstractProjectGeneratorTask.groovy
@@ -25,9 +25,9 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.testing.performance.generator.DependencyGraph
 import org.gradle.testing.performance.generator.MavenJarCreator
 import org.gradle.testing.performance.generator.MavenRepository
@@ -98,7 +98,7 @@ abstract class AbstractProjectGeneratorTask extends TemplateProjectGeneratorTask
         return templateDirectories
     }
 
-    int getTestSourceFiles() {
+    Integer getTestSourceFiles() {
         return testSourceFiles ?: sourceFiles
     }
 


### PR DESCRIPTION
Fix type of `AbstractProjectGeneratorTask.testSourceFiles`.

Without this change the  https://github.com/gradle/gradle/pull/8933 fails to run `GradleBuildPerformanceTest.help on the gradle build comparing the build`, as the improved validation chokes on the invalid annotation.