### PR TITLE
Add factory methods to create NamedDomainObjectContainer and DomainObjectSet on ObjectFactory

### DIFF
--- a/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
+++ b/subprojects/core-api/src/main/java/org/gradle/api/model/ObjectFactory.java
@@ -16,8 +16,11 @@
 
 package org.gradle.api.model;
 
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Incubating;
 import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
@@ -98,6 +101,42 @@ public interface ObjectFactory {
     ConfigurableFileCollection fileCollection();
 
     /**
+     * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The specified type must have a public constructor which takes the name as a String parameter.</p>
+     *
+     * <p>All objects <b>MUST</b> expose their name as a bean property named "name". The name must be constant for the life of the object.</p>
+     *
+     * @param elementType The type of objects for the container to contain.
+     * @param <T> The type of objects for the container to contain.
+     * @return The container. Never returns null.
+     * @since 5.5
+     */
+    <T> NamedDomainObjectContainer<T> container(Class<T> elementType);
+
+    /**
+     * <p>Creates a new {@link NamedDomainObjectContainer} for managing named objects of the specified type. The given factory is used to create object instances.</p>
+     *
+     * <p>All objects <b>MUST</b> expose their name as a bean property named "name". The name must be constant for the life of the object.</p>
+     *
+     *
+     * @param elementType The type of objects for the container to contain.
+     * @param factory The factory to use to create object instances.
+     * @param <T> The type of objects for the container to contain.
+     * @return The container. Never returns null.
+     * @since 5.5
+     */
+    <T> NamedDomainObjectContainer<T> container(Class<T> elementType,  NamedDomainObjectFactory<T> factory);
+
+    /**
+     * Creates a new {@link DomainObjectSet} for managing objects of the specified type.
+     *
+     * @param elementType The type of objects for the domain object set to contain.
+     * @param <T> The type of objects for the domain object set to contain.
+     * @return The domain object set. Never returns null.
+     * @since 5.5
+     */
+    <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType);
+
+    /**
      * Creates a {@link Property} implementation to hold values of the given type. The property has no initial value.
      *
      * <p>For certain types, there are more specialized property factory methods available:</p>
@@ -122,7 +161,7 @@ public interface ObjectFactory {
      *
      * @param elementType The type of element.
      * @param <T> The type of element.
-     * @return The property. Never returns null;
+     * @return The property. Never returns null.
      * @since 4.3
      */
     <T> ListProperty<T> listProperty(Class<T> elementType);
@@ -134,7 +173,7 @@ public interface ObjectFactory {
      *
      * @param elementType The type of element.
      * @param <T> The type of element.
-     * @return The property. Never returns null;
+     * @return The property. Never returns null.
      * @since 4.5
      */
     <T> SetProperty<T> setProperty(Class<T> elementType);

--- a/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/internal/model/ObjectFactoryIntegrationTest.groovy
@@ -499,4 +499,61 @@ class ObjectFactoryIntegrationTest extends AbstractIntegrationSpec {
         expect:
         succeeds()
     }
+
+    def "plugin can create NamedDomainObjectContainer instances"() {
+        given:
+        buildFile << """
+            class NamedThing implements Named {
+                final String name
+                NamedThing(String name) {
+                    this.name = name
+                }
+            }
+
+            def container = project.objects.container(NamedThing)
+            assert container != null
+            def element = container.create('foo')
+            assert element.name == 'foo'
+            assert container.size() == 1
+        """
+
+        expect:
+        succeeds()
+    }
+
+    def "plugin can create NamedDomainObjectContainer instances with factory"() {
+        given:
+        buildFile << """
+            class NamedThing implements Named {
+                final String name
+                NamedThing(String name) {
+                    this.name = name
+                }
+            }
+
+            def container = project.objects.container(NamedThing) {
+                return new NamedThing("prefix-" + it)
+            }
+            assert container != null
+            def element = container.create("foo")
+            assert element.name == 'prefix-foo'
+            assert container.size() == 1
+        """
+
+        expect:
+        succeeds()
+    }
+
+    def "plugin can create DomainObjectSet instances"() {
+        given:
+        buildFile << """
+            def domainObjectSet = project.objects.domainObjectSet(String)
+            assert domainObjectSet != null
+            assert domainObjectSet.add('foo')
+            assert domainObjectSet.size() == 1
+        """
+
+        expect:
+        succeeds()
+    }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
@@ -16,15 +16,19 @@
 
 package org.gradle.api.internal.collections;
 
+import groovy.lang.Closure;
+import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DynamicPropertyNamer;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.MutationGuard;
 import org.gradle.api.internal.ReflectiveNamedDomainObjectFactory;
+import org.gradle.internal.Cast;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistry;
@@ -47,18 +51,29 @@ public class DefaultDomainObjectCollectionFactory implements DomainObjectCollect
         // TODO - this should also be using the decorating instantiator but cannot for backwards compatibility
         ReflectiveNamedDomainObjectFactory<T> objectFactory = new ReflectiveNamedDomainObjectFactory<T>(elementType, instantiatorFactory.injectLenient(servicesToInject));
         Instantiator instantiator = instantiatorFactory.decorateLenient();
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, elementType, instantiator, new DynamicPropertyNamer(), objectFactory, mutationGuard, collectionCallbackActionDecorator);
+        return Cast.uncheckedCast(instantiator.newInstance(FactoryNamedDomainObjectContainer.class, elementType, instantiator, new DynamicPropertyNamer(), objectFactory, mutationGuard, collectionCallbackActionDecorator));
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
         Instantiator instantiator = instantiatorFactory.decorateLenient();
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, elementType, instantiator, new DynamicPropertyNamer(), factory, mutationGuard, collectionCallbackActionDecorator);
+        return Cast.uncheckedCast(instantiator.newInstance(FactoryNamedDomainObjectContainer.class, elementType, instantiator, new DynamicPropertyNamer(), factory, mutationGuard, collectionCallbackActionDecorator));
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> type, Closure factoryClosure) {
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return Cast.uncheckedCast(instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure, mutationGuard, collectionCallbackActionDecorator));
     }
 
     @Override
     public <T> DomainObjectSet<T> newDomainObjectSet(Class<T> elementType) {
         Instantiator instantiator = instantiatorFactory.decorateLenient();
-        return instantiator.newInstance(DefaultDomainObjectSet.class, elementType, collectionCallbackActionDecorator);
+        return Cast.uncheckedCast(instantiator.newInstance(DefaultDomainObjectSet.class, elementType, collectionCallbackActionDecorator));
+    }
+
+    @Override
+    public <T> CompositeDomainObjectSet<T> newDomainObjectSet(Class<T> elementType, DomainObjectCollection<? extends T>... collections) {
+        return CompositeDomainObjectSet.create(elementType, collectionCallbackActionDecorator, collections);
     }
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections;
+
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.DynamicPropertyNamer;
+import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
+import org.gradle.api.internal.MutationGuard;
+import org.gradle.api.internal.MutationGuards;
+import org.gradle.api.internal.ReflectiveNamedDomainObjectFactory;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.ServiceRegistry;
+
+public class DefaultDomainObjectCollectionFactory implements DomainObjectCollectionFactory {
+    private final InstantiatorFactory instantiatorFactory;
+    private final ServiceRegistry servicesToInject;
+    private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
+    private final MutationGuard mutationGuard;
+
+    public DefaultDomainObjectCollectionFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry servicesToInject, CollectionCallbackActionDecorator collectionCallbackActionDecorator, MutationGuard mutationGuard) {
+        this.instantiatorFactory = instantiatorFactory;
+        this.servicesToInject = servicesToInject;
+        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+        this.mutationGuard = mutationGuard;
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> elementType) {
+        // TODO - this should also be using the decorating instantiator but cannot for backwards compatibility
+        ReflectiveNamedDomainObjectFactory<T> objectFactory = new ReflectiveNamedDomainObjectFactory<T>(elementType, instantiatorFactory.injectLenient(servicesToInject));
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, elementType, instantiator, new DynamicPropertyNamer(), objectFactory, mutationGuard, collectionCallbackActionDecorator);
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, elementType, instantiator, new DynamicPropertyNamer(), factory, mutationGuard, collectionCallbackActionDecorator);
+    }
+
+    @Override
+    public <T> DomainObjectSet<T> newDomainObjectSet(Class<T> elementType) {
+        Instantiator instantiator = instantiatorFactory.decorateLenient();
+        return instantiator.newInstance(DefaultDomainObjectSet.class, elementType, collectionCallbackActionDecorator);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DefaultDomainObjectCollectionFactory.java
@@ -24,7 +24,6 @@ import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DynamicPropertyNamer;
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.MutationGuard;
-import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.ReflectiveNamedDomainObjectFactory;
 import org.gradle.internal.instantiation.InstantiatorFactory;
 import org.gradle.internal.reflect.Instantiator;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
@@ -16,9 +16,18 @@
 
 package org.gradle.api.internal.collections;
 
+import groovy.lang.Closure;
+import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.CompositeDomainObjectSet;
+import org.gradle.api.internal.DynamicPropertyNamer;
+import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
+import org.gradle.api.internal.MutationGuards;
+import org.gradle.internal.instantiation.InstantiatorFactory;
+import org.gradle.internal.reflect.Instantiator;
 
 public interface DomainObjectCollectionFactory {
     /**
@@ -32,7 +41,17 @@ public interface DomainObjectCollectionFactory {
     <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory);
 
     /**
+     * Creates a {@link NamedDomainObjectContainer} for managing named objects of the specified type. The given closure is used to create object instances. The name of the instance to be created is passed as a parameter to the closure.
+     */
+    <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> type, Closure factoryClosure);
+
+    /**
      * Creates a {@link DomainObjectSet} for managing objects of the specified type.
      */
     <T> DomainObjectSet<T> newDomainObjectSet(Class<T> elementType);
+
+    /**
+     * Creates a {@link CompositeDomainObjectSet} for managing a collection of {@link DomainObjectCollection} of the specified type.
+     */
+    <T> CompositeDomainObjectSet<T> newDomainObjectSet(Class<T> elementType, DomainObjectCollection<? extends T>... collections);
 }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.api.internal.collections;
+
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectFactory;
+
+public interface DomainObjectCollectionFactory {
+    /**
+     * Creates a {@link NamedDomainObjectContainer} for managing named objects of the specified type.
+     */
+    <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> elementType);
+
+    /**
+     * Creates a {@link NamedDomainObjectContainer} for managing named objects of the specified type created with the given factory.
+     */
+    <T> NamedDomainObjectContainer<T> newNamedDomainObjectContainer(Class<T> elementType, NamedDomainObjectFactory<T> factory);
+
+    /**
+     * Creates a {@link DomainObjectSet} for managing objects of the specified type.
+     */
+    <T> DomainObjectSet<T> newDomainObjectSet(Class<T> elementType);
+}

--- a/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/collections/DomainObjectCollectionFactory.java
@@ -21,13 +21,7 @@ import org.gradle.api.DomainObjectCollection;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
-import org.gradle.api.internal.DynamicPropertyNamer;
-import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
-import org.gradle.api.internal.MutationGuards;
-import org.gradle.internal.instantiation.InstantiatorFactory;
-import org.gradle.internal.reflect.Instantiator;
 
 public interface DomainObjectCollectionFactory {
     /**

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/DefaultObjectFactory.java
@@ -16,13 +16,17 @@
 
 package org.gradle.api.internal.model;
 
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.file.SourceDirectorySet;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultSourceDirectorySet;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FilePropertyFactory;
@@ -56,14 +60,16 @@ public class DefaultObjectFactory implements ObjectFactory {
     private final DirectoryFileTreeFactory directoryFileTreeFactory;
     private final FilePropertyFactory filePropertyFactory;
     private final FileCollectionFactory fileCollectionFactory;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
-    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory) {
+    public DefaultObjectFactory(Instantiator instantiator, NamedObjectInstantiator namedObjectInstantiator, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.instantiator = instantiator;
         this.namedObjectInstantiator = namedObjectInstantiator;
         this.fileResolver = fileResolver;
         this.directoryFileTreeFactory = directoryFileTreeFactory;
         this.filePropertyFactory = filePropertyFactory;
         this.fileCollectionFactory = fileCollectionFactory;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
     }
 
     @Override
@@ -100,6 +106,21 @@ public class DefaultObjectFactory implements ObjectFactory {
     @Override
     public RegularFileProperty fileProperty() {
         return filePropertyFactory.newFileProperty();
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType) {
+        return domainObjectCollectionFactory.newNamedDomainObjectContainer(elementType);
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
+        return domainObjectCollectionFactory.newNamedDomainObjectContainer(elementType, factory);
+    }
+
+    @Override
+    public <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType) {
+        return domainObjectCollectionFactory.newDomainObjectSet(elementType);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/model/InstantiatorBackedObjectFactory.java
@@ -15,7 +15,10 @@
  */
 package org.gradle.api.internal.model;
 
+import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
@@ -49,6 +52,21 @@ public class InstantiatorBackedObjectFactory implements ObjectFactory {
     @Override
     public ConfigurableFileCollection fileCollection() {
         throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing file collections");
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType) {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object container");
+    }
+
+    @Override
+    public <T> NamedDomainObjectContainer<T> container(Class<T> elementType, NamedDomainObjectFactory<T> factory) {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing named domain object container with factory");
+    }
+
+    @Override
+    public <T> DomainObjectSet<T> domainObjectSet(Class<T> elementType) {
+        throw new UnsupportedOperationException("This ObjectFactory implementation does not support constructing domain object set");
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/plugins/DefaultPluginManager.java
@@ -23,7 +23,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.Plugin;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.plugins.AppliedPlugin;
 import org.gradle.api.plugins.InvalidPluginException;
 import org.gradle.api.plugins.PluginContainer;
@@ -56,7 +56,6 @@ public class DefaultPluginManager implements PluginManagerInternal {
     private final Instantiator instantiator;
     private final PluginTarget target;
     private final PluginRegistry pluginRegistry;
-    private final CollectionCallbackActionDecorator callbackDecorator;
     private final DefaultPluginContainer pluginContainer;
     private final Map<Class<?>, PluginImplementation<?>> plugins = Maps.newHashMap();
     private final Map<Class<?>, Plugin> instances = Maps.newLinkedHashMap();
@@ -64,15 +63,16 @@ public class DefaultPluginManager implements PluginManagerInternal {
 
     private final BuildOperationExecutor buildOperationExecutor;
     private final UserCodeApplicationContext userCodeApplicationContext;
+    private DomainObjectCollectionFactory domainObjectCollectionFactory;
 
-    public DefaultPluginManager(final PluginRegistry pluginRegistry, Instantiator instantiator, final PluginTarget target, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator callbackDecorator) {
+    public DefaultPluginManager(final PluginRegistry pluginRegistry, Instantiator instantiator, final PluginTarget target, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator callbackDecorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.instantiator = instantiator;
         this.target = target;
         this.pluginRegistry = pluginRegistry;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.pluginContainer = new DefaultPluginContainer(pluginRegistry, this, callbackDecorator);
         this.buildOperationExecutor = buildOperationExecutor;
         this.userCodeApplicationContext = userCodeApplicationContext;
-        this.callbackDecorator = callbackDecorator;
     }
 
     private <T> T instantiatePlugin(Class<T> type) {
@@ -213,7 +213,7 @@ public class DefaultPluginManager implements PluginManagerInternal {
         PluginId pluginId = DefaultPluginId.unvalidated(id);
         DomainObjectSet<PluginWithId> pluginsForId = idMappings.get(pluginId);
         if (pluginsForId == null) {
-            pluginsForId = new DefaultDomainObjectSet<PluginWithId>(PluginWithId.class, callbackDecorator);
+            pluginsForId = domainObjectCollectionFactory.newDomainObjectSet(PluginWithId.class);
             idMappings.put(pluginId, pluginsForId);
             for (PluginImplementation<?> plugin : plugins.values()) {
                 if (plugin.isAlsoKnownAs(pluginId)) {

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -46,8 +46,6 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DynamicObjectAware;
-import org.gradle.api.internal.DynamicPropertyNamer;
-import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.ProcessOperations;
@@ -1324,8 +1322,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, Closure factoryClosure) {
-        Instantiator instantiator = getServices().get(InstantiatorFactory.class).decorateLenient();
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factoryClosure, MutationGuards.of(getProjectConfigurator()), services.get(CollectionCallbackActionDecorator.class));
+        return getServices().get(DomainObjectCollectionFactory.class).newNamedDomainObjectContainer(type, factoryClosure);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -51,7 +51,6 @@ import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.ProcessOperations;
-import org.gradle.api.internal.ReflectiveNamedDomainObjectFactory;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -54,6 +54,7 @@ import org.gradle.api.internal.ProcessOperations;
 import org.gradle.api.internal.ReflectiveNamedDomainObjectFactory;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultProjectLayout;
 import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
@@ -1314,17 +1315,12 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type) {
-        InstantiatorFactory instantiatorFactory = getServices().get(InstantiatorFactory.class);
-        // TODO - this should also be using the decorating instantiator but cannot for backwards compatibility
-        ReflectiveNamedDomainObjectFactory<T> objectFactory = new ReflectiveNamedDomainObjectFactory<T>(type, instantiatorFactory.injectLenient(getServices()));
-        Instantiator instantiator = instantiatorFactory.decorateLenient();
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), objectFactory, MutationGuards.of(getProjectConfigurator()), services.get(CollectionCallbackActionDecorator.class));
+        return getServices().get(DomainObjectCollectionFactory.class).newNamedDomainObjectContainer(type);
     }
 
     @Override
     public <T> NamedDomainObjectContainer<T> container(Class<T> type, NamedDomainObjectFactory<T> factory) {
-        Instantiator instantiator = getServices().get(InstantiatorFactory.class).decorateLenient();
-        return instantiator.newInstance(FactoryNamedDomainObjectContainer.class, type, instantiator, new DynamicPropertyNamer(), factory, MutationGuards.of(getProjectConfigurator()), services.get(CollectionCallbackActionDecorator.class));
+        return getServices().get(DomainObjectCollectionFactory.class).newNamedDomainObjectContainer(type, factory);
     }
 
     @Override

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -19,8 +19,11 @@ package org.gradle.internal.service.scopes;
 import com.google.common.collect.Iterables;
 import org.gradle.api.execution.internal.DefaultTaskInputsListener;
 import org.gradle.api.execution.internal.TaskInputsListener;
+import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
+import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -247,7 +250,8 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
             fileResolver,
             directoryFileTreeFactory,
             new DefaultFilePropertyFactory(fileResolver),
-            fileCollectionFactory);
+            fileCollectionFactory,
+            new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, CollectionCallbackActionDecorator.NOOP, MutationGuards.identity()));
     }
 
     ProviderFactory createProviderFactory() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GlobalScopeServices.java
@@ -24,6 +24,7 @@ import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.StartParameterInternal;
 import org.gradle.api.internal.cache.StringInterner;
 import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.DefaultFilePropertyFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -243,7 +244,7 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
         return new DefaultMemoryManager(osMemoryInfo, jvmMemoryInfo, listenerManager, executorFactory);
     }
 
-    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory) {
+    ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FileCollectionFactory fileCollectionFactory, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         return new DefaultObjectFactory(
             instantiatorFactory.injectAndDecorate(services),
             NamedObjectInstantiator.INSTANCE,
@@ -251,7 +252,11 @@ public class GlobalScopeServices extends WorkerSharedGlobalScopeServices {
             directoryFileTreeFactory,
             new DefaultFilePropertyFactory(fileResolver),
             fileCollectionFactory,
-            new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, CollectionCallbackActionDecorator.NOOP, MutationGuards.identity()));
+            domainObjectCollectionFactory);
+    }
+
+    DomainObjectCollectionFactory createDomainObjectCollectionFactory(InstantiatorFactory instantiatorFactory, ServiceRegistry services) {
+        return new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, CollectionCallbackActionDecorator.NOOP, MutationGuards.identity());
     }
 
     ProviderFactory createProviderFactory() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -21,6 +21,7 @@ import org.gradle.api.execution.TaskExecutionListener;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
 import org.gradle.api.internal.plugins.ImperativeOnlyPluginTarget;
@@ -258,9 +259,9 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return parentRegistry.createChild(get(GradleInternal.class).getClassLoaderScope());
     }
 
-    PluginManagerInternal createPluginManager(Instantiator instantiator, GradleInternal gradleInternal, PluginRegistry pluginRegistry, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator decorator) {
+    PluginManagerInternal createPluginManager(Instantiator instantiator, GradleInternal gradleInternal, PluginRegistry pluginRegistry, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator decorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         PluginTarget target = new ImperativeOnlyPluginTarget<GradleInternal>(gradleInternal);
-        return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor, userCodeApplicationContext, decorator);
+        return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor, userCodeApplicationContext, decorator, domainObjectCollectionFactory);
     }
 
     FileContentCacheFactory createFileContentCacheFactory(FileContentCacheFactory globalCacheFactory, ListenerManager listenerManager, FileSystemSnapshotter fileSystemSnapshotter, CacheRepository cacheRepository, InMemoryCacheDecoratorFactory inMemoryCacheDecoratorFactory, Gradle gradle, WellKnownFileLocations wellKnownFileLocations) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -21,11 +21,13 @@ import org.gradle.api.AntBuilder;
 import org.gradle.api.component.SoftwareComponentContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
+import org.gradle.api.internal.MutationGuards;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;
 import org.gradle.api.internal.artifacts.Module;
 import org.gradle.api.internal.artifacts.ProjectBackedModule;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.artifacts.dsl.dependencies.ProjectFinder;
+import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
 import org.gradle.api.internal.component.ComponentRegistry;
 import org.gradle.api.internal.component.DefaultSoftwareComponentContainer;
 import org.gradle.api.internal.file.BaseDirFileResolver;
@@ -308,9 +310,10 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultFileCollectionFactory(fileResolver, taskResolver);
     }
 
-    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory) {
-        Instantiator instantiator = instantiatorFactory.injectAndDecorate(ProjectScopeServices.this);
-        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory, fileCollectionFactory);
+    protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator, CrossProjectConfigurator projectConfigurator) {
+        ServiceRegistry services = ProjectScopeServices.this;
+        Instantiator instantiator = instantiatorFactory.injectAndDecorate(services);
+        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory, fileCollectionFactory, new DefaultDomainObjectCollectionFactory(instantiatorFactory,services, collectionCallbackActionDecorator, MutationGuards.of(projectConfigurator)));
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -313,7 +313,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
     protected ObjectFactory createObjectFactory(InstantiatorFactory instantiatorFactory, FileResolver fileResolver, DirectoryFileTreeFactory directoryFileTreeFactory, FilePropertyFactory filePropertyFactory, FileCollectionFactory fileCollectionFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator, CrossProjectConfigurator projectConfigurator) {
         ServiceRegistry services = ProjectScopeServices.this;
         Instantiator instantiator = instantiatorFactory.injectAndDecorate(services);
-        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory, fileCollectionFactory, new DefaultDomainObjectCollectionFactory(instantiatorFactory,services, collectionCallbackActionDecorator, MutationGuards.of(projectConfigurator)));
+        return new DefaultObjectFactory(instantiator, NamedObjectInstantiator.INSTANCE, fileResolver, directoryFileTreeFactory, filePropertyFactory, fileCollectionFactory, new DefaultDomainObjectCollectionFactory(instantiatorFactory, services, collectionCallbackActionDecorator, MutationGuards.of(projectConfigurator)));
     }
 
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/SettingsScopeServices.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.SettingsInternal;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.BaseDirFileResolver;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
@@ -62,9 +63,9 @@ public class SettingsScopeServices extends DefaultServiceRegistry {
         return parentRegistry.createChild(settings.getClassLoaderScope());
     }
 
-    protected PluginManagerInternal createPluginManager(Instantiator instantiator, PluginRegistry pluginRegistry, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator decorator) {
+    protected PluginManagerInternal createPluginManager(Instantiator instantiator, PluginRegistry pluginRegistry, InstantiatorFactory instantiatorFactory, BuildOperationExecutor buildOperationExecutor, UserCodeApplicationContext userCodeApplicationContext, CollectionCallbackActionDecorator decorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         PluginTarget target = new ImperativeOnlyPluginTarget<SettingsInternal>(settings);
-        return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor, userCodeApplicationContext, decorator);
+        return instantiator.newInstance(DefaultPluginManager.class, pluginRegistry, instantiatorFactory.inject(this), target, buildOperationExecutor, userCodeApplicationContext, decorator, domainObjectCollectionFactory);
     }
 
     protected ProjectDescriptorRegistry createProjectDescriptorRegistry() {

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/model/DefaultObjectFactoryTest.groovy
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.model
 
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
@@ -26,7 +27,7 @@ import spock.lang.Unroll
 
 
 class DefaultObjectFactoryTest extends Specification {
-    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory), Stub(FileCollectionFactory))
+    def factory = new DefaultObjectFactory(Stub(Instantiator), Stub(NamedObjectInstantiator), Stub(FileResolver), Stub(DirectoryFileTreeFactory), Stub(FilePropertyFactory), Stub(FileCollectionFactory), Stub(DomainObjectCollectionFactory))
 
     def "property has no value"() {
         expect:

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -37,7 +37,7 @@ class DefaultPluginContainerTest extends Specification {
     def pluginRegistry = new DefaultPluginRegistry(pluginInspector, scope(classLoader))
     def target = Mock(PluginTarget)
     def instantiator = TestUtil.instantiatorFactory().inject()
-    def pluginManager = new DefaultPluginManager(pluginRegistry, instantiator, target, new TestBuildOperationExecutor(), new DefaultUserCodeApplicationContext(), CollectionCallbackActionDecorator.NOOP)
+    def pluginManager = new DefaultPluginManager(pluginRegistry, instantiator, target, new TestBuildOperationExecutor(), new DefaultUserCodeApplicationContext(), CollectionCallbackActionDecorator.NOOP, domainObjectCollectionFactory)
 
     @Subject
     def container = pluginManager.pluginContainer

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginContainerTest.groovy
@@ -37,7 +37,7 @@ class DefaultPluginContainerTest extends Specification {
     def pluginRegistry = new DefaultPluginRegistry(pluginInspector, scope(classLoader))
     def target = Mock(PluginTarget)
     def instantiator = TestUtil.instantiatorFactory().inject()
-    def pluginManager = new DefaultPluginManager(pluginRegistry, instantiator, target, new TestBuildOperationExecutor(), new DefaultUserCodeApplicationContext(), CollectionCallbackActionDecorator.NOOP, domainObjectCollectionFactory)
+    def pluginManager = new DefaultPluginManager(pluginRegistry, instantiator, target, new TestBuildOperationExecutor(), new DefaultUserCodeApplicationContext(), CollectionCallbackActionDecorator.NOOP, TestUtil.domainObjectCollectionFactory())
 
     @Subject
     def container = pluginManager.pluginContainer

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/plugins/DefaultPluginManagerTest.groovy
@@ -38,7 +38,7 @@ class DefaultPluginManagerTest extends Specification {
     }
     def registry = new DefaultPluginRegistry(new PluginInspector(new ModelRuleSourceDetector()), classLoaderScope)
     def target = Mock(PluginTarget)
-    def manager = new DefaultPluginManager(registry, TestUtil.instantiatorFactory().inject(), target, new TestBuildOperationExecutor(), new DefaultUserCodeApplicationContext(), CollectionCallbackActionDecorator.NOOP)
+    def manager = new DefaultPluginManager(registry, TestUtil.instantiatorFactory().inject(), target, new TestBuildOperationExecutor(), new DefaultUserCodeApplicationContext(), CollectionCallbackActionDecorator.NOOP, TestUtil.domainObjectCollectionFactory())
 
     Class<?> rulesClass
     Class<? extends Plugin> hybridClass

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -42,6 +42,7 @@ import org.gradle.api.internal.ProcessOperations
 import org.gradle.api.internal.artifacts.Module
 import org.gradle.api.internal.artifacts.ProjectBackedModule
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory
 import org.gradle.api.internal.file.DefaultProjectLayout
 import org.gradle.api.internal.file.FileCollectionFactory
 import org.gradle.api.internal.file.FileOperations
@@ -204,10 +205,11 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) PluginManagerInternal) >> pluginManager
         serviceRegistryMock.get((Type) TextResourceLoader) >> textResourceLoader
         serviceRegistryMock.get(ManagedProxyFactory) >> managedProxyFactory
-        serviceRegistryMock.get(AttributesSchema)  >> attributesSchema
-        serviceRegistryMock.get(BuildOperationExecutor)  >> buildOperationExecutor
-        serviceRegistryMock.get((Type) ListenerBuildOperationDecorator)  >> listenerBuildOperationDecorator
-        serviceRegistryMock.get((Type) CrossProjectConfigurator)  >> crossProjectConfigurator
+        serviceRegistryMock.get(AttributesSchema) >> attributesSchema
+        serviceRegistryMock.get(BuildOperationExecutor) >> buildOperationExecutor
+        serviceRegistryMock.get((Type) ListenerBuildOperationDecorator) >> listenerBuildOperationDecorator
+        serviceRegistryMock.get((Type) CrossProjectConfigurator) >> crossProjectConfigurator
+        serviceRegistryMock.get(DomainObjectCollectionFactory) >> TestUtil.domainObjectCollectionFactory()
         pluginManager.getPluginContainer() >> pluginContainer
 
         serviceRegistryMock.get((Type) DeferredProjectConfiguration) >> Stub(DeferredProjectConfiguration)

--- a/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/util/NameValidatorTest.groovy
@@ -46,7 +46,7 @@ class NameValidatorTest extends Specification {
     @Shared
     def domainObjectContainersWithValidation = [
             ["artifact types", new DefaultArtifactTypeContainer(TestUtil.instantiatorFactory().decorateLenient(), AttributeTestUtil.attributesFactory(), CollectionCallbackActionDecorator.NOOP)],
-            ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null)],
+            ["configurations", new DefaultConfigurationContainer(null, TestUtil.instantiatorFactory().decorateLenient(), domainObjectContext(), Mock(ListenerManager), null, null, null, null, Mock(FileCollectionFactory), null, null, null, null, null, AttributeTestUtil.attributesFactory(), null, null, null, null, Stub(DocumentationRegistry), CollectionCallbackActionDecorator.NOOP, null, TestUtil.domainObjectCollectionFactory())],
             ["flavors", new DefaultFlavorContainer(TestUtil.instantiatorFactory().decorateLenient(), CollectionCallbackActionDecorator.NOOP)],
             ["source sets", new DefaultSourceSetContainer(TestFiles.resolver(), null, TestUtil.instantiatorFactory().decorateLenient(), TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)]
     ]

--- a/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
+++ b/subprojects/core/src/testFixtures/groovy/org/gradle/util/TestUtil.groovy
@@ -17,7 +17,10 @@ package org.gradle.util
 
 
 import org.gradle.api.Task
+import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FeaturePreviews
+import org.gradle.api.internal.MutationGuards
+import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory
 import org.gradle.api.internal.file.DefaultFilePropertyFactory
 import org.gradle.api.internal.file.FileResolver
 import org.gradle.api.internal.file.TestFiles
@@ -73,7 +76,8 @@ class TestUtil {
         DefaultServiceRegistry services = new DefaultServiceRegistry()
         services.add(ProviderFactory, new DefaultProviderFactory())
         services.add(InstantiatorFactory, instantiatorFactory())
-        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver), TestFiles.fileCollectionFactory())
+
+        return new DefaultObjectFactory(instantiatorFactory().injectAndDecorate(services), NamedObjectInstantiator.INSTANCE, fileResolver, TestFiles.directoryFileTreeFactory(), new DefaultFilePropertyFactory(fileResolver), TestFiles.fileCollectionFactory(), new DefaultDomainObjectCollectionFactory(instantiatorFactory(), services, CollectionCallbackActionDecorator.NOOP, MutationGuards.identity()))
     }
 
     static NamedObjectInstantiator objectInstantiator() {

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/DefaultDependencyManagementServices.java
@@ -93,6 +93,7 @@ import org.gradle.api.internal.artifacts.type.DefaultArtifactTypeRegistry;
 import org.gradle.api.internal.attributes.AttributesSchemaInternal;
 import org.gradle.api.internal.attributes.DefaultAttributesSchema;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.component.ComponentTypeRegistry;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileResolver;
@@ -463,7 +464,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                                                                     ProjectStateRegistry projectStateRegistry,
                                                                     DocumentationRegistry documentationRegistry,
                                                                     CollectionCallbackActionDecorator callbackDecorator,
-                                                                    UserCodeApplicationContext userCodeApplicationContext) {
+                                                                    UserCodeApplicationContext userCodeApplicationContext,
+                                                                    DomainObjectCollectionFactory domainObjectCollectionFactory) {
             return instantiator.newInstance(DefaultConfigurationContainer.class,
                 configurationResolver,
                 instantiator,
@@ -486,7 +488,8 @@ public class DefaultDependencyManagementServices implements DependencyManagement
                 projectStateRegistry,
                 documentationRegistry,
                 callbackDecorator,
-                userCodeApplicationContext
+                userCodeApplicationContext,
+                domainObjectCollectionFactory
             );
         }
 

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -52,7 +52,6 @@ import org.gradle.api.attributes.Attribute;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.CompositeDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DocumentationRegistry;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfiguration.java
@@ -81,6 +81,7 @@ import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
 import org.gradle.api.internal.attributes.ImmutableAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionInternal;
@@ -217,8 +218,8 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
     private final FileCollection intrinsicFiles;
 
     private final DisplayName displayName;
-    private CollectionCallbackActionDecorator callbackActionDecorator;
     private UserCodeApplicationContext userCodeApplicationContext;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
     private Action<? super ConfigurationInternal> beforeLocking;
 
@@ -239,12 +240,12 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
                                 ImmutableAttributesFactory attributesFactory,
                                 RootComponentMetadataBuilder rootComponentMetadataBuilder,
                                 DocumentationRegistry documentationRegistry,
-                                CollectionCallbackActionDecorator callbackDecorator,
                                 UserCodeApplicationContext userCodeApplicationContext,
-                                DomainObjectProjectStateHandler domainObjectProjectStateHandler
+                                DomainObjectProjectStateHandler domainObjectProjectStateHandler,
+                                DomainObjectCollectionFactory domainObjectCollectionFactory
     ) {
-        this.callbackActionDecorator = callbackDecorator;
         this.userCodeApplicationContext = userCodeApplicationContext;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.identityPath = domainObjectContext.identityPath(name);
         this.name = name;
         this.configurationsProvider = configurationsProvider;
@@ -270,20 +271,20 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         displayName = Describables.memoize(new ConfigurationDescription(identityPath));
 
-        this.ownDependencies = new DefaultDomainObjectSet<Dependency>(Dependency.class, callbackDecorator);
+        this.ownDependencies = (DefaultDomainObjectSet<Dependency>)domainObjectCollectionFactory.newDomainObjectSet(Dependency.class);
         this.ownDependencies.beforeCollectionChanges(validateMutationType(this, MutationType.DEPENDENCIES));
-        this.ownDependencyConstraints = new DefaultDomainObjectSet<DependencyConstraint>(DependencyConstraint.class, callbackDecorator);
+        this.ownDependencyConstraints = (DefaultDomainObjectSet<DependencyConstraint>) domainObjectCollectionFactory.newDomainObjectSet(DependencyConstraint.class);
         this.ownDependencyConstraints.beforeCollectionChanges(validateMutationType(this, MutationType.DEPENDENCIES));
 
         this.dependencies = new DefaultDependencySet(Describables.of(displayName, "dependencies"), this, ownDependencies);
         this.dependencyConstraints = new DefaultDependencyConstraintSet(Describables.of(displayName, "dependency constraints"), ownDependencyConstraints);
 
-        this.ownArtifacts = new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact.class, callbackDecorator);
+        this.ownArtifacts = (DefaultDomainObjectSet<PublishArtifact>)domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class);
         this.ownArtifacts.beforeCollectionChanges(validateMutationType(this, MutationType.ARTIFACTS));
 
         this.artifacts = new DefaultPublishArtifactSet(Describables.of(displayName, "artifacts"), ownArtifacts, fileCollectionFactory);
 
-        this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, callbackDecorator);
+        this.outgoing = instantiator.newInstance(DefaultConfigurationPublications.class, displayName, artifacts, new AllArtifactsProvider(), configurationAttributes, instantiator, artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory);
         this.rootComponentMetadataBuilder = rootComponentMetadataBuilder;
         this.projectStateHandler = domainObjectProjectStateHandler;
         path = domainObjectContext.projectPath(name);
@@ -738,7 +739,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         if (allDependencies != null) {
             return;
         }
-        inheritedDependencies = CompositeDomainObjectSet.create(Dependency.class, callbackActionDecorator, ownDependencies);
+        inheritedDependencies = domainObjectCollectionFactory.newDomainObjectSet(Dependency.class, ownDependencies);
         for (Configuration configuration : this.extendsFrom) {
             inheritedDependencies.addCollection(configuration.getAllDependencies());
         }
@@ -762,7 +763,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         if (allDependencyConstraints != null) {
             return;
         }
-        inheritedDependencyConstraints = CompositeDomainObjectSet.create(DependencyConstraint.class, callbackActionDecorator, ownDependencyConstraints);
+        inheritedDependencyConstraints = domainObjectCollectionFactory.newDomainObjectSet(DependencyConstraint.class, ownDependencyConstraints);
         for (Configuration configuration : this.extendsFrom) {
             inheritedDependencyConstraints.addCollection(configuration.getAllDependencyConstraints());
         }
@@ -792,14 +793,14 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
 
         if (canBeMutated) {
             // If the configuration can still be mutated, we need to create a composite
-            inheritedArtifacts = CompositeDomainObjectSet.create(PublishArtifact.class, callbackActionDecorator, ownArtifacts);
+            inheritedArtifacts = domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class, ownArtifacts);
         }
         for (Configuration configuration : this.extendsFrom) {
             PublishArtifactSet allArtifacts = configuration.getAllArtifacts();
             if (inheritedArtifacts != null || !allArtifacts.isEmpty()) {
                 if (inheritedArtifacts == null) {
                     // This configuration cannot be mutated, but some parent configurations provide artifacts
-                    inheritedArtifacts = CompositeDomainObjectSet.create(PublishArtifact.class, callbackActionDecorator, ownArtifacts);
+                    inheritedArtifacts = domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class, ownArtifacts);
                 }
                 inheritedArtifacts.addCollection(allArtifacts);
             }
@@ -928,7 +929,7 @@ public class DefaultConfiguration extends AbstractFileCollection implements Conf
         Factory<ResolutionStrategyInternal> childResolutionStrategy = resolutionStrategy != null ? Factories.constant(resolutionStrategy.copy()) : resolutionStrategyFactory;
         DefaultConfiguration copiedConfiguration = instantiator.newInstance(DefaultConfiguration.class, domainObjectContext, newName,
             configurationsProvider, resolver, listenerManager, metaDataProvider, childResolutionStrategy, projectAccessListener, projectFinder, fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory,
-            rootComponentMetadataBuilder, documentationRegistry, callbackActionDecorator, userCodeApplicationContext, projectStateHandler);
+            rootComponentMetadataBuilder, documentationRegistry, userCodeApplicationContext, projectStateHandler, domainObjectCollectionFactory);
         configurationsProvider.setTheOnlyConfiguration(copiedConfiguration);
         // state, cachedResolvedConfiguration, and extendsFrom intentionally not copied - must re-resolve copy
         // copying extendsFrom could mess up dependencies when copy was re-resolved

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainer.java
@@ -40,6 +40,7 @@ import org.gradle.api.internal.artifacts.ivyservice.moduleconverter.LocalCompone
 import org.gradle.api.internal.artifacts.ivyservice.resolutionstrategy.DefaultResolutionStrategy;
 import org.gradle.api.internal.artifacts.transform.DomainObjectProjectStateHandler;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.internal.tasks.TaskResolver;
@@ -78,6 +79,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     private int detachedConfigurationDefaultNameCounter = 1;
     private final Factory<ResolutionStrategyInternal> resolutionStrategyFactory;
     private final DefaultRootComponentMetadataBuilder rootComponentMetadataBuilder;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
     public DefaultConfigurationContainer(ConfigurationResolver resolver,
                                          final Instantiator instantiator, DomainObjectContext context, ListenerManager listenerManager,
@@ -96,7 +98,8 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
                                          ProjectStateRegistry projectStateRegistry,
                                          DocumentationRegistry documentationRegistry,
                                          CollectionCallbackActionDecorator callbackDecorator,
-                                         UserCodeApplicationContext userCodeApplicationContext) {
+                                         UserCodeApplicationContext userCodeApplicationContext,
+                                         DomainObjectCollectionFactory domainObjectCollectionFactory) {
         super(Configuration.class, instantiator, new Configuration.Namer(), callbackDecorator);
         this.resolver = resolver;
         this.instantiator = instantiator;
@@ -108,6 +111,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
         this.fileCollectionFactory = fileCollectionFactory;
         this.buildOperationExecutor = buildOperationExecutor;
         this.userCodeApplicationContext = userCodeApplicationContext;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.artifactNotationParser = new PublishArtifactNotationParserFactory(instantiator, dependencyMetaDataProvider, taskResolver).create();
         this.capabilityNotationParser = new CapabilityNotationParserFactory(true).create();
         this.attributesFactory = attributesFactory;
@@ -126,7 +130,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
     protected Configuration doCreate(String name) {
         DefaultConfiguration configuration = instantiator.newInstance(DefaultConfiguration.class, context, name, this, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
-            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory, rootComponentMetadataBuilder, documentationRegistry, getEventRegister().getDecorator(), userCodeApplicationContext, new DomainObjectProjectStateHandler(projectStateRegistry, context, projectFinder));
+            fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory, rootComponentMetadataBuilder, documentationRegistry, userCodeApplicationContext, new DomainObjectProjectStateHandler(projectStateRegistry, context, projectFinder), domainObjectCollectionFactory);
         configuration.addMutationValidator(rootComponentMetadataBuilder.getValidator());
         return configuration;
     }
@@ -157,7 +161,7 @@ public class DefaultConfigurationContainer extends AbstractValidatingNamedDomain
             context, name, detachedConfigurationsProvider, resolver,
             listenerManager, dependencyMetaDataProvider, resolutionStrategyFactory, projectAccessListener, projectFinder,
             fileCollectionFactory, buildOperationExecutor, instantiator, artifactNotationParser, capabilityNotationParser, attributesFactory,
-            rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider), documentationRegistry, getEventRegister().getDecorator(), userCodeApplicationContext, new DomainObjectProjectStateHandler(projectStateRegistry, context, projectFinder));
+            rootComponentMetadataBuilder.withConfigurationsProvider(detachedConfigurationsProvider), documentationRegistry, userCodeApplicationContext, new DomainObjectProjectStateHandler(projectStateRegistry, context, projectFinder), domainObjectCollectionFactory);
         DomainObjectSet<Dependency> detachedDependencies = detachedConfiguration.getDependencies();
         for (Dependency dependency : dependencies) {
             detachedDependencies.add(dependency.copy());

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -30,8 +30,6 @@ import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.capabilities.Capability;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublications.java
@@ -35,6 +35,7 @@ import org.gradle.api.internal.FactoryNamedDomainObjectContainer;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.DisplayName;
 import org.gradle.internal.reflect.Instantiator;
@@ -56,8 +57,8 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
     private final NotationParser<Object, Capability> capabilityNotationParser;
     private final FileCollectionFactory fileCollectionFactory;
     private final ImmutableAttributesFactory attributesFactory;
-    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
-    private FactoryNamedDomainObjectContainer<ConfigurationVariant> variants;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
+    private NamedDomainObjectContainer<ConfigurationVariant> variants;
     private ConfigurationVariantFactory variantFactory;
     private List<Capability> capabilities;
     private boolean canCreate = true;
@@ -71,7 +72,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
                                             NotationParser<Object, Capability> capabilityNotationParser,
                                             FileCollectionFactory fileCollectionFactory,
                                             ImmutableAttributesFactory attributesFactory,
-                                            CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+                                            DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.displayName = displayName;
         this.artifacts = artifacts;
         this.allArtifacts = allArtifacts;
@@ -81,7 +82,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         this.capabilityNotationParser = capabilityNotationParser;
         this.fileCollectionFactory = fileCollectionFactory;
         this.attributesFactory = attributesFactory;
-        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         this.attributes = attributesFactory.mutable(parentAttributes);
     }
 
@@ -155,7 +156,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         if (variants == null) {
             // Create variants container only as required
             variantFactory = new ConfigurationVariantFactory();
-            variants = new FactoryNamedDomainObjectContainer<ConfigurationVariant>(ConfigurationVariant.class, instantiator, variantFactory, collectionCallbackActionDecorator);
+            variants = domainObjectCollectionFactory.newNamedDomainObjectContainer(ConfigurationVariant.class, variantFactory);
         }
         return variants;
     }
@@ -196,7 +197,7 @@ public class DefaultConfigurationPublications implements ConfigurationPublicatio
         @Override
         public ConfigurationVariant create(String name) {
             if (canCreate) {
-                return instantiator.newInstance(DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, collectionCallbackActionDecorator);
+                return instantiator.newInstance(DefaultVariant.class, displayName, name, parentAttributes, artifactNotationParser, fileCollectionFactory, attributesFactory, domainObjectCollectionFactory);
             } else {
                 throw new InvalidUserCodeException("Cannot create variant '" + name + "' after " + displayName + " has been resolved");
             }

--- a/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
+++ b/subprojects/dependency-management/src/main/java/org/gradle/api/internal/artifacts/configurations/DefaultVariant.java
@@ -23,13 +23,12 @@ import org.gradle.api.artifacts.ConfigurationVariant;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.artifacts.PublishArtifactSet;
 import org.gradle.api.attributes.AttributeContainer;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.artifacts.ConfigurationVariantInternal;
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet;
 import org.gradle.api.internal.attributes.AttributeContainerInternal;
 import org.gradle.api.internal.attributes.ImmutableAttributeContainerWithErrorMessage;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.internal.Describables;
 import org.gradle.internal.DisplayName;
@@ -47,12 +46,12 @@ public class DefaultVariant implements ConfigurationVariantInternal {
                           NotationParser<Object, ConfigurablePublishArtifact> artifactNotationParser,
                           FileCollectionFactory fileCollectionFactory,
                           ImmutableAttributesFactory cache,
-                          CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+                          DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.parentDisplayName = parentDisplayName;
         this.name = name;
         attributes = cache.mutable(parentAttributes);
         this.artifactNotationParser = artifactNotationParser;
-        artifacts = new DefaultPublishArtifactSet(getAsDescribable(), new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact.class, collectionCallbackActionDecorator), fileCollectionFactory);
+        artifacts = new DefaultPublishArtifactSet(getAsDescribable(), domainObjectCollectionFactory.newDomainObjectSet(PublishArtifact.class), fileCollectionFactory);
     }
 
     @Override

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerSpec.groovy
@@ -70,13 +70,13 @@ class DefaultConfigurationContainerSpec extends Specification {
     private DocumentationRegistry documentationRegistry = Mock()
     private UserCodeApplicationContext userCodeApplicationContext = Mock()
 
-    private CollectionCallbackActionDecorator domainObjectCollectioncallbackActionDecorator = Mock()
+    private CollectionCallbackActionDecorator domainObjectCollectionCallbackActionDecorator = Mock()
     def immutableAttributesFactory = AttributeTestUtil.attributesFactory()
 
     private DefaultConfigurationContainer configurationContainer = new DefaultConfigurationContainer(resolver, instantiator, domainObjectContext, listenerManager, metaDataProvider,
-        projectAccessListener, projectFinder, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
-        immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, projectStateRegistry, documentationRegistry,
-        domainObjectCollectioncallbackActionDecorator, userCodeApplicationContext)
+            projectAccessListener, projectFinder, metaDataBuilder, fileCollectionFactory, globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
+            immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, dependencyLockingProvider, projectStateRegistry, documentationRegistry,
+            domainObjectCollectionCallbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory())
 
     def "adds and gets"() {
         1 * domainObjectContext.identityPath("compile") >> Path.path(":build:compile")

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationContainerTest.groovy
@@ -76,7 +76,7 @@ class DefaultConfigurationContainerTest extends Specification {
             listenerManager, metaDataProvider, projectAccessListener, projectFinder, metaDataBuilder, TestFiles.fileCollectionFactory(),
             globalSubstitutionRules, vcsMappingsInternal, componentIdentifierFactory, buildOperationExecutor, taskResolver,
             immutableAttributesFactory, moduleIdentifierFactory, componentSelectorConverter, lockingProvider, projectStateRegistry,
-            documentationRegistry, callbackActionDecorator, userCodeApplicationContext)
+            documentationRegistry, callbackActionDecorator, userCodeApplicationContext, TestUtil.domainObjectCollectionFactory())
 
     def addsNewConfigurationWhenConfiguringSelf() {
         when:

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationPublicationsTest.groovy
@@ -18,8 +18,6 @@ package org.gradle.api.internal.artifacts.configurations
 
 import org.gradle.api.artifacts.PublishArtifact
 import org.gradle.api.attributes.Attribute
-import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.artifacts.DefaultPublishArtifactSet
 import org.gradle.api.internal.attributes.ImmutableAttributes
 import org.gradle.api.internal.file.TestFiles
@@ -31,8 +29,8 @@ import spock.lang.Specification
 
 class DefaultConfigurationPublicationsTest extends Specification {
     def parentAttributes = ImmutableAttributes.EMPTY
-    def artifacts = new DefaultPublishArtifactSet("artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, CollectionCallbackActionDecorator.NOOP), TestFiles.fileCollectionFactory())
-    def allArtifacts = new DefaultPublishArtifactSet("artifacts", new DefaultDomainObjectSet<PublishArtifact>(PublishArtifact, CollectionCallbackActionDecorator.NOOP), TestFiles.fileCollectionFactory())
+    def artifacts = new DefaultPublishArtifactSet("artifacts", TestUtil.domainObjectCollectionFactory().newDomainObjectSet(PublishArtifact), TestFiles.fileCollectionFactory())
+    def allArtifacts = new DefaultPublishArtifactSet("artifacts", TestUtil.domainObjectCollectionFactory().newDomainObjectSet(PublishArtifact), TestFiles.fileCollectionFactory())
     def artifactNotationParser = Stub(NotationParser)
     def capabilityNotationParser = Stub(NotationParser)
     def fileCollectionFactory = TestFiles.fileCollectionFactory()
@@ -40,7 +38,7 @@ class DefaultConfigurationPublicationsTest extends Specification {
     def displayName = Describables.of("<config>")
     def publications = new DefaultConfigurationPublications(displayName, artifacts, {
         allArtifacts
-    }, parentAttributes, TestUtil.instantiatorFactory().decorateLenient(), artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, CollectionCallbackActionDecorator.NOOP)
+    }, parentAttributes, TestUtil.instantiatorFactory().decorateLenient(), artifactNotationParser, capabilityNotationParser, fileCollectionFactory, attributesFactory, TestUtil.domainObjectCollectionFactory())
 
     def setup() {
         artifacts.whenObjectAdded { allArtifacts.add(it) }

--- a/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
+++ b/subprojects/dependency-management/src/test/groovy/org/gradle/api/internal/artifacts/configurations/DefaultConfigurationSpec.groovy
@@ -1759,8 +1759,7 @@ All Artifacts:
         def publishArtifactNotationParser = NotationParserBuilder.toType(ConfigurablePublishArtifact).toComposite()
         new DefaultConfiguration(domainObjectContext, confName, configurationsProvider, resolver, listenerManager, metaDataProvider,
             Factories.constant(resolutionStrategy), projectAccessListener, projectFinder, TestFiles.fileCollectionFactory(),
-            new TestBuildOperationExecutor(), instantiator, publishArtifactNotationParser, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder, Stub(DocumentationRegistry),
-            domainObjectCollectioncallbackActionDecorator, userCodeApplicationContext, new DomainObjectProjectStateHandler(projectStateRegistry, domainObjectContext, projectFinder))
+            new TestBuildOperationExecutor(), instantiator, publishArtifactNotationParser, Stub(NotationParser), immutableAttributesFactory, rootComponentMetadataBuilder, Stub(DocumentationRegistry), userCodeApplicationContext, new DomainObjectProjectStateHandler(projectStateRegistry, domainObjectContext, projectFinder), TestUtil.domainObjectCollectionFactory())
     }
 
     private DefaultPublishArtifact artifact(String name) {

--- a/subprojects/distributions/src/changes/accepted-public-api-changes.json
+++ b/subprojects/distributions/src/changes/accepted-public-api-changes.json
@@ -1,3 +1,10 @@
 {
-    "acceptedApiChanges": []
+    "acceptedApiChanges": [
+        {
+            "type": "org.gradle.platform.base.binary.BaseBinarySpec",
+            "member": "Method org.gradle.platform.base.binary.BaseBinarySpec.create(java.lang.Class,java.lang.Class,org.gradle.platform.base.internal.ComponentSpecIdentifier,org.gradle.model.internal.core.MutableModelNode,org.gradle.model.internal.core.MutableModelNode,org.gradle.internal.reflect.Instantiator,org.gradle.model.internal.core.NamedEntityInstantiator,org.gradle.api.internal.CollectionCallbackActionDecorator,org.gradle.api.internal.collections.DomainObjectCollectionFactory)",
+            "acceptation": "Change to internal factory method",
+            "changes": []
+        }
+    ]
 }

--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -50,6 +50,10 @@ The `init` task can now generate simple Gradle plugins. You can use these as a s
 
 See the [User manual](userguide/build_init_plugin.html) for more details.
 
+### New factory method for creating `NamedDomainObjectContainer` and `DomainObjectSet`
+
+The `ObjectFactory` can now be used for creating `NamedDomainObjectContainer` and `DomainObjectSet`.
+
 ## Define organization-wide properties with a custom Gradle Distribution
 
 Gradle now looks for a `gradle.properties` file in the Gradle distribution used by the build.  This file has the [lowest precedence of any `gradle.properties`](userguide/build_environment.html#sec:gradle_configuration_properties) and properties defined in other locations will override values defined here.

--- a/subprojects/docs/src/docs/userguide/custom_plugins.adoc
+++ b/subprojects/docs/src/docs/userguide/custom_plugins.adoc
@@ -257,15 +257,26 @@ There are several services, such as `ObjectFactory`, that are available for inje
 [[sec:maintaining_multiple_domain_objects]]
 === Configuring a collection of objects
 
-Gradle provides some utility classes for maintaining collections of objects, intended to work well with the Gradle DSL. One such type is link:{javadocPath}/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer] which manages a set of objects. Gradle uses this type extensively throughout the API. For example, the `tasks` object used to manage the tasks of a project is a `NamedDomainObjectContainer`.
+Gradle provides some utility classes for maintaining collections of objects, intended to work well with the Gradle DSL.
+One such type is link:{javadocPath}/org/gradle/api/NamedDomainObjectContainer.html[NamedDomainObjectContainer] which manages a set of objects.
+Gradle uses this type extensively throughout the API.
+For example, the `tasks` object used to manage the tasks of a project is a `NamedDomainObjectContainer`.
 
-You can create a container instance using the link:{javadocPath}/org/gradle/api/Project.html#container-java.lang.Class-[Project.container()] method. Services are available for injection into the elements of the container. See <<custom_tasks.adoc#service_injection,service injection for tasks>>. for details.
+You can create a container instance using the link:{javadocPath}/org/gradle/api/Project.html#container-java.lang.Class-[Project.container()] method.
+You can also use link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#container-java.lang.Class-[ObjectFactory.container()].
+Services are available for injection into the elements of the container.
+See <<custom_tasks.adoc#service_injection,service injection for tasks>>. for details.
 
 .Managing a collection of objects
 ====
 include::sample[dir="userguide/customPlugins/customPluginWithDomainObjectContainer/groovy",files="build.gradle[]"]
 include::sample[dir="userguide/customPlugins/customPluginWithDomainObjectContainer/kotlin",files="build.gradle.kts[]"]
 ====
+
+Another type is link:{javadocPath}/org/gradle/api/DomainObjectSet.html[DomainObjectSet] which maintains a simple set of objects.
+Compared to the `NamedDomainObjectContainer`, the `DomainObjectSet` doesn't manage the objects in the collection.
+They need to be created and added manually.
+You can create an instance using link:{javadocPath}/org/gradle/api/model/ObjectFactory.html#domainObjectSet-java.lang.Class-[ObjectFactory.domainObjectSet()].
 
 ==== Output of **`gradle -q books`**
 [source.multi-language-sample,groovy]

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppApplication.java
@@ -18,7 +18,6 @@ package org.gradle.language.cpp.internal;
 
 import org.gradle.api.Action;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.internal.Describables;
@@ -41,12 +40,12 @@ public class DefaultCppApplication extends DefaultCppComponent implements CppApp
     private final DefaultComponentDependencies dependencies;
 
     @Inject
-    public DefaultCppApplication(String name, ObjectFactory objectFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public DefaultCppApplication(String name, ObjectFactory objectFactory) {
         super(name, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(CppExecutable.class);
         this.dependencies = objectFactory.newInstance(DefaultComponentDependencies.class, getNames().withSuffix("implementation"));
-        this.mainVariant = new MainExecutableVariant(collectionCallbackActionDecorator);
+        this.mainVariant = new MainExecutableVariant(objectFactory);
     }
 
     public DefaultCppExecutable addExecutable(NativeVariantIdentity identity, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/DefaultCppLibrary.java
@@ -25,7 +25,6 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.artifacts.ArtifactAttributes;
 import org.gradle.api.internal.attributes.ImmutableAttributesFactory;
 import org.gradle.api.model.ObjectFactory;
@@ -58,7 +57,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
     private final DefaultLibraryDependencies dependencies;
 
     @Inject
-    public DefaultCppLibrary(String name, ObjectFactory objectFactory, ConfigurationContainer configurations, ImmutableAttributesFactory immutableAttributesFactory, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public DefaultCppLibrary(String name, ObjectFactory objectFactory, ConfigurationContainer configurations, ImmutableAttributesFactory immutableAttributesFactory) {
         super(name, objectFactory);
         this.objectFactory = objectFactory;
         this.developmentBinary = objectFactory.property(CppBinary.class);
@@ -81,7 +80,7 @@ public class DefaultCppLibrary extends DefaultCppComponent implements CppLibrary
         AttributeContainer publicationAttributes = immutableAttributesFactory.mutable();
         publicationAttributes.attribute(Usage.USAGE_ATTRIBUTE, apiUsage);
         publicationAttributes.attribute(ArtifactAttributes.ARTIFACT_FORMAT, ArtifactTypeDefinition.ZIP_TYPE);
-        mainVariant = new MainLibraryVariant("api", apiUsage, apiElements, publicationAttributes, collectionCallbackActionDecorator);
+        mainVariant = new MainLibraryVariant("api", apiUsage, apiElements, publicationAttributes, objectFactory);
     }
 
     public DefaultCppSharedLibrary addSharedLibrary(NativeVariantIdentity identity, CppPlatform targetPlatform, NativeToolChainInternal toolChain, PlatformToolProvider platformToolProvider) {

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainExecutableVariant.java
@@ -20,18 +20,17 @@ import com.google.common.collect.ImmutableSet;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.model.ObjectFactory;
 
 import java.util.Set;
 
 public class MainExecutableVariant implements SoftwareComponentInternal, ComponentWithVariants {
     private final DomainObjectSet<SoftwareComponent> variants;
 
-    public MainExecutableVariant(CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-        variants = new DefaultDomainObjectSet<SoftwareComponent>(SoftwareComponent.class, collectionCallbackActionDecorator);
+    public MainExecutableVariant(ObjectFactory objectFactory) {
+        variants = objectFactory.domainObjectSet(SoftwareComponent.class);
     }
 
     @Override

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -24,7 +24,6 @@ import org.gradle.api.attributes.AttributeContainer;
 import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
 import org.gradle.api.model.ObjectFactory;

--- a/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
+++ b/subprojects/language-native/src/main/java/org/gradle/language/cpp/internal/MainLibraryVariant.java
@@ -25,9 +25,9 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.ComponentWithVariants;
 import org.gradle.api.component.SoftwareComponent;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.component.SoftwareComponentInternal;
 import org.gradle.api.internal.component.UsageContext;
+import org.gradle.api.model.ObjectFactory;
 
 import java.util.LinkedHashSet;
 import java.util.Set;
@@ -40,12 +40,12 @@ public class MainLibraryVariant implements ComponentWithVariants, SoftwareCompon
     private final DomainObjectSet<SoftwareComponent> variants;
     private final AttributeContainer attributeContainer;
 
-    public MainLibraryVariant(String name, Usage usage, Configuration dependencies, AttributeContainer attributeContainer, CollectionCallbackActionDecorator decorator) {
+    public MainLibraryVariant(String name, Usage usage, Configuration dependencies, AttributeContainer attributeContainer, ObjectFactory objectFactory) {
         this.name = name;
         this.usage = usage;
         this.dependencies = dependencies;
         this.attributeContainer = attributeContainer;
-        this.variants = new DefaultDomainObjectSet<SoftwareComponent>(SoftwareComponent.class, decorator);
+        this.variants = objectFactory.domainObjectSet(SoftwareComponent.class);
     }
 
     @Override

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/binary/BaseBinarySpec.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/binary/BaseBinarySpec.java
@@ -23,7 +23,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.internal.AbstractBuildableComponentSpec;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.reflect.ObjectInstantiationException;
 import org.gradle.internal.component.local.model.DefaultLibraryBinaryIdentifier;
 import org.gradle.internal.reflect.Instantiator;
@@ -79,8 +79,8 @@ public class BaseBinarySpec extends AbstractBuildableComponentSpec implements Bi
     public static <T extends BaseBinarySpec> T create(Class<? extends BinarySpec> publicType, Class<T> implementationType,
                                                       ComponentSpecIdentifier componentId, MutableModelNode modelNode, @Nullable MutableModelNode componentNode,
                                                       Instantiator instantiator, NamedEntityInstantiator<Task> taskInstantiator,
-                                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-        NEXT_BINARY_INFO.set(new BinaryInfo(componentId, publicType, modelNode, componentNode, taskInstantiator, instantiator, collectionCallbackActionDecorator));
+                                                      CollectionCallbackActionDecorator collectionCallbackActionDecorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
+        NEXT_BINARY_INFO.set(new BinaryInfo(componentId, publicType, modelNode, componentNode, taskInstantiator, instantiator, collectionCallbackActionDecorator, domainObjectCollectionFactory));
         try {
             try {
                 return instantiator.newInstance(implementationType);
@@ -101,7 +101,7 @@ public class BaseBinarySpec extends AbstractBuildableComponentSpec implements Bi
         this.publicType = info.publicType;
         this.componentNode = info.componentNode;
         this.tasks = info.instantiator.newInstance(DefaultBinaryTasksCollection.class, this, info.taskInstantiator, info.collectionCallbackActionDecorator);
-        this.inputSourceSets = new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet.class, info.collectionCallbackActionDecorator);
+        this.inputSourceSets = info.domainObjectCollectionFactory.newDomainObjectSet(LanguageSourceSet.class);
 
         MutableModelNode modelNode = info.modelNode;
         sources = ModelMaps.addModelMapNode(modelNode, LANGUAGE_SOURCE_SET_MODELTYPE, "sources");
@@ -223,8 +223,9 @@ public class BaseBinarySpec extends AbstractBuildableComponentSpec implements Bi
         private final Instantiator instantiator;
         private final ComponentSpecIdentifier componentId;
         private final CollectionCallbackActionDecorator collectionCallbackActionDecorator;
+        private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
-        private BinaryInfo(ComponentSpecIdentifier componentId, Class<? extends BinarySpec> publicType, MutableModelNode modelNode, MutableModelNode componentNode, NamedEntityInstantiator<Task> taskInstantiator, Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        private BinaryInfo(ComponentSpecIdentifier componentId, Class<? extends BinarySpec> publicType, MutableModelNode modelNode, MutableModelNode componentNode, NamedEntityInstantiator<Task> taskInstantiator, Instantiator instantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
             this.componentId = componentId;
             this.publicType = publicType;
             this.modelNode = modelNode;
@@ -232,6 +233,7 @@ public class BaseBinarySpec extends AbstractBuildableComponentSpec implements Bi
             this.taskInstantiator = taskInstantiator;
             this.instantiator = instantiator;
             this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+            this.domainObjectCollectionFactory = domainObjectCollectionFactory;
         }
     }
 

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/component/internal/ComponentSpecFactory.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/component/internal/ComponentSpecFactory.java
@@ -18,6 +18,7 @@ package org.gradle.platform.base.component.internal;
 
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.Cast;
@@ -41,7 +42,7 @@ public class ComponentSpecFactory extends BaseInstanceFactory<ComponentSpec> {
     private final ProjectIdentifier projectIdentifier;
 
     public ComponentSpecFactory(final ProjectIdentifier projectIdentifier, final Instantiator instantiator, final NamedEntityInstantiator<Task> taskInstantiator, final ObjectFactory objectFactory,
-                                final CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+                                final CollectionCallbackActionDecorator collectionCallbackActionDecorator, final DomainObjectCollectionFactory domainObjectCollectionFactory) {
         super(ComponentSpec.class);
         this.projectIdentifier = projectIdentifier;
         registerFactory(DefaultComponentSpec.class, new ImplementationFactory<ComponentSpec, DefaultComponentSpec>() {
@@ -64,7 +65,8 @@ public class ComponentSpecFactory extends BaseInstanceFactory<ComponentSpec> {
                     componentNode,
                     instantiator,
                     taskInstantiator,
-                    collectionCallbackActionDecorator);
+                    collectionCallbackActionDecorator,
+                    domainObjectCollectionFactory);
             }
         });
         registerFactory(BaseLanguageSourceSet.class, new ImplementationFactory<LanguageSourceSet, BaseLanguageSourceSet>() {

--- a/subprojects/platform-base/src/main/java/org/gradle/platform/base/plugins/ComponentBasePlugin.java
+++ b/subprojects/platform-base/src/main/java/org/gradle/platform/base/plugins/ComponentBasePlugin.java
@@ -21,9 +21,11 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.project.ProjectIdentifier;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.reflect.Instantiator;
+import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 import org.gradle.model.Model;
 import org.gradle.model.Mutate;
@@ -63,8 +65,9 @@ public class ComponentBasePlugin implements Plugin<Project> {
 
         @Hidden
         @Model
-        ComponentSpecFactory componentSpecFactory(ProjectIdentifier projectIdentifier, Instantiator instantiator, ObjectFactory objectFactory, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
-            return new ComponentSpecFactory(projectIdentifier, instantiator, taskInstantiator, objectFactory, collectionCallbackActionDecorator);
+        ComponentSpecFactory componentSpecFactory(ProjectIdentifier projectIdentifier, Instantiator instantiator, ObjectFactory objectFactory, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator, ServiceRegistry serviceRegistry) {
+            DomainObjectCollectionFactory domainObjectCollectionFactory = serviceRegistry.get(DomainObjectCollectionFactory.class);
+            return new ComponentSpecFactory(projectIdentifier, instantiator, taskInstantiator, objectFactory, collectionCallbackActionDecorator, domainObjectCollectionFactory);
         }
 
         @ComponentType

--- a/subprojects/platform-base/src/testFixtures/groovy/org/gradle/platform/base/binary/BaseBinaryFixtures.groovy
+++ b/subprojects/platform-base/src/testFixtures/groovy/org/gradle/platform/base/binary/BaseBinaryFixtures.groovy
@@ -32,7 +32,7 @@ class BaseBinaryFixtures {
     static <T extends BinarySpec, I extends BaseBinarySpec> T create(Class<T> publicType, Class<I> implType, String name, MutableModelNode componentNode) {
         return BaseInstanceFixtureSupport.create(publicType, BinarySpecInternal, implType, name) { MutableModelNode node ->
             def identifier = componentNode ? componentNode.asImmutable(ModelType.of(ComponentSpecInternal), null).instance.identifier.child(name) : new DefaultComponentSpecIdentifier("project", name)
-            return BaseBinarySpec.create(publicType, implType, identifier, node, componentNode, TestUtil.instantiatorFactory().injectLenient(), {} as NamedEntityInstantiator, CollectionCallbackActionDecorator.NOOP)
+            return BaseBinarySpec.create(publicType, implType, identifier, node, componentNode, TestUtil.instantiatorFactory().injectLenient(), {} as NamedEntityInstantiator, CollectionCallbackActionDecorator.NOOP, TestUtil.domainObjectCollectionFactory())
         }
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraries.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraries.java
@@ -20,6 +20,7 @@ import org.gradle.api.Action;
 import org.gradle.api.artifacts.repositories.RepositoryContentDescriptor;
 import org.gradle.api.internal.AbstractNamedDomainObjectContainer;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.nativeplatform.PrebuiltLibraries;
@@ -28,15 +29,15 @@ import org.gradle.nativeplatform.PrebuiltLibrary;
 public class DefaultPrebuiltLibraries extends AbstractNamedDomainObjectContainer<PrebuiltLibrary> implements PrebuiltLibraries {
     private final ObjectFactory objectFactory;
     private final Action<PrebuiltLibrary> libraryInitializer;
-    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
     private String name;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
-    public DefaultPrebuiltLibraries(String name, Instantiator instantiator, ObjectFactory objectFactory, Action<PrebuiltLibrary> libraryInitializer, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public DefaultPrebuiltLibraries(String name, Instantiator instantiator, ObjectFactory objectFactory, Action<PrebuiltLibrary> libraryInitializer, CollectionCallbackActionDecorator collectionCallbackActionDecorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         super(PrebuiltLibrary.class, instantiator, collectionCallbackActionDecorator);
         this.name = name;
         this.objectFactory = objectFactory;
         this.libraryInitializer = libraryInitializer;
-        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
     }
 
     @Override
@@ -56,7 +57,7 @@ public class DefaultPrebuiltLibraries extends AbstractNamedDomainObjectContainer
 
     @Override
     protected PrebuiltLibrary doCreate(String name) {
-        return getInstantiator().newInstance(DefaultPrebuiltLibrary.class, name, objectFactory, collectionCallbackActionDecorator);
+        return getInstantiator().newInstance(DefaultPrebuiltLibrary.class, name, objectFactory, domainObjectCollectionFactory);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibrary.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibrary.java
@@ -18,8 +18,7 @@ package org.gradle.nativeplatform.internal.prebuilt;
 
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.file.SourceDirectorySet;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.nativeplatform.NativeLibraryBinary;
 import org.gradle.nativeplatform.PrebuiltLibrary;
@@ -30,10 +29,10 @@ public class DefaultPrebuiltLibrary implements PrebuiltLibrary {
     private final SourceDirectorySet headers;
     private final DomainObjectSet<NativeLibraryBinary> binaries;
 
-    public DefaultPrebuiltLibrary(String name, ObjectFactory objectFactory, CollectionCallbackActionDecorator decorator) {
+    public DefaultPrebuiltLibrary(String name, ObjectFactory objectFactory, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.name = name;
         headers = objectFactory.sourceDirectorySet("headers", "headers for prebuilt library '" + name + "'");
-        binaries = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class, decorator);
+        binaries = domainObjectCollectionFactory.newDomainObjectSet(NativeLibraryBinary.class);
     }
 
     @Override

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
@@ -25,14 +25,14 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CachingLibraryBinaryLocator implements LibraryBinaryLocator {
-    private static DomainObjectSet<NativeLibraryBinary> NULL_RESULT;
+    private static DomainObjectSet<NativeLibraryBinary> nullResult;
     private final LibraryBinaryLocator delegate;
     private final Map<LibraryIdentifier, DomainObjectSet<NativeLibraryBinary>> libraries = new HashMap<LibraryIdentifier, DomainObjectSet<NativeLibraryBinary>>();
 
     public CachingLibraryBinaryLocator(LibraryBinaryLocator delegate, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.delegate = delegate;
-        if (NULL_RESULT == null) {
-            NULL_RESULT = domainObjectCollectionFactory.newDomainObjectSet(NativeLibraryBinary.class);
+        if (nullResult == null) {
+            nullResult = domainObjectCollectionFactory.newDomainObjectSet(NativeLibraryBinary.class);
         }
     }
 
@@ -43,10 +43,10 @@ public class CachingLibraryBinaryLocator implements LibraryBinaryLocator {
         if (libraryBinaries == null) {
             libraryBinaries = delegate.getBinaries(library);
             if (libraryBinaries == null) {
-                libraryBinaries = NULL_RESULT;
+                libraryBinaries = nullResult;
             }
             libraries.put(library, libraryBinaries);
         }
-        return libraryBinaries == NULL_RESULT ? null : libraryBinaries;
+        return libraryBinaries == nullResult ? null : libraryBinaries;
     }
 }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
@@ -17,9 +17,6 @@
 package org.gradle.nativeplatform.internal.resolve;
 
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
-import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
 import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.nativeplatform.NativeLibraryBinary;
 

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocator.java
@@ -19,6 +19,8 @@ package org.gradle.nativeplatform.internal.resolve;
 import org.gradle.api.DomainObjectSet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.collections.DefaultDomainObjectCollectionFactory;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.nativeplatform.NativeLibraryBinary;
 
 import javax.annotation.Nullable;
@@ -26,12 +28,15 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class CachingLibraryBinaryLocator implements LibraryBinaryLocator {
-    private static final DomainObjectSet<NativeLibraryBinary> NULL_RESULT = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class, CollectionCallbackActionDecorator.NOOP);
+    private static DomainObjectSet<NativeLibraryBinary> NULL_RESULT;
     private final LibraryBinaryLocator delegate;
     private final Map<LibraryIdentifier, DomainObjectSet<NativeLibraryBinary>> libraries = new HashMap<LibraryIdentifier, DomainObjectSet<NativeLibraryBinary>>();
 
-    public CachingLibraryBinaryLocator(LibraryBinaryLocator delegate) {
+    public CachingLibraryBinaryLocator(LibraryBinaryLocator delegate, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.delegate = delegate;
+        if (NULL_RESULT == null) {
+            NULL_RESULT = domainObjectCollectionFactory.newDomainObjectSet(NativeLibraryBinary.class);
+        }
     }
 
     @Nullable

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/NativeDependencyResolverServices.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/NativeDependencyResolverServices.java
@@ -15,7 +15,7 @@
  */
 package org.gradle.nativeplatform.internal.resolve;
 
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.resolve.ProjectModelResolver;
 import org.gradle.nativeplatform.internal.prebuilt.PrebuiltLibraryBinaryLocator;
@@ -24,11 +24,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class NativeDependencyResolverServices {
-    public LibraryBinaryLocator createLibraryBinaryLocator(ProjectModelResolver projectModelResolver, CollectionCallbackActionDecorator callbackActionDecorator) {
+    public LibraryBinaryLocator createLibraryBinaryLocator(ProjectModelResolver projectModelResolver, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         List<LibraryBinaryLocator> locators = new ArrayList<LibraryBinaryLocator>();
-        locators.add(new ProjectLibraryBinaryLocator(projectModelResolver, callbackActionDecorator));
+        locators.add(new ProjectLibraryBinaryLocator(projectModelResolver, domainObjectCollectionFactory));
         locators.add(new PrebuiltLibraryBinaryLocator(projectModelResolver));
-        return new CachingLibraryBinaryLocator(new ChainedLibraryBinaryLocator(locators));
+        return new CachingLibraryBinaryLocator(new ChainedLibraryBinaryLocator(locators), domainObjectCollectionFactory);
     }
 
     public NativeDependencyResolver createResolver(LibraryBinaryLocator locator, FileCollectionFactory fileCollectionFactory) {

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocator.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocator.java
@@ -16,8 +16,7 @@
 package org.gradle.nativeplatform.internal.resolve;
 
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.resolve.ProjectModelResolver;
 import org.gradle.model.ModelMap;
 import org.gradle.model.internal.registry.ModelRegistry;
@@ -30,11 +29,11 @@ import javax.annotation.Nullable;
 
 public class ProjectLibraryBinaryLocator implements LibraryBinaryLocator {
     private final ProjectModelResolver projectModelResolver;
-    private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
-    public ProjectLibraryBinaryLocator(ProjectModelResolver projectModelResolver, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public ProjectLibraryBinaryLocator(ProjectModelResolver projectModelResolver, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.projectModelResolver = projectModelResolver;
-        this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
     }
 
     // Converts the binaries of a project library into regular binary instances
@@ -52,7 +51,7 @@ public class ProjectLibraryBinaryLocator implements LibraryBinaryLocator {
             return null;
         }
         ModelMap<NativeBinarySpec> projectBinaries = library.getBinaries().withType(NativeBinarySpec.class);
-        DomainObjectSet<NativeLibraryBinary> binaries = new DefaultDomainObjectSet<NativeLibraryBinary>(NativeLibraryBinary.class, collectionCallbackActionDecorator);
+        DomainObjectSet<NativeLibraryBinary> binaries = domainObjectCollectionFactory.newDomainObjectSet(NativeLibraryBinary.class);
         for (NativeBinarySpec nativeBinarySpec : projectBinaries.values()) {
             binaries.add((NativeLibraryBinary) nativeBinarySpec);
         }

--- a/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
+++ b/subprojects/platform-native/src/main/java/org/gradle/nativeplatform/plugins/NativeComponentModelPlugin.java
@@ -28,6 +28,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DefaultPolymorphicDomainObjectContainer;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.internal.project.ProjectRegistry;
@@ -167,7 +168,8 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
             NativePlatforms nativePlatforms = serviceRegistry.get(NativePlatforms.class);
             FileCollectionFactory fileCollectionFactory = serviceRegistry.get(FileCollectionFactory.class);
             Action<PrebuiltLibrary> initializer = new PrebuiltLibraryInitializer(instantiator, fileCollectionFactory, nativePlatforms, platforms.withType(NativePlatform.class), buildTypes, flavors);
-            return new DefaultRepositories(instantiator, sourceDirectorySetFactory, initializer, callbackActionDecorator);
+            DomainObjectCollectionFactory domainObjectCollectionFactory = serviceRegistry.get(DomainObjectCollectionFactory.class);
+            return new DefaultRepositories(instantiator, sourceDirectorySetFactory, initializer, callbackActionDecorator, domainObjectCollectionFactory);
         }
 
         @Model
@@ -423,14 +425,15 @@ public class NativeComponentModelPlugin implements Plugin<ProjectInternal> {
     }
 
     private static class DefaultRepositories extends DefaultPolymorphicDomainObjectContainer<ArtifactRepository> implements Repositories {
-        private DefaultRepositories(final Instantiator instantiator,
-                                    final ObjectFactory objectFactory,
-                                    final Action<PrebuiltLibrary> binaryFactory,
-                                    final CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+        private DefaultRepositories(Instantiator instantiator,
+                                    ObjectFactory objectFactory,
+                                    Action<PrebuiltLibrary> binaryFactory,
+                                    CollectionCallbackActionDecorator collectionCallbackActionDecorator,
+                                    DomainObjectCollectionFactory domainObjectCollectionFactory) {
             super(ArtifactRepository.class, instantiator, new ArtifactRepositoryNamer(), collectionCallbackActionDecorator);
             registerFactory(PrebuiltLibraries.class, new NamedDomainObjectFactory<PrebuiltLibraries>() {
                 public PrebuiltLibraries create(String name) {
-                    return instantiator.newInstance(DefaultPrebuiltLibraries.class, name, instantiator, objectFactory, binaryFactory, collectionCallbackActionDecorator);
+                    return instantiator.newInstance(DefaultPrebuiltLibraries.class, name, instantiator, objectFactory, binaryFactory, collectionCallbackActionDecorator, domainObjectCollectionFactory);
                 }
             });
         }

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraryTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/prebuilt/DefaultPrebuiltLibraryTest.groovy
@@ -16,13 +16,13 @@
 
 package org.gradle.nativeplatform.internal.prebuilt
 
-import org.gradle.api.internal.CollectionCallbackActionDecorator
+
 import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class DefaultPrebuiltLibraryTest extends Specification {
     def "has useful display name"() {
-        def lib = new DefaultPrebuiltLibrary("someLib", TestUtil.objectFactory(), CollectionCallbackActionDecorator.NOOP)
+        def lib = new DefaultPrebuiltLibrary("someLib", TestUtil.objectFactory(), TestUtil.domainObjectCollectionFactory())
 
         expect:
         lib.toString() == "prebuilt library 'someLib'"

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/CachingLibraryBinaryLocatorTest.groovy
@@ -17,11 +17,12 @@
 package org.gradle.nativeplatform.internal.resolve
 
 import org.gradle.api.DomainObjectSet
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 class CachingLibraryBinaryLocatorTest extends Specification {
     def target = Mock(LibraryBinaryLocator)
-    def locator = new CachingLibraryBinaryLocator(target)
+    def locator = new CachingLibraryBinaryLocator(target, TestUtil.domainObjectCollectionFactory())
 
     def "locates library once and reuses result for subsequent lookups"() {
         def lib = new LibraryIdentifier("project", "lib")

--- a/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocatorTest.groovy
+++ b/subprojects/platform-native/src/test/groovy/org/gradle/nativeplatform/internal/resolve/ProjectLibraryBinaryLocatorTest.groovy
@@ -16,8 +16,6 @@
 package org.gradle.nativeplatform.internal.resolve
 
 import org.gradle.api.UnknownProjectException
-import org.gradle.api.internal.CollectionCallbackActionDecorator
-import org.gradle.api.internal.DefaultDomainObjectSet
 import org.gradle.api.internal.resolve.ProjectModelResolver
 import org.gradle.model.ModelMap
 import org.gradle.model.internal.registry.ModelRegistry
@@ -25,6 +23,7 @@ import org.gradle.nativeplatform.NativeBinarySpec
 import org.gradle.nativeplatform.NativeLibraryBinary
 import org.gradle.nativeplatform.NativeLibrarySpec
 import org.gradle.platform.base.ComponentSpecContainer
+import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.model.internal.type.ModelTypes.modelMap
@@ -36,8 +35,8 @@ class ProjectLibraryBinaryLocatorTest extends Specification {
     def binary = Mock(MockNativeLibraryBinary)
     def binaries = Mock(ModelMap)
     def nativeBinaries = Mock(ModelMap)
-    def convertedBinaries = new DefaultDomainObjectSet(NativeLibraryBinary, CollectionCallbackActionDecorator.NOOP)
-    def locator = new ProjectLibraryBinaryLocator(projectLocator, CollectionCallbackActionDecorator.NOOP)
+    def convertedBinaries = TestUtil.domainObjectCollectionFactory().newDomainObjectSet(NativeLibraryBinary)
+    def locator = new ProjectLibraryBinaryLocator(projectLocator, TestUtil.domainObjectCollectionFactory())
 
     def setup() {
         convertedBinaries.add(binary)

--- a/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
+++ b/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/GradlePluginDevelopmentExtension.java
@@ -62,7 +62,7 @@ public class GradlePluginDevelopmentExtension {
     }
 
     public GradlePluginDevelopmentExtension(Project project, SourceSet pluginSourceSet, SourceSet[] testSourceSets) {
-        this.plugins = project.container(PluginDeclaration.class);
+        this.plugins = project.getObjects().container(PluginDeclaration.class);
         this.pluginSourceSet = pluginSourceSet;
         testSourceSets(testSourceSets);
     }

--- a/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpec.java
@@ -20,7 +20,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.component.LibraryBinaryIdentifier;
 import org.gradle.api.internal.AbstractBuildableComponentSpec;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.jvm.ClassDirectoryBinarySpec;
@@ -44,19 +44,19 @@ import javax.annotation.Nullable;
 import java.io.File;
 
 public class DefaultClassDirectoryBinarySpec extends AbstractBuildableComponentSpec implements ClassDirectoryBinarySpecInternal {
-    private final DefaultDomainObjectSet<LanguageSourceSet> sourceSets;
+    private final DomainObjectSet<LanguageSourceSet> sourceSets;
     private final SourceSet sourceSet;
     private final JavaToolChain toolChain;
     private final JavaPlatform platform;
     private final BinaryTasksCollection tasks;
     private boolean buildable = true;
 
-    public DefaultClassDirectoryBinarySpec(ComponentSpecIdentifier componentIdentifier, SourceSet sourceSet, JavaToolChain toolChain, JavaPlatform platform, Instantiator instantiator, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public DefaultClassDirectoryBinarySpec(ComponentSpecIdentifier componentIdentifier, SourceSet sourceSet, JavaToolChain toolChain, JavaPlatform platform, Instantiator instantiator, NamedEntityInstantiator<Task> taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         super(componentIdentifier, ClassDirectoryBinarySpec.class);
         this.sourceSet = sourceSet;
         this.toolChain = toolChain;
         this.platform = platform;
-        this.sourceSets = new DefaultDomainObjectSet<LanguageSourceSet>(LanguageSourceSet.class, collectionCallbackActionDecorator);
+        this.sourceSets = domainObjectCollectionFactory.newDomainObjectSet(LanguageSourceSet.class);
         this.tasks = instantiator.newInstance(DefaultBinaryTasksCollection.class, this, taskInstantiator, collectionCallbackActionDecorator);
     }
 

--- a/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
+++ b/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaBasePluginRules.java
@@ -22,6 +22,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
+import org.gradle.api.internal.collections.DomainObjectCollectionFactory;
 import org.gradle.api.internal.java.DefaultJavaSourceSet;
 import org.gradle.api.internal.java.DefaultJvmResourceSet;
 import org.gradle.api.internal.jvm.ClassDirectoryBinarySpecInternal;
@@ -61,14 +62,16 @@ class JavaBasePluginRules implements Plugin<Project> {
     private final JavaToolChain javaToolChain;
     private final NamedEntityInstantiator<Task> taskInstantiator;
     private CollectionCallbackActionDecorator collectionCallbackActionDecorator;
+    private final DomainObjectCollectionFactory domainObjectCollectionFactory;
 
     @Inject
-    public JavaBasePluginRules(ModelRegistry modelRegistry, Instantiator instantiator, JavaToolChain javaToolChain, TaskInstantiator taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator) {
+    public JavaBasePluginRules(ModelRegistry modelRegistry, Instantiator instantiator, JavaToolChain javaToolChain, TaskInstantiator taskInstantiator, CollectionCallbackActionDecorator collectionCallbackActionDecorator, DomainObjectCollectionFactory domainObjectCollectionFactory) {
         this.modelRegistry = modelRegistry;
         this.instantiator = instantiator;
         this.javaToolChain = javaToolChain;
         this.taskInstantiator = taskInstantiator;
         this.collectionCallbackActionDecorator = collectionCallbackActionDecorator;
+        this.domainObjectCollectionFactory = domainObjectCollectionFactory;
     }
 
     @Override
@@ -95,7 +98,7 @@ class JavaBasePluginRules implements Plugin<Project> {
                 Provider<JavaCompile> compileTask = tasks.named(sourceSet.getCompileJavaTaskName(), JavaCompile.class);
 
                 DefaultComponentSpecIdentifier binaryId = new DefaultComponentSpecIdentifier(project.getPath(), sourceSet.getName());
-                ClassDirectoryBinarySpecInternal binary = instantiator.newInstance(DefaultClassDirectoryBinarySpec.class, binaryId, sourceSet, javaToolChain, DefaultJavaPlatform.current(), instantiator, taskInstantiator, collectionCallbackActionDecorator);
+                ClassDirectoryBinarySpecInternal binary = instantiator.newInstance(DefaultClassDirectoryBinarySpec.class, binaryId, sourceSet, javaToolChain, DefaultJavaPlatform.current(), instantiator, taskInstantiator, collectionCallbackActionDecorator, domainObjectCollectionFactory);
 
                 Classpath compileClasspath = new SourceSetCompileClasspath(sourceSet);
                 DefaultJavaSourceSet javaSourceSet = instantiator.newInstance(DefaultJavaSourceSet.class, binaryId.child("java"), sourceSet.getJava(), compileClasspath);

--- a/subprojects/plugins/src/test/groovy/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpecTest.groovy
+++ b/subprojects/plugins/src/test/groovy/org/gradle/api/internal/jvm/DefaultClassDirectoryBinarySpecTest.groovy
@@ -35,6 +35,6 @@ class DefaultClassDirectoryBinarySpecTest extends Specification {
 
     private DefaultClassDirectoryBinarySpec binary(String name) {
         new DefaultClassDirectoryBinarySpec(new DefaultComponentSpecIdentifier(":", name), Stub(SourceSet), Stub(JavaToolChain), Stub(JavaPlatform),
-                TestUtil.instantiatorFactory().decorateLenient(), Mock(NamedEntityInstantiator), CollectionCallbackActionDecorator.NOOP)
+                TestUtil.instantiatorFactory().decorateLenient(), Mock(NamedEntityInstantiator), CollectionCallbackActionDecorator.NOOP, TestUtil.domainObjectCollectionFactory())
     }
 }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -64,11 +64,10 @@ public class Sign extends DefaultTask implements SignatureSpec {
     private SignatureType signatureType;
     private Signatory signatory;
     private boolean required = true;
-    private final DefaultDomainObjectSet<Signature> signatures;
+    private final DomainObjectSet<Signature> signatures = getProject().getObjects().domainObjectSet(Signature.class);
 
     @Inject
     public Sign() {
-        this.signatures = new DefaultDomainObjectSet<Signature>(Signature.class, getCallbackActionDecorator());
         // If we aren't required and don't have a signatory then we just don't run
         onlyIf(task -> isRequired() || getSignatory() != null);
     }

--- a/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
+++ b/subprojects/signing/src/main/java/org/gradle/plugins/signing/Sign.java
@@ -28,7 +28,6 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
-import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.file.FileCollectionFactory;
 import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationArtifact;


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
<!--- Link to relevant issues or forum discussions here -->
A tiny bit of refactoring within the scope of improving the domain object collection usage by the plugin authors.

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and [CI build status](https://builds.gradle.org/project.html?projectId=Gradle_Check&tab=projectOverview&branch_Gradle_Check=lacasseio%2Fcore%2Fdomain-object-collection-factory)
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
