### PR TITLE
Make Hashing slightly more consistent

### DIFF
--- a/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashCode.java
+++ b/subprojects/base-services/src/main/java/org/gradle/internal/hash/HashCode.java
@@ -16,6 +16,8 @@
 
 package org.gradle.internal.hash;
 
+import com.google.common.primitives.Ints;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -50,12 +52,8 @@ public class HashCode implements Serializable, Comparable<HashCode> {
     }
 
     public static HashCode fromInt(int value) {
-        return fromBytesNoCopy(new byte[] {
-            (byte) (value >> 24),
-            (byte) (value >> 16),
-            (byte) (value >> 8),
-            (byte) value
-        });
+        byte[] bytes = Ints.toByteArray(value); // Big-endian
+        return fromBytesNoCopy(bytes);
     }
 
     public static HashCode fromString(String string) {


### PR DESCRIPTION
Few minor changes to make Hashing more consistent like:
* Make `MessageDigestHasher` slightly less stateful by replacing `ByteBuffer` with explicit conversion
* Add new hasher tests for `Hashing#hash` consistency
* Prohibit calling `Hashing#hash` multiple times, since it will reset the state in-between and return different result

It's a fallback of https://github.com/gradle/gradle/pull/9298

Please review [commit-by-commit](https://github.com/gradle/gradle/pull/9315/commits).