### PR TITLE
Collection utils speedup for sized iterables

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.Transformer;
 import org.gradle.api.specs.Spec;
-import org.gradle.internal.Cast;
 import org.gradle.internal.Factory;
 import org.gradle.internal.Pair;
 import org.gradle.internal.Transformers;
@@ -50,6 +49,8 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 
 import static org.gradle.internal.Cast.cast;
+import static org.gradle.internal.Cast.uncheckedCast;
+import static org.gradle.internal.Cast.uncheckedNonnullCast;
 
 public abstract class CollectionUtils {
 
@@ -80,7 +81,7 @@ public abstract class CollectionUtils {
         for (Object o : input) {
             cast(type, o);
         }
-        return Cast.uncheckedCast(input);
+        return uncheckedCast(input);
     }
 
     @Nullable
@@ -184,10 +185,6 @@ public abstract class CollectionUtils {
         return destination;
     }
 
-    public static <R, I> List<R> collect(List<? extends I> list, Transformer<? extends R, ? super I> transformer) {
-        return collect(list, new ArrayList<R>(list.size()), transformer);
-    }
-
     public static <R, I> List<R> collect(I[] list, Transformer<? extends R, ? super I> transformer) {
         return collect(Arrays.asList(list), transformer);
     }
@@ -197,7 +194,12 @@ public abstract class CollectionUtils {
     }
 
     public static <R, I> List<R> collect(Iterable<? extends I> source, Transformer<? extends R, ? super I> transformer) {
-        return collect(source, new LinkedList<R>(), transformer);
+        if (source instanceof Collection<?>) {
+            Collection<? extends I> collection = uncheckedNonnullCast(source);
+            return collect(source, new ArrayList<R>(collection.size()), transformer);
+        } else {
+            return collect(source, new LinkedList<R>(), transformer);
+        }
     }
 
     public static <R, I, C extends Collection<R>> C collect(Iterable<? extends I> source, C destination, Transformer<? extends R, ? super I> transformer) {

--- a/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
+++ b/subprojects/base-services/src/main/java/org/gradle/util/CollectionUtils.java
@@ -193,7 +193,7 @@ public abstract class CollectionUtils {
     }
 
     public static <R, I> Set<R> collect(Set<? extends I> set, Transformer<? extends R, ? super I> transformer) {
-        return collect(set, new HashSet<R>(), transformer);
+        return collect(set, new HashSet<R>(set.size()), transformer);
     }
 
     public static <R, I> List<R> collect(Iterable<? extends I> source, Transformer<? extends R, ? super I> transformer) {

--- a/subprojects/base-services/src/test/groovy/org/gradle/util/CollectionUtilsTest.groovy
+++ b/subprojects/base-services/src/test/groovy/org/gradle/util/CollectionUtilsTest.groovy
@@ -126,8 +126,13 @@ class CollectionUtilsTest extends Specification {
         collect([1, 2, 3] as Object[], transformer { it * 2 }) == [2, 4, 6]
     }
 
-    def "collect iterable"() {
+    def "collect non-collection Iterable"() {
         expect:
+        def nonCollectionIterable = [iterator: { [1, 2, 3].iterator() }] as Iterable
+        collect(nonCollectionIterable, transformer { it * 2 }) == [2, 4, 6]
+    }
+
+    def "collect of collection iterable"() {
         collect([1, 2, 3] as Iterable, transformer { it * 2 }) == [2, 4, 6]
     }
 


### PR DESCRIPTION
It's easier to create copies of `Collection`s than `Iterable`s, because of their known size.
This PR takes advantage of that in a few simple cases.

Before:
```
Benchmark                                    (size)   Mode  Cnt         Score        Error  Units
CollectionUtilsBenchmark.collect_collection      10  thrpt   20  17594714.598 ±  93418.600  ops/s
CollectionUtilsBenchmark.collect_collection     100  thrpt   20   1879849.351 ±  81698.302  ops/s
CollectionUtilsBenchmark.collect_collection    1000  thrpt   20    194278.105 ±   5444.248  ops/s
CollectionUtilsBenchmark.collect_iterable        10  thrpt   20  17400146.689 ± 159109.940  ops/s
CollectionUtilsBenchmark.collect_iterable       100  thrpt   20   2044732.571 ±  22123.885  ops/s
CollectionUtilsBenchmark.collect_iterable      1000  thrpt   20    206728.343 ±   2648.332  ops/s
CollectionUtilsBenchmark.collect_set             10  thrpt   20   9334146.882 ±  52347.921  ops/s
CollectionUtilsBenchmark.collect_set            100  thrpt   20    585551.459 ±  15429.135  ops/s
CollectionUtilsBenchmark.collect_set           1000  thrpt   20     62993.322 ±   1863.450  ops/s
```
After:
```
Benchmark                                    (size)   Mode  Cnt         Score        Error  Units
CollectionUtilsBenchmark.collect_collection      10  thrpt   20  25044591.599 ± 470130.788  ops/s
CollectionUtilsBenchmark.collect_collection     100  thrpt   20   2874923.581 ±  40558.137  ops/s
CollectionUtilsBenchmark.collect_collection    1000  thrpt   20    295896.916 ±   1213.754  ops/s
CollectionUtilsBenchmark.collect_iterable        10  thrpt   20  17647067.697 ± 385483.786  ops/s
CollectionUtilsBenchmark.collect_iterable       100  thrpt   20   2058919.036 ±  28507.690  ops/s
CollectionUtilsBenchmark.collect_iterable      1000  thrpt   20    208554.590 ±   1459.872  ops/s
CollectionUtilsBenchmark.collect_set             10  thrpt   20   9243910.992 ± 104211.609  ops/s
CollectionUtilsBenchmark.collect_set            100  thrpt   20    692530.109 ±  19110.223  ops/s
CollectionUtilsBenchmark.collect_set           1000  thrpt   20     71080.103 ±   2151.557  ops/s
```

This should also generate less garbage, since `collect` won't need so many `ArrayList` and `HashSet` resizes.