### PR TITLE
WIP Reduce hashing garbage by reusing `MessageDigest` instances via `ThreadLocal`

### DIFF
--- a/subprojects/base-services/base-services.gradle.kts
+++ b/subprojects/base-services/base-services.gradle.kts
@@ -6,7 +6,6 @@
  */
 
 import org.gradle.gradlebuild.unittestandcompile.ModuleType
-import java.util.concurrent.Callable
 
 plugins {
     `java-library`
@@ -42,8 +41,13 @@ testFixtures {
 
 jmh {
     withGroovyBuilder {
-        setProperty("include", listOf("HashingAlgorithmsBenchmark"))
+        setProperty("include", listOf("HashingBenchmark"/*, "HashingAlgorithmsBenchmark", "MessageDigestHasherBenchmark", "MessageDigestThreadingBenchmark" */))
     }
+    profilers = listOf("hs_gc"/*, "stack"*/)
+    // jvmArgs = listOf("-Xmx4G", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseEpsilonGC")
+    // forceGC = true // no-op for epsilon
+    failOnError = true
+    resultFormat = "JSON"
 }
 
 val buildReceiptPackage: String by rootProject.extra

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingAlgorithmsBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingAlgorithmsBenchmark.java
@@ -16,143 +16,160 @@
 
 package org.gradle.internal.reflect;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import org.bouncycastle.jcajce.provider.digest.Blake2b;
+import org.apache.commons.lang.RandomStringUtils;
+import org.bouncycastle.crypto.digests.Blake2bDigest;
 import org.bouncycastle.jcajce.provider.digest.MD5;
 import org.bouncycastle.jcajce.provider.digest.SHA1;
+import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 
 import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Map;
-import java.util.Random;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * https://preshing.com/20110504/hash-collision-probabilities
+ * https://github.com/rurban/smhasher
+ * https://en.wikipedia.org/wiki/Hash_function_security_summary
+ *
+ * Benchmark                                                        (hashSize)   Mode  Cnt          Score          Error  Units
+ * HashingAlgorithmsBenchmark.blake2b_128_bc                              1024  thrpt    5     392412.167 ±     7840.282  ops/s
+ * HashingAlgorithmsBenchmark.blake2b_128_bc                             65536  thrpt    5       6372.976 ±     1077.810  ops/s
+ * HashingAlgorithmsBenchmark.blake2b_128_bc                          67108864  thrpt    5          6.201 ±        0.606  ops/s
+ * HashingAlgorithmsBenchmark.md5_bc                                      1024  thrpt    5     408892.744 ±     2075.719  ops/s
+ * HashingAlgorithmsBenchmark.md5_bc                                     65536  thrpt    5       6629.605 ±       61.378  ops/s
+ * HashingAlgorithmsBenchmark.md5_bc                                  67108864  thrpt    5          6.375 ±        0.033  ops/s
+ * HashingAlgorithmsBenchmark.md5_guava                                   1024  thrpt    5     479881.416 ±     5646.316  ops/s
+ * HashingAlgorithmsBenchmark.md5_guava                                  65536  thrpt    5       8126.245 ±       73.154  ops/s
+ * HashingAlgorithmsBenchmark.md5_guava                               67108864  thrpt    5          8.016 ±        0.083  ops/s
+ * HashingAlgorithmsBenchmark.md5_java                                    1024  thrpt    5     486863.854 ±     6423.621  ops/s
+ * HashingAlgorithmsBenchmark.md5_java                                   65536  thrpt    5       8169.438 ±       90.108  ops/s
+ * HashingAlgorithmsBenchmark.md5_java                                67108864  thrpt    5          8.005 ±        0.109  ops/s
+ * HashingAlgorithmsBenchmark.murmur3_128_guava_non_cryptographic         1024  thrpt    5    3599095.009 ±    30686.631  ops/s
+ * HashingAlgorithmsBenchmark.murmur3_128_guava_non_cryptographic        65536  thrpt    5      82838.124 ±      833.338  ops/s
+ * HashingAlgorithmsBenchmark.murmur3_128_guava_non_cryptographic     67108864  thrpt    5         87.683 ±        2.072  ops/s
+ * HashingAlgorithmsBenchmark.sha1_bc                                     1024  thrpt    5     286221.423 ±      880.325  ops/s
+ * HashingAlgorithmsBenchmark.sha1_bc                                    65536  thrpt    5       4654.420 ±       42.925  ops/s
+ * HashingAlgorithmsBenchmark.sha1_bc                                 67108864  thrpt    5          4.754 ±        0.021  ops/s
+ * HashingAlgorithmsBenchmark.sha1_java                                   1024  thrpt    5     346946.993 ±     3125.038  ops/s
+ * HashingAlgorithmsBenchmark.sha1_java                                  65536  thrpt    5       5792.155 ±       53.079  ops/s
+ * HashingAlgorithmsBenchmark.sha1_java                               67108864  thrpt    5          5.671 ±        0.045  ops/s
+ * HashingAlgorithmsBenchmark.sha3_224_bc                                 1024  thrpt    5     311901.853 ±     4168.865  ops/s
+ * HashingAlgorithmsBenchmark.sha3_224_bc                                65536  thrpt    5       5365.516 ±      309.016  ops/s
+ * HashingAlgorithmsBenchmark.sha3_224_bc                             67108864  thrpt    5          5.324 ±        0.047  ops/s
+ * HashingAlgorithmsBenchmark.sipHash24_64_guava_non_cryptographic        1024  thrpt    5    1485656.535 ±    38410.281  ops/s
+ * HashingAlgorithmsBenchmark.sipHash24_64_guava_non_cryptographic       65536  thrpt    5      26365.336 ±      118.140  ops/s
+ * HashingAlgorithmsBenchmark.sipHash24_64_guava_non_cryptographic    67108864  thrpt    5         24.639 ±        1.265  ops/s
+ **/
 @Fork(1)
-@Threads(4)
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
 @State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
 public class HashingAlgorithmsBenchmark {
-
-    private static MessageDigest getDigest(String name) {
-        try {
-            return MessageDigest.getInstance(name);
-        } catch (NoSuchAlgorithmException e) {
-            throw new AssertionError();
-        }
-    }
-
-    static final Map<String, HashProcessorFactory> HASHERS = ImmutableMap.<String, HashProcessorFactory>builder()
-        .put("md5.java", new MessageDigestHashProcessorFactory(getDigest("MD5")))
-        .put("md5.bc", new MessageDigestHashProcessorFactory(new MD5.Digest()))
-        .put("sha1.java", new MessageDigestHashProcessorFactory(getDigest("SHA-1")))
-        .put("sha1.bc", new MessageDigestHashProcessorFactory(new SHA1.Digest()))
-        .put("blake2b.bc", new MessageDigestHashProcessorFactory(new Blake2b.Blake2b160()))
-        .put("murmur3.guava", new GuavaProcessorFactory(Hashing.murmur3_128()))
-        .build();
-
-    Random random = new Random(1234L);
-
-    @Param({"16", "1024", "65536"})
+    @Param({"1024", "65536", "67108864"})
     int hashSize;
 
-    // @Param({"md5.java", "md5.bc", "sha1.java", "sha1.bc", "blake2b.bc"})
-    @Param({"md5.java", "murmur3.guava"})
-    String type;
-
     byte[] input;
-    HashProcessorFactory processorFactory;
 
-    @Setup(Level.Iteration)
-    public void setup() throws CloneNotSupportedException {
-        input = new byte[hashSize];
-        random.nextBytes(input);
-        processorFactory = HASHERS.get(type);
+    MessageDigest md5_java;
+    MD5.Digest md5_bc;
+    HashFunction md5_guava;
+
+    MessageDigest sha1_java;
+    SHA1.Digest sha1_bc;
+    SHA3.Digest224 sha3_224_bc;
+
+    Blake2bDigest blake2b_128_bc;
+
+    HashFunction murmur3_128_guava;
+
+    HashFunction sipHash24_64_guava;
+
+    @Setup
+    public void setup() throws Exception {
+        input = RandomStringUtils.random(hashSize).getBytes();
+
+        md5_java = MessageDigest.getInstance("MD5");
+        md5_bc = new MD5.Digest();
+        md5_guava = Hashing.md5();
+
+        sha1_java = MessageDigest.getInstance("SHA-1");
+        sha1_bc = new SHA1.Digest();
+        sha3_224_bc = new SHA3.Digest224();
+
+        blake2b_128_bc = new Blake2bDigest(128);
+
+        murmur3_128_guava = Hashing.murmur3_128();
+
+        sipHash24_64_guava = Hashing.sipHash24();
     }
 
     @Benchmark
-    public void measure(Blackhole blackhole) {
-        HashProcessor processor = processorFactory.create();
-        processor.process(input, blackhole);
+    public byte[] md5_java() {
+        md5_java.update(input);
+        return md5_java.digest();
     }
 
-    interface HashProcessor {
-        void process(byte[] input, Blackhole blackhole);
+    @Benchmark
+    public byte[] md5_bc() {
+        md5_bc.update(input);
+        return md5_bc.digest();
     }
 
-    interface HashProcessorFactory {
-        HashProcessor create();
+    @Benchmark
+    public byte[] md5_guava() {
+        Hasher hasher = md5_guava.newHasher(input.length);
+        hasher.putBytes(input);
+        return hasher.hash().asBytes();
     }
 
-    private static class MessageDigestHashProcessorFactory implements HashProcessorFactory {
-        private final MessageDigest baseDigest;
-
-        public MessageDigestHashProcessorFactory(MessageDigest baseDigest) {
-            this.baseDigest = baseDigest;
-        }
-
-        @Override
-        public HashProcessor create() {
-            try {
-                return new MessageDigestProcessor((MessageDigest) baseDigest.clone());
-            } catch (CloneNotSupportedException e) {
-                throw new AssertionError(e);
-            }
-        }
+    @Benchmark
+    public byte[] sha1_java() {
+        sha1_java.update(input);
+        return sha1_java.digest();
     }
 
-    private static class MessageDigestProcessor implements HashProcessor {
-        private final MessageDigest digest;
-
-        public MessageDigestProcessor(MessageDigest digest) {
-            this.digest = digest;
-        }
-
-        @Override
-        public void process(byte[] input, Blackhole blackhole) {
-            digest.update(input);
-            byte[] hash = digest.digest();
-            blackhole.consume(hash);
-        }
+    @Benchmark
+    public byte[] sha1_bc() {
+        sha1_bc.update(input);
+        return sha1_bc.digest();
     }
 
-    private static class GuavaProcessorFactory implements HashProcessorFactory {
-        private final HashFunction hashFunction;
-
-        public GuavaProcessorFactory(HashFunction hashFunction) {
-            this.hashFunction = hashFunction;
-        }
-
-        @Override
-        public HashProcessor create() {
-            return new GuavaProcessor(hashFunction.newHasher());
-        }
+    @Benchmark
+    public byte[] sha3_224_bc() {
+        sha3_224_bc.update(input);
+        return sha3_224_bc.digest();
     }
 
-    private static class GuavaProcessor implements HashProcessor {
-        private final Hasher hasher;
+    @Benchmark
+    public byte[] blake2b_128_bc() {
+        blake2b_128_bc.update(input, 0, input.length);
+        byte[] hash = new byte[128];
+        blake2b_128_bc.doFinal(hash, 0);
+        return hash;
+    }
 
-        public GuavaProcessor(Hasher hasher) {
-            this.hasher = hasher;
-        }
+    @Benchmark
+    public byte[] murmur3_128_guava_non_cryptographic() {
+        Hasher hasher = murmur3_128_guava.newHasher();
+        hasher.putBytes(input);
+        return hasher.hash().asBytes();
+    }
 
-        @Override
-        public void process(byte[] input, Blackhole blackhole) {
-            hasher.putBytes(input);
-            blackhole.consume(hasher.hash());
-        }
+    @Benchmark
+    public byte[] sipHash24_64_guava_non_cryptographic() {
+        Hasher hasher = sipHash24_64_guava.newHasher();
+        hasher.putBytes(input);
+        return hasher.hash().asBytes();
     }
 }

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingBenchmark.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.HashFunction;
+import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.hash.Hashing;
+import org.gradle.internal.hash.PrimitiveHasher;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Benchmark                                             (hashSize)   Mode  Cnt           Score             Error  Units
+ * HashingBenchmark.md5                                          10  thrpt    5     3209491.988 ±     611068.193  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations          10  thrpt    5           8.400 ±          2.109      ?
+ * HashingBenchmark.md5                                        1024  thrpt    5     1191001.690 ±       57112.884  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations        1024  thrpt    5           5.200 ±           1.722
+ * HashingBenchmark.md5                                       65536  thrpt    5       29156.429 ±         601.009  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations       65536  thrpt    5           0.200 ±           1.722
+ * HashingBenchmark.md5                                    67108864  thrpt    5          30.158 ±           1.137  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations    67108864  thrpt    5             ≈ 0
+ * HashingBenchmark.sha1                                         10  thrpt    5     2555776.330 ±     280579.732  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations         10  thrpt    5          10.600 ±          2.109      ?
+ * HashingBenchmark.sha1                                       1024  thrpt    5      839273.401 ±       27667.597  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations       1024  thrpt    5           6.000 ±           0.001
+ * HashingBenchmark.sha1                                      65536  thrpt    5       19024.530 ±        2316.586  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations      65536  thrpt    5           0.200 ±           1.722
+ * HashingBenchmark.sha1                                   67108864  thrpt    5          19.661 ±           0.196  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations   67108864  thrpt    5             ≈ 0
+ **/
+@Fork(1)
+@Threads(4)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+public class HashingBenchmark {
+    private static final HashCode DUMMY_HASH = HashCode.fromInt(1);
+    private static final String DUMMY_STRING = "dummy";
+    private static final byte[] DUMMY_BYTES = DUMMY_STRING.getBytes();
+
+    @Param({"10", "1024", "65536", "67108864"})
+    int hashSize;
+
+    byte[] input;
+
+    HashFunction sha1, md5;
+
+    @Setup
+    public void setup() {
+        input = RandomStringUtils.random(hashSize).getBytes();
+
+        sha1 = Hashing.sha1();
+        md5 = Hashing.md5();
+    }
+
+    @Benchmark
+    public void sha1(Blackhole bh) {
+        bh.consume(sha1.hashBytes(input));
+        bh.consume(putStuff(sha1.defaultHasher()).hash());
+        bh.consume(putStuff(sha1.primitiveHasher()).hash());
+    }
+
+    @Benchmark
+    public void md5(Blackhole bh) {
+        bh.consume(md5.hashBytes(input));
+        bh.consume(putStuff(md5.defaultHasher()).hash());
+        bh.consume(putStuff(md5.primitiveHasher()).hash());
+    }
+
+    private Hasher putStuff(Hasher hasher) {
+        hasher.putBoolean(true);
+        hasher.putDouble(1D);
+        hasher.putInt(1);
+        hasher.putInt(Integer.MAX_VALUE);
+        hasher.putLong(1L);
+        hasher.putLong(Long.MAX_VALUE);
+        hasher.putByte((byte) 1);
+        hasher.putBytes(DUMMY_BYTES);
+        hasher.putHash(DUMMY_HASH);
+        hasher.putString(DUMMY_STRING);
+        hasher.putNull();
+        return hasher;
+    }
+
+    private PrimitiveHasher putStuff(PrimitiveHasher hasher) {
+        hasher.putBoolean(true);
+        hasher.putDouble(1D);
+        hasher.putInt(1);
+        hasher.putInt(Integer.MAX_VALUE);
+        hasher.putLong(1L);
+        hasher.putLong(Long.MAX_VALUE);
+        hasher.putByte((byte) 1);
+        hasher.putBytes(DUMMY_BYTES);
+        hasher.putHash(DUMMY_HASH);
+        hasher.putString(DUMMY_STRING);
+        return hasher;
+    }
+}

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingBenchmark.java
@@ -94,16 +94,7 @@ public class HashingBenchmark {
     }
 
     private Hasher putStuff(Hasher hasher) {
-        hasher.putBoolean(true);
-        hasher.putDouble(1D);
-        hasher.putInt(1);
-        hasher.putInt(Integer.MAX_VALUE);
-        hasher.putLong(1L);
-        hasher.putLong(Long.MAX_VALUE);
-        hasher.putByte((byte) 1);
-        hasher.putBytes(DUMMY_BYTES);
-        hasher.putHash(DUMMY_HASH);
-        hasher.putString(DUMMY_STRING);
+        putStuff((PrimitiveHasher) hasher);
         hasher.putNull();
         return hasher;
     }

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/HashingBenchmark.java
@@ -36,22 +36,22 @@ import org.openjdk.jmh.infra.Blackhole;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
- * Benchmark                                             (hashSize)   Mode  Cnt           Score             Error  Units
- * HashingBenchmark.md5                                          10  thrpt    5     3209491.988 ±     611068.193  ops/s
- * HashingBenchmark.md5:·sun.gc.collector.0.invocations          10  thrpt    5           8.400 ±          2.109      ?
- * HashingBenchmark.md5                                        1024  thrpt    5     1191001.690 ±       57112.884  ops/s
- * HashingBenchmark.md5:·sun.gc.collector.0.invocations        1024  thrpt    5           5.200 ±           1.722
- * HashingBenchmark.md5                                       65536  thrpt    5       29156.429 ±         601.009  ops/s
- * HashingBenchmark.md5:·sun.gc.collector.0.invocations       65536  thrpt    5           0.200 ±           1.722
- * HashingBenchmark.md5                                    67108864  thrpt    5          30.158 ±           1.137  ops/s
+ * Benchmark                                             (hashSize)   Mode  Cnt           Score           Error  Units
+ * HashingBenchmark.md5                                          10  thrpt    5     3220072.840 ±    153467.463  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations          10  thrpt    5           7.800 ±         1.722
+ * HashingBenchmark.md5                                        1024  thrpt    5     1126665.490 ±     53890.024  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations        1024  thrpt    5           2.600 ±         2.109
+ * HashingBenchmark.md5                                       65536  thrpt    5       28483.327 ±      1419.431  ops/s
+ * HashingBenchmark.md5:·sun.gc.collector.0.invocations       65536  thrpt    5             ≈ 0
+ * HashingBenchmark.md5                                    67108864  thrpt    5          30.371 ±         0.497  ops/s
  * HashingBenchmark.md5:·sun.gc.collector.0.invocations    67108864  thrpt    5             ≈ 0
- * HashingBenchmark.sha1                                         10  thrpt    5     2555776.330 ±     280579.732  ops/s
- * HashingBenchmark.sha1:·sun.gc.collector.0.invocations         10  thrpt    5          10.600 ±          2.109      ?
- * HashingBenchmark.sha1                                       1024  thrpt    5      839273.401 ±       27667.597  ops/s
- * HashingBenchmark.sha1:·sun.gc.collector.0.invocations       1024  thrpt    5           6.000 ±           0.001
- * HashingBenchmark.sha1                                      65536  thrpt    5       19024.530 ±        2316.586  ops/s
- * HashingBenchmark.sha1:·sun.gc.collector.0.invocations      65536  thrpt    5           0.200 ±           1.722
- * HashingBenchmark.sha1                                   67108864  thrpt    5          19.661 ±           0.196  ops/s
+ * HashingBenchmark.sha1                                         10  thrpt    5     2695525.955 ±    131374.572  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations         10  thrpt    5           6.600 ±         2.109
+ * HashingBenchmark.sha1                                       1024  thrpt    5      847143.033 ±     39044.031  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations       1024  thrpt    5           2.200 ±         1.722
+ * HashingBenchmark.sha1                                      65536  thrpt    5       19323.252 ±       694.755  ops/s
+ * HashingBenchmark.sha1:·sun.gc.collector.0.invocations      65536  thrpt    5             ≈ 0
+ * HashingBenchmark.sha1                                   67108864  thrpt    5          20.130 ±         2.504  ops/s
  * HashingBenchmark.sha1:·sun.gc.collector.0.invocations   67108864  thrpt    5             ≈ 0
  **/
 @Fork(1)

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/MessageDigestHasherBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/MessageDigestHasherBenchmark.java
@@ -33,12 +33,12 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * Benchmark                               Mode  Cnt          Score          Error  Units
- * MessageDigestHasherBenchmark.md5_int   thrpt    5   17463088.108 ±   422892.544  ops/s
- * MessageDigestHasherBenchmark.md5_long  thrpt    5   17456480.070 ±   137585.599  ops/s
- * MessageDigestHasherBenchmark.md5_null  thrpt    5   16795469.708 ±  1165065.339  ops/s
- * MessageDigestHasherBenchmark.sha1_int  thrpt    5   12422861.152 ±   270839.818  ops/s
- * MessageDigestHasherBenchmark.sha1_long thrpt    5   12110906.032 ±    79880.942  ops/s
- * MessageDigestHasherBenchmark.sha1_null thrpt    5   12403574.931 ±   215304.201  ops/s
+ * MessageDigestHasherBenchmark.md5_int   thrpt    5   17072888.496 ±   302858.912  ops/s
+ * MessageDigestHasherBenchmark.md5_long  thrpt    5   17727372.147 ±   151062.619  ops/s
+ * MessageDigestHasherBenchmark.md5_null  thrpt    5   18030982.386 ±   103535.132  ops/s
+ * MessageDigestHasherBenchmark.sha1_int  thrpt    5   13559438.368 ±   149806.651  ops/s
+ * MessageDigestHasherBenchmark.sha1_long thrpt    5   11535723.755 ±   155336.223  ops/s
+ * MessageDigestHasherBenchmark.sha1_null thrpt    5   13357694.157 ±    50179.359  ops/s
  **/
 @Fork(1)
 @Threads(4)

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/MessageDigestHasherBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/MessageDigestHasherBenchmark.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect;
+
+import org.gradle.internal.hash.HashCode;
+import org.gradle.internal.hash.HashFunction;
+import org.gradle.internal.hash.Hasher;
+import org.gradle.internal.hash.Hashing;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Benchmark                               Mode  Cnt          Score          Error  Units
+ * MessageDigestHasherBenchmark.md5_int   thrpt    5   17463088.108 ±   422892.544  ops/s
+ * MessageDigestHasherBenchmark.md5_long  thrpt    5   17456480.070 ±   137585.599  ops/s
+ * MessageDigestHasherBenchmark.md5_null  thrpt    5   16795469.708 ±  1165065.339  ops/s
+ * MessageDigestHasherBenchmark.sha1_int  thrpt    5   12422861.152 ±   270839.818  ops/s
+ * MessageDigestHasherBenchmark.sha1_long thrpt    5   12110906.032 ±    79880.942  ops/s
+ * MessageDigestHasherBenchmark.sha1_null thrpt    5   12403574.931 ±   215304.201  ops/s
+ **/
+@Fork(1)
+@Threads(4)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+public class MessageDigestHasherBenchmark {
+    HashFunction sha1, md5;
+
+    @Setup
+    public void setup() {
+        sha1 = Hashing.sha1();
+        md5 = Hashing.md5();
+    }
+
+    @Benchmark
+    public HashCode sha1_int() {
+        Hasher hasher = sha1.defaultHasher();
+        hasher.putInt(Integer.MAX_VALUE);
+        return hasher.hash();
+    }
+
+    @Benchmark
+    public HashCode sha1_long() {
+        Hasher hasher = sha1.defaultHasher();
+        hasher.putLong(Long.MAX_VALUE);
+        return hasher.hash();
+    }
+
+    @Benchmark
+    public HashCode sha1_null() {
+        Hasher hasher = sha1.defaultHasher();
+        hasher.putNull();
+        return hasher.hash();
+    }
+
+    @Benchmark
+    public HashCode md5_int() {
+        Hasher hasher = md5.defaultHasher();
+        hasher.putInt(Integer.MAX_VALUE);
+        return hasher.hash();
+    }
+
+    @Benchmark
+    public HashCode md5_long() {
+        Hasher hasher = md5.defaultHasher();
+        hasher.putLong(Long.MAX_VALUE);
+        return hasher.hash();
+    }
+
+    @Benchmark
+    public HashCode md5_null() {
+        Hasher hasher = md5.defaultHasher();
+        hasher.putNull();
+        return hasher.hash();
+    }
+}

--- a/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/MessageDigestThreadingBenchmark.java
+++ b/subprojects/base-services/src/jmh/java/org/gradle/internal/reflect/MessageDigestThreadingBenchmark.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.reflect;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.security.MessageDigest;
+import java.util.function.Supplier;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Benchmark                                         Mode  Cnt          Score          Error  Units
+ * MessageDigestThreadingBenchmark.md5_clone        thrpt    5   52338355.375 ±   153545.495  ops/s
+ * MessageDigestThreadingBenchmark.md5_threadLocal  thrpt    5  890364532.949 ± 11466693.846  ops/s
+ * MessageDigestThreadingBenchmark.sha1_clone       thrpt    5   27785773.663 ±   147045.446  ops/s
+ * MessageDigestThreadingBenchmark.sha1_threadLocal thrpt    5  891209465.144 ±  7541321.105  ops/s
+ **/
+@Fork(1)
+@Threads(4)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1, timeUnit = SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = SECONDS)
+public class MessageDigestThreadingBenchmark {
+    MessageDigest md5, sha1;
+    ThreadLocal<MessageDigest> md5_TL, sha1_TL;
+
+    @Setup
+    public void setup() throws Exception {
+        md5 = MessageDigest.getInstance("MD5");
+        md5_TL = ThreadLocal.withInitial(new Supplier<MessageDigest>() {
+            public MessageDigest get() {
+                try {
+                    return (MessageDigest) md5.clone();
+                } catch (CloneNotSupportedException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        });
+
+        sha1 = MessageDigest.getInstance("SHA-1");
+        sha1_TL = ThreadLocal.withInitial(new Supplier<MessageDigest>() {
+            public MessageDigest get() {
+                try {
+                    return (MessageDigest) sha1.clone();
+                } catch (CloneNotSupportedException e) {
+                    throw new IllegalStateException(e);
+                }
+            }
+        });
+    }
+
+    @Benchmark
+    public Object md5_clone() throws Exception {
+        return md5.clone();
+    }
+
+    @Benchmark
+    public Object md5_threadLocal() {
+        return md5_TL.get();
+    }
+
+    @Benchmark
+    public Object sha1_clone() throws Exception {
+        return sha1.clone();
+    }
+
+    @Benchmark
+    public Object sha1_threadLocal() {
+        return sha1_TL.get();
+    }
+}

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.hash;
 
+import com.google.common.primitives.Ints;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -50,12 +52,8 @@ public class HashCode implements Serializable, Comparable<HashCode> {
     }
 
     public static HashCode fromInt(int value) {
-        return fromBytesNoCopy(new byte[] {
-            (byte) (value >> 24),
-            (byte) (value >> 16),
-            (byte) (value >> 8),
-            (byte) value
-        });
+        byte[] bytes = Ints.toByteArray(value);
+        return fromBytesNoCopy(bytes);
     }
 
     public static HashCode fromString(String string) {

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashFunction.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashFunction.java
@@ -24,12 +24,12 @@ public interface HashFunction {
     /**
      * Returns a primitive hasher using the hash function.
      */
-    PrimitiveHasher newPrimitiveHasher();
+    PrimitiveHasher primitiveHasher();
 
     /**
      * Returns a prefixing hasher using the hash function.
      */
-    Hasher newHasher();
+    Hasher defaultHasher();
 
     /**
      * Hash the given bytes using the hash function.

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hasher.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hasher.java
@@ -21,52 +21,7 @@ package org.gradle.internal.hash;
  *
  * In order to avoid collisions we prepend the length of the next bytes to the underlying hasher (see this <a href="http://crypto.stackexchange.com/a/10065">answer</a> on stackexchange).
  */
-public interface Hasher {
-    /**
-     * Feed a bunch of bytes into the hasher.
-     */
-    void putBytes(byte[] bytes);
-
-    /**
-     * Feed a given number of bytes into the hasher from the given offset.
-     */
-    void putBytes(byte[] bytes, int off, int len);
-
-    /**
-     * Feed a single byte into the hasher.
-     */
-    void putByte(byte value);
-
-    /**
-     * Feed an integer byte into the hasher.
-     */
-    void putInt(int value);
-
-    /**
-     * Feed a long value byte into the hasher.
-     */
-    void putLong(long value);
-
-    /**
-     * Feed a double value into the hasher.
-     */
-    void putDouble(double value);
-
-    /**
-     * Feed a boolean value into the hasher.
-     */
-    void putBoolean(boolean value);
-
-    /**
-     * Feed a string into the hasher.
-     */
-    void putString(CharSequence value);
-
-    /**
-     * Feed a hash code into the hasher.
-     */
-    void putHash(HashCode hashCode);
-
+public interface Hasher extends PrimitiveHasher {
     /**
      * Feed a {@code null} value into the hasher.
      */
@@ -87,13 +42,4 @@ public interface Hasher {
      * Reason why the hash is not valid.
      */
     String getInvalidReason();
-
-    /**
-     * Returns the combined hash.
-     *
-     * If the build cache hash is invalid, an exception is thrown.
-     *
-     * @throws IllegalStateException if the hasher state is invalid.
-     */
-    HashCode hash();
 }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -197,39 +197,28 @@ public class Hashing {
 
     private static class MessageDigestHasher implements PrimitiveHasher {
         private final MessageDigest digest;
-        private boolean done;
 
         public MessageDigestHasher(MessageDigest digest) {
             this.digest = digest;
         }
 
-        private void checkNotDone() {
-            if (done) {
-                throw new IllegalStateException("Cannot reuse hasher");
-            }
-        }
-
         @Override
         public void putByte(byte b) {
-            checkNotDone();
             digest.update(b);
         }
 
         @Override
         public void putBytes(byte[] bytes) {
-            checkNotDone();
             digest.update(bytes);
         }
 
         @Override
         public void putBytes(byte[] bytes, int off, int len) {
-            checkNotDone();
             digest.update(bytes, off, len);
         }
 
         @Override
         public HashCode hash() {
-            done = true;
             byte[] bytes = digest.digest();
             return HashCode.fromBytesNoCopy(bytes);
         }
@@ -271,7 +260,6 @@ public class Hashing {
 
         @Override
         public void putBoolean(boolean value) {
-            checkNotDone();
             putByte((byte) (value ? 1 : 0));
         }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -18,6 +18,8 @@ package org.gradle.internal.hash;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
 import org.gradle.internal.io.NullOutputStream;
 
 import java.io.OutputStream;
@@ -193,30 +195,13 @@ public class Hashing {
 
         @Override
         public void putInt(int value) {
-            byte[] bytes = new byte[]{
-                (byte) value,
-                (byte) (value >> 8),
-                (byte) (value >> 16),
-                (byte) (value >> 24)
-            };
-            // TODO change to bigendian Ints.toByteArray(value);
-            // TODO: apply to org.gradle.internal.hash.HashCode.fromInt, too
+            byte[] bytes = Ints.toByteArray(value);
             putBytes(bytes);
         }
 
         @Override
         public void putLong(long value) {
-            byte[] bytes = new byte[]{
-                (byte) value,
-                (byte) (value >> 8),
-                (byte) (value >> 16),
-                (byte) (value >> 24),
-                (byte) (value >> 32),
-                (byte) (value >> 40),
-                (byte) (value >> 48),
-                (byte) (value >> 56)
-            };
-            // TODO change to bigendian Longs.toByteArray(value);
+            byte[] bytes = Longs.toByteArray(value);
             putBytes(bytes);
         }
 

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -18,12 +18,9 @@ package org.gradle.internal.hash;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
-import org.gradle.internal.io.BufferCaster;
 import org.gradle.internal.io.NullOutputStream;
 
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
@@ -200,7 +197,6 @@ public class Hashing {
 
     private static class MessageDigestHasher implements PrimitiveHasher {
         private final MessageDigest digest;
-        private final ByteBuffer buffer = ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN);
         private boolean done;
 
         public MessageDigestHasher(MessageDigest digest) {
@@ -238,22 +234,33 @@ public class Hashing {
             return HashCode.fromBytesNoCopy(bytes);
         }
 
-        private void update(int length) {
-            checkNotDone();
-            digest.update(buffer.array(), 0, length);
-            BufferCaster.cast(buffer).clear();
-        }
-
         @Override
         public void putInt(int value) {
-            buffer.putInt(value);
-            update(4);
+            byte[] bytes = new byte[]{
+                (byte) value,
+                (byte) (value >> 8),
+                (byte) (value >> 16),
+                (byte) (value >> 24)
+            };
+            // TODO change to bigendian Ints.toByteArray(value);
+            // TODO: apply to org.gradle.internal.hash.HashCode.fromInt, too
+            putBytes(bytes);
         }
 
         @Override
         public void putLong(long value) {
-            buffer.putLong(value);
-            update(8);
+            byte[] bytes = new byte[]{
+                (byte) value,
+                (byte) (value >> 8),
+                (byte) (value >> 16),
+                (byte) (value >> 24),
+                (byte) (value >> 32),
+                (byte) (value >> 40),
+                (byte) (value >> 48),
+                (byte) (value >> 56)
+            };
+            // TODO change to bigendian Longs.toByteArray(value);
+            putBytes(bytes);
         }
 
         @Override

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/Hashing.java
@@ -44,14 +44,14 @@ public class Hashing {
      * Returns a new {@link Hasher} based on the default hashing implementation.
      */
     public static Hasher newHasher() {
-        return DEFAULT.newHasher();
+        return DEFAULT.defaultHasher();
     }
 
     /**
      * Returns a new {@link PrimitiveHasher} based on the default hashing implementation.
      */
     public static PrimitiveHasher newPrimitiveHasher() {
-        return DEFAULT.newPrimitiveHasher();
+        return DEFAULT.primitiveHasher();
     }
 
     /**
@@ -65,7 +65,7 @@ public class Hashing {
      * Returns a hash code to use as a signature for a given thing.
      */
     public static HashCode signature(String thing) {
-        Hasher hasher = DEFAULT.newHasher();
+        Hasher hasher = DEFAULT.defaultHasher();
         hasher.putString("SIGNATURE");
         hasher.putString(thing);
         return hasher.hash();
@@ -137,26 +137,26 @@ public class Hashing {
         }
 
         @Override
-        public PrimitiveHasher newPrimitiveHasher() {
+        public PrimitiveHasher primitiveHasher() {
             MessageDigest digest = createDigest();
             return new MessageDigestHasher(digest);
         }
 
         @Override
-        public Hasher newHasher() {
-            return new DefaultHasher(newPrimitiveHasher());
+        public Hasher defaultHasher() {
+            return new DefaultHasher(primitiveHasher());
         }
 
         @Override
         public HashCode hashBytes(byte[] bytes) {
-            PrimitiveHasher hasher = newPrimitiveHasher();
+            PrimitiveHasher hasher = primitiveHasher();
             hasher.putBytes(bytes);
             return hasher.hash();
         }
 
         @Override
         public HashCode hashString(CharSequence string) {
-            PrimitiveHasher hasher = newPrimitiveHasher();
+            PrimitiveHasher hasher = primitiveHasher();
             hasher.putString(string);
             return hasher.hash();
         }

--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashingOutputStream.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashingOutputStream.java
@@ -31,7 +31,7 @@ public final class HashingOutputStream extends FilterOutputStream {
 
     public HashingOutputStream(HashFunction hashFunction, OutputStream out) {
         super(checkNotNull(out));
-        this.hasher = checkNotNull(hashFunction.newPrimitiveHasher());
+        this.hasher = checkNotNull(hashFunction.primitiveHasher());
     }
 
     @Override

--- a/subprojects/base-services/src/test/groovy/org/gradle/internal/hash/HashingTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/internal/hash/HashingTest.groovy
@@ -58,7 +58,7 @@ class HashingTest extends Specification {
             sharedHasher.putBytes(input)
 
             MessageDigest newHasher = MessageDigest.getInstance("MD5")
-            newHasher.update([input.length, (input.length >> 8), (input.length >> 16), (input.length >> 24)] as byte[])
+            newHasher.update([(input.length >> 24), (input.length >> 16), (input.length >> 8), input.length] as byte[])
             newHasher.update(input)
 
             assert sharedHasher.hash().toByteArray() == newHasher.digest()

--- a/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheKeyBuilder.java
+++ b/subprojects/persistent-cache/src/main/java/org/gradle/cache/internal/DefaultCacheKeyBuilder.java
@@ -87,7 +87,7 @@ class DefaultCacheKeyBuilder implements CacheKeyBuilder {
     }
 
     private HashCode combinedHashOf(Object[] components) {
-        Hasher hasher = hashFunction.newHasher();
+        Hasher hasher = hashFunction.defaultHasher();
         for (Object component : components) {
             hasher.putHash(hashOf(component));
         }

--- a/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheKeyBuilderTest.groovy
+++ b/subprojects/persistent-cache/src/test/groovy/org/gradle/cache/internal/DefaultCacheKeyBuilderTest.groovy
@@ -147,7 +147,7 @@ class DefaultCacheKeyBuilderTest extends Specification {
         def key = subject.build(CacheKeySpec.withPrefix(prefix) + string + file)
 
         then:
-        1 * hashFunction.newHasher() >> hasher
+        1 * hashFunction.defaultHasher() >> hasher
         1 * hashFunction.hashString(string) >> stringHash
         1 * fileHasher.hash(file) >> fileHash
         1 * hasher.putHash(stringHash)


### PR DESCRIPTION
Test failure reason before the change:
![cannot-reuse-hasher](https://user-images.githubusercontent.com/1841944/56802681-f4fd6480-6820-11e9-99e9-b44138c16e07.png)

* Hashing uses big-endian from now on, consistently
* Made `Hashing` reusable instead of cloning it every time
  * Made `MessageDigestHasher` slightly less stateful by replacing `ByteBuffer` with explicit conversion
  * Rename `HashFunction` methods hinting at object allocation
* Added benchmarks for multi-threaded hashing alternatives

Performance is basically the same (see benchmark commits), but gc usage is lower please see: https://github.com/gradle/gradle/pull/9298/commits/8d1a9f5559189be0ddf407947c10c0cb7bb75e6c

Please review [commit-by-commit](https://github.com/gradle/gradle/pull/9298/commits) to have a smaller context.

Related discussion for `aws-sdk-java`: https://github.com/aws/aws-sdk-java/issues/1704#issuecomment-410380550 (summary: they chose to use `ThreadLocal` and provide a cleaning api for the users)