### PR TITLE
Prohibit underscore in package names and improve package validation performance

### DIFF
--- a/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
+++ b/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
@@ -24,11 +24,11 @@ import org.openjdk.jmh.infra.Blackhole;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Benchmark                                                              Mode  Cnt        Score        Error  Units
- * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20    35684.227 ±   1098.363  ops/s
- * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  2106646.292 ± 116983.831  ops/s
- * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20    13254.202 ±    615.072  ops/s
- * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  1529536.526 ±  23929.243  ops/s
+ * Benchmark                                                              Mode  Cnt        Score       Error  Units
+ * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   864371.691 ± 65456.038  ops/s
+ * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  1124642.130 ± 32982.479  ops/s
+ * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   687804.950 ± 16936.767  ops/s
+ * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20   818511.320 ± 99481.866  ops/s
  **/
 @Fork(2)
 @Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
@@ -52,37 +52,29 @@ public class JvmPackageNameBenchmark {
     @Benchmark
     public void valid_package_name_creation(Blackhole bh) {
         for (String p : VALID_PACKAGES) {
-            JvmPackageName packageName = JvmPackageName.of(p);
-            bh.consume(packageName);
+            boolean isValid = JvmPackageName.isValid(p);
+            bh.consume(isValid);
         }
     }
 
     @Benchmark
     public void invalid_package_name_creation(Blackhole bh) {
         for (String p : INVALID_PACKAGES) {
-            try {
-                bh.consume(JvmPackageName.of(p));
-                throw new IllegalStateException("Should be invalid!");
-            } catch (IllegalArgumentException e) {
-                bh.consume(e);
-            }
+            boolean isValid = JvmPackageName.isValid(p);
+            bh.consume(isValid);
         }
     }
 
     @Benchmark
     public void reserved_java_keywords_package_name_creation(Blackhole bh) {
         for (String p : RESERVED_JAVA_KEYWORDS) {
-            try {
-                bh.consume(JvmPackageName.of(p));
-                throw new IllegalStateException("Should be invalid!");
-            } catch (IllegalArgumentException e) {
-                bh.consume(e);
-            }
+            boolean isValid = JvmPackageName.isValid(p);
+            bh.consume(isValid);
         }
     }
 
     @Benchmark
     public Object package_name_with_lots_of_fragments() {
-        return JvmPackageName.of("AaBb.CcDd.EeFf.GgHh.IiJj.KkLl.MmNn.OoPp.QqRr.SsTt.UuVv.WwXx.YyZz.AaBb.CcDd.EeFf.GgHh.IiJj.KkLl.MmNn.OoPp.QqRr.SsTt.UuVv.WwXx.YyZz");
+        return JvmPackageName.isValid("AaBb.CcDd.EeFf.GgHh.IiJj.KkLl.MmNn.OoPp.QqRr.SsTt.UuVv.WwXx.YyZz.AaBb.CcDd.EeFf.GgHh.IiJj.KkLl.MmNn.OoPp.QqRr.SsTt.UuVv.WwXx.YyZz");
     }
 }

--- a/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
+++ b/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
@@ -24,11 +24,11 @@ import org.openjdk.jmh.infra.Blackhole;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Benchmark                                                              Mode  Cnt        Score       Error  Units
- * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20    33603.198 ±  1169.740  ops/s
- * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  1451739.754 ± 21663.099  ops/s
- * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20    13180.444 ±   309.500  ops/s
- * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20   999055.552 ±  5643.646  ops/s
+ * Benchmark                                                              Mode  Cnt        Score        Error  Units
+ * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20    35684.227 ±   1098.363  ops/s
+ * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  2106646.292 ± 116983.831  ops/s
+ * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20    13254.202 ±    615.072  ops/s
+ * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  1529536.526 ±  23929.243  ops/s
  **/
 @Fork(2)
 @Warmup(iterations = 10, time = 1, timeUnit = SECONDS)

