### PR TITLE
Update build scan plugin to 2.3-rc-1

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.8")
     implementation("org.jsoup:jsoup:1.11.3")
-    implementation("com.gradle:build-scan-plugin:2.2.1")
+    implementation("com.gradle:build-scan-plugin:2.3-rc-1-20190426133611-release")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
     implementation(project(":plugins"))


### PR DESCRIPTION
### Context
Update build scan plugin used by the Gradle project to 2.3-rc-1