### PR TITLE
Polish Kotlin DSL

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/provider/KotlinScriptClassPathProvider.kt
@@ -25,7 +25,7 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.internal.ClassPathRegistry
 import org.gradle.api.internal.artifacts.dsl.dependencies.DependencyFactory
 import org.gradle.api.internal.classpath.ModuleRegistry
-import org.gradle.api.internal.file.DefaultFileCollectionFactory
+import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.initialization.ClassLoaderScope
 
 import org.gradle.internal.classloader.ClassLoaderVisitor
@@ -59,15 +59,15 @@ fun gradleKotlinDslOf(project: Project): List<File> =
 
 
 fun gradleKotlinDslJarsOf(project: Project): FileCollection =
-    fileCollectionOf(
+    project.fileCollectionOf(
         kotlinScriptClassPathProviderOf(project).gradleKotlinDslJars.asFiles.filter(::isGradleKotlinDslJar),
         "gradleKotlinDsl"
     )
 
 
 internal
-fun fileCollectionOf(files: Collection<File>, name: String): FileCollection =
-    DefaultFileCollectionFactory().fixed(name, files)
+fun Project.fileCollectionOf(files: Collection<File>, name: String): FileCollection =
+    serviceOf<FileCollectionFactory>().fixed(name, files)
 
 
 internal

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/support/delegates/ClientModuleDelegate.kt
@@ -48,7 +48,7 @@ abstract class ClientModuleDelegate : ClientModule {
 
     override fun getGroup(): String =
         /** Because this also implements [ModuleVersionSelector.getGroup] it must not return `null` */
-        delegate.group ?: ""
+        (delegate as Dependency).group ?: ""
 
     override fun addDependency(dependency: ModuleDependency) =
         delegate.addDependency(dependency)


### PR DESCRIPTION
This PR removes a couple of warnings from the Kotlin DSL codebase and, more importantly, improves precompiled script plugin validation by emitting a help message when the user specifies a version number in a script plugin `plugins` block.