### PR TITLE
Exclude already used names when naming eclipse projects

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -24,6 +24,13 @@ details of 2
 ## n
 -->
 
+## Improved Eclipse project name deduplication in Buildship
+
+Gradle can now be informed about the current eclipse workpace state using the Tooling API. This allows gradle to include non gradle projects when
+deduplicating project names and reduce the chance of conflicts when non-gradle projects have the same name as gradle (sub-)projects.
+ 
+To benefit from this change a recent Buildship version is required.
+
 ## Upgrade Instructions
 
 Switch your build to use Gradle @version@ by updating your wrapper:
@@ -77,7 +84,15 @@ The following are the newly deprecated items in this Gradle release. If you have
 ### Example deprecation
 -->
 
-### Breaking changes
+## Potential breaking changes
+
+### User supplied Eclipse project names may be ignored on conflict
+
+Project names configured in the build script via [`EclipseProject.setName(...)`](javadoc/org/gradle/plugins/ide/eclipse/model/EclipseProject.html) where previously honored by gradle
+and Buildship even if they caused conflicts and import and synchronization errors. Gradle now will now deduplicate these names if they would conflict with other project names
+in the eclipse workspace. This change can lead to different eclipse project names for projects with user-specified names.
+
+## Breaking changes
 
 <!-- summary and links -->
 

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/EclipseModelAwareUniqueProjectNameProvider.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/configurer/EclipseModelAwareUniqueProjectNameProvider.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.plugins.ide.internal.configurer;
+
+import org.gradle.api.Project;
+import org.gradle.api.internal.project.ProjectInternal;
+import org.gradle.api.internal.project.ProjectState;
+import org.gradle.api.internal.project.ProjectStateRegistry;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EclipseModelAwareUniqueProjectNameProvider implements UniqueProjectNameProvider {
+    private final ProjectStateRegistry projectRegistry;
+    private Map<ProjectState, String> deduplicated;
+    private List<ProjectStateWrapper> reservedNames = Collections.emptyList();
+    private Map<ProjectState, ProjectStateWrapper> projectToInformationMap = Collections.emptyMap();
+
+    public EclipseModelAwareUniqueProjectNameProvider(ProjectStateRegistry projectRegistry) {
+        this.projectRegistry = projectRegistry;
+    }
+
+    public synchronized void setReservedProjectNames(List<String> reservedNames) {
+        this.reservedNames = reservedNames.stream().map(ProjectStateWrapper::new).collect(Collectors.toList());
+        deduplicated = null;
+    }
+
+    @Override
+    public String getUniqueName(Project project) {
+        ProjectState state = projectRegistry.stateFor(project);
+        String uniqueName = getDeduplicatedNames().get(state);
+        if (uniqueName != null) {
+            return uniqueName;
+        }
+
+        // ProjectStateWrapper might contain the configured eclipse project name
+        ProjectStateWrapper information = projectToInformationMap.get(state);
+        if (information != null) {
+            return information.name;
+        }
+        return state.getName();
+    }
+
+    private synchronized Map<ProjectState, String> getDeduplicatedNames() {
+        if (deduplicated == null) {
+
+            projectToInformationMap = new HashMap<>();
+            for (ProjectState state : projectRegistry.getAllProjects()) {
+                // try to get the name from EclipseProject.name
+                ProjectInternal project = state.getOwner().getLoadedSettings().getGradle().getRootProject().findProject(
+                    state.getComponentIdentifier().getProjectPath());
+                if (project != null) {
+                    EclipseModel model = project.getExtensions().findByType(EclipseModel.class);
+                    if (model != null && model.getProject().getName() != null) {
+                        projectToInformationMap.put(state, new ProjectStateWrapper(model.getProject().getName(), state, state.getParent()));
+                        continue;
+                    }
+                }
+                // fallback: take the name from the ProjectState
+                projectToInformationMap.put(state, new ProjectStateWrapper(state.getName(), state, state.getParent()));
+            }
+
+            HierarchicalElementDeduplicator<ProjectStateWrapper> deduplicator = new HierarchicalElementDeduplicator<>(new ProjectPathDeduplicationAdapter(projectToInformationMap));
+            List<ProjectStateWrapper> allElements = new ArrayList<>();
+            allElements.addAll(reservedNames);
+            allElements.addAll(projectToInformationMap.values());
+
+            this.deduplicated = deduplicator.deduplicate(allElements).entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey().project, Map.Entry::getValue));
+        }
+        return deduplicated;
+    }
+
+    private static class ProjectStateWrapper {
+        private final String name;
+        private final ProjectState project;
+        private final ProjectState parent;
+
+        public ProjectStateWrapper(String name, ProjectState project, ProjectState parent) {
+            this.name = name;
+            this.project = project;
+            this.parent = parent;
+        }
+
+        public ProjectStateWrapper(String name) {
+            this(name, null, null);
+        }
+    }
+
+    private static class ProjectPathDeduplicationAdapter implements HierarchicalElementAdapter<ProjectStateWrapper> {
+        private final Map<ProjectState, ProjectStateWrapper> projectToInformationMap;
+
+        public ProjectPathDeduplicationAdapter(Map<ProjectState, ProjectStateWrapper> projectToInformationMap) {
+            this.projectToInformationMap = projectToInformationMap;
+        }
+
+        @Override
+        public String getName(ProjectStateWrapper element) {
+            return element.name;
+        }
+
+        @Override
+        public ProjectStateWrapper getParent(ProjectStateWrapper element) {
+            return projectToInformationMap.get(element.parent);
+        }
+    }
+
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
@@ -32,8 +32,8 @@ import org.gradle.plugins.ear.EarPlugin
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 import org.gradle.plugins.ide.eclipse.EclipseWtpPlugin
 import org.gradle.plugins.ide.eclipse.model.BuildCommand
-import org.gradle.plugins.ide.eclipse.model.EclipseProject
 import org.gradle.plugins.ide.eclipse.model.Link
+import org.gradle.plugins.ide.internal.configurer.EclipseModelAwareUniqueProjectNameProvider
 import org.gradle.plugins.ide.internal.tooling.EclipseModelBuilder
 import org.gradle.plugins.ide.internal.tooling.GradleProjectBuilder
 import org.gradle.test.fixtures.AbstractProjectBuilderSpec
@@ -326,8 +326,11 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
     private def createEclipseModelBuilder() {
         def gradleProjectBuilder = new GradleProjectBuilder()
         def serviceRegistry = new DefaultServiceRegistry()
+        def uniqueProjectNameProvider = Stub(EclipseModelAwareUniqueProjectNameProvider) {
+            getUniqueName( _ as Project) >> { Project p -> p.getName()}
+        }
         serviceRegistry.add(LocalComponentRegistry, Stub(LocalComponentRegistry))
         serviceRegistry.add(CompositeBuildContext, Stub(CompositeBuildContext))
-        new EclipseModelBuilder(gradleProjectBuilder, serviceRegistry)
+        new EclipseModelBuilder(gradleProjectBuilder, serviceRegistry, uniqueProjectNameProvider)
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/CompositeDeduplicationCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/CompositeDeduplicationCrossVersionSpec.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r55
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.tooling.model.eclipse.EclipseProject
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+@TargetGradleVersion('>=5.5')
+class CompositeDeduplicationCrossVersionSpec extends ToolingApiSpecification {
+
+    @Rule
+    TemporaryFolder externalProjectFolder = new TemporaryFolder();
+
+    def setup() {
+        buildFile << """
+        project(':b') {
+            apply plugin: 'eclipse'
+            eclipse {
+                project.name='explicitName'
+            }
+        }
+        """
+        settingsFile << """
+        rootProject.name = 'root'
+        include ':a', ':b'
+        """
+    }
+
+    @TargetGradleVersion(">=4.0")
+    def "Included builds are deduplicated"() {
+        given:
+        settingsFile << """
+                includeBuild 'includedBuild1'
+                includeBuild 'includedBuild2'
+            """
+        multiProjectBuildInSubFolder("includedBuild1", ["a", "b", "c"])
+        multiProjectBuildInSubFolder("includedBuild2", ["a", "b", "c"])
+
+        when:
+        def eclipseModels = withConnection { con -> con.action(new LoadCompositeEclipseModels()).run() }
+
+        then:
+        eclipseModels.collect {
+            collectProjects(it)
+        }.flatten().collect {
+            it.name
+        }.containsAll([
+            'root', 'root-a', 'explicitName',
+            'includedBuild1', 'includedBuild1-a', 'includedBuild1-b', 'includedBuild1-c',
+            'includedBuild2', 'includedBuild2-a', 'includedBuild2-b', 'includedBuild2-c'])
+    }
+
+    Collection<EclipseProject> collectProjects(EclipseProject parent) {
+        return parent.children.collect { collectProjects(it) }.flatten() + [parent]
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/DefaultEclipseWorkspace.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/DefaultEclipseWorkspace.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r55;
+
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
+
+import java.io.File;
+import java.io.Serializable;
+import java.util.List;
+
+public class DefaultEclipseWorkspace implements EclipseWorkspace, Serializable {
+
+    private final File location;
+    private final List<EclipseWorkspaceProject> workspaceProjects;
+
+    public DefaultEclipseWorkspace(File location, List<EclipseWorkspaceProject> workspaceProjects) {
+        this.location = location;
+        this.workspaceProjects = workspaceProjects;
+    }
+
+    @Override
+    public File getLocation() {
+        return location;
+    }
+
+    @Override
+    public List<EclipseWorkspaceProject> getProjects() {
+        return workspaceProjects;
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/DefaultEclipseWorkspaceProject.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/DefaultEclipseWorkspaceProject.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r55;
+
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
+
+import java.io.File;
+import java.io.Serializable;
+
+public class DefaultEclipseWorkspaceProject implements EclipseWorkspaceProject, Serializable {
+
+    private final String name;
+    private final File location;
+
+    public DefaultEclipseWorkspaceProject(String name, File location) {
+        this.name = name;
+        this.location = location;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public File getLocation() {
+        return location;
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/LoadCompositeEclipseModels.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/LoadCompositeEclipseModels.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r55;
+
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class LoadCompositeEclipseModels implements BuildAction<Collection<EclipseProject>>, Serializable {
+
+    @Override
+    public Collection<EclipseProject> execute(BuildController controller) {
+        Collection<EclipseProject> models = new ArrayList<EclipseProject>();
+        collectRootModels(controller, controller.getBuildModel(), models);
+        return models;
+    }
+
+    private void collectRootModels(BuildController controller, GradleBuild build, Collection<EclipseProject> models) {
+        models.add(controller.getModel(build.getRootProject(), EclipseProject.class));
+
+        for (GradleBuild includedBuild : build.getIncludedBuilds()) {
+            collectRootModels(controller, includedBuild, models);
+        }
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/LoadEclipseModel.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/LoadEclipseModel.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r55;
+
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+
+import java.io.Serializable;
+
+public class LoadEclipseModel implements BuildAction<EclipseProject>, Serializable {
+
+    private final EclipseWorkspace workspace;
+
+    public LoadEclipseModel() {
+        this(null);
+    }
+
+    public LoadEclipseModel(EclipseWorkspace workspace) {
+
+        this.workspace = workspace;
+    }
+
+    @Override
+    public EclipseProject execute(BuildController controller) {
+        if (workspace != null) {
+            return controller.getModel(EclipseProject.class, EclipseRuntime.class, new EclipseRuntimeAction(workspace));
+        }
+        return controller.getModel(EclipseProject.class);
+    }
+
+    private static class EclipseRuntimeAction implements Action<EclipseRuntime>, Serializable {
+        private final EclipseWorkspace workspace;
+
+        public EclipseRuntimeAction(EclipseWorkspace workspace) {
+
+            this.workspace = workspace;
+        }
+
+        @Override
+        public void execute(EclipseRuntime eclipseRuntime) {
+            eclipseRuntime.setWorkspace(workspace);
+        }
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/ReservedProjectNamesCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/ReservedProjectNamesCrossVersionSpec.groovy
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r55
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.tooling.model.eclipse.EclipseProject
+import org.gradle.tooling.model.eclipse.EclipseWorkspace
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+@TargetGradleVersion('>=5.5')
+@ToolingApiVersion(">=5.5")
+class ReservedProjectNamesCrossVersionSpec extends ToolingApiSpecification {
+
+    @Rule
+    TemporaryFolder externalProjectFolder = new TemporaryFolder();
+
+    def setup() {
+        buildFile << """
+        project(':b') {
+            apply plugin: 'eclipse'
+            eclipse {
+                project.name='explicitName'
+            }
+        }
+        """
+        settingsFile << """
+        rootProject.name = 'root'
+        include ':a', ':b'
+        """
+    }
+
+    def "externally used project names can be supplied and are deduplicated"() {
+        when:
+        EclipseProject model = withConnection { connection ->
+            return connection.action(new LoadEclipseModel(eclipseWorkspace([
+                gradleProject("a"),
+                externalProject("a")
+            ]))).run()
+        }
+
+        then:
+        def projects = collectProjects(model)
+        !projects.collect({ it.name }).contains("a")
+        projects.collect({ it.name }).contains("root-a")
+    }
+
+    def "name collisions are resolved"() {
+        when:
+        EclipseProject model = withConnection { connection ->
+            return connection.action(new LoadEclipseModel(eclipseWorkspace([
+                externalProject("a")
+            ]))).run()
+        }
+
+        then:
+        def projects = collectProjects(model)
+        !projects.collect({ it.name }).contains("a")
+        projects.collect({ it.name }).contains("root-a")
+    }
+
+    def "gradle projects are recognized and not wrongly deduplicated"() {
+        when:
+        EclipseProject model = withConnection { connection ->
+            return connection.action(new LoadEclipseModel(eclipseWorkspace([
+                project("root", projectDir),
+                gradleProject("a"),
+                project("explicitName", file("b"))
+            ]))).run()
+        }
+
+        then:
+        collectProjects(model).collect({ it.name }).containsAll(["root", "a", "explicitName"])
+    }
+
+    def "model can be fetched via connection "() {
+        when:
+        EclipseProject model = withConnection { connection ->
+            connection.getModel(EclipseProject.class)
+        }
+
+        then:
+        collectProjects(model).collect({ it.name }).contains("a")
+    }
+
+    def "model can be fetched without parameters"() {
+        when:
+        EclipseProject model = withConnection { connection ->
+            connection.action(new LoadEclipseModel()).run()
+        }
+
+        then:
+        collectProjects(model).collect({ it.name }).contains("a")
+    }
+
+    def "buildscript names are deduplicated"() {
+        when:
+        EclipseProject model = withConnection { connection ->
+            connection.action(new LoadEclipseModel(eclipseWorkspace([externalProject("explicitName")]))).run()
+        }
+
+        then:
+        def projects = collectProjects(model)
+        projects.collect({ it.name }).contains("root-explicitName")
+        !projects.collect({ it.name }).contains("explicitName")
+
+    }
+
+    def "Reserved names work in composite builds"() {
+        given:
+        settingsFile << """
+                includeBuild 'includedBuild1'
+                includeBuild 'includedBuild2'
+            """
+        def inc1 = multiProjectBuildInSubFolder("includedBuild1", ["a", "b", "c"])
+        def inc2 = multiProjectBuildInSubFolder("includedBuild2", ["a", "b", "c"])
+        def workspace = eclipseWorkspace([
+            project("root", projectDir), gradleProject("a"), project("explicitName", file("b")),
+            externalProject("root-a"),
+            project("includedBuild1", inc1), project("includedBuild1-a", inc1.file("a")), project("includedBuild1-includedBuild1-b", inc1.file("b")), project("includedBuild1-c", inc1.file("c")),
+            externalProject("includedBuild1-b"),
+            project("includedBuild2", inc2), project("includedBuild2-a", inc2.file("a")), project("includedBuild2-includedBuild2-b", inc2.file("b")), project("includedBuild2-c", inc2.file("c")),
+            externalProject("includedBuild2-b"),
+        ])
+
+        when:
+        def eclipseModels = withConnection { con -> con.action(new SupplyRuntimeAndLoadCompositeEclipseModels(workspace)).run() }
+
+        then:
+        eclipseModels.collect {
+            collectProjects(it)
+        }.flatten().collect {
+            it.name
+        }.containsAll([
+            'root', 'root-root-a', 'explicitName',
+            'includedBuild1', 'includedBuild1-a', 'includedBuild1-includedBuild1-b', 'includedBuild1-c',
+            'includedBuild2', 'includedBuild2-a', 'includedBuild2-includedBuild2-b', 'includedBuild2-c'])
+    }
+
+
+    Collection<EclipseProject> collectProjects(EclipseProject parent) {
+        return parent.children.collect { collectProjects(it) }.flatten() + [parent]
+    }
+
+    EclipseWorkspace eclipseWorkspace(List<EclipseWorkspaceProject> projects) {
+        new DefaultEclipseWorkspace(externalProjectFolder.newFolder("workspace"), projects)
+    }
+
+    EclipseWorkspaceProject gradleProject(String name) {
+        project(name, file(name))
+    }
+
+    EclipseWorkspaceProject project(String name, File location) {
+        new DefaultEclipseWorkspaceProject(name, location)
+    }
+
+    EclipseWorkspaceProject externalProject(String name) {
+        new DefaultEclipseWorkspaceProject(name, externalProjectFolder.newFolder(name))
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/SupplyRuntimeAndLoadCompositeEclipseModels.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r55/SupplyRuntimeAndLoadCompositeEclipseModels.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r55;
+
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class SupplyRuntimeAndLoadCompositeEclipseModels implements BuildAction<Collection<EclipseProject>>, Serializable {
+
+    private final EclipseWorkspace workspace;
+
+    public SupplyRuntimeAndLoadCompositeEclipseModels(EclipseWorkspace workspace) {
+
+        this.workspace = workspace;
+    }
+
+    @Override
+    public Collection<EclipseProject> execute(BuildController controller) {
+        Collection<EclipseProject> models = new ArrayList<EclipseProject>();
+        collectRootModels(controller, controller.getBuildModel(), models);
+        return models;
+    }
+
+    private void collectRootModels(BuildController controller, GradleBuild build, Collection<EclipseProject> models) {
+        models.add(controller.getModel(build.getRootProject(), EclipseProject.class, EclipseRuntime.class, new EclipseRuntimeAction(workspace)));
+
+        for (GradleBuild includedBuild : build.getIncludedBuilds()) {
+            collectRootModels(controller, includedBuild, models);
+        }
+    }
+
+    private static class EclipseRuntimeAction implements Action<EclipseRuntime>, Serializable {
+        private final EclipseWorkspace eclipseWorkspace;
+
+        public EclipseRuntimeAction(EclipseWorkspace eclipseWorkspace) {
+            this.eclipseWorkspace = eclipseWorkspace;
+        }
+
+        @Override
+        public void execute(EclipseRuntime eclipseRuntime) {
+            eclipseRuntime.setWorkspace(eclipseWorkspace);
+        }
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseRuntime.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseRuntime.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.model.eclipse;
+
+import org.gradle.api.Action;
+import org.gradle.api.Incubating;
+
+/**
+ * Information about the eclipse instance.
+ *
+ * This is a possible parameter for the {@link EclipseProject} model resolution.
+ * It provides additional information to gradle so it can build a more accurate {@link EclipseProject} model.
+ *
+ * @see EclipseProject
+ * @see org.gradle.tooling.BuildController#getModel(Class, Class, Action)
+ * @since 5.5
+ */
+@Incubating
+public interface EclipseRuntime {
+    EclipseWorkspace getWorkspace();
+
+    /**
+     * The eclipse workspace
+     */
+    @Incubating
+    void setWorkspace(EclipseWorkspace eclipseWorkspace);
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseWorkspace.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseWorkspace.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.model.eclipse;
+
+import org.gradle.api.Incubating;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Information about the eclipse workspace.
+ *
+ * @since 5.5
+ */
+@Incubating
+public interface EclipseWorkspace {
+    /**
+     * The filesystem location of the eclipse workspace
+     */
+    @Incubating
+    File getLocation();
+
+    /**
+     * The list of projects in the eclipse workspace.
+     *
+     * This list should include all projects and not make a distinction between gradle and non gradle projects.
+     */
+    @Incubating
+    List<EclipseWorkspaceProject> getProjects();
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseWorkspaceProject.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/EclipseWorkspaceProject.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.tooling.model.eclipse;
+
+import org.gradle.api.Incubating;
+
+import java.io.File;
+
+/**
+ * Information about a project in the eclipse workspace.
+ *
+ * @since 5.5
+ */
+@Incubating
+public interface EclipseWorkspaceProject {
+    /**
+     * The name of the eclipse project
+     *
+     * @return the name of the project, never null
+     */
+    @Incubating
+    String getName();
+
+    /**
+     * The filesystem location of the eclipse project
+     *
+     * @return the location of the eclipse project, may be null in case of remote projects
+     */
+    @Incubating
+    File getLocation();
+}


### PR DESCRIPTION
### Context
Projects in eclipse workspaces need unique names. Gradle already ensures this for projects in the same build. This commit adds a tooling model that can be used to inform gradle of already used project names in the current eclipse workspace. These names will then be considered in use and not assigned to eclipse projects by gradle.

<!--- Link to relevant issues or forum discussions here -->
Related Buildship issue: https://github.com/eclipse/buildship/issues/829

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
