### PR TITLE
Partial ordering of module selectors

### DIFF
--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -185,8 +185,8 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
 
         repositoryInteractions {
             'org:foo:1.0' {
-                expectGetMetadata()
                 if (!available) {
+                    expectGetMetadata()
                     expectGetArtifact()
                 }
             }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/PublishedDependencyConstraintsIntegrationTest.groovy
@@ -16,6 +16,8 @@
 package org.gradle.integtests.resolve
 
 import org.gradle.integtests.fixtures.GradleMetadataResolveRunner
+import org.gradle.integtests.fixtures.RequiredFeature
+import org.gradle.integtests.fixtures.RequiredFeatures
 
 class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDependencyResolveTest {
 
@@ -397,6 +399,66 @@ class PublishedDependencyConstraintsIntegrationTest extends AbstractModuleDepend
                     } else {
                         module("org:foo:1.0")
                     }
+                }
+            }
+        }
+    }
+
+    @RequiredFeatures(
+        [@RequiredFeature(feature = GradleMetadataResolveRunner.GRADLE_METADATA, value="true")]
+    )
+    void "deferred selector still resolved when constraint disappears"() {
+        repository {
+            'org:bar:1.0'()
+            'org:bar:1.1'()
+
+            'org:other:1.0' {
+                dependsOn 'org:bar:1.0'
+                dependsOn 'org:weird:1.1'
+            }
+
+            // Version 1.0 has a constraint, 1.1 does not
+            'org:weird:1.0' {
+                constraint 'org:bar:1.1'
+            }
+            'org:weird:1.1'()
+        }
+
+        buildFile << """
+dependencies {
+    conf 'org:weird:1.0'
+    conf 'org:other:1.0'
+}
+"""
+
+        repositoryInteractions {
+            'org:weird:1.0' {
+                expectGetMetadata()
+            }
+            'org:weird:1.1' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:other:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+            'org:bar:1.0' {
+                expectGetMetadata()
+                expectGetArtifact()
+            }
+        }
+
+        when:
+        run 'checkDeps'
+
+        then:
+        resolve.expectGraph {
+            root(':', ':test:') {
+                edge('org:weird:1.0', 'org:weird:1.1')
+                module('org:other:1.0') {
+                    module('org:bar:1.0')
+                    module('org:weird:1.1')
                 }
             }
         }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/DependencyLockingIntegrationTest.groovy
@@ -65,9 +65,7 @@ dependencies {
         resolve.expectDefaultConfiguration('runtime')
         resolve.expectGraph {
             root(":", ":depLock:") {
-                edge("org:foo:1.+", "org:foo:1.0") {
-                    byReason("rejected version 1.1")
-                }
+                edge("org:foo:1.+", "org:foo:1.0")
                 constraint("org:foo:{strictly 1.0}", "org:foo:1.0") {
                     byConstraint("dependency was locked to version '1.0'")
                 }

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/locking/LockingInteractionsIntegrationTest.groovy
@@ -17,7 +17,6 @@
 package org.gradle.integtests.resolve.locking
 
 import org.gradle.integtests.fixtures.AbstractHttpDependencyResolutionTest
-import org.gradle.util.ToBeImplemented
 import spock.lang.Unroll
 
 class LockingInteractionsIntegrationTest extends AbstractHttpDependencyResolutionTest {
@@ -491,10 +490,9 @@ task resolve {
         succeeds 'resolve', '--include-build', 'composite'
     }
 
-    @ToBeImplemented
     def "avoids HTTP requests for dynamic version when lock exists"() {
         def foo10 = mavenHttpRepo.module('org', 'foo', '1.0').publish()
-        def foo11 = mavenHttpRepo.module('org', 'foo', '1.1').publish()
+        mavenHttpRepo.module('org', 'foo', '1.1').publish()
         mavenHttpRepo.module('org', 'foo', '2.0').publish()
         def bar10 = mavenHttpRepo.module('org', 'bar', '1.0').dependsOn('org', 'foo', '[1.0,2.0)').publish()
 
@@ -520,9 +518,6 @@ dependencies {
 }
 """
         when:
-        // TODO Should not need to load the maven-metadata to get the version list
-        foo10.rootMetaData.expectGet()
-        foo11.pom.expectGet()
         foo10.pom.expectGet()
         bar10.pom.expectGet()
 

--- a/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
+++ b/subprojects/dependency-management/src/integTest/groovy/org/gradle/integtests/resolve/rules/DependencyMetadataRulesIntegrationTest.groovy
@@ -982,8 +982,8 @@ class DependencyMetadataRulesIntegrationTest extends AbstractModuleDependencyRes
             }
             'org.test:moduleC'() {
                 '1.0' {
-                    expectGetMetadata()
                     if (constraintsUnsupported) {
+                        expectGetMetadata()
                         expectGetArtifact()
                     }
                 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ResolvedVersionConstraint.java
@@ -22,4 +22,5 @@ public interface ResolvedVersionConstraint {
     VersionSelector getRequiredSelector();
     VersionSelector getRejectedSelector();
     boolean isRejectAll();
+    boolean isDynamic();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/dependencies/DefaultResolvedVersionConstraint.java
@@ -87,6 +87,17 @@ public class DefaultResolvedVersionConstraint implements ResolvedVersionConstrai
         return rejectAll;
     }
 
+    @Override
+    public boolean isDynamic() {
+        if (requiredVersionSelector != null) {
+            return requiredVersionSelector.isDynamic();
+        }
+        if (preferredVersionSelector != null) {
+            return preferredVersionSelector.isDynamic();
+        }
+        return false;
+    }
+
     private static boolean isRejectAll(String preferredVersion, List<String> rejectedVersions) {
         return "".equals(preferredVersion)
             && hasMatchAllSelector(rejectedVersions);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/EdgeState.java
@@ -194,6 +194,23 @@ class EdgeState implements DependencyGraphEdge {
                     targetNodes.add(node);
                 }
             }
+            if (targetNodes.isEmpty()) {
+                // There is a chance we could not attach target configurations previously
+                List<EdgeState> unattachedDependencies = targetComponent.getModule().getUnattachedDependencies();
+                if (!unattachedDependencies.isEmpty()) {
+                    for (EdgeState otherEdge : unattachedDependencies) {
+                        if (otherEdge != this && !otherEdge.isConstraint()) {
+                            otherEdge.attachToTargetConfigurations();
+                            break;
+                        }
+                    }
+                }
+                for (NodeState node : nodes) {
+                    if (node.isSelected()) {
+                        targetNodes.add(node);
+                    }
+                }
+            }
             return;
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -266,8 +266,8 @@ class ModuleResolveState implements CandidateModule {
         return moduleRevision;
     }
 
-    void addSelector(SelectorState selector) {
-        selectors.add(selector);
+    void addSelector(SelectorState selector, boolean deferSelection) {
+        selectors.add(selector, deferSelection);
         mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
         if (overriddenSelection) {
             assert selected != null : "An overridden module cannot have selected == null";
@@ -365,6 +365,10 @@ class ModuleResolveState implements CandidateModule {
 
 
     public boolean maybeUpdateSelection() {
+        if (selectors.checkDeferSelection()) {
+            // Selection deferred as we know another selector will be added soon
+            return false;
+        }
         ComponentState newSelected = selectorStateResolver.selectBest(getId(), selectors);
         if (selected == null) {
             select(newSelected);

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -267,7 +267,6 @@ class ModuleResolveState implements CandidateModule {
     }
 
     void addSelector(SelectorState selector) {
-        assert !selectors.contains(selector) : "Inconsistent call to addSelector: should only be done if the selector isn't in use";
         selectors.add(selector);
         mergedConstraintAttributes = appendAttributes(mergedConstraintAttributes, selector);
         if (overriddenSelection) {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleResolveState.java
@@ -56,7 +56,7 @@ class ModuleResolveState implements CandidateModule {
     private final ModuleIdentifier id;
     private final List<EdgeState> unattachedDependencies = new LinkedList<EdgeState>();
     private final Map<ModuleVersionIdentifier, ComponentState> versions = new LinkedHashMap<ModuleVersionIdentifier, ComponentState>();
-    private final List<SelectorState> selectors = Lists.newArrayListWithExpectedSize(4);
+    private final ModuleSelectors<SelectorState> selectors = new ModuleSelectors<>();
     private final ImmutableAttributesFactory attributesFactory;
     private final Comparator<Version> versionComparator;
     private final VersionParser versionParser;
@@ -284,7 +284,7 @@ class ModuleResolveState implements CandidateModule {
         }
     }
 
-    public List<SelectorState> getSelectors() {
+    public Iterable<SelectorState> getSelectors() {
         return selectors;
     }
 
@@ -366,7 +366,7 @@ class ModuleResolveState implements CandidateModule {
 
 
     public boolean maybeUpdateSelection() {
-        ComponentState newSelected = selectorStateResolver.selectBest(getId(), getSelectors());
+        ComponentState newSelected = selectorStateResolver.selectBest(getId(), selectors);
         if (selected == null) {
             select(newSelected);
             return true;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
+
+import com.google.common.collect.Lists;
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
+
+import java.util.Iterator;
+import java.util.List;
+
+public class ModuleSelectors<T extends ResolvableSelectorState> implements Iterable<T> {
+
+    List<T> selectors = Lists.newArrayListWithExpectedSize(4);
+
+    @Override
+    public Iterator<T> iterator() {
+        return selectors.iterator();
+    }
+
+    public boolean contains(T selector) {
+        return selectors.contains(selector);
+    }
+
+    public void add(T selector) {
+        selectors.add(selector);
+    }
+
+    public boolean remove(T selector) {
+        return selectors.remove(selector);
+    }
+
+    public int size() {
+        return selectors.size();
+    }
+
+    public T first() {
+        return selectors.get(0);
+    }
+}

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectors.java
@@ -16,38 +16,164 @@
 
 package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder;
 
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 public class ModuleSelectors<T extends ResolvableSelectorState> implements Iterable<T> {
 
-    List<T> selectors = Lists.newArrayListWithExpectedSize(4);
+    private final Iterator<T> emptyIterator = new EmptyIterator<>();
+
+    private int selectorsCount = 0;
+    private T singleSelector;
+    private List<T> selectors;
+    private List<T> dynamicSelectors;
 
     @Override
     public Iterator<T> iterator() {
-        return selectors.iterator();
-    }
-
-    public boolean contains(T selector) {
-        return selectors.contains(selector);
+        if (selectorsCount == 0) {
+            return emptyIterator;
+        } else if (selectorsCount == 1) {
+            return Iterators.singletonIterator(singleSelector);
+        } else {
+            if (selectors != null && dynamicSelectors != null) {
+                return Iterators.concat(selectors.iterator(), dynamicSelectors.iterator());
+            } else if (selectors != null) {
+                return selectors.iterator();
+            } else {
+                return dynamicSelectors.iterator();
+            }
+        }
     }
 
     public void add(T selector) {
+        assert !contains(selector) : "Inconsistent call to add: should only be done if the selector isn't in use";
+        if (selectorsCount == 0) {
+            singleSelector = selector;
+        } else if (selectorsCount == 1) {
+            addSelector(singleSelector);
+            addSelector(selector);
+        } else {
+            addSelector(selector);
+        }
+        selectorsCount++;
+    }
+
+    private void addSelector(T selector) {
+        if (isDynamicSelector(selector)) {
+            addDynamicSelector(selector);
+        } else {
+            addSimpleSelector(selector);
+        }
+    }
+
+    private boolean isDynamicSelector(T selector) {
+        return selector.getVersionConstraint() != null && selector.getVersionConstraint().isDynamic();
+    }
+
+    private void addSimpleSelector(T selector) {
+        if (selectors == null) {
+            selectors = Lists.newArrayListWithExpectedSize(3);
+        }
         selectors.add(selector);
     }
 
+    private void addDynamicSelector(T selector) {
+        if (dynamicSelectors == null) {
+            dynamicSelectors = Lists.newArrayListWithExpectedSize(3);
+        }
+        dynamicSelectors.add(selector);
+    }
+
     public boolean remove(T selector) {
-        return selectors.remove(selector);
+        assert contains(selector) : "Inconsistent call to remove: should only be done if the selector is in use";
+        boolean removed = false;
+        if (selectorsCount == 0) {
+            return false;
+        } else if (selectorsCount == 1) {
+            removed = singleSelector.equals(selector);
+            if (removed) {
+                singleSelector = null;
+            }
+        } else {
+            if (isDynamicSelector(selector)) {
+                if (dynamicSelectors != null) {
+                    removed = dynamicSelectors.remove(selector);
+                    if (dynamicSelectors.isEmpty()) {
+                        dynamicSelectors = null;
+                    }
+                }
+            } else {
+                if (selectors != null) {
+                    removed = selectors.remove(selector);
+                    if (selectors.isEmpty()) {
+                        selectors = null;
+                    }
+                }
+            }
+        }
+        if (removed) {
+            selectorsCount--;
+            if (selectorsCount == 1) {
+                if (selectors != null) {
+                    singleSelector = selectors.get(0);
+                    selectors = null;
+                } else {
+                    singleSelector = dynamicSelectors.get(0);
+                    dynamicSelectors = null;
+                }
+            }
+        }
+        return removed;
     }
 
     public int size() {
-        return selectors.size();
+        return selectorsCount;
     }
 
     public T first() {
-        return selectors.get(0);
+        if (selectorsCount == 0) {
+            return null;
+        } else if (selectorsCount == 1) {
+            return singleSelector;
+        } else {
+            if (selectors != null) {
+                return selectors.get(0);
+            } else {
+                return dynamicSelectors.get(0);
+            }
+        }
+    }
+
+    // Only used for assertions
+    private boolean contains(T selector) {
+        if (selectorsCount == 0) {
+            return false;
+        } else if (selectorsCount == 1) {
+            return singleSelector.equals(selector);
+        } else {
+            if (isDynamicSelector(selector)) {
+                return dynamicSelectors != null && dynamicSelectors.contains(selector);
+            } else {
+                return selectors != null && selectors.contains(selector);
+            }
+        }
+    }
+
+    private static class EmptyIterator<U> implements Iterator<U> {
+
+        @Override
+        public boolean hasNext() {
+            return false;
+        }
+
+        @Override
+        public U next() {
+            throw new NoSuchElementException("Empty iterator has no elements");
+        }
     }
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/NodeState.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -82,6 +83,7 @@ public class NodeState implements DependencyGraphNode {
     private boolean evicted;
     private Set<ModuleIdentifier> upcomingNoLongerPendingConstraints;
     private boolean virtualPlatformNeedsRefresh;
+    private HashSet<EdgeState> edgesToRecompute;
 
     public NodeState(Long resultId, ResolvedConfigurationIdentifier id, ComponentState component, ResolveState resolveState, ConfigurationMetadata md) {
         this.resultId = resultId;
@@ -194,6 +196,19 @@ public class NodeState implements DependencyGraphNode {
 
         if (!component.isSelected()) {
             LOGGER.debug("version for {} is not selected. ignoring.", this);
+            if (upcomingNoLongerPendingConstraints != null) {
+                for (ModuleIdentifier identifier : upcomingNoLongerPendingConstraints) {
+                    ModuleResolveState module = resolveState.getModule(identifier);
+                    for (EdgeState unattachedDependency : module.getUnattachedDependencies()) {
+                        if (!unattachedDependency.getSelector().isResolved()) {
+                            // Unresolved - we have a selector that was deferred but the constraint has been removed in between
+                            NodeState from = unattachedDependency.getFrom();
+                            from.prepareToRecomputeEdge(unattachedDependency);
+                        }
+                    }
+                }
+                upcomingNoLongerPendingConstraints = null;
+            }
             return;
         }
 
@@ -213,10 +228,9 @@ public class NodeState implements DependencyGraphNode {
         if (!isVirtualPlatformNeedsRefresh()) {
             // Check if node was previously traversed with the same net exclusion when not a virtual platform
             if (previousTraversalExclusions != null && previousTraversalExclusions.excludesSameModulesAs(resolutionFilter)) {
-                if (hasNewConstraints()) {
-                    // Previously traversed but new constraints no longer pending, so partial traversing
-                    visitAdditionalConstraints(discoveredEdges);
-                } else {
+                boolean newConstraints = handleNewConstraints(discoveredEdges);
+                boolean edgesToRecompute = handleEdgesToRecompute(discoveredEdges);
+                if (!newConstraints && !edgesToRecompute) {
                     // Was previously traversed, and no change to the set of modules that are linked by outgoing edges.
                     // Don't need to traverse again, but hang on to the new filter since it may change the set of excluded artifacts.
                     LOGGER.debug("Changed edges for {} selects same versions as previous traversal. ignoring", this);
@@ -229,14 +243,38 @@ public class NodeState implements DependencyGraphNode {
         // Clear previous traversal state, if any
         if (previousTraversalExclusions != null) {
             removeOutgoingEdges();
+            upcomingNoLongerPendingConstraints = null;
+            edgesToRecompute = null;
         }
 
         visitDependencies(resolutionFilter, discoveredEdges);
         visitOwners(discoveredEdges);
     }
 
-    private boolean hasNewConstraints() {
-        return upcomingNoLongerPendingConstraints != null;
+    private void prepareToRecomputeEdge(EdgeState edgeToRecompute) {
+        if (edgesToRecompute == null) {
+            edgesToRecompute = new HashSet<>();
+        }
+        edgesToRecompute.add(edgeToRecompute);
+        resolveState.onMoreSelected(this);
+    }
+
+    private boolean handleEdgesToRecompute(Collection<EdgeState> discoveredEdges) {
+        if (edgesToRecompute != null) {
+            discoveredEdges.addAll(edgesToRecompute);
+            edgesToRecompute = null;
+            return true;
+        }
+        return false;
+    }
+
+    private boolean handleNewConstraints(Collection<EdgeState> discoveredEdges) {
+        if (upcomingNoLongerPendingConstraints != null) {
+            // Previously traversed but new constraints no longer pending, so partial traversing
+            visitAdditionalConstraints(discoveredEdges);
+            return true;
+        }
+        return false;
     }
 
     private boolean isVirtualPlatformNeedsRefresh() {
@@ -500,7 +538,6 @@ public class NodeState implements DependencyGraphNode {
         }
         virtualEdges = null;
         previousTraversalExclusions = null;
-        upcomingNoLongerPendingConstraints = null;
         virtualPlatformNeedsRefresh = false;
     }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesVisitor.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/PendingDependenciesVisitor.java
@@ -19,9 +19,26 @@ package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
 import org.gradle.api.artifacts.ModuleIdentifier;
 
 public interface PendingDependenciesVisitor {
-    boolean maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState);
 
-    void markNotPending(ModuleIdentifier id);
+    enum PendingState {
+        PENDING(true),
+        NOT_PENDING(false),
+        NOT_PENDING_ACTIVATING(false);
+
+        private boolean pending;
+
+        PendingState(boolean pending) {
+            this.pending = pending;
+        }
+
+        boolean isPending() {
+            return this.pending;
+        }
+    }
+
+    PendingState maybeAddAsPendingDependency(NodeState node, DependencyState dependencyState);
+
+    boolean markNotPending(ModuleIdentifier id);
 
     void complete();
 }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/SelectorState.java
@@ -98,10 +98,10 @@ class SelectorState implements DependencyGraphSelector, ResolvableSelectorState 
         this.versionConstraint = resolveVersionConstraint(firstSeenDependency.getSelector());
     }
 
-    public void use() {
+    public void use(boolean deferSelection) {
         outgoingEdgeCount++;
         if (outgoingEdgeCount == 1) {
-            targetModule.addSelector(this);
+            targetModule.addSelector(this, deferSelection);
         }
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectorsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/builder/ModuleSelectorsTest.groovy
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder
+
+import org.gradle.api.internal.artifacts.ResolvedVersionConstraint
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.selectors.ResolvableSelectorState
+import spock.lang.Specification
+import spock.lang.Unroll
+
+class ModuleSelectorsTest extends Specification {
+
+    def selectors = new ModuleSelectors()
+
+    def 'empty by default'() {
+        expect:
+        verifyEmpty(selectors)
+    }
+
+    def 'can add a selector not marked as deferring'() {
+        given:
+        def selector = Mock(ResolvableSelectorState)
+
+        when:
+        selectors.add(selector, false)
+
+        then:
+        selectors.size() == 1
+        selectors.first() == selector
+        selectors.iterator().next() == selector
+        !selectors.checkDeferSelection()
+    }
+
+    def 'can remove a selector'() {
+        given:
+        def selector = Mock(ResolvableSelectorState)
+        selectors.add(selector, false)
+
+        when:
+        def result = selectors.remove(selector)
+
+        then:
+        result
+        verifyEmpty(selectors)
+    }
+
+    def 'can ad a selector marked as deferring'() {
+        given:
+        def selector = Mock(ResolvableSelectorState)
+
+        when:
+        selectors.add(selector, true)
+
+        then:
+        selectors.checkDeferSelection()
+    }
+
+    def 'clears deferring state on first access'() {
+        given:
+        def selector = Mock(ResolvableSelectorState)
+        selectors.add(selector, true)
+
+        when:
+        selectors.checkDeferSelection()
+
+        then:
+        !selectors.checkDeferSelection()
+    }
+
+    def 'can add 2 selectors'() {
+        given:
+        def selector1 = Mock(ResolvableSelectorState)
+        selectors.add(selector1, false)
+        def selector2 = Mock(ResolvableSelectorState)
+
+        when:
+        selectors.add(selector2, false)
+
+        then:
+        selectors.size() == 2
+        selectors.first() == selector1
+
+        when:
+        def iterator = selectors.iterator()
+
+        then:
+        iterator.next() == selector1
+        iterator.next() == selector2
+        !iterator.hasNext()
+    }
+
+    def 'when adding 2 selectors and one dynamic, non-dynamic is first'() {
+        given:
+        def selector1 = dynamicSelector()
+        def selector2 = Mock(ResolvableSelectorState)
+
+        when:
+        selectors.add(selector1, false)
+        selectors.add(selector2, false)
+
+        then:
+        selectors.size() == 2
+        selectors.first() == selector2
+
+        when:
+        def iterator = selectors.iterator()
+
+        then:
+        iterator.next() == selector2
+        iterator.next() == selector1
+        !iterator.hasNext()
+    }
+
+    @Unroll
+    def 'can add and remove selectors in any order'() {
+        given:
+        def selector1 =dynamicSelector()
+        def selector2 = Mock(ResolvableSelectorState)
+        def selector3 = dynamicSelector()
+        def selector4 = Mock(ResolvableSelectorState)
+
+        def candidateSelectors = [selector1, selector2, selector3, selector4]
+
+        when:
+        indexes.each {
+            selectors.add(candidateSelectors[it], false)
+        }
+        indexes.each {
+            selectors.remove(candidateSelectors[it])
+        }
+
+        then:
+        verifyEmpty(selectors)
+
+        where:
+        indexes << [0, 1, 2, 3].permutations()
+
+    }
+
+    void verifyEmpty(ModuleSelectors<? extends ResolvableSelectorState> selectors) {
+        assert selectors.size() == 0
+        assert selectors.first() == null
+        assert !selectors.iterator().hasNext()
+        assert !selectors.checkDeferSelection()
+    }
+
+    ResolvableSelectorState dynamicSelector() {
+        Mock(ResolvableSelectorState) {
+            getVersionConstraint() >> Mock(ResolvedVersionConstraint) {
+                isDynamic() >> true
+            }
+        }
+    }
+}

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -246,7 +246,7 @@ class SelectorStateResolverTest extends Specification {
 
     ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
         def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>()
-        selectors.forEach {moduleSelectors.add(it) }
+        selectors.forEach { moduleSelectors.add(it) }
         return moduleSelectors
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -246,7 +246,7 @@ class SelectorStateResolverTest extends Specification {
 
     ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
         def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>()
-        selectors.forEach { moduleSelectors.add(it) }
+        selectors.forEach { moduleSelectors.add(it, false) }
         return moduleSelectors
     }
 

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/ivyservice/resolveengine/graph/selectors/SelectorStateResolverTest.groovy
@@ -34,6 +34,7 @@ import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ComponentResol
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverDetails
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ConflictResolverFactory
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.ModuleConflictResolver
+import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ModuleSelectors
 import org.gradle.api.internal.artifacts.ivyservice.resolveengine.graph.builder.ResolveOptimizations
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.internal.component.external.model.DefaultModuleComponentIdentifier
@@ -187,7 +188,7 @@ class SelectorStateResolverTest extends Specification {
         SelectorStateResolver resolverWithMock = new SelectorStateResolver(mockResolver, componentFactory, root, resolveOptimizations)
 
         when:
-        def selected = resolverWithMock.selectBest(moduleId, [nine, otherNine])
+        def selected = resolverWithMock.selectBest(moduleId, moduleSelectors([nine, otherNine]))
 
         then:
         selected.componentId == projectId
@@ -203,7 +204,7 @@ class SelectorStateResolverTest extends Specification {
         def missingHigh = new TestModuleSelectorState(componentIdResolver, RANGE_14_16.versionConstraint)
 
         when:
-        def selected = conflictHandlingResolver.selectBest(moduleId, [missingLow, nine, ten, range, missingHigh])
+        def selected = conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow, nine, ten, range, missingHigh]))
 
         then:
         selected.version == "10"
@@ -217,19 +218,19 @@ class SelectorStateResolverTest extends Specification {
         def valid = new TestModuleSelectorState(componentIdResolver, FIXED_10.versionConstraint)
 
         when:
-        conflictHandlingResolver.selectBest(moduleId, [missingLow])
+        conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow]))
 
         then:
         thrown(ModuleVersionResolveException)
 
         when:
-        conflictHandlingResolver.selectBest(moduleId, [missingLow, missingHigh])
+        conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow, missingHigh]))
 
         then:
         thrown(ModuleVersionResolveException)
 
         when:
-        conflictHandlingResolver.selectBest(moduleId, [missingLow, missingHigh, valid])
+        conflictHandlingResolver.selectBest(moduleId, moduleSelectors([missingLow, missingHigh, valid]))
 
         then:
         noExceptionThrown()
@@ -243,6 +244,12 @@ class SelectorStateResolverTest extends Specification {
         return new TestResolver(failingResolver)
     }
 
+    ModuleSelectors moduleSelectors(List<? extends ResolvableSelectorState> selectors) {
+        def moduleSelectors = new ModuleSelectors<ResolvableSelectorState>()
+        selectors.forEach {moduleSelectors.add(it) }
+        return moduleSelectors
+    }
+
     class TestResolver {
         final SelectorStateResolver ssr
 
@@ -254,7 +261,7 @@ class SelectorStateResolverTest extends Specification {
             List<TestModuleSelectorState> selectors = versions.collect { version ->
                 new TestModuleSelectorState(componentIdResolver, version.versionConstraint)
             }
-            def currentSelection = ssr.selectBest(moduleId, selectors)
+            def currentSelection = ssr.selectBest(moduleId, moduleSelectors(selectors))
             if (selectors.any { it.requireResult?.failure != null || it.preferResult?.failure != null }) {
                 return VersionRangeResolveTestScenarios.FAILED
             }

--- a/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
+++ b/subprojects/diagnostics/src/integTest/groovy/org/gradle/api/tasks/diagnostics/DependencyInsightReportTaskIntegrationTest.groovy
@@ -2761,8 +2761,8 @@ org:foo:1.0
          org.gradle.jvm.version         = ${JavaVersion.current().majorVersion}
    ]
    Selection reasons:
-      - Was requested : rejected versions 1.2, 1.1
       - By constraint
+      - Was requested : rejected versions 1.2, 1.1
 
 org:foo:{reject 1.2} -> 1.0
 \\--- compileClasspath

--- a/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
+++ b/subprojects/performance/src/performanceTest/groovy/org/gradle/performance/regression/corefeature/LargeDependencyGraphPerformanceTest.groovy
@@ -27,7 +27,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
     public static final String MAX_MEMORY = "-Xmx800m"
 
     def setup() {
-        runner.minimumVersion = '4.6'
+        runner.minimumVersion = '4.8'
         runner.targetVersions = ["5.3-20190211022529+0000"]
     }
 
@@ -47,7 +47,7 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
     }
 
     @Unroll
-    def "resolve large dependency graph (parallel = #parallel)"() {
+    def "resolve large dependency graph (parallel = #parallel, locking = #locking)"() {
         runner.testProject = TEST_PROJECT_NAME
         startServer()
 
@@ -57,6 +57,9 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
         runner.args = ['-PuseHttp', "-PhttpPort=${serverPort}", '-PnoExcludes']
         if (parallel) {
             runner.args += '--parallel'
+        }
+        if (locking) {
+            runner.args += '-PuseLocking'
         }
 
         when:
@@ -69,7 +72,8 @@ class LargeDependencyGraphPerformanceTest extends AbstractCrossVersionPerformanc
         stopServer()
 
         where:
-        parallel << [false, true]
+        parallel << [false, true, false, true]
+        locking << [false, false, true, true]
     }
 
 }


### PR DESCRIPTION
we do a partial sort on the selectors, where we place
the dynamic selectors at the end compared to the other ones.
This allows a more efficient resolution in some cases.

One such case is when using constraints, as resolving the selector happened before the constraint was really accounted for in the graph. Now these constraints get resolved at the same time, reducing the number of potential version changes for a given dependency.

This is particularly impactful when using dependency locking as this means there is a strict constraint for each dependency in the graph.