### PR TITLE
Provide details of post-action wait time for task action

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskActionBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/tasks/execution/ExecuteTaskActionBuildOperationType.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.tasks.execution;
+
+import org.gradle.internal.operations.BuildOperationType;
+
+import javax.annotation.Nullable;
+
+/**
+ * The execution of a single task action.
+ */
+public final class ExecuteTaskActionBuildOperationType implements BuildOperationType<ExecuteTaskActionBuildOperationType.Details, ExecuteTaskActionBuildOperationType.Result> {
+
+    public interface Details {
+    }
+
+    public interface Result {
+        /**
+         * Provides the time spent waiting for work items and/or locks after the task action has completed.
+         * @return the post-action wait time, or `null` if no wait was required.
+         */
+        @Nullable
+        Wait getPostActionWait();
+
+        interface Wait {
+            long getStartTime();
+            long getDuration();
+        }
+    }
+
+    private ExecuteTaskActionBuildOperationType() {
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildSessionScopeServices.java
@@ -215,8 +215,8 @@ public class BuildSessionScopeServices extends DefaultServiceRegistry {
         return new DefaultImmutableAttributesFactory(isolatableFactory, NamedObjectInstantiator.INSTANCE);
     }
 
-    AsyncWorkTracker createAsyncWorkTracker(ProjectLeaseRegistry projectLeaseRegistry) {
-        return new DefaultAsyncWorkTracker(projectLeaseRegistry);
+    AsyncWorkTracker createAsyncWorkTracker(ProjectLeaseRegistry projectLeaseRegistry, Clock clock) {
+        return new DefaultAsyncWorkTracker(projectLeaseRegistry, clock);
     }
 
     UserScopeId createUserScopeId(PersistentScopeIdLoader persistentScopeIdLoader) {

--- a/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/work/AsyncWorkTracker.java
@@ -40,10 +40,17 @@ public interface AsyncWorkTracker {
      * @param operation - The build operation whose asynchronous work should be completed
      * @param releaseLocks - Whether or not project locks should be released while waiting on work
      */
-    void waitForCompletion(BuildOperationRef operation, boolean releaseLocks);
+    WaitDetails waitForCompletion(BuildOperationRef operation, boolean releaseLocks);
 
     /**
      * Returns true if the given operation has work registered that has not completed.
      */
     boolean hasUncompletedWork(BuildOperationRef operation);
+
+    interface WaitDetails {
+        boolean getDidWait();
+        long getStartTime();
+        long getEndTime();
+        long getDuration();
+    }
 }

--- a/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/internal/work/DefaultAsyncWorkTrackerTest.groovy
@@ -22,12 +22,15 @@ import org.gradle.internal.operations.BuildOperationRef
 import org.gradle.internal.resources.DefaultResourceLockCoordinationService
 import org.gradle.internal.resources.ProjectLeaseRegistry
 import org.gradle.internal.resources.ResourceLockCoordinationService
+import org.gradle.internal.time.Clock
+import org.gradle.internal.time.MockClock
 import org.gradle.test.fixtures.concurrent.ConcurrentSpec
 
 class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
     ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
     WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
-    AsyncWorkTracker asyncWorkTracker = new DefaultAsyncWorkTracker(workerLeaseService)
+    Clock clock = new MockClock()
+    AsyncWorkTracker asyncWorkTracker = new DefaultAsyncWorkTracker(workerLeaseService, clock)
 
     def "can wait for async work to complete"() {
         def operation = Mock(BuildOperationRef)
@@ -276,7 +279,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "releases a project lock before waiting on async work"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, clock)
         def operation1 = Mock(BuildOperationRef)
 
         when:
@@ -303,7 +306,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "does not release a project lock before waiting on async work when releaseLocks is false"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, clock)
         def operation1 = Mock(BuildOperationRef)
 
         when:
@@ -330,7 +333,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "does not release a project lock before waiting on async work when no work is registered"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, clock)
         def operation1 = Mock(BuildOperationRef)
 
         when:
@@ -342,7 +345,7 @@ class DefaultAsyncWorkTrackerTest extends ConcurrentSpec {
 
     def "does not release a project lock when all async work is already completed"() {
         def projectLockService = Mock(ProjectLeaseRegistry)
-        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService)
+        def asyncWorkTracker = new DefaultAsyncWorkTracker(projectLockService, clock)
         def operation1 = Mock(BuildOperationRef)
 
         when:


### PR DESCRIPTION
This PR adds a typed build operation for execution of a single task action, and includes details of the time spent waiting for work items and/or locks after the action has completed.