### PR TITLE
Update build scan plugin to 2.3

### DIFF
--- a/buildSrc/subprojects/profiling/profiling.gradle.kts
+++ b/buildSrc/subprojects/profiling/profiling.gradle.kts
@@ -1,7 +1,7 @@
 dependencies {
     implementation("me.champeau.gradle:jmh-gradle-plugin:0.4.8")
     implementation("org.jsoup:jsoup:1.11.3")
-    implementation("com.gradle:build-scan-plugin:2.2.1")
+    implementation("com.gradle:build-scan-plugin:2.3")
     implementation(project(":configuration"))
     implementation(project(":kotlinDsl"))
     implementation(project(":plugins"))

--- a/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedBuildScanPlugin.java
+++ b/subprojects/core/src/main/java/org/gradle/plugin/management/internal/autoapply/AutoAppliedBuildScanPlugin.java
@@ -31,7 +31,7 @@ public final class AutoAppliedBuildScanPlugin {
     public static final PluginId ID = new DefaultPluginId("com.gradle.build-scan");
     public static final String GROUP = "com.gradle";
     public static final String NAME = "build-scan-plugin";
-    public static final String VERSION = "2.2.1";
+    public static final String VERSION = "2.3";
 
     /**
      * Adds the {@code build-scan} plugin spec to the given {@link PluginDependenciesSpec} and returns the

--- a/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
+++ b/subprojects/smoke-test/src/smokeTest/groovy/org/gradle/smoketests/BuildScanPluginSmokeTest.groovy
@@ -33,6 +33,7 @@ class BuildScanPluginSmokeTest extends AbstractSmokeTest {
     ]
 
     private static final List<String> SUPPORTED = [
+            "2.3",
             "2.2.1",
             "2.2",
             "2.1",


### PR DESCRIPTION
### Context

We just released build scan plugin 2.3

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