--- a/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
+++ b/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
@@ -25,10 +25,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Benchmark                                                              Mode  Cnt       Score       Error  Units
- * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   30394.430 ±   642.439  ops/s
- * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  375886.800 ± 15573.145  ops/s
- * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   13369.155 ±   388.070  ops/s
- * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  321294.496 ±  9347.673  ops/s
+ * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   30766.401 ±  1007.699  ops/s
+ * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  375519.862 ± 10892.600  ops/s
+ * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   12830.440 ±   176.311  ops/s
+ * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  373973.671 ±  7612.138  ops/s
  **/
 @Fork(2)
 @Warmup(iterations = 10, time = 1, timeUnit = SECONDS)

--- a/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
+++ b/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
@@ -25,10 +25,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Benchmark                                                              Mode  Cnt       Score       Error  Units
- * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   30766.401 ±  1007.699  ops/s
- * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  375519.862 ± 10892.600  ops/s
- * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   12830.440 ±   176.311  ops/s
- * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  373973.671 ±  7612.138  ops/s
+ * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   31665.507 ±   600.959  ops/s
+ * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  380145.432 ±  6377.326  ops/s
+ * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   13437.031 ±   480.949  ops/s
+ * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  345300.875 ± 30565.989  ops/s
  **/
 @Fork(2)
 @Warmup(iterations = 10, time = 1, timeUnit = SECONDS)

--- a/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
+++ b/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
@@ -24,11 +24,11 @@ import org.openjdk.jmh.infra.Blackhole;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Benchmark                                                              Mode  Cnt       Score       Error  Units
- * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   31665.507 ±   600.959  ops/s
- * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  380145.432 ±  6377.326  ops/s
- * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   13437.031 ±   480.949  ops/s
- * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  345300.875 ± 30565.989  ops/s
+ * Benchmark                                                              Mode  Cnt        Score       Error  Units
+ * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20    33603.198 ±  1169.740  ops/s
+ * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  1451739.754 ± 21663.099  ops/s
+ * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20    13180.444 ±   309.500  ops/s
+ * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20   999055.552 ±  5643.646  ops/s
  **/
 @Fork(2)
 @Warmup(iterations = 10, time = 1, timeUnit = SECONDS)

