### PR TITLE
Provide basic services registry to workers

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/WorkerSharedGlobalScopeServices.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.service.scopes;
+
+import org.gradle.api.internal.ClassPathRegistry;
+import org.gradle.api.internal.DefaultClassPathProvider;
+import org.gradle.api.internal.DefaultClassPathRegistry;
+import org.gradle.api.internal.DynamicModulesClassPathProvider;
+import org.gradle.api.internal.classpath.DefaultModuleRegistry;
+import org.gradle.api.internal.classpath.DefaultPluginModuleRegistry;
+import org.gradle.api.internal.classpath.ModuleRegistry;
+import org.gradle.api.internal.classpath.PluginModuleRegistry;
+import org.gradle.cache.FileLockManager;
+import org.gradle.cache.internal.CacheFactory;
+import org.gradle.cache.internal.CrossBuildInMemoryCacheFactory;
+import org.gradle.cache.internal.DefaultCacheFactory;
+import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
+import org.gradle.initialization.ClassLoaderRegistry;
+import org.gradle.initialization.DefaultClassLoaderRegistry;
+import org.gradle.initialization.DefaultLegacyTypesSupport;
+import org.gradle.initialization.FlatClassLoaderRegistry;
+import org.gradle.initialization.LegacyTypesSupport;
+import org.gradle.internal.classpath.ClassPath;
+import org.gradle.internal.concurrent.ExecutorFactory;
+import org.gradle.internal.event.ListenerManager;
+import org.gradle.internal.installation.CurrentGradleInstallation;
+import org.gradle.internal.installation.GradleRuntimeShadedJarDetector;
+import org.gradle.internal.logging.events.OutputEventListener;
+import org.gradle.internal.logging.progress.DefaultProgressLoggerFactory;
+import org.gradle.internal.logging.progress.ProgressLoggerFactory;
+import org.gradle.internal.logging.services.ProgressLoggingBridge;
+import org.gradle.internal.operations.BuildOperationIdFactory;
+import org.gradle.internal.operations.DefaultBuildOperationIdFactory;
+import org.gradle.internal.reflect.DirectInstantiator;
+import org.gradle.internal.time.Clock;
+import org.gradle.internal.time.Time;
+
+public class WorkerSharedGlobalScopeServices extends BasicGlobalScopeServices {
+
+    protected final ClassPath additionalModuleClassPath;
+
+    public WorkerSharedGlobalScopeServices() {
+        this(ClassPath.EMPTY);
+    }
+
+    public WorkerSharedGlobalScopeServices(ClassPath additionalModuleClassPath) {
+        this.additionalModuleClassPath = additionalModuleClassPath;
+    }
+
+    ClassPathRegistry createClassPathRegistry(ModuleRegistry moduleRegistry, PluginModuleRegistry pluginModuleRegistry) {
+        return new DefaultClassPathRegistry(
+            new DefaultClassPathProvider(moduleRegistry),
+            new DynamicModulesClassPathProvider(moduleRegistry,
+                pluginModuleRegistry));
+    }
+
+    DefaultModuleRegistry createModuleRegistry(CurrentGradleInstallation currentGradleInstallation) {
+        return new DefaultModuleRegistry(additionalModuleClassPath, currentGradleInstallation.getInstallation());
+    }
+
+    CurrentGradleInstallation createCurrentGradleInstallation() {
+        return CurrentGradleInstallation.locate();
+    }
+
+    PluginModuleRegistry createPluginModuleRegistry(ModuleRegistry moduleRegistry) {
+        return new DefaultPluginModuleRegistry(moduleRegistry);
+    }
+
+    protected CacheFactory createCacheFactory(FileLockManager fileLockManager, ExecutorFactory executorFactory, ProgressLoggerFactory progressLoggerFactory) {
+        return new DefaultCacheFactory(fileLockManager, executorFactory, progressLoggerFactory);
+    }
+
+    ClassLoaderRegistry createClassLoaderRegistry(ClassPathRegistry classPathRegistry, LegacyTypesSupport legacyTypesSupport) {
+        if (GradleRuntimeShadedJarDetector.isLoadedFrom(getClass())) {
+            return new FlatClassLoaderRegistry(getClass().getClassLoader());
+        }
+
+        // Use DirectInstantiator here to avoid setting up the instantiation infrastructure early
+        return new DefaultClassLoaderRegistry(classPathRegistry, legacyTypesSupport, DirectInstantiator.INSTANCE);
+    }
+
+    LegacyTypesSupport createLegacyTypesSupport() {
+        return new DefaultLegacyTypesSupport();
+    }
+
+    BuildOperationIdFactory createBuildOperationIdProvider() {
+        return new DefaultBuildOperationIdFactory();
+    }
+
+    ProgressLoggerFactory createProgressLoggerFactory(OutputEventListener outputEventListener, Clock clock, BuildOperationIdFactory buildOperationIdFactory) {
+        return new DefaultProgressLoggerFactory(new ProgressLoggingBridge(outputEventListener), clock, buildOperationIdFactory);
+    }
+
+    Clock createClock() {
+        return Time.clock();
+    }
+
+    CrossBuildInMemoryCacheFactory createCrossBuildInMemoryCacheFactory(ListenerManager listenerManager) {
+        return new DefaultCrossBuildInMemoryCacheFactory(listenerManager);
+    }
+}

--- a/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
+++ b/subprojects/language-groovy/src/main/java/org/gradle/api/internal/tasks/compile/daemon/DaemonGroovyCompiler.java
@@ -109,6 +109,13 @@ public class DaemonGroovyCompiler extends AbstractDaemonCompiler<GroovyJavaJoint
         gradleFilterSpec.allowPackage("org.gradle.internal.nativeintegration");
         gradleFilterSpec.allowPackage("org.gradle.internal.nativeplatform");
         gradleFilterSpec.allowPackage("net.rubygrapefruit.platform");
+        // Service Registry
+        gradleFilterSpec.allowPackage("org.gradle.internal.service");
+        // Instantiation
+        gradleFilterSpec.allowPackage("org.gradle.internal.instantiation");
+        gradleFilterSpec.allowPackage("org.gradle.internal.reflect");
+        // Inject
+        gradleFilterSpec.allowPackage("javax.inject");
 
         return gradleFilterSpec;
     }

--- a/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
+++ b/subprojects/language-scala/src/main/java/org/gradle/api/internal/tasks/scala/ZincScalaCompilerFactory.java
@@ -30,10 +30,8 @@ import org.gradle.cache.internal.CacheRepositoryServices;
 import org.gradle.internal.Factory;
 import org.gradle.internal.SystemProperties;
 import org.gradle.internal.jvm.Jvm;
-import org.gradle.internal.logging.services.LoggingServiceRegistry;
-import org.gradle.internal.nativeintegration.services.NativeServices;
 import org.gradle.internal.service.DefaultServiceRegistry;
-import org.gradle.internal.service.scopes.GlobalScopeServices;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.time.Time;
 import org.gradle.internal.time.Timer;
 import org.gradle.util.GFileUtils;
@@ -49,9 +47,9 @@ import static org.gradle.cache.internal.filelock.LockOptionsBuilder.mode;
 public class ZincScalaCompilerFactory {
     private static final Logger LOGGER = Logging.getLogger(ZincScalaCompilerFactory.class);
 
-    static Compiler createParallelSafeCompiler(final Iterable<File> scalaClasspath, final Iterable<File> zincClasspath, final xsbti.Logger logger, File gradleUserHome) {
+    static Compiler createParallelSafeCompiler(ServiceRegistry serviceRegistry, final Iterable<File> scalaClasspath, final Iterable<File> zincClasspath, final xsbti.Logger logger, File gradleUserHome) {
         File zincCacheHomeDir = new File(System.getProperty(ZincScalaCompilerUtil.ZINC_CACHE_HOME_DIR_SYSTEM_PROPERTY, gradleUserHome.getAbsolutePath()));
-        CacheRepository cacheRepository = ZincCompilerServices.getInstance(zincCacheHomeDir).get(CacheRepository.class);
+        CacheRepository cacheRepository = ZincCompilerServices.getInstance(serviceRegistry, zincCacheHomeDir).get(CacheRepository.class);
 
         String zincVersion = Setup.zincVersion().published();
         String zincCacheKey = String.format("zinc-%s", zincVersion);
@@ -166,18 +164,14 @@ public class ZincScalaCompilerFactory {
     private static class ZincCompilerServices extends DefaultServiceRegistry {
         private static ZincCompilerServices instance;
 
-        private ZincCompilerServices(File gradleUserHome) {
-            super(NativeServices.getInstance());
-
-            addProvider(LoggingServiceRegistry.NO_OP);
-            addProvider(new GlobalScopeServices(true));
+        private ZincCompilerServices(ServiceRegistry parent, File gradleUserHome) {
+            super(parent);
             addProvider(new CacheRepositoryServices(gradleUserHome, null));
         }
 
-        public static ZincCompilerServices getInstance(File gradleUserHome) {
+        public static ZincCompilerServices getInstance(ServiceRegistry parent, File gradleUserHome) {
             if (instance == null) {
-                NativeServices.initialize(gradleUserHome);
-                instance = new ZincCompilerServices(gradleUserHome);
+                instance = new ZincCompilerServices(parent, gradleUserHome);
             }
             return instance;
         }

--- a/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/compile/RequiresServices.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/language/base/internal/compile/RequiresServices.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.language.base.internal.compile;
+
+import org.gradle.internal.service.ServiceRegistry;
+
+public interface RequiresServices {
+    void setServiceRegistry(ServiceRegistry serviceRegistry);
+}

--- a/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
+++ b/subprojects/workers/src/integTest/groovy/org/gradle/workers/internal/WorkerExecutorInjectionIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.workers.internal
 
 import org.gradle.api.Project
-import org.gradle.api.internal.file.FileResolver
 import org.gradle.integtests.fixtures.timeout.IntegrationTestTimeout
 import spock.lang.Unroll
 
@@ -39,7 +38,7 @@ class WorkerExecutorInjectionIntegrationTest extends AbstractWorkerExecutorInteg
         failure.assertHasCause("Unable to determine constructor argument #1: missing parameter of $forbiddenType, or no service of type $forbiddenType")
 
         where:
-        forbiddenType << [Project, FileResolver]
+        forbiddenType << [Project]
     }
 
     String getRunnableInjecting(String isolationMode, String injectedClass) {

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/DefaultWorkerServer.java
@@ -17,7 +17,9 @@
 package org.gradle.workers.internal;
 
 import org.gradle.api.tasks.WorkResult;
+import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.ServiceRegistry;
 
 import javax.inject.Inject;
 import java.util.concurrent.Callable;
@@ -26,8 +28,8 @@ public class DefaultWorkerServer implements WorkerProtocol {
     private final Instantiator instantiator;
 
     @Inject
-    public DefaultWorkerServer(Instantiator instantiator) {
-        this.instantiator = instantiator;
+    public DefaultWorkerServer(ServiceRegistry serviceRegistry) {
+        this.instantiator = serviceRegistry.get(InstantiatorFactory.class).inject(serviceRegistry);
     }
 
     @Override

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -18,7 +18,6 @@ package org.gradle.workers.internal;
 
 import org.gradle.api.internal.classloading.GroovySystemLoader;
 import org.gradle.api.internal.classloading.GroovySystemLoaderFactory;
-import org.gradle.cache.internal.DefaultCrossBuildInMemoryCacheFactory;
 import org.gradle.initialization.GradleApiUtil;
 import org.gradle.internal.UncheckedException;
 import org.gradle.internal.classloader.ClassLoaderSpec;
@@ -26,15 +25,14 @@ import org.gradle.internal.classloader.FilteringClassLoader;
 import org.gradle.internal.classloader.VisitableURLClassLoader;
 import org.gradle.internal.classpath.DefaultClassPath;
 import org.gradle.internal.concurrent.CompositeStoppable;
-import org.gradle.internal.event.DefaultListenerManager;
-import org.gradle.internal.instantiation.DefaultInstantiatorFactory;
-import org.gradle.internal.instantiation.InjectAnnotationHandler;
 import org.gradle.internal.io.ClassLoaderObjectInputStream;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.operations.BuildOperationRef;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.internal.serialize.ExceptionReplacingObjectInputStream;
 import org.gradle.internal.serialize.ExceptionReplacingObjectOutputStream;
+import org.gradle.internal.service.DefaultServiceRegistry;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.util.GUtil;
 import org.gradle.workers.IsolationMode;
 
@@ -45,15 +43,17 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
-import java.util.Collections;
+import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 
 public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
     private final BuildOperationExecutor buildOperationExecutor;
     private final GroovySystemLoaderFactory groovySystemLoaderFactory = new GroovySystemLoaderFactory();
+    private final ServiceRegistry serviceRegistry;
 
-    public IsolatedClassloaderWorkerFactory(BuildOperationExecutor buildOperationExecutor) {
+    public IsolatedClassloaderWorkerFactory(BuildOperationExecutor buildOperationExecutor, ServiceRegistry parent) {
         this.buildOperationExecutor = buildOperationExecutor;
+        this.serviceRegistry = new IsolatedClassloaderServices(parent);
     }
 
     @Override
@@ -96,6 +96,7 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
         try {
             Thread.currentThread().setContextClassLoader(workerClassLoader);
             Callable<?> worker = transferWorkerIntoWorkerClassloader(spec, workerClassLoader);
+            injectServiceRegistry(worker);
             Object result = worker.call();
             return transferResultFromWorkerClassLoader(result);
         } catch (Exception e) {
@@ -104,6 +105,15 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
             workerClasspathGroovy.shutdown();
             CompositeStoppable.stoppable(workerClassLoader).stop();
             Thread.currentThread().setContextClassLoader(previousContextLoader);
+        }
+    }
+
+    private void injectServiceRegistry(Object worker) {
+        try {
+            Method setServicesMethod = worker.getClass().getDeclaredMethod("setServiceRegistry", ServiceRegistry.class);
+            setServicesMethod.invoke(worker, serviceRegistry);
+        } catch (Exception e) {
+            throw UncheckedException.throwAsUncheckedException(e);
         }
     }
 
@@ -161,6 +171,7 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
      */
     private static class WorkerCallable implements Callable<Object>, Serializable {
         private final ActionExecutionSpec spec;
+        private ServiceRegistry serviceRegistry;
 
         private WorkerCallable(ActionExecutionSpec spec) {
             this.spec = spec;
@@ -168,10 +179,22 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
 
         @Override
         public Object call() throws Exception {
-            // TODO - reuse these services, either by making the global instances visible or by reusing the worker ClassLoaders and retaining a reference to them
-            DefaultInstantiatorFactory instantiatorFactory = new DefaultInstantiatorFactory(new DefaultCrossBuildInMemoryCacheFactory(new DefaultListenerManager()), Collections.<InjectAnnotationHandler>emptyList());
-            WorkerProtocol worker = new DefaultWorkerServer(instantiatorFactory.inject());
+            WorkerProtocol worker = new DefaultWorkerServer(serviceRegistry);
             return worker.execute(spec);
+        }
+
+        public void setServiceRegistry(ServiceRegistry serviceRegistry) {
+            this.serviceRegistry = serviceRegistry;
+        }
+    }
+
+    private static class IsolatedClassloaderServices extends DefaultServiceRegistry {
+        public IsolatedClassloaderServices(ServiceRegistry... parents) {
+            super("IsolatedClassloaderServices", parents);
+        }
+
+        IsolatedClassloaderServices createIsolatedWorkerServices() {
+            return this;
         }
     }
 }

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/IsolatedClassloaderWorkerFactory.java
@@ -169,7 +169,7 @@ public class IsolatedClassloaderWorkerFactory implements WorkerFactory {
     /**
      * This is serialized across into the worker ClassLoader and then executed.
      */
-    private static class WorkerCallable implements Callable<Object>, Serializable {
+    public static class WorkerCallable implements Callable<Object>, Serializable {
         private final ActionExecutionSpec spec;
         private ServiceRegistry serviceRegistry;
 

--- a/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
+++ b/subprojects/workers/src/main/java/org/gradle/workers/internal/WorkersServices.java
@@ -25,6 +25,7 @@ import org.gradle.internal.logging.LoggingManagerInternal;
 import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.resources.ResourceLockCoordinationService;
 import org.gradle.internal.service.ServiceRegistration;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.AbstractPluginServiceRegistry;
 import org.gradle.internal.work.AsyncWorkTracker;
 import org.gradle.internal.work.ConditionalExecutionQueueFactory;
@@ -60,8 +61,8 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
             return new WorkerDaemonFactory(workerDaemonClientsManager, buildOperationExecutor);
         }
 
-        IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(BuildOperationExecutor buildOperationExecutor) {
-            return new IsolatedClassloaderWorkerFactory(buildOperationExecutor);
+        IsolatedClassloaderWorkerFactory createIsolatedClassloaderWorkerFactory(BuildOperationExecutor buildOperationExecutor, ServiceRegistry serviceRegistry) {
+            return new IsolatedClassloaderWorkerFactory(buildOperationExecutor, serviceRegistry);
         }
 
         WorkerDirectoryProvider createWorkerDirectoryProvider(GradleUserHomeDirProvider gradleUserHomeDirProvider) {
@@ -88,8 +89,8 @@ public class WorkersServices extends AbstractPluginServiceRegistry {
     }
 
     private static class ProjectScopeServices {
-        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory workerExecutionQueueFactory) {
-            NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, asyncWorkTracker, instantiatorFactory);
+        WorkerExecutor createWorkerExecutor(InstantiatorFactory instantiatorFactory, WorkerDaemonFactory daemonWorkerFactory, IsolatedClassloaderWorkerFactory isolatedClassloaderWorkerFactory, JavaForkOptionsFactory forkOptionsFactory, WorkerLeaseRegistry workerLeaseRegistry, BuildOperationExecutor buildOperationExecutor, AsyncWorkTracker asyncWorkTracker, WorkerDirectoryProvider workerDirectoryProvider, WorkerExecutionQueueFactory workerExecutionQueueFactory, ServiceRegistry serviceRegistry) {
+            NoIsolationWorkerFactory noIsolationWorkerFactory = new NoIsolationWorkerFactory(buildOperationExecutor, asyncWorkTracker, serviceRegistry);
             DefaultWorkerExecutor workerExecutor = instantiatorFactory.decorateLenient().newInstance(DefaultWorkerExecutor.class, daemonWorkerFactory, isolatedClassloaderWorkerFactory, noIsolationWorkerFactory, forkOptionsFactory, workerLeaseRegistry, buildOperationExecutor, asyncWorkTracker, workerDirectoryProvider, workerExecutionQueueFactory);
             noIsolationWorkerFactory.setWorkerExecutor(workerExecutor);
             return workerExecutor;


### PR DESCRIPTION
This is prep for changing the classloader hierarchy in worker daemons to match the hierarchy for in-process isolated classloader workers.  This does a couple of things:

- Refactors `GlobalScopeServices` into a set of services available only in build processes and a shared set of services that are available in worker processes.
- Refactors `ZincScalaCompilerFactory` so that it uses the shared worker services instead of creating its own stack of services.
- Sets up all worker types to have a service-injection enabled instantiator.  This sets us up for providing user-visible services to work implementations in a follow-up story.