### PR TITLE
Add a build operation that covers the time a task spends waiting

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -215,8 +215,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultImmutableAttributesFactory(isolatableFactory, NamedObjectInstantiator.INSTANCE);
     }
 
-    AsyncWorkTracker createAsyncWorkTracker(ProjectLeaseRegistry projectLeaseRegistry) {
-        return new DefaultAsyncWorkTracker(projectLeaseRegistry);
+    AsyncWorkTracker createAsyncWorkTracker(ProjectLeaseRegistry projectLeaseRegistry, BuildOperationExecutor buildOperationExecutor) {
+        return new DefaultAsyncWorkTracker(projectLeaseRegistry, buildOperationExecutor);
     }
 
     UserScopeId createUserScopeId(PersistentScopeIdLoader persistentScopeIdLoader) {

--- a/subprojects/core/src/main/java/org/gradle/internal/work/TaskWaitingBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/TaskWaitingBuildOperationType.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.internal.work;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+/**
+ * Represents the time a task spends waiting for other operations to complete.
+ *
+ * @since 5.5
+ */
+public final class TaskWaitingBuildOperationType implements BuildOperationType<TaskWaitingBuildOperationType.Details, TaskWaitingBuildOperationType.Result> {
+
+    public interface Details {
+    }
+
+    public interface Result {
+    }
+
+    private TaskWaitingBuildOperationType() {
+    }
+
+}

--- a/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
@@ -18,7 +18,9 @@ package org.gradle.internal.work
 
 import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.exceptions.DefaultMultiCauseException
+import org.gradle.internal.operations.BuildOperationExecutor
 import org.gradle.internal.operations.BuildOperationRef
+import org.gradle.internal.operations.TestBuildOperationExecutor
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ProjectLeaseRegistry
 import org.gradle.internal.resources.ResourceLockCoordinationService
@@ -27,7 +29,8 @@ import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
     ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
     WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
-    AsyncWorkTracker asyncWorkTracker = new DefaultAsyncWorkTracker(workerLeaseService)
+    BuildOperationExecutor buildOperationExecutor = new TestBuildOperationExecutor()
+    AsyncWorkTracker asyncWorkTracker = new DefaultAsyncWorkTracker(workerLeaseService, buildOperationExecutor)
 
     def "can wait for async work to complete"() {
         def operation = Mock(BuildOperationRef)
@@ -276,7 +279,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "releases a project lock before waiting on async work"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, buildOperationExecutor)
         def operation1 = Mock(BuildOperationRef)
 
         when:
@@ -303,7 +306,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "does not release a project lock before waiting on async work when releaseLocks is false"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, buildOperationExecutor)
         def operation1 = Mock(BuildOperationRef)
 
         when:
@@ -330,7 +333,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "does not release a project lock before waiting on async work when no work is registered"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, buildOperationExecutor)
         def operation1 = Mock(BuildOperationRef)
 
         when:
@@ -342,7 +345,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "does not release a project lock when all async work is already completed"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, buildOperationExecutor)
         def operation1 = Mock(BuildOperationRef)
 
         when:


### PR DESCRIPTION
When a task submits jobs via the worker API, it needs to wait for:
- Work items to complete
- The project lock to be available

This PR adds a build operation that makes that time visible.