--- a/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
+++ b/subprojects/platform-jvm/src/jmh/java/org/gradle/jvm/internal/JvmPackageNameBenchmark.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.jvm.internal;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Benchmark                                                              Mode  Cnt       Score       Error  Units
+ * JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   30394.430 ±   642.439  ops/s
+ * JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  375886.800 ± 15573.145  ops/s
+ * JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   13369.155 ±   388.070  ops/s
+ * JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  321294.496 ±  9347.673  ops/s
+ **/
+@Fork(2)
+@Warmup(iterations = 10, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 10, time = 1, timeUnit = SECONDS)
+public class JvmPackageNameBenchmark {
+
+    // values from `JvmPackageNameTest`
+    private static final String[] VALID_PACKAGES = {"", "c", "com", "com.p", "com.example", "com.example.p1", "String.i3.αρετη.MAX_VALUE.isLetterOrDigit", "null_", "true_", "_false", "const_", "_public", "com._private", "int_.example", "$", "a.$.b"};
+    private static final String[] INVALID_PACKAGES = {" ", ".", "..", "com.", ".com", "1", "com.1", "1com", "com.example.p-1", "com.example.1p", "com/example/1p", "com.example.p 1", "com..example.p1", "null", "true", "false", "const", "public", "com.private", "_", "a._.b"};
+
+    // https://docs.oracle.com/javase/specs/jls/se12/html/jls-3.html#jls-Identifier
+    private static final String[] RESERVED_JAVA_KEYWORDS = {
+        // https://docs.oracle.com/javase/specs/jls/se12/html/jls-3.html#jls-Keyword
+        "abstract", "continue", "for", "new", "switch", "assert", "default", "if", "package", "synchronized", "boolean", "do", "goto", "private", "this", "break", "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum", "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface", "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while",
+        // https://docs.oracle.com/javase/specs/jls/se12/html/jls-3.html#jls-BooleanLiteral
+        "true", "false",
+        // https://docs.oracle.com/javase/specs/jls/se12/html/jls-3.html#jls-NullLiteral
+        "null"
+    };
+
+    @Benchmark
+    public void valid_package_name_creation(Blackhole bh) {
+        for (String p : VALID_PACKAGES) {
+            JvmPackageName packageName = JvmPackageName.of(p);
+            bh.consume(packageName);
+        }
+    }
+
+    @Benchmark
+    public void invalid_package_name_creation(Blackhole bh) {
+        for (String p : INVALID_PACKAGES) {
+            try {
+                bh.consume(JvmPackageName.of(p));
+                throw new IllegalStateException("Should be invalid!");
+            } catch (IllegalArgumentException e) {
+                bh.consume(e);
+            }
+        }
+    }
+
+    @Benchmark
+    public void reserved_java_keywords_package_name_creation(Blackhole bh) {
+        for (String p : RESERVED_JAVA_KEYWORDS) {
+            try {
+                bh.consume(JvmPackageName.of(p));
+                throw new IllegalStateException("Should be invalid!");
+            } catch (IllegalArgumentException e) {
+                bh.consume(e);
+            }
+        }
+    }
+
+    @Benchmark
+    public Object package_name_with_lots_of_fragments() {
+        return JvmPackageName.of("AaBb.CcDd.EeFf.GgHh.IiJj.KkLl.MmNn.OoPp.QqRr.SsTt.UuVv.WwXx.YyZz.AaBb.CcDd.EeFf.GgHh.IiJj.KkLl.MmNn.OoPp.QqRr.SsTt.UuVv.WwXx.YyZz");
+    }
+}

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DefaultJvmApiSpec.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/DefaultJvmApiSpec.java
@@ -43,11 +43,8 @@ public class DefaultJvmApiSpec implements JvmApiSpec {
     }
 
     private void validatePackageName(String value) {
-        try {
-            JvmPackageName.of(value);
-        } catch (IllegalArgumentException cause) {
-            throw new InvalidUserDataException(
-                format("Invalid public API specification: %s", cause.getMessage()), cause);
+        if (!JvmPackageName.isValid(value)) {
+            throw new InvalidUserDataException(format("Invalid public API specification: '%s' is not a valid package name", value));
         }
     }
 

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -91,14 +91,11 @@ public class JvmPackageName {
     private static boolean isValidPackageName(String value) {
         if (UNNAMED_PACKAGE.equals(value)) {
             return true;
-        }
-        if (value == null
-                || value.startsWith(".")
-                || value.endsWith(".")) {
+        } else if (value == null || DELIMITER == value.charAt(0) || DELIMITER == value.charAt(value.length() - 1)) {
             return false;
+        } else {
+            return fragmentsAreValid(value);
         }
-
-        return fragmentsAreValid(value);
     }
 
     private static boolean fragmentsAreValid(String value) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -16,8 +16,9 @@
 
 package org.gradle.jvm.internal;
 
-import java.util.Arrays;
-import java.util.List;
+import com.google.common.collect.Sets;
+
+import java.util.Set;
 
 /**
  * An immutable representation of a valid Java package name.
@@ -35,15 +36,16 @@ import java.util.List;
 public class JvmPackageName {
     private static final char DELIMITER = '.';
 
-    private static final List<String> JAVA_KEYWORDS = Arrays.asList(
+    private static final Set<String> INVALID_PACKAGE_KEYWORDS = Sets.newHashSet(
         "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
         "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if",
         "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private",
         "protected", "public", "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this",
-        "throw", "throws", "transient", "try", "void", "volatile", "while", "_"
+        "throw", "throws", "transient", "try", "void", "volatile", "while", "_",
+        "true", "false",
+        "null",
+        ""
     );
-
-    private static final List<String> BOOLEAN_AND_NULL_LITERALS = Arrays.asList("true", "false", "null");
 
     private static final String UNNAMED_PACKAGE = "";
 
@@ -114,20 +116,23 @@ public class JvmPackageName {
     }
 
     private static boolean isIdentifier(String token) {
-        if (token.isEmpty()
-                || JAVA_KEYWORDS.contains(token)
-                || BOOLEAN_AND_NULL_LITERALS.contains(token)
-                || !Character.isJavaIdentifierStart(token.charAt(0))) {
+        return !INVALID_PACKAGE_KEYWORDS.contains(token)
+            && isValidJavaIdentifier(token);
+    }
+
+    private static boolean isValidJavaIdentifier(String token) {
+        if (!Character.isJavaIdentifierStart(token.charAt(0))) {
             return false;
-        }
-        if (token.length() > 1) {
-            for (char c : token.substring(1).toCharArray()) {
-                if (!Character.isJavaIdentifierPart(c)) {
-                    return false;
+        } else {
+            if (token.length() > 1) {
+                for (char c : token.substring(1).toCharArray()) {
+                    if (!Character.isJavaIdentifierPart(c)) {
+                        return false;
+                    }
                 }
             }
+            return true;
         }
-        return true;
     }
 
     @Override

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -39,7 +39,7 @@ public class JvmPackageName {
         "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if",
         "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private",
         "protected", "public", "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this",
-        "throw", "throws", "transient", "try", "void", "volatile", "while"
+        "throw", "throws", "transient", "try", "void", "volatile", "while", "_"
     );
 
     private static final List<String> BOOLEAN_AND_NULL_LITERALS = Arrays.asList("true", "false", "null");

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -21,23 +21,10 @@ import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
-/**
- * An immutable representation of a valid Java package name.
- *
- * <p>While {@code JvmPackageName} values are guaranteed to be valid per JLS package
- * naming rules, no validation is performed to ensure that the named package actually
- * exists.</p>
- *
- * <p>Note that due to vagaries inherent in Java naming, a valid package name is also
- * always a valid type name.</p>
- *
- * @see #of(String)
- * @since 2.10
- */
 public class JvmPackageName {
     private static final char DELIMITER = '.';
-    private static Splitter packageFragmentSplitter = Splitter.on(DELIMITER);
-
+    private static final Splitter PACKAGE_FRAGMENT_SPLITTER = Splitter.on(DELIMITER);
+    private static final String UNNAMED_PACKAGE = "";
 
     private static final Set<String> INVALID_PACKAGE_KEYWORDS = ImmutableSet.of(
         "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
@@ -50,50 +37,23 @@ public class JvmPackageName {
         ""
     );
 
-    private static final String UNNAMED_PACKAGE = "";
-
-    private final String value;
-
-    private JvmPackageName(String value) {
-        this.value = value;
+    private JvmPackageName() {
     }
 
     /**
-     * The underlying package name value, e.g. "com.example.p1".
-     */
-    public String getValue() {
-        return value;
-    }
-
-    /**
-     * Validate, create and return a new {@code PackageName} instance from the given
-     * package name.
+     * Validate a given package name.
      *
      * <p>See JLS sections:
      * <ul>
-     *   <li><em><a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.8">
-     *     3.8. Identifiers</a></em></li>
-     *   <li><em><a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-6.html#jls-6.2">
-     *     6.2. Names and Identifiers</a></em></li>
-     *   <li><em><a href="https://docs.oracle.com/javase/specs/jls/se7/html/jls-7.html#jls-7.4">
-     *     7.4. Package Declarations</a></em></li>
+     * <li><em><a href="https://docs.oracle.com/javase/specs/jls/se12/html/jls-3.html#jls-3.8"> 3.8. Identifiers</a></em></li>
+     * <li><em><a href="https://docs.oracle.com/javase/specs/jls/se12/html/jls-6.html#jls-6.2"> 6.2. Names and Identifiers</a></em></li>
+     * <li><em><a href="https://docs.oracle.com/javase/specs/jls/se12/html/jls-7.html#jls-7.4"> 7.4. Package Declarations</a></em></li>
      * </ul>
      * </p>
      *
-     * @param value the candidate package name, e.g.: {@code com.example.p1} or an empty
-     * string indicating an <em>unnamed package</em>
-     * @return the validated package name instance, never null
-     * @throws IllegalArgumentException if value is null or does not conform to valid
-     * package naming per the JLS
+     * @return whether value is null or does not conform to valid package naming per the JLS
      */
-    public static JvmPackageName of(String value) {
-        if (!isValidPackageName(value)) {
-            throw new IllegalArgumentException(String.format("'%s' is not a valid package name", value));
-        }
-        return new JvmPackageName(value);
-    }
-
-    private static boolean isValidPackageName(String value) {
+    public static boolean isValid(String value) {
         if (UNNAMED_PACKAGE.equals(value)) {
             return true;
         } else if (value == null) {
@@ -104,7 +64,7 @@ public class JvmPackageName {
     }
 
     private static boolean fragmentsAreValid(String value) {
-        for (String packageFragment : packageFragmentSplitter.split(value)) {
+        for (String packageFragment : PACKAGE_FRAGMENT_SPLITTER.split(value)) {
             if (!isIdentifier(packageFragment)) {
                 return false;
             }
@@ -128,27 +88,5 @@ public class JvmPackageName {
             }
             return true;
         }
-    }
-
-    @Override
-    public String toString() {
-        return value;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        JvmPackageName that = (JvmPackageName) o;
-        return value.equals(that.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return value.hashCode();
     }
 }

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -93,7 +93,7 @@ public class JvmPackageName {
     private static boolean isValidPackageName(String value) {
         if (UNNAMED_PACKAGE.equals(value)) {
             return true;
-        } else if (value == null || DELIMITER == value.charAt(0) || DELIMITER == value.charAt(value.length() - 1)) {
+        } else if (value == null) {
             return false;
         } else {
             return fragmentsAreValid(value);

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -124,11 +124,9 @@ public class JvmPackageName {
         if (!Character.isJavaIdentifierStart(token.charAt(0))) {
             return false;
         } else {
-            if (token.length() > 1) {
-                for (char c : token.substring(1).toCharArray()) {
-                    if (!Character.isJavaIdentifierPart(c)) {
-                        return false;
-                    }
+            for (int i = 1; i < token.length(); i++) {
+                if (!Character.isJavaIdentifierPart(token.charAt(i))) {
+                    return false;
                 }
             }
             return true;

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -16,7 +16,8 @@
 
 package org.gradle.jvm.internal;
 
-import com.google.common.collect.Sets;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
 
@@ -35,8 +36,10 @@ import java.util.Set;
  */
 public class JvmPackageName {
     private static final char DELIMITER = '.';
+    private static Splitter packageFragmentSplitter = Splitter.on(DELIMITER);
 
-    private static final Set<String> INVALID_PACKAGE_KEYWORDS = Sets.newHashSet(
+
+    private static final Set<String> INVALID_PACKAGE_KEYWORDS = ImmutableSet.of(
         "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
         "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if",
         "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private",
@@ -101,18 +104,12 @@ public class JvmPackageName {
     }
 
     private static boolean fragmentsAreValid(String value) {
-        int i = -1;
-        for (int j = value.indexOf(DELIMITER);
-             j > i;
-             i = j, j = value.indexOf(DELIMITER, i + 1)
-        ) {
-            String token = value.substring(i + 1, j);
-            if (!isIdentifier(token)) {
+        for (String packageFragment : packageFragmentSplitter.split(value)) {
+            if (!isIdentifier(packageFragment)) {
                 return false;
             }
         }
-        String lastToken = value.substring(i + 1);
-        return isIdentifier(lastToken);
+        return true;
     }
 
     private static boolean isIdentifier(String token) {

--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/internal/JvmPackageName.java
@@ -33,6 +33,7 @@ import java.util.List;
  * @since 2.10
  */
 public class JvmPackageName {
+    private static final char DELIMITER = '.';
 
     private static final List<String> JAVA_KEYWORDS = Arrays.asList(
         "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue",
@@ -96,12 +97,23 @@ public class JvmPackageName {
                 || value.endsWith(".")) {
             return false;
         }
-        for (String token : value.split("\\.")) {
+
+        return fragmentsAreValid(value);
+    }
+
+    private static boolean fragmentsAreValid(String value) {
+        int i = -1;
+        for (int j = value.indexOf(DELIMITER);
+             j > i;
+             i = j, j = value.indexOf(DELIMITER, i + 1)
+        ) {
+            String token = value.substring(i + 1, j);
             if (!isIdentifier(token)) {
                 return false;
             }
         }
-        return true;
+        String lastToken = value.substring(i + 1);
+        return isIdentifier(lastToken);
     }
 
     private static boolean isIdentifier(String token) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/internal/JvmPackageNameTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/internal/JvmPackageNameTest.groovy
@@ -33,7 +33,7 @@ class JvmPackageNameTest extends Specification {
         where:
         value << [
             '', 'c', 'com', 'com.p', 'com.example', 'com.example.p1', 'String.i3.αρετη.MAX_VALUE.isLetterOrDigit',
-            'null_', 'true_', '_false', 'const_', '_public', 'com._private', 'int_.example'
+            'null_', 'true_', '_false', 'const_', '_public', 'com._private', 'int_.example', '$', 'a.$.b'
         ]
     }
 
@@ -49,7 +49,7 @@ class JvmPackageNameTest extends Specification {
         where:
         value << [
             ' ', '.', '..', 'com.', '.com', '1', 'com.1', '1com', 'com.example.p-1', 'com.example.1p', 'com/example/1p',
-            'com.example.p 1', 'com..example.p1', 'null', 'true', 'false', 'const', 'public', 'com.private'
+            'com.example.p 1', 'com..example.p1', 'null', 'true', 'false', 'const', 'public', 'com.private', '_', 'a._.b'
         ]
     }
 

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/internal/JvmPackageNameTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/internal/JvmPackageNameTest.groovy
@@ -23,12 +23,8 @@ class JvmPackageNameTest extends Specification {
 
     @Unroll
     def "should accept valid package name '#value'"() {
-        when:
-        def packageName = JvmPackageName.of(value)
-
-        then:
-        notThrown(IllegalArgumentException)
-        packageName.getValue() == value
+        expect:
+        JvmPackageName.isValid(value)
 
         where:
         value << [
@@ -39,41 +35,13 @@ class JvmPackageNameTest extends Specification {
 
     @Unroll
     def "should reject invalid package name '#value'"() {
-        when:
-        JvmPackageName.of(value)
-
-        then:
-        def e = thrown(IllegalArgumentException)
-        e.message.contains("'$value' is not a valid package name")
+        expect:
+        !JvmPackageName.isValid(value)
 
         where:
         value << [
             ' ', '.', '..', 'com.', '.com', '1', 'com.1', '1com', 'com.example.p-1', 'com.example.1p', 'com/example/1p',
             'com.example.p 1', 'com..example.p1', 'null', 'true', 'false', 'const', 'public', 'com.private', '_', 'a._.b'
         ]
-    }
-
-    def "should compare equality based on string value"() {
-        given:
-        def pkgA = JvmPackageName.of('com.example.p1')
-        def pkgB = JvmPackageName.of('com.example.p2')
-        def pkgC = JvmPackageName.of('com.example.p1') // same value as pkgA
-        def packages = new HashSet<JvmPackageName>()
-
-        expect:
-        pkgA != pkgB
-        pkgB != pkgC
-        pkgC == pkgA
-        packages.add(pkgA)
-        packages.add(pkgB)
-        !packages.add(pkgC)
-    }
-
-    def "should render toString based on underlying value"() {
-        given:
-        def pkg = JvmPackageName.of('com.example.p1')
-
-        expect:
-        pkg.toString() == 'com.example.p1'
     }
 }


### PR DESCRIPTION
### Context
Java 11 introduced `_` as [keyword](https://docs.oracle.com/javase/specs/jls/se12/html/jls-3.html#jls-Keyword), making it prohibited in package names.

This PR adds it to the package validation and improve the validation's performance.

Please review commit-by-commit to have better context.

----

Failure reason before the fix:
![image](https://user-images.githubusercontent.com/1841944/56750706-a3070100-6784-11e9-9312-7994a9405a87.png)

----

Speed improvements, as measure by the `JvmPackageNameBenchmark` JMH benchmark:
Before:
```
Benchmark                                                              Mode  Cnt       Score       Error  Units
JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   30394.430 ±   642.439  ops/s
JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  375886.800 ± 15573.145  ops/s
JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   13369.155 ±   388.070  ops/s
JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20  321294.496 ±  9347.673  ops/s
```
After:
```
Benchmark                                                              Mode  Cnt        Score       Error  Units
JvmPackageNameBenchmark.invalid_package_name_creation                 thrpt   20   864371.691 ± 65456.038  ops/s
JvmPackageNameBenchmark.package_name_with_lots_of_fragments           thrpt   20  1124642.130 ± 32982.479  ops/s
JvmPackageNameBenchmark.reserved_java_keywords_package_name_creation  thrpt   20   687804.950 ± 16936.767  ops/s
JvmPackageNameBenchmark.valid_package_name_creation                   thrpt   20   818511.320 ± 99481.866  ops/s
```

i.e. on average ~3x faster validation.