### PR TITLE
Remove `vcs()` method that doesn't seem to exist for `VcsMappings`

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/vcs/VcsMappings.java
+++ b/subprojects/core-api/src/main/java/org/gradle/vcs/VcsMappings.java
@@ -34,7 +34,7 @@ import org.gradle.internal.HasInternalProtocol;
  *     }
  *     all { details -&gt;
  *       if (details.requested.group == "org.gradle") {
- *         from vcs(GitVersionControlSpec) {
+ *         from(GitVersionControlSpec) {
  *           url = uri("https://github.com/gradle/${details.requested.module}")
  *         }
  *       }


### PR DESCRIPTION
Signed-off-by: Mike Kobit <mkobit@gmail.com>

### Context

Trying to try out source dependencies adapting from https://docs.gradle.org/current/javadoc/org/gradle/vcs/VcsMappings.html in the `kotlin-dsl` but the Javadoc seems to point to a method `vcs` that was removed or is unclear

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
