### PR TITLE
Use JaCoCo 0.8.4 by default

### DIFF
--- a/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
+++ b/subprojects/docs/src/docs/dsl/org.gradle.testing.jacoco.plugins.JacocoPluginExtension.xml
@@ -26,7 +26,7 @@
             </thead>
             <tr>
                 <td>toolVersion</td>
-                <td><literal>0.8.3</literal></td>
+                <td><literal>0.8.4</literal></td>
             </tr>
             <tr>
                 <td>reportsDir</td>

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -105,6 +105,10 @@ See the [Gradle 5.x upgrade guide](userguide/upgrading_version_5.html#changes_@b
 
 We love getting contributions from the Gradle community. For information on contributing, please see [gradle.org/contribute](https://gradle.org/contribute).
 
+### Default JaCoCo version upgraded to 0.8.4
+
+[The JaCoCo plugin](userguide/jacoco_plugin.html) has been upgraded to use [JaCoCo version 0.8.4](http://www.jacoco.org/jacoco/trunk/doc/changes.html) instead of 0.8.3 by default.
+
 ## Reporting Problems
 
 If you find a problem with this release, please file a bug on [GitHub Issues](https://github.com/gradle/gradle/issues) adhering to our issue guidelines. 

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/groovy/build.gradle
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/groovy/build.gradle
@@ -26,7 +26,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.3"
+    toolVersion = "0.8.4"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/docs/src/samples/testing/jacoco/quickstart/kotlin/build.gradle.kts
+++ b/subprojects/docs/src/samples/testing/jacoco/quickstart/kotlin/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 // tag::jacoco-configuration[]
 jacoco {
-    toolVersion = "0.8.3"
+    toolVersion = "0.8.4"
     reportsDir = file("$buildDir/customJacocoReportDir")
 }
 // end::jacoco-configuration[]

--- a/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
+++ b/subprojects/jacoco/src/main/java/org/gradle/testing/jacoco/plugins/JacocoPlugin.java
@@ -53,7 +53,7 @@ public class JacocoPlugin implements Plugin<ProjectInternal> {
      * The jacoco version used if none is explicitly specified.
      * @since 3.4
      */
-    public static final String DEFAULT_JACOCO_VERSION = "0.8.3";
+    public static final String DEFAULT_JACOCO_VERSION = "0.8.4";
     public static final String AGENT_CONFIGURATION_NAME = "jacocoAgent";
     public static final String ANT_CONFIGURATION_NAME = "jacocoAnt";
     public static final String PLUGIN_EXTENSION_NAME = "jacoco";

--- a/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
+++ b/subprojects/jacoco/src/test/groovy/org/gradle/internal/jacoco/JacocoAgentJarTest.groovy
@@ -43,6 +43,7 @@ class JacocoAgentJarTest extends Specification {
         '0.7.6.201602180812'  | true
         '0.7.8'               | true
         '0.8.3'               | true
+        '0.8.4'               | true
     }
 
     @Unroll
@@ -63,5 +64,6 @@ class JacocoAgentJarTest extends Specification {
         '0.7.6.201602180812'  | true
         '0.7.8'               | true
         '0.8.3'               | true
+        '0.8.4'               | true
     }
 }


### PR DESCRIPTION
This release is of particular interest for people
* who use recently released Kotlin compiler version 1.3.30+ and coroutines
* who compile into Java 11+ bytecode

Full changelog - http://www.jacoco.org/jacoco/trunk/doc/changes.html