### PR TITLE
Partial ordering of module selectors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -65,9 +65,7 @@ dependencies {
         resolve.expectDefaultConfiguration('runtime')
         resolve.expectGraph {
             root(":", ":depLock:") {
-                edge("org:foo:1.+", "org:foo:1.0") {
-                    byReason("rejected version 1.1")
-                }
+                edge("org:foo:1.+", "org:foo:1.0")
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0") {
                     byConstraint("dependency was locked to version '1.0'")
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/maven/MavenDynamicResolveIntegrationTest.groovy
@@ -434,21 +434,4 @@ Searched in the following locations:
         then:
         file('libs').assertHasDescendants('projectA-1.5.jar')
     }
-
-    static String createBuildFile(URI... repoUris) {
-        """
-         repositories {
-             ${repoUris.collect { "maven { url '${it.toString()}' }" }.join("\n")}
-         }
-         configurations { compile }
-         dependencies {
-             compile 'group:projectA:1.+'
-         }
- 
-        task retrieve(type: Sync) {
-            into 'libs'
-             from configurations.compile
-         }
-         """
-    }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
@@ -22,4 +22,5 @@ public interface ResolvedVersionConstraint {
     VersionSelector getRequiredSelector();
     VersionSelector getRejectedSelector();
     boolean isRejectAll();
+    boolean isDynamic();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
@@ -87,6 +87,17 @@ public class DefaultResolvedVersionConstraint implements ResolvedVersionConstrai
         return rejectAll;
     }
 
+    @Override
+    public boolean isDynamic() {
+        if (requiredVersionSelector != null) {
+            return requiredVersionSelector.isDynamic();
+        }
+        if (preferredVersionSelector != null) {
+            return preferredVersionSelector.isDynamic();
+        }
+        return false;
+    }
+
     private static boolean isRejectAll(String preferredVersion, List<String> rejectedVersions) {
         return "".equals(preferredVersion)
             && hasMatchAllSelector(rejectedVersions);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -267,7 +267,6 @@ class ModuleResolveState implements CandidateModule {
     }
 
     void addSelector(SelectorState selector) {
-        assert !selectors.contains(selector) : "Inconsistent call to addSelector: should only be done if the selector isn't in use";
         selectors.add(selector);
         mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
         if (overriddenSelection) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -56,7 +56,7 @@ class ModuleResolveState implements CandidateModule {
     private final ModuleIdentifier id;
     private final List<EdgeState> unattachedDependencies = new LinkedList<EdgeState>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<ModuleVersionIdentifier, ComponentState>();
-    private final List<SelectorState> selectors = Lists.newArrayListWithExpectedSize(4);
+    private final ModuleSelectors<SelectorState> selectors = new ModuleSelectors<>();
     private final ImmutableAttributesFactory attributesFactory;
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
@@ -284,7 +284,7 @@ class ModuleResolveState implements CandidateModule {
         }
     }
 
-    public List<SelectorState> getSelectors() {
+    public Iterable<SelectorState> getSelectors() {
         return selectors;
     }
 
@@ -366,7 +366,7 @@ class ModuleResolveState implements CandidateModule {
 
 
     public boolean maybeUpdateSelection() {
-        ComponentState newSelected = selectorStateResolver.selectBest(getId(), getSelectors());
+        ComponentState newSelected = selectorStateResolver.selectBest(getId(), selectors);
         if (selected == null) {
             select(newSelected);
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class ModuleSelectors<T extends ResolvableSelectorState> implements Iterable<T> {
+
+    List<T> selectors = Lists.newArrayListWithExpectedSize(4);
+
+    @Override
+    public Iterator<T> iterator() {
+        return selectors.iterator();
+    }
+
+    public boolean contains(T selector) {
+        return selectors.contains(selector);
+    }
+
+    public void add(T selector) {
+        selectors.add(selector);
+    }
+
+    public boolean remove(T selector) {
+        return selectors.remove(selector);
+    }
+
+    public int size() {
+        return selectors.size();
+    }
+
+    public T first() {
+        return selectors.get(0);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -16,38 +16,164 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class ModuleSelectors<T extends ResolvableSelectorState> implements Iterable<T> {
 
-    List<T> selectors = Lists.newArrayListWithExpectedSize(4);
+    private final Iterator<T> emptyIterator = new EmptyIterator<>();
+
+    private int selectorsCount = 0;
+    private T singleSelector;
+    private List<T> selectors;
+    private List<T> dynamicSelectors;
 
     @Override
     public Iterator<T> iterator() {
-        return selectors.iterator();
-    }
-
-    public boolean contains(T selector) {
-        return selectors.contains(selector);
+        if (selectorsCount == 0) {
+            return emptyIterator;
+        } else if (selectorsCount == 1) {
+            return Iterators.singletonIterator(singleSelector);
+        } else {
+            if (selectors != null && dynamicSelectors != null) {
+                return Iterators.concat(selectors.iterator(), dynamicSelectors.iterator());
+            } else if (selectors != null) {
+                return selectors.iterator();
+            } else {
+                return dynamicSelectors.iterator();
+            }
+        }
     }
 
     public void add(T selector) {
+        assert !contains(selector) : "Inconsistent call to add: should only be done if the selector isn't in use";
+        if (selectorsCount == 0) {
+            singleSelector = selector;
+        } else if (selectorsCount == 1) {
+            addSelector(singleSelector);
+            addSelector(selector);
+        } else {
+            addSelector(selector);
+        }
+        selectorsCount++;
+    }
+
+    private void addSelector(T selector) {
+        if (isDynamicSelector(selector)) {
+            addDynamicSelector(selector);
+        } else {
+            addSimpleSelector(selector);
+        }
+    }
+
+    private boolean isDynamicSelector(T selector) {
+        return selector.getVersionConstraint() != null && selector.getVersionConstraint().isDynamic();
+    }
+
+    private void addSimpleSelector(T selector) {
+        if (selectors == null) {
+            selectors = Lists.newArrayListWithExpectedSize(3);
+        }
         selectors.add(selector);
     }
 
+    private void addDynamicSelector(T selector) {
+        if (dynamicSelectors == null) {
+            dynamicSelectors = Lists.newArrayListWithExpectedSize(3);
+        }
+        dynamicSelectors.add(selector);
+    }
+
     public boolean remove(T selector) {
-        return selectors.remove(selector);
+        assert contains(selector) : "Inconsistent call to remove: should only be done if the selector is in use";
+        boolean removed = false;
+        if (selectorsCount == 0) {
+            return false;
+        } else if (selectorsCount == 1) {
+            removed = singleSelector.equals(selector);
+            if (removed) {
+                singleSelector = null;
+            }
+        } else {
+            if (isDynamicSelector(selector)) {
+                if (dynamicSelectors != null) {
+                    removed = dynamicSelectors.remove(selector);
+                    if (dynamicSelectors.isEmpty()) {
+                        dynamicSelectors = null;
+                    }
+                }
+            } else {
+                if (selectors != null) {
+                    removed = selectors.remove(selector);
+                    if (selectors.isEmpty()) {
+                        selectors = null;
+                    }
+                }
+            }
+        }
+        if (removed) {
+            selectorsCount--;
+            if (selectorsCount == 1) {
+                if (selectors != null) {
+                    singleSelector = selectors.get(0);
+                    selectors = null;
+                } else {
+                    singleSelector = dynamicSelectors.get(0);
+                    dynamicSelectors = null;
+                }
+            }
+        }
+        return removed;
     }
 
     public int size() {
-        return selectors.size();
+        return selectorsCount;
     }
 
     public T first() {
-        return selectors.get(0);
+        if (selectorsCount == 0) {
+            return null;
+        } else if (selectorsCount == 1) {
+            return singleSelector;
+        } else {
+            if (selectors != null) {
+                return selectors.get(0);
+            } else {
+                return dynamicSelectors.get(0);
+            }
+        }
+    }
+
+    // Only used for assertions
+    private boolean contains(T selector) {
+        if (selectorsCount == 0) {
+            return false;
+        } else if (selectorsCount == 1) {
+            return singleSelector.equals(selector);
+        } else {
+            if (isDynamicSelector(selector)) {
+                return dynamicSelectors != null && dynamicSelectors.contains(selector);
+            } else {
+                return selectors != null && selectors.contains(selector);
+            }
+        }
+    }
+
+    private static class EmptyIterator<U> implements Iterator<U> {
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public U next() {
+            throw new NoSuchElementException("Empty iterator has no elements");
+        }
     }
 }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -246,7 +246,7 @@ class SelectorStateResolverTest extends Specification {
 
     ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
         def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>()
-        selectors.forEach {moduleSelectors.add(it) }
+        selectors.forEach { moduleSelectors.add(it) }
         return moduleSelectors
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResol
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverFactory
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ModuleSelectors
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ResolveOptimizations
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -187,7 +188,7 @@ class SelectorStateResolverTest extends Specification {
         SelectorStateResolver resolverWithMock = new SelectorStateResolver(mockResolver, componentFactory, root, resolveOptimizations)
 
         when:
-        def selected = resolverWithMock.selectBest(moduleId, [nine, otherNine])
+        def selected = resolverWithMock.selectBest(moduleId, moduleSelectors([nine, otherNine]))
 
         then:
         selected.componentId == projectId
@@ -203,7 +204,7 @@ class SelectorStateResolverTest extends Specification {
         def missingHigh = new TestModuleSelectorState(componentIdResolver, RANGE_14_16.versionConstraint)
 
         when:
-        def selected = conflictHandlingResolver.selectBest(moduleId, [missingLow, nine, ten, range, missingHigh])
+        def selected = conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow, nine, ten, range, missingHigh]))
 
         then:
         selected.version == "10"
@@ -217,19 +218,19 @@ class SelectorStateResolverTest extends Specification {
         def valid = new TestModuleSelectorState(componentIdResolver, FIXED_10.versionConstraint)
 
         when:
-        conflictHandlingResolver.selectBest(moduleId, [missingLow])
+        conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow]))
 
         then:
         thrown(ModuleVersionResolveException)
 
         when:
-        conflictHandlingResolver.selectBest(moduleId, [missingLow, missingHigh])
+        conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow, missingHigh]))
 
         then:
         thrown(ModuleVersionResolveException)
 
         when:
-        conflictHandlingResolver.selectBest(moduleId, [missingLow, missingHigh, valid])
+        conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow, missingHigh, valid]))
 
         then:
         noExceptionThrown()
@@ -243,6 +244,12 @@ class SelectorStateResolverTest extends Specification {
         return new TestResolver(failingResolver)
     }
 
+    ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
+        def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>()
+        selectors.forEach {moduleSelectors.add(it) }
+        return moduleSelectors
+    }
+
     class TestResolver {
         final SelectorStateResolver ssr
 
@@ -254,7 +261,7 @@ class SelectorStateResolverTest extends Specification {
             List<TestModuleSelectorState> selectors = versions.collect { version ->
                 new TestModuleSelectorState(componentIdResolver, version.versionConstraint)
             }
-            def currentSelection = ssr.selectBest(moduleId, selectors)
+            def currentSelection = ssr.selectBest(moduleId, moduleSelectors(selectors))
             if (selectors.any { it.requireResult?.failure != null || it.preferResult?.failure != null }) {
                 return VersionRangeResolveTestScenarios.FAILED
             }


### PR DESCRIPTION
we do a partial sort on the selectors, where we place
the dynamic selectors at the end compared to the other ones.
This allows a more efficient resolution in some corner cases but is
mostly preparation work for follow up changes.

This is WIP.