### PR TITLE
Support build scan generation via `--scan` when using instant execution

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -60,6 +60,7 @@ import org.gradle.api.internal.file.FileOperations;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.plugins.DefaultObjectConfigurationAction;
 import org.gradle.api.internal.plugins.ExtensionContainerInternal;
 import org.gradle.api.internal.plugins.PluginManagerInternal;
@@ -376,7 +377,7 @@ public class DefaultProject extends AbstractPluginAware implements ProjectIntern
 
     @Inject
     @Override
-    public ScriptHandler getBuildscript() {
+    public ScriptHandlerInternal getBuildscript() {
         // Decoration takes care of the implementation
         throw new UnsupportedOperationException();
     }

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/DefaultProject.java
@@ -44,7 +44,6 @@ import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DeleteSpec;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DynamicObjectAware;
 import org.gradle.api.internal.DynamicPropertyNamer;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -21,7 +21,6 @@ import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.UnknownProjectException;
 import org.gradle.api.attributes.Attribute;
-import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;

--- a/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
+++ b/subprojects/core/src/main/java/org/gradle/api/internal/project/ProjectInternal.java
@@ -21,12 +21,14 @@ import org.gradle.api.Project;
 import org.gradle.api.ProjectEvaluationListener;
 import org.gradle.api.UnknownProjectException;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.internal.artifacts.configurations.DependencyMetaDataProvider;
 import org.gradle.api.internal.file.FileResolver;
 import org.gradle.api.internal.file.HasScriptServices;
 import org.gradle.api.internal.initialization.ClassLoaderScope;
+import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.plugins.ExtensionContainerInternal;
 import org.gradle.api.internal.plugins.PluginAwareInternal;
 import org.gradle.api.internal.tasks.TaskContainerInternal;
@@ -134,4 +136,7 @@ public interface ProjectInternal extends Project, ProjectIdentifier, HasScriptSe
     ProjectEvaluationListener stepEvaluationListener(ProjectEvaluationListener listener, Action<ProjectEvaluationListener> action);
 
     ProjectState getMutationState();
+
+    @Override
+    ScriptHandlerInternal getBuildscript();
 }

--- a/subprojects/core/src/main/java/org/gradle/configuration/BuildConfigurer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/BuildConfigurer.java
@@ -18,5 +18,5 @@ package org.gradle.configuration;
 import org.gradle.api.internal.GradleInternal;
 
 public interface BuildConfigurer {
-    void configure(GradleInternal gradleInternal);
+    void configure(GradleInternal gradle);
 }

--- a/subprojects/core/src/main/java/org/gradle/configuration/NotifyingBuildConfigurer.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/NotifyingBuildConfigurer.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.configuration;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.initialization.ConfigureBuildBuildOperationType;
+import org.gradle.internal.operations.BuildOperationCategory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+public class NotifyingBuildConfigurer implements BuildConfigurer {
+    private static final ConfigureBuildBuildOperationType.Result CONFIGURE_BUILD_RESULT = new ConfigureBuildBuildOperationType.Result() {
+    };
+    private final BuildConfigurer delegate;
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public NotifyingBuildConfigurer(BuildConfigurer delegate, BuildOperationExecutor buildOperationExecutor) {
+        this.delegate = delegate;
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public void configure(GradleInternal gradle) {
+        buildOperationExecutor.run(new ConfigureBuild(gradle));
+    }
+
+    private class ConfigureBuild implements RunnableBuildOperation {
+        private final GradleInternal gradle;
+
+        public ConfigureBuild(GradleInternal gradle) {
+            this.gradle = gradle;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            delegate.configure(gradle);
+            context.setResult(CONFIGURE_BUILD_RESULT);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            BuildOperationDescriptor.Builder builder = BuildOperationDescriptor.displayName(gradle.contextualize("Configure build"));
+            if (gradle.getParent() == null) {
+                builder.operationType(BuildOperationCategory.CONFIGURE_ROOT_BUILD);
+            } else {
+                builder.operationType(BuildOperationCategory.CONFIGURE_BUILD);
+            }
+            builder.totalProgress(gradle.getSettings().getProjectRegistry().size());
+            return builder.details(new ConfigureBuildBuildOperationType.Details() {
+                @Override
+                public String getBuildPath() {
+                    return gradle.getIdentityPath().toString();
+                }
+            });
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/configuration/project/ConfigureProjectBuildOperationType.java
+++ b/subprojects/core/src/main/java/org/gradle/configuration/project/ConfigureProjectBuildOperationType.java
@@ -44,13 +44,13 @@ public final class ConfigureProjectBuildOperationType implements BuildOperationT
 
     }
 
-    static class DetailsImpl implements Details {
+    public static class DetailsImpl implements Details {
 
         private final Path buildPath;
         private final File rootDir;
         private final Path projectPath;
 
-        DetailsImpl(Path projectPath, Path buildPath, File rootDir) {
+        public DetailsImpl(Path projectPath, Path buildPath, File rootDir) {
             this.projectPath = projectPath;
             this.buildPath = buildPath;
             this.rootDir = rootDir;

--- a/subprojects/core/src/main/java/org/gradle/execution/IncludedBuildLifecycleBuildExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/IncludedBuildLifecycleBuildExecuter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.composite.internal.IncludedBuildControllers;
+
+import java.util.Collection;
+
+public class IncludedBuildLifecycleBuildExecuter implements BuildExecuter {
+    private final BuildExecuter delegate;
+    private final IncludedBuildControllers includedBuildControllers;
+
+    public IncludedBuildLifecycleBuildExecuter(BuildExecuter delegate, IncludedBuildControllers includedBuildControllers) {
+        this.delegate = delegate;
+        this.includedBuildControllers = includedBuildControllers;
+    }
+
+    @Override
+    public void execute(GradleInternal gradle, Collection<? super Throwable> taskFailures) {
+        includedBuildControllers.startTaskExecution();
+        delegate.execute(gradle, taskFailures);
+        includedBuildControllers.awaitTaskCompletion(taskFailures);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/execution/NotifyingBuildExecuter.java
+++ b/subprojects/core/src/main/java/org/gradle/execution/NotifyingBuildExecuter.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.execution;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.operations.BuildOperationCategory;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class NotifyingBuildExecuter implements BuildExecuter {
+    private final BuildExecuter delegate;
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public NotifyingBuildExecuter(BuildExecuter delegate, BuildOperationExecutor buildOperationExecutor) {
+        this.delegate = delegate;
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public void execute(GradleInternal gradle, Collection<? super Throwable> taskFailures) {
+        buildOperationExecutor.run(new ExecuteTasks(gradle, taskFailures));
+    }
+
+    private class ExecuteTasks implements RunnableBuildOperation {
+        private final GradleInternal gradle;
+        private final Collection<? super Throwable> taskFailures;
+
+        public ExecuteTasks(GradleInternal gradle, Collection<? super Throwable> taskFailures) {
+            this.gradle = gradle;
+            this.taskFailures = taskFailures;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            List<Throwable> failures = new ArrayList<Throwable>();
+            delegate.execute(gradle, failures);
+            if (!failures.isEmpty()) {
+                context.failed(failures.get(0));
+            }
+            taskFailures.addAll(failures);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            BuildOperationDescriptor.Builder builder = BuildOperationDescriptor.displayName(gradle.contextualize("Run tasks"));
+            if (gradle.getParent() == null) {
+                builder.operationType(BuildOperationCategory.RUN_WORK_ROOT_BUILD);
+            } else {
+                builder.operationType(BuildOperationCategory.RUN_WORK);
+            }
+            builder.totalProgress(gradle.getTaskGraph().size());
+            return builder;
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncher.java
@@ -147,6 +147,7 @@ public class DefaultGradleLauncher implements GradleLauncher {
     }
 
     private void doInstantExecution() {
+        buildListener.buildStarted(gradle);
         instantExecution.loadTaskGraph();
         stage = Stage.TaskGraph;
         runTasks();

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -129,9 +129,9 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         DeprecatedUsageBuildOperationProgressBroadaster deprecationWarningBuildOperationProgressBroadaster = serviceRegistry.get(DeprecatedUsageBuildOperationProgressBroadaster.class);
         DeprecationLogger.init(usageLocationReporter, startParameter.getWarningMode(), deprecationWarningBuildOperationProgressBroadaster);
 
-        SettingsLoaderFactory settingsLoaderFactory = serviceRegistry.get(SettingsLoaderFactory.class);
-        SettingsLoader settingsLoader = parent != null ? settingsLoaderFactory.forNestedBuild() : settingsLoaderFactory.forTopLevelBuild();
         GradleInternal parentBuild = parent == null ? null : parent.getGradle();
+
+        SettingsPreparer settingsPreparer = serviceRegistry.get(SettingsPreparer.class);
 
         GradleInternal gradle = serviceRegistry.get(Instantiator.class).newInstance(DefaultGradle.class, parentBuild, startParameter, serviceRegistry.get(ServiceRegistryFactory.class));
 
@@ -143,8 +143,6 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
         }
         DefaultGradleLauncher gradleLauncher = new DefaultGradleLauncher(
             gradle,
-            serviceRegistry.get(InitScriptHandler.class),
-            settingsLoader,
             serviceRegistry.get(BuildLoader.class),
             serviceRegistry.get(BuildConfigurer.class),
             serviceRegistry.get(ExceptionAnalyser.class),
@@ -157,7 +155,7 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             serviceRegistry,
             servicesToStop,
             includedBuildControllers,
-            buildDefinition.getFromBuild()
+            settingsPreparer
         );
         nestedBuildFactory.setParent(gradleLauncher);
         nestedBuildFactory.setBuildCancellationToken(buildTreeScopeServices.get(BuildCancellationToken.class));

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -26,7 +26,6 @@ import org.gradle.api.logging.configuration.ShowStacktrace;
 import org.gradle.composite.internal.IncludedBuildControllers;
 import org.gradle.configuration.BuildConfigurer;
 import org.gradle.deployment.internal.DefaultDeploymentRegistry;
-import org.gradle.execution.BuildConfigurationActionExecuter;
 import org.gradle.execution.BuildExecuter;
 import org.gradle.initialization.exception.ExceptionAnalyser;
 import org.gradle.internal.InternalBuildAdapter;
@@ -135,12 +134,9 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
 
         GradleInternal gradle = serviceRegistry.get(Instantiator.class).newInstance(DefaultGradle.class, parentBuild, startParameter, serviceRegistry.get(ServiceRegistryFactory.class));
 
-        IncludedBuildControllers includedBuildControllers;
-        if (parent == null) {
-            includedBuildControllers = buildTreeScopeServices.get(IncludedBuildControllers.class);
-        } else {
-            includedBuildControllers = IncludedBuildControllers.EMPTY;
-        }
+        IncludedBuildControllers includedBuildControllers = gradle.getServices().get(IncludedBuildControllers.class);
+        TaskExecutionPreparer taskExecutionPreparer = gradle.getServices().get(TaskExecutionPreparer.class);
+
         DefaultGradleLauncher gradleLauncher = new DefaultGradleLauncher(
             gradle,
             serviceRegistry.get(BuildLoader.class),
@@ -150,12 +146,12 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
             listenerManager.getBroadcaster(ModelConfigurationListener.class),
             listenerManager.getBroadcaster(BuildCompletionListener.class),
             buildOperationExecutor,
-            gradle.getServices().get(BuildConfigurationActionExecuter.class),
             gradle.getServices().get(BuildExecuter.class),
             serviceRegistry,
             servicesToStop,
             includedBuildControllers,
-            settingsPreparer
+            settingsPreparer,
+            taskExecutionPreparer
         );
         nestedBuildFactory.setParent(gradleLauncher);
         nestedBuildFactory.setBuildCancellationToken(buildTreeScopeServices.get(BuildCancellationToken.class));

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultGradleLauncherFactory.java
@@ -40,7 +40,6 @@ import org.gradle.internal.event.ListenerManager;
 import org.gradle.internal.featurelifecycle.DeprecatedUsageBuildOperationProgressBroadaster;
 import org.gradle.internal.featurelifecycle.LoggingDeprecatedFeatureHandler;
 import org.gradle.internal.featurelifecycle.ScriptUsageLocationReporter;
-import org.gradle.internal.operations.BuildOperationExecutor;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.service.scopes.BuildScopeListenerManagerAction;
@@ -124,7 +123,6 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
                 LoggingDeprecatedFeatureHandler.setTraceLoggingEnabled(false);
         }
 
-        BuildOperationExecutor buildOperationExecutor = serviceRegistry.get(BuildOperationExecutor.class);
         DeprecatedUsageBuildOperationProgressBroadaster deprecationWarningBuildOperationProgressBroadaster = serviceRegistry.get(DeprecatedUsageBuildOperationProgressBroadaster.class);
         DeprecationLogger.init(usageLocationReporter, startParameter.getWarningMode(), deprecationWarningBuildOperationProgressBroadaster);
 
@@ -139,19 +137,17 @@ public class DefaultGradleLauncherFactory implements GradleLauncherFactory {
 
         DefaultGradleLauncher gradleLauncher = new DefaultGradleLauncher(
             gradle,
-            serviceRegistry.get(BuildLoader.class),
             serviceRegistry.get(BuildConfigurer.class),
             serviceRegistry.get(ExceptionAnalyser.class),
             gradle.getBuildListenerBroadcaster(),
-            listenerManager.getBroadcaster(ModelConfigurationListener.class),
             listenerManager.getBroadcaster(BuildCompletionListener.class),
-            buildOperationExecutor,
             gradle.getServices().get(BuildExecuter.class),
             serviceRegistry,
             servicesToStop,
             includedBuildControllers,
             settingsPreparer,
-            taskExecutionPreparer
+            taskExecutionPreparer,
+            gradle.getServices().get(InstantExecution.class)
         );
         nestedBuildFactory.setParent(gradleLauncher);
         nestedBuildFactory.setBuildCancellationToken(buildTreeScopeServices.get(BuildCancellationToken.class));

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultSettingsPreparer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+
+public class DefaultSettingsPreparer implements SettingsPreparer {
+    private final InitScriptHandler initScriptHandler;
+    private final SettingsLoaderFactory settingsLoaderFactory;
+
+    public DefaultSettingsPreparer(InitScriptHandler initScriptHandler, SettingsLoaderFactory settingsLoaderFactory) {
+        this.initScriptHandler = initScriptHandler;
+        this.settingsLoaderFactory = settingsLoaderFactory;
+    }
+
+    @Override
+    public void prepareSettings(GradleInternal gradle) {
+        // Evaluate init scripts
+        initScriptHandler.executeScripts(gradle);
+        // Build `buildSrc`, load settings.gradle, and construct composite (if appropriate)
+        SettingsLoader settingsLoader = gradle.getParent() != null ? settingsLoaderFactory.forNestedBuild() : settingsLoaderFactory.forTopLevelBuild();
+        settingsLoader.findAndLoadSettings(gradle);
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/DefaultTaskExecutionPreparer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.composite.internal.IncludedBuildControllers;
+import org.gradle.execution.BuildConfigurationActionExecuter;
+import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
+import org.gradle.internal.operations.BuildOperationExecutor;
+
+public class DefaultTaskExecutionPreparer implements TaskExecutionPreparer {
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final BuildConfigurationActionExecuter buildConfigurationActionExecuter;
+    private final IncludedBuildControllers includedBuildControllers;
+
+    public DefaultTaskExecutionPreparer(BuildConfigurationActionExecuter buildConfigurationActionExecuter, IncludedBuildControllers includedBuildControllers, BuildOperationExecutor buildOperationExecutor) {
+        this.buildConfigurationActionExecuter = buildConfigurationActionExecuter;
+        this.includedBuildControllers = includedBuildControllers;
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public void prepareForTaskExecution(GradleInternal gradle) {
+        buildConfigurationActionExecuter.select(gradle);
+
+        TaskExecutionGraphInternal taskGraph = gradle.getTaskGraph();
+        taskGraph.populate();
+
+        includedBuildControllers.populateTaskGraphs();
+
+        if (gradle.getStartParameter().isConfigureOnDemand()) {
+            new ProjectsEvaluatedNotifier(buildOperationExecutor).notify(gradle);
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/NotifyingSettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NotifyingSettingsPreparer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.build.PublicBuildPath;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+public class NotifyingSettingsPreparer implements SettingsPreparer {
+    private static final LoadBuildBuildOperationType.Result RESULT = new LoadBuildBuildOperationType.Result() {
+    };
+
+    private final SettingsPreparer delegate;
+    private final BuildOperationExecutor buildOperationExecutor;
+    private final PublicBuildPath fromBuild;
+
+    public NotifyingSettingsPreparer(SettingsPreparer delegate, BuildOperationExecutor buildOperationExecutor, PublicBuildPath fromBuild) {
+        this.delegate = delegate;
+        this.buildOperationExecutor = buildOperationExecutor;
+        this.fromBuild = fromBuild;
+    }
+
+    @Override
+    public void prepareSettings(GradleInternal gradle) {
+        buildOperationExecutor.run(new LoadBuild(gradle));
+    }
+
+    private class LoadBuild implements RunnableBuildOperation {
+        private final GradleInternal gradle;
+
+        public LoadBuild(GradleInternal gradle) {
+            this.gradle = gradle;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            doLoadBuild();
+            context.setResult(RESULT);
+        }
+
+        void doLoadBuild() {
+            delegate.prepareSettings(gradle);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor.displayName(gradle.contextualize("Load build"))
+                .details(new LoadBuildBuildOperationType.Details() {
+                    @Override
+                    public String getBuildPath() {
+                        return gradle.getIdentityPath().toString();
+                    }
+
+                    @Override
+                    public String getIncludedBy() {
+                        return fromBuild == null ? null : fromBuild.getBuildPath().toString();
+                    }
+                });
+        }
+    }
+
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/NotifyingTaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/NotifyingTaskExecutionPreparer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableSortedSet;
+import org.gradle.api.Task;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.execution.taskgraph.TaskExecutionGraphInternal;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+import org.gradle.internal.taskgraph.CalculateTaskGraphBuildOperationType;
+
+import java.util.List;
+import java.util.Set;
+
+public class NotifyingTaskExecutionPreparer implements TaskExecutionPreparer {
+    private final TaskExecutionPreparer delegate;
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public NotifyingTaskExecutionPreparer(TaskExecutionPreparer delegate, BuildOperationExecutor buildOperationExecutor) {
+        this.delegate = delegate;
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    @Override
+    public void prepareForTaskExecution(GradleInternal gradle) {
+        buildOperationExecutor.run(new CalculateTaskGraph(gradle));
+    }
+
+    private class CalculateTaskGraph implements RunnableBuildOperation {
+        private final GradleInternal gradle;
+
+        public CalculateTaskGraph(GradleInternal gradle) {
+            this.gradle = gradle;
+        }
+
+        @Override
+        public void run(BuildOperationContext buildOperationContext) {
+            final TaskExecutionGraphInternal taskGraph = populateTaskGraph();
+
+            buildOperationContext.setResult(new CalculateTaskGraphBuildOperationType.Result() {
+                @Override
+                public List<String> getRequestedTaskPaths() {
+                    return toTaskPaths(taskGraph.getRequestedTasks());
+                }
+
+                @Override
+                public List<String> getExcludedTaskPaths() {
+                    return toTaskPaths(taskGraph.getFilteredTasks());
+                }
+
+                private List<String> toTaskPaths(Set<Task> tasks) {
+                    return ImmutableSortedSet.copyOf(Collections2.transform(tasks, new Function<Task, String>() {
+                        @Override
+                        public String apply(Task task) {
+                            return task.getPath();
+                        }
+                    })).asList();
+                }
+            });
+        }
+
+        TaskExecutionGraphInternal populateTaskGraph() {
+            delegate.prepareForTaskExecution(gradle);
+            return gradle.getTaskGraph();
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor.displayName(gradle.contextualize("Calculate task graph"))
+                .details(new CalculateTaskGraphBuildOperationType.Details() {
+                    @Override
+                    public String getBuildPath() {
+                        return gradle.getIdentityPath().getPath();
+                    }
+                });
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectsEvaluatedNotifier.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectsEvaluatedNotifier.java
@@ -31,7 +31,7 @@ public class ProjectsEvaluatedNotifier {
         this.buildOperationExecutor = buildOperationExecutor;
     }
 
-    void notify(GradleInternal gradle) {
+    public void notify(GradleInternal gradle) {
         buildOperationExecutor.run(new NotifyProjectsEvaluatedListeners(gradle));
     }
 

--- a/subprojects/core/src/main/java/org/gradle/initialization/ProjectsEvaluatedNotifier.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/ProjectsEvaluatedNotifier.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.initialization;
+
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.internal.operations.BuildOperationContext;
+import org.gradle.internal.operations.BuildOperationDescriptor;
+import org.gradle.internal.operations.BuildOperationExecutor;
+import org.gradle.internal.operations.RunnableBuildOperation;
+
+public class ProjectsEvaluatedNotifier {
+    private static final NotifyProjectsEvaluatedBuildOperationType.Result PROJECTS_EVALUATED_RESULT = new NotifyProjectsEvaluatedBuildOperationType.Result() {
+    };
+    private final BuildOperationExecutor buildOperationExecutor;
+
+    public ProjectsEvaluatedNotifier(BuildOperationExecutor buildOperationExecutor) {
+        this.buildOperationExecutor = buildOperationExecutor;
+    }
+
+    void notify(GradleInternal gradle) {
+        buildOperationExecutor.run(new NotifyProjectsEvaluatedListeners(gradle));
+    }
+
+    private class NotifyProjectsEvaluatedListeners implements RunnableBuildOperation {
+        private final GradleInternal gradle;
+
+        public NotifyProjectsEvaluatedListeners(GradleInternal gradle) {
+            this.gradle = gradle;
+        }
+
+        @Override
+        public void run(BuildOperationContext context) {
+            gradle.getBuildListenerBroadcaster().projectsEvaluated(gradle);
+            context.setResult(PROJECTS_EVALUATED_RESULT);
+        }
+
+        @Override
+        public BuildOperationDescriptor.Builder description() {
+            return BuildOperationDescriptor.displayName(gradle.contextualize("Notify projectsEvaluated listeners"))
+                .details(new NotifyProjectsEvaluatedBuildOperationType.Details() {
+                    @Override
+                    public String getBuildPath() {
+                        return gradle.getIdentityPath().toString();
+                    }
+                });
+        }
+    }
+}

--- a/subprojects/core/src/main/java/org/gradle/initialization/SettingsPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/SettingsPreparer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2011 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,15 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.gradle.initialization;
 
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.internal.SettingsInternal;
 
-public interface BuildLoader {
-    /**
-     * Creates prepares the {@link org.gradle.api.internal.project.ProjectInternal} instances for the given settings,
-     * ready for the projects to be configured.
-     */
-    void load(SettingsInternal settings, GradleInternal gradle);
+/**
+ * Responsible ensuring the `Settings` object for a newly created `Gradle` instance has been created and configured, ready to load the projects.
+ *
+ * <p>This includes running the init scripts and settings script.</p>
+ */
+public interface SettingsPreparer {
+    void prepareSettings(GradleInternal gradle);
 }

--- a/subprojects/core/src/main/java/org/gradle/initialization/TaskExecutionPreparer.java
+++ b/subprojects/core/src/main/java/org/gradle/initialization/TaskExecutionPreparer.java
@@ -19,10 +19,10 @@ package org.gradle.initialization;
 import org.gradle.api.internal.GradleInternal;
 
 /**
- * Responsible creating and configuring the `Settings` object for a newly created `Gradle` instance, ready to load the projects.
+ * Responsible for preparing `Gradle` instances for task execution, following configuration of the projects.
  *
- * <p>This includes running the init scripts and settings script.</p>
+ * <p>This includes resolving the entry tasks and calculating the task graph.</p>
  */
-public interface SettingsPreparer {
-    void prepareSettings(GradleInternal gradle);
+public interface TaskExecutionPreparer {
+    void prepareForTaskExecution(GradleInternal gradle);
 }

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -81,6 +81,7 @@ import org.gradle.configuration.DefaultBuildConfigurer;
 import org.gradle.configuration.DefaultInitScriptProcessor;
 import org.gradle.configuration.DefaultScriptPluginFactory;
 import org.gradle.configuration.ImportsReader;
+import org.gradle.configuration.NotifyingBuildConfigurer;
 import org.gradle.configuration.ScriptPluginFactory;
 import org.gradle.configuration.ScriptPluginFactorySelector;
 import org.gradle.configuration.internal.UserCodeApplicationContext;
@@ -115,6 +116,7 @@ import org.gradle.initialization.DefaultSettingsPreparer;
 import org.gradle.initialization.IGradlePropertiesLoader;
 import org.gradle.initialization.InitScriptHandler;
 import org.gradle.initialization.InstantiatingBuildLoader;
+import org.gradle.initialization.ModelConfigurationListener;
 import org.gradle.initialization.NotifyingBuildLoader;
 import org.gradle.initialization.NotifyingSettingsPreparer;
 import org.gradle.initialization.ProjectAccessListener;
@@ -400,8 +402,16 @@ public class BuildScopeServices extends DefaultServiceRegistry {
         return new TaskPathProjectEvaluator(cancellationToken);
     }
 
-    protected BuildConfigurer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildStateRegistry buildStateRegistry) {
-        return new DefaultBuildConfigurer(projectConfigurer, buildStateRegistry);
+    protected BuildConfigurer createBuildConfigurer(ProjectConfigurer projectConfigurer, BuildStateRegistry buildStateRegistry, BuildLoader buildLoader, ListenerManager listenerManager, BuildOperationExecutor buildOperationExecutor) {
+        ModelConfigurationListener modelConfigurationListener = listenerManager.getBroadcaster(ModelConfigurationListener.class);
+        return new NotifyingBuildConfigurer(
+            new DefaultBuildConfigurer(
+                projectConfigurer,
+                buildStateRegistry,
+                buildLoader,
+                modelConfigurationListener,
+                buildOperationExecutor),
+            buildOperationExecutor);
     }
 
     protected ProjectAccessListener createProjectAccessListener() {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -19,6 +19,7 @@ package org.gradle.internal.service.scopes;
 import org.gradle.StartParameter;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.internal.BuildDefinition;
 import org.gradle.api.internal.ClassPathRegistry;
 import org.gradle.api.internal.DefaultClassPathProvider;
 import org.gradle.api.internal.DefaultClassPathRegistry;
@@ -110,10 +111,12 @@ import org.gradle.initialization.DefaultClassLoaderScopeRegistry;
 import org.gradle.initialization.DefaultGradlePropertiesLoader;
 import org.gradle.initialization.DefaultSettingsFinder;
 import org.gradle.initialization.DefaultSettingsLoaderFactory;
+import org.gradle.initialization.DefaultSettingsPreparer;
 import org.gradle.initialization.IGradlePropertiesLoader;
 import org.gradle.initialization.InitScriptHandler;
 import org.gradle.initialization.InstantiatingBuildLoader;
 import org.gradle.initialization.NotifyingBuildLoader;
+import org.gradle.initialization.NotifyingSettingsPreparer;
 import org.gradle.initialization.ProjectAccessListener;
 import org.gradle.initialization.ProjectPropertySettingBuildLoader;
 import org.gradle.initialization.PropertiesLoadingSettingsProcessor;
@@ -122,6 +125,7 @@ import org.gradle.initialization.ScriptEvaluatingSettingsProcessor;
 import org.gradle.initialization.SettingsEvaluatedCallbackFiringSettingsProcessor;
 import org.gradle.initialization.SettingsFactory;
 import org.gradle.initialization.SettingsLoaderFactory;
+import org.gradle.initialization.SettingsPreparer;
 import org.gradle.initialization.SettingsProcessor;
 import org.gradle.initialization.buildsrc.BuildSourceBuilder;
 import org.gradle.initialization.buildsrc.BuildSrcBuildListenerFactory;
@@ -368,6 +372,10 @@ public class BuildScopeServices extends DefaultServiceRegistry {
                 )
             ),
             buildOperationExecutor);
+    }
+
+    protected SettingsPreparer createSettingsPreparer(InitScriptHandler initScriptHandler, SettingsLoaderFactory settingsLoaderFactory, BuildOperationExecutor buildOperationExecutor, BuildDefinition buildDefinition) {
+        return new NotifyingSettingsPreparer(new DefaultSettingsPreparer(initScriptHandler, settingsLoaderFactory), buildOperationExecutor, buildDefinition.getFromBuild());
     }
 
     protected ScriptClassPathResolver createScriptClassPathResolver(List<ScriptClassPathInitializer> initializers) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/BuildScopeServices.java
@@ -375,7 +375,12 @@ public class BuildScopeServices extends DefaultServiceRegistry {
     }
 
     protected SettingsPreparer createSettingsPreparer(InitScriptHandler initScriptHandler, SettingsLoaderFactory settingsLoaderFactory, BuildOperationExecutor buildOperationExecutor, BuildDefinition buildDefinition) {
-        return new NotifyingSettingsPreparer(new DefaultSettingsPreparer(initScriptHandler, settingsLoaderFactory), buildOperationExecutor, buildDefinition.getFromBuild());
+        return new NotifyingSettingsPreparer(
+            new DefaultSettingsPreparer(
+                initScriptHandler,
+                settingsLoaderFactory),
+            buildOperationExecutor,
+            buildDefinition.getFromBuild());
     }
 
     protected ScriptClassPathResolver createScriptClassPathResolver(List<ScriptClassPathInitializer> initializers) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/GradleScopeServices.java
@@ -49,6 +49,8 @@ import org.gradle.execution.DefaultBuildExecuter;
 import org.gradle.execution.DefaultTasksBuildExecutionAction;
 import org.gradle.execution.DryRunBuildExecutionAction;
 import org.gradle.execution.ExcludedTaskFilteringBuildConfigurationAction;
+import org.gradle.execution.IncludedBuildLifecycleBuildExecuter;
+import org.gradle.execution.NotifyingBuildExecuter;
 import org.gradle.execution.ProjectConfigurer;
 import org.gradle.execution.SelectedTaskExecutionAction;
 import org.gradle.execution.TaskNameResolvingBuildConfigurationAction;
@@ -146,10 +148,14 @@ public class GradleScopeServices extends DefaultServiceRegistry {
         return new CommandLineTaskParser(new CommandLineTaskConfigurer(optionReader), taskSelector);
     }
 
-    BuildExecuter createBuildExecuter(StyledTextOutputFactory textOutputFactory) {
-        return new DefaultBuildExecuter(
-            asList(new DryRunBuildExecutionAction(textOutputFactory),
-                new SelectedTaskExecutionAction()));
+    BuildExecuter createBuildExecuter(StyledTextOutputFactory textOutputFactory, IncludedBuildControllers includedBuildControllers, BuildOperationExecutor buildOperationExecutor) {
+        return new NotifyingBuildExecuter(
+            new IncludedBuildLifecycleBuildExecuter(
+                new DefaultBuildExecuter(
+                    asList(new DryRunBuildExecutionAction(textOutputFactory),
+                        new SelectedTaskExecutionAction())),
+                includedBuildControllers),
+            buildOperationExecutor);
     }
 
     BuildConfigurationActionExecuter createBuildConfigurationActionExecuter(CommandLineTaskParser commandLineTaskParser, TaskSelector taskSelector, ProjectConfigurer projectConfigurer, ProjectStateRegistry projectStateRegistry) {

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -45,6 +45,7 @@ import org.gradle.api.internal.file.collections.DirectoryFileTreeFactory;
 import org.gradle.api.internal.initialization.DefaultScriptHandlerFactory;
 import org.gradle.api.internal.initialization.ScriptClassPathResolver;
 import org.gradle.api.internal.initialization.ScriptHandlerFactory;
+import org.gradle.api.internal.initialization.ScriptHandlerInternal;
 import org.gradle.api.internal.model.DefaultObjectFactory;
 import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.internal.plugins.DefaultPluginManager;
@@ -220,7 +221,7 @@ public class ProjectScopeServices extends DefaultServiceRegistry {
         return new DefaultModelRegistry(ruleExtractor, project.getPath());
     }
 
-    protected ScriptHandler createScriptHandler() {
+    protected ScriptHandlerInternal createScriptHandler() {
         ScriptHandlerFactory factory = new DefaultScriptHandlerFactory(
             get(DependencyManagementServices.class),
             get(FileResolver.class),

--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ProjectScopeServices.java
@@ -19,7 +19,6 @@ package org.gradle.internal.service.scopes;
 import org.gradle.api.Action;
 import org.gradle.api.AntBuilder;
 import org.gradle.api.component.SoftwareComponentContainer;
-import org.gradle.api.initialization.dsl.ScriptHandler;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.api.internal.DomainObjectContext;
 import org.gradle.api.internal.artifacts.DependencyManagementServices;

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/DefaultProjectTest.groovy
@@ -35,7 +35,6 @@ import org.gradle.api.artifacts.dsl.DependencyLockingHandler
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.attributes.AttributesSchema
 import org.gradle.api.component.SoftwareComponentContainer
-import org.gradle.api.initialization.dsl.ScriptHandler
 import org.gradle.api.internal.CollectionCallbackActionDecorator
 import org.gradle.api.internal.FactoryNamedDomainObjectContainer
 import org.gradle.api.internal.GradleInternal
@@ -51,6 +50,7 @@ import org.gradle.api.internal.file.TestFiles
 import org.gradle.api.internal.initialization.ClassLoaderScope
 import org.gradle.api.internal.initialization.RootClassLoaderScope
 import org.gradle.api.internal.initialization.ScriptHandlerFactory
+import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.initialization.loadercache.DummyClassLoaderCache
 import org.gradle.api.internal.plugins.PluginManagerInternal
 import org.gradle.api.internal.project.ant.AntLoggingAdapter
@@ -127,7 +127,7 @@ class DefaultProjectTest extends Specification {
     RepositoryHandler repositoryHandlerMock = Stub(RepositoryHandler)
     DependencyHandler dependencyHandlerMock = Stub(DependencyHandler)
     ComponentMetadataHandler moduleHandlerMock = Stub(ComponentMetadataHandler)
-    ScriptHandler scriptHandlerMock = Mock(ScriptHandler)
+    ScriptHandlerInternal scriptHandlerMock = Mock(ScriptHandlerInternal)
     DependencyMetaDataProvider dependencyMetaDataProviderMock = Stub(DependencyMetaDataProvider)
     GradleInternal build = Stub(GradleInternal)
     ConfigurationTargetIdentifier configurationTargetIdentifier = Stub(ConfigurationTargetIdentifier)
@@ -187,7 +187,7 @@ class DefaultProjectTest extends Specification {
         serviceRegistryMock.get((Type) InputNormalizationHandler) >> inputNormalizationHandler
         serviceRegistryMock.get(ProjectEvaluator) >> projectEvaluator
         serviceRegistryMock.getFactory(AntBuilder) >> antBuilderFactoryMock
-        serviceRegistryMock.get((Type) ScriptHandler) >> scriptHandlerMock
+        serviceRegistryMock.get((Type) ScriptHandlerInternal) >> scriptHandlerMock
         serviceRegistryMock.get((Type) LoggingManagerInternal) >> loggingManagerMock
         serviceRegistryMock.get(projectRegistryType) >> projectRegistry
         serviceRegistryMock.get(DependencyMetaDataProvider) >> dependencyMetaDataProviderMock

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultBuildConfigurerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/DefaultBuildConfigurerTest.groovy
@@ -19,16 +19,22 @@ import org.gradle.StartParameter
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.execution.ProjectConfigurer
+import org.gradle.initialization.BuildLoader
+import org.gradle.initialization.ModelConfigurationListener
 import org.gradle.internal.build.BuildStateRegistry
+import org.gradle.internal.operations.BuildOperationExecutor
 import spock.lang.Specification
 
 class DefaultBuildConfigurerTest extends Specification {
-    private startParameter = Mock(StartParameter)
-    private gradle = Mock(GradleInternal)
-    private rootProject = Mock(ProjectInternal)
-    private projectConfigurer = Mock(ProjectConfigurer)
-    private buildRegistry = Mock(BuildStateRegistry)
-    private configurer = new DefaultBuildConfigurer(projectConfigurer, buildRegistry)
+    def startParameter = Mock(StartParameter)
+    def gradle = Mock(GradleInternal)
+    def rootProject = Mock(ProjectInternal)
+    def projectConfigurer = Mock(ProjectConfigurer)
+    def buildRegistry = Mock(BuildStateRegistry)
+    def buildLoader = Mock(BuildLoader)
+    def modelListener = Mock(ModelConfigurationListener)
+    def buildOperationExecutor = Mock(BuildOperationExecutor)
+    private configurer = new DefaultBuildConfigurer(projectConfigurer, buildRegistry, buildLoader, modelListener, buildOperationExecutor)
 
     def setup() {
         gradle.startParameter >> startParameter

--- a/subprojects/core/src/test/groovy/org/gradle/configuration/project/BuildScriptProcessorTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/configuration/project/BuildScriptProcessorTest.groovy
@@ -15,8 +15,9 @@
  */
 package org.gradle.configuration.project
 
-import org.gradle.api.initialization.dsl.ScriptHandler
+
 import org.gradle.api.internal.initialization.ClassLoaderScope
+import org.gradle.api.internal.initialization.ScriptHandlerInternal
 import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.internal.project.ProjectState
 import org.gradle.configuration.ScriptPlugin
@@ -24,7 +25,7 @@ import org.gradle.configuration.ScriptPluginFactory
 import org.gradle.groovy.scripts.ScriptSource
 import spock.lang.Specification
 
-public class BuildScriptProcessorTest extends Specification {
+class BuildScriptProcessorTest extends Specification {
     def project = Mock(ProjectInternal)
     def scriptSource = Mock(ScriptSource)
     def configurerFactory = Mock(ScriptPluginFactory)
@@ -32,12 +33,11 @@ public class BuildScriptProcessorTest extends Specification {
     def targetScope = Mock(ClassLoaderScope)
     def baseScope = Mock(ClassLoaderScope)
     def projectState = Mock(ProjectState)
-    def BuildScriptProcessor buildScriptProcessor = new BuildScriptProcessor(configurerFactory)
-    private ScriptHandler scriptHandler;
+    def buildScriptProcessor = new BuildScriptProcessor(configurerFactory)
+    def scriptHandler = Mock(ScriptHandlerInternal)
 
     def "setup"() {
         _ * project.buildScriptSource >> scriptSource
-        scriptHandler = Mock(ScriptHandler)
         project.getBuildscript() >> scriptHandler
         project.getClassLoaderScope() >> targetScope
         project.getBaseClassLoaderScope() >> baseScope

--- a/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/initialization/DefaultGradleLauncherSpec.groovy
@@ -17,33 +17,17 @@
 package org.gradle.initialization
 
 import org.gradle.BuildListener
-import org.gradle.StartParameter
-import org.gradle.api.Task
-import org.gradle.api.initialization.ProjectDescriptor
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
-import org.gradle.api.internal.file.TestFiles
-import org.gradle.api.internal.initialization.ClassLoaderScope
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.internal.project.ProjectRegistry
 import org.gradle.composite.internal.IncludedBuildControllers
 import org.gradle.configuration.BuildConfigurer
 import org.gradle.execution.BuildExecuter
 import org.gradle.execution.MultipleBuildFailures
 import org.gradle.execution.taskgraph.TaskExecutionGraphInternal
 import org.gradle.initialization.exception.ExceptionAnalyser
-import org.gradle.internal.concurrent.ParallelismConfigurationManagerFixture
 import org.gradle.internal.concurrent.Stoppable
-import org.gradle.internal.execution.history.ExecutionHistoryCacheAccess
-import org.gradle.internal.operations.TestBuildOperationExecutor
-import org.gradle.internal.resources.DefaultResourceLockCoordinationService
-import org.gradle.internal.resources.ResourceLockCoordinationService
-import org.gradle.internal.service.ServiceRegistry
 import org.gradle.internal.service.scopes.BuildScopeServices
-import org.gradle.internal.work.DefaultWorkerLeaseService
-import org.gradle.internal.work.WorkerLeaseService
 import org.gradle.test.fixtures.file.TestNameTestDirectoryProvider
-import org.gradle.util.TestUtil
 import spock.lang.Specification
 
 import static org.gradle.util.Path.path
@@ -51,90 +35,37 @@ import static org.gradle.util.Path.path
 class DefaultGradleLauncherSpec extends Specification {
     def settingsPreparerMock = Mock(SettingsPreparer)
     def taskExecutionPreparerMock = Mock(TaskExecutionPreparer)
-    def buildLoaderMock = Mock(BuildLoader)
     def taskGraphMock = Mock(TaskExecutionGraphInternal)
     def buildConfigurerMock = Mock(BuildConfigurer)
     def buildBroadcaster = Mock(BuildListener)
     def buildExecuter = Mock(BuildExecuter)
-    def buildScopeServices = Mock(ServiceRegistry)
-    def cacheAccess = Mock(ExecutionHistoryCacheAccess)
 
-    private ProjectInternal expectedRootProject
-    private ProjectInternal expectedCurrentProject
-    private StartParameter expectedStartParams
-    private SettingsInternal settingsMock = Mock(SettingsInternal.class)
-    private GradleInternal gradleMock = Mock(GradleInternal.class)
+    def settingsMock = Mock(SettingsInternal.class)
+    def gradleMock = Mock(GradleInternal.class)
 
-    private ProjectDescriptor expectedRootProjectDescriptor
-
-    private ClassLoaderScope baseClassLoaderScope = Mock(ClassLoaderScope.class)
-    private ExceptionAnalyser exceptionAnalyserMock = Mock(ExceptionAnalyser)
-    private ModelConfigurationListener modelListenerMock = Mock(ModelConfigurationListener.class)
-    private BuildCompletionListener buildCompletionListener = Mock(BuildCompletionListener.class)
-    private TestBuildOperationExecutor buildOperationExecutor = new TestBuildOperationExecutor()
-    private ResourceLockCoordinationService coordinationService = new DefaultResourceLockCoordinationService()
-    private WorkerLeaseService workerLeaseService = new DefaultWorkerLeaseService(coordinationService, new ParallelismConfigurationManagerFixture(true, 1))
-    private BuildScopeServices buildServices = Mock(BuildScopeServices.class)
-    private Stoppable otherService = Mock(Stoppable)
-    private IncludedBuildControllers includedBuildControllers = Mock()
-    private InstantExecution instantExecution = Mock()
+    def exceptionAnalyserMock = Mock(ExceptionAnalyser)
+    def buildCompletionListener = Mock(BuildCompletionListener.class)
+    def buildServices = Mock(BuildScopeServices.class)
+    def otherService = Mock(Stoppable)
+    def includedBuildControllers = Mock(IncludedBuildControllers)
+    def instantExecution = Mock(InstantExecution)
     public TestNameTestDirectoryProvider tmpDir = new TestNameTestDirectoryProvider()
 
-    final RuntimeException failure = new RuntimeException("main")
-    final RuntimeException transformedException = new RuntimeException("transformed")
+    def failure = new RuntimeException("main")
+    def transformedException = new RuntimeException("transformed")
 
     def setup() {
-        boolean expectedSearchUpwards = false
-
-        File expectedRootDir = tmpDir.file("rootDir")
-        File expectedCurrentDir = new File(expectedRootDir, "currentDir")
-
-        expectedRootProjectDescriptor = new DefaultProjectDescriptor(null, "someName", new File("somedir"), new DefaultProjectDescriptorRegistry(),
-            TestFiles.resolver(expectedRootDir))
-        expectedRootProject = TestUtil.createRootProject(expectedRootDir)
-        expectedCurrentProject = TestUtil.createRootProject(expectedCurrentDir)
-
-        expectedStartParams = new StartParameter()
-        expectedStartParams.setCurrentDir(expectedCurrentDir)
-        expectedStartParams.setSearchUpwards(expectedSearchUpwards)
-        expectedStartParams.setGradleUserHomeDir(tmpDir.createDir("gradleUserHome"))
-
         _ * exceptionAnalyserMock.transform(failure) >> transformedException
 
-        _ * settingsMock.getRootProject() >> expectedRootProjectDescriptor
-        _ * settingsMock.getDefaultProject() >> expectedRootProjectDescriptor
-        _ * settingsMock.getIncludedBuilds() >> []
-        _ * settingsMock.getRootClassLoaderScope() >> baseClassLoaderScope
-        _ * settingsMock.getProjectRegistry() >> Stub(ProjectRegistry)
-        0 * settingsMock._
-
-        _ * gradleMock.getRootProject() >> expectedRootProject
-        _ * gradleMock.getDefaultProject() >> expectedCurrentProject
-        _ * gradleMock.getTaskGraph() >> taskGraphMock
-        _ * taskGraphMock.getRequestedTasks() >> [Mock(Task)]
-        _ * taskGraphMock.getFilteredTasks() >> [Mock(Task)]
-        _ * gradleMock.getStartParameter() >> expectedStartParams
-        _ * gradleMock.getServices() >> buildScopeServices
-        _ * gradleMock.includedBuilds >> []
-        _ * gradleMock.getBuildOperation() >> null
+        _ * gradleMock.taskGraph >> taskGraphMock
         _ * gradleMock.settings >> settingsMock
         _ * gradleMock.buildListenerBroadcaster >> buildBroadcaster
-
-        buildScopeServices.get(ExecutionHistoryCacheAccess) >> cacheAccess
-        buildScopeServices.get(IncludedBuildControllers) >> includedBuildControllers
-        buildScopeServices.get(InstantExecution) >> instantExecution
-        buildServices.get(WorkerLeaseService) >> workerLeaseService
-    }
-
-    def cleanup() {
-        workerLeaseService.stop()
     }
 
     DefaultGradleLauncher launcher() {
-        return new DefaultGradleLauncher(gradleMock, buildLoaderMock,
-            buildConfigurerMock, exceptionAnalyserMock, buildBroadcaster,
-            modelListenerMock, buildCompletionListener, buildOperationExecutor, buildExecuter,
-            buildServices, [otherService], includedBuildControllers, settingsPreparerMock, taskExecutionPreparerMock)
+        return new DefaultGradleLauncher(gradleMock, buildConfigurerMock, exceptionAnalyserMock, buildBroadcaster,
+            buildCompletionListener, buildExecuter, buildServices, [otherService], includedBuildControllers,
+            settingsPreparerMock, taskExecutionPreparerMock, instantExecution)
     }
 
     void testRunTasks() {
@@ -149,7 +80,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         then:
         result == gradleMock
-        expectedBuildOperationsFired()
     }
 
     void testRunAsNestedBuild() {
@@ -165,12 +95,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         then:
         result == gradleMock
-
-        and:
-        assert buildOperationExecutor.operations.size() == 3
-        assert buildOperationExecutor.operations[0].displayName == "Configure build (:nested)"
-        assert buildOperationExecutor.operations[1].displayName == "Notify projectsEvaluated listeners (:nested)"
-        assert buildOperationExecutor.operations[2].displayName == "Run tasks (:nested)"
     }
 
     void testGetBuildAnalysis() {
@@ -179,7 +103,6 @@ class DefaultGradleLauncherSpec extends Specification {
         expectSettingsBuilt()
         expectBuildListenerCallbacks()
 
-        1 * buildLoaderMock.load(settingsMock, gradleMock)
         1 * buildConfigurerMock.configure(gradleMock)
 
         DefaultGradleLauncher gradleLauncher = launcher()
@@ -256,8 +179,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         and:
         1 * buildBroadcaster.buildStarted(gradleMock)
-        1 * buildBroadcaster.projectsEvaluated(gradleMock)
-        1 * modelListenerMock.onConfigure(gradleMock)
         1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.cause == failure }) >> transformedException
         1 * buildBroadcaster.buildFinished({ it.failure == transformedException })
 
@@ -281,8 +202,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         and:
         1 * buildBroadcaster.buildStarted(gradleMock)
-        1 * buildBroadcaster.projectsEvaluated(gradleMock)
-        1 * modelListenerMock.onConfigure(gradleMock)
         1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2] }) >> transformedException
         1 * buildBroadcaster.buildFinished({ it.failure == transformedException })
 
@@ -304,8 +223,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         and:
         1 * buildBroadcaster.buildStarted(gradleMock)
-        1 * buildBroadcaster.projectsEvaluated(gradleMock)
-        1 * modelListenerMock.onConfigure(gradleMock)
         1 * buildBroadcaster.buildFinished({ it.failure == null }) >> { throw failure }
         1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.cause == failure }) >> transformedException
 
@@ -334,8 +251,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
         and:
         1 * buildBroadcaster.buildStarted(gradleMock)
-        1 * buildBroadcaster.projectsEvaluated(gradleMock)
-        1 * modelListenerMock.onConfigure(gradleMock)
         1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2] }) >> transformedException
         1 * buildBroadcaster.buildFinished({ it.failure == transformedException }) >> { throw failure3 }
         1 * exceptionAnalyserMock.transform({ it instanceof MultipleBuildFailures && it.causes == [failure, failure2, failure3] }) >> finalException
@@ -362,17 +277,10 @@ class DefaultGradleLauncherSpec extends Specification {
         1 * buildCompletionListener.completed()
     }
 
-    private void expectedBuildOperationsFired() {
-        assert buildOperationExecutor.operations.size() == 3
-        assert buildOperationExecutor.operations[0].displayName == "Configure build"
-        assert buildOperationExecutor.operations[1].displayName == "Notify projectsEvaluated listeners"
-        assert buildOperationExecutor.operations[2].displayName == "Run tasks"
-    }
-
     private void isNestedBuild() {
         _ * gradleMock.parent >> Mock(GradleInternal)
         _ * gradleMock.findIdentityPath() >> path(":nested")
-        _ * gradleMock.contextualize(_) >> {"${it[0]} (:nested)"}
+        _ * gradleMock.contextualize(_) >> { "${it[0]} (:nested)" }
     }
 
     private void isRootBuild() {
@@ -386,8 +294,6 @@ class DefaultGradleLauncherSpec extends Specification {
 
     private void expectBuildListenerCallbacks() {
         1 * buildBroadcaster.buildStarted(gradleMock)
-        1 * buildBroadcaster.projectsEvaluated(gradleMock)
-        1 * modelListenerMock.onConfigure(gradleMock)
     }
 
     private void expectTaskGraphBuilt() {
@@ -395,19 +301,14 @@ class DefaultGradleLauncherSpec extends Specification {
     }
 
     private void expectTasksRun() {
-        1 * includedBuildControllers.startTaskExecution()
         1 * buildExecuter.execute(gradleMock, _)
-        1 * includedBuildControllers.awaitTaskCompletion(_)
     }
 
     private void expectTasksRunWithFailure(Throwable failure, Throwable other = null) {
-        1 * includedBuildControllers.startTaskExecution()
         1 * buildExecuter.execute(gradleMock, _) >> { GradleInternal g, List failures ->
             failures.add(failure)
-        }
-        1 * includedBuildControllers.awaitTaskCompletion(_) >> { List args ->
             if (other != null) {
-                args[0].add(other)
+                failures.add(other)
             }
         }
         1 * includedBuildControllers.finishBuild(_)

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":modelCore"))
     implementation(project(":files"))
+    // TODO instant-execution: review this dependency
+    implementation(project(":pluginUse")) 
 
     compile(futureKotlin("stdlib-jdk8"))
 }

--- a/subprojects/instant-execution/instant-execution.gradle.kts
+++ b/subprojects/instant-execution/instant-execution.gradle.kts
@@ -9,8 +9,6 @@ dependencies {
     implementation(project(":core"))
     implementation(project(":modelCore"))
     implementation(project(":files"))
-    // TODO instant-execution: review this dependency
-    implementation(project(":pluginUse")) 
 
     compile(futureKotlin("stdlib-jdk8"))
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/ClassicModeBuild.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.instantexecution
+
+import org.gradle.api.Task
+import org.gradle.api.internal.project.ProjectInternal
+
+
+interface ClassicModeBuild {
+    val rootProject: ProjectInternal
+
+    val scheduledTasks: List<Task>
+
+    fun dependenciesOf(task: Task): Set<Task>
+}

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/DefaultInstantExecution.kt
@@ -37,9 +37,6 @@ import org.gradle.internal.classpath.DefaultClassPath
 import org.gradle.internal.serialize.BaseSerializerFactory
 import org.gradle.internal.serialize.kryo.KryoBackedDecoder
 import org.gradle.internal.serialize.kryo.KryoBackedEncoder
-import org.gradle.plugin.management.internal.DefaultPluginRequests
-import org.gradle.plugin.management.internal.autoapply.DefaultAutoAppliedPluginRegistry
-import org.gradle.plugin.use.internal.PluginRequestApplicator
 import org.gradle.util.Path
 import java.io.File
 import java.lang.reflect.Field
@@ -87,29 +84,10 @@ class DefaultInstantExecution(
         }
     }
 
-    private val buildScanPluginRequired: Boolean
-        get() {
-            return host.startParameter.isBuildScan()
-        }
-
     override fun loadTaskGraph() {
         val build = host.createBuild()
-        if (buildScanPluginRequired) {
-            applyBuildScanPluginTo(build)
-        }
+        build.autoApplyPlugins()
         build.scheduleTasks(loadTasksFor(build))
-    }
-
-    private fun applyBuildScanPluginTo(build: InstantExecutionBuild) {
-        // TODO - figure out why this is not being set
-        val buildScanUrl = host.getSystemProperty("com.gradle.scan.server")
-        if (buildScanUrl != null) {
-            System.setProperty("com.gradle.scan.server", buildScanUrl)
-        }
-
-        val pluginRequests = DefaultPluginRequests(listOf(DefaultAutoAppliedPluginRegistry.createScanPluginRequest()))
-        val rootProject = build.getProject(":")
-        host.getService(PluginRequestApplicator::class.java).applyPlugins(pluginRequests, rootProject.buildscript, rootProject.pluginManager, rootProject.classLoaderScope)
     }
 
     private

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution
 
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.internal.project.ProjectInternal
 
 
 interface InstantExecutionBuild {
@@ -26,7 +27,7 @@ interface InstantExecutionBuild {
 
     fun registerProjects()
 
-    fun getProject(path: String): Project
+    fun getProject(path: String): ProjectInternal
 
     fun scheduleTasks(tasks: Iterable<Task>)
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionBuild.kt
@@ -25,9 +25,11 @@ interface InstantExecutionBuild {
 
     fun createProject(path: String): Project
 
-    fun registerProjects()
-
     fun getProject(path: String): ProjectInternal
+
+    fun autoApplyPlugins()
+
+    fun registerProjects()
 
     fun scheduleTasks(tasks: Iterable<Task>)
 }

--- a/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
+++ b/subprojects/instant-execution/src/main/kotlin/org/gradle/instantexecution/InstantExecutionHost.kt
@@ -18,6 +18,7 @@ package org.gradle.instantexecution
 
 import org.gradle.StartParameter
 import org.gradle.api.Task
+import org.gradle.api.internal.BuildDefinition
 import org.gradle.api.internal.GradleInternal
 import org.gradle.api.internal.SettingsInternal
 import org.gradle.api.internal.file.FileCollectionFactory
@@ -38,7 +39,9 @@ import org.gradle.initialization.ClassLoaderScopeRegistry
 import org.gradle.initialization.DefaultProjectDescriptor
 import org.gradle.initialization.DefaultSettings
 import org.gradle.initialization.NotifyingBuildLoader
+import org.gradle.initialization.NotifyingSettingsPreparer
 import org.gradle.initialization.SettingsLocation
+import org.gradle.initialization.SettingsPreparer
 import org.gradle.initialization.SettingsProcessor
 import org.gradle.internal.build.BuildState
 import org.gradle.internal.classpath.ClassPath
@@ -109,6 +112,14 @@ class InstantExecutionHost internal constructor(
         init {
             gradle.run {
                 settings = createSettings()
+
+                // Fire build operation required by build scan to determine startup duration and settings evaluated duration
+                val settingsPreparer = NotifyingSettingsPreparer(SettingsPreparer {
+                    // Nothing to do
+                    // TODO - instant-execution: instead, create and attach the settings object
+                }, getService(BuildOperationExecutor::class.java), getService(BuildDefinition::class.java).fromBuild)
+                settingsPreparer.prepareSettings(this)
+
                 rootProject = createProject(":")
             }
         }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -26,7 +26,6 @@ import org.gradle.api.internal.artifacts.DefaultModuleIdentifier;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionSelector;
 import org.gradle.plugin.management.internal.DefaultPluginRequest;
 import org.gradle.plugin.management.internal.DefaultPluginRequests;
-import org.gradle.plugin.management.internal.PluginRequestInternal;
 import org.gradle.plugin.management.internal.PluginRequests;
 
 import java.util.Collections;
@@ -47,7 +46,7 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
     @Override
     public PluginRequests getAutoAppliedPlugins(Project target) {
         if (shouldApplyScanPlugin(target)) {
-            return new DefaultPluginRequests(Collections.<PluginRequestInternal>singletonList(createScanPluginRequest()));
+            return new DefaultPluginRequests(Collections.singletonList(createScanPluginRequest()));
         }
         return DefaultPluginRequests.EMPTY;
     }
@@ -62,8 +61,7 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
         return startParameter.isBuildScan() && target.getParent() == null && target.getGradle().getParent() == null;
     }
 
-    // TODO - instant-execution: review visibility
-    public static DefaultPluginRequest createScanPluginRequest() {
+    private static DefaultPluginRequest createScanPluginRequest() {
         ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(AUTO_APPLIED_ID, AutoAppliedBuildScanPlugin.VERSION);
         return new DefaultPluginRequest(AutoAppliedBuildScanPlugin.ID, AutoAppliedBuildScanPlugin.VERSION, true, null, getScriptDisplayName(), artifact);
     }

--- a/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
+++ b/subprojects/plugin-use/src/main/java/org/gradle/plugin/management/internal/autoapply/DefaultAutoAppliedPluginRegistry.java
@@ -62,7 +62,8 @@ public class DefaultAutoAppliedPluginRegistry implements AutoAppliedPluginRegist
         return startParameter.isBuildScan() && target.getParent() == null && target.getGradle().getParent() == null;
     }
 
-    private DefaultPluginRequest createScanPluginRequest() {
+    // TODO - instant-execution: review visibility
+    public static DefaultPluginRequest createScanPluginRequest() {
         ModuleVersionSelector artifact = DefaultModuleVersionSelector.newSelector(AUTO_APPLIED_ID, AutoAppliedBuildScanPlugin.VERSION);
         return new DefaultPluginRequest(AutoAppliedBuildScanPlugin.ID, AutoAppliedBuildScanPlugin.VERSION, true, null, getScriptDisplayName(), artifact);
     }


### PR DESCRIPTION
### Context

This PR adds some basic support for build scans with instant execution. Only the `--scan` option is supported for now. The build scan plugin is currently ignored when applied via an init script or build script, as is any configuration done via the build scan extension (server location, accept license, tags, etc).

This PR also changes the implementation of instant execution to include the Gradle version and requested tasks as part of the task graph cache file name, meaning that when these things change, the build is configured and the task graph calculated.

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
