### PR TITLE
Proposed fix for issue #4675

### DIFF
--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptTemplateBindingFactory.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/plugins/StartScriptTemplateBindingFactory.java
@@ -169,6 +169,12 @@ public class StartScriptTemplateBindingFactory implements Transformer<Map<String
 
     String createJoinedAppHomeRelativePath(String scriptRelPath) {
         int depth = StringUtils.countMatches(scriptRelPath, "/");
+
+        // Do not count the initial "/", if present
+        if (scriptRelPath.startsWith("/")) {
+            depth--;
+        }
+
         if (depth == 0) {
             return "";
         }


### PR DESCRIPTION
This fixed the generation of start scripts when `executableDir` is set to `''`

Signed-off-by: Tomas Pluskal <plusik@gmail.com>


### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
