### PR TITLE
Support for closed projects in buildship

### DIFF
--- a/subprojects/docs/src/docs/release/notes.md
+++ b/subprojects/docs/src/docs/release/notes.md
@@ -20,6 +20,13 @@ details of 2
 ## n
 -->
 
+## Substitute closed Eclipse projects in Buildship
+
+Closed gradle projects in an eclipse workspace can now be substituted for their respective jar files. In addition to this 
+those jars can now be built during Buildship eclipse model synchronization.
+
+The upcoming version of Buildship is required to take advantage of this behavior.
+
 ## Upgrade Instructions
 
 Switch your build to use Gradle @version@ by updating your wrapper:

--- a/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
+++ b/subprojects/ide/src/crossVersionTest/groovy/org/gradle/plugins/ide/tooling/r31/PersistentCompositeDependencySubstitutionCrossVersionSpec.groovy
@@ -95,7 +95,7 @@ class PersistentCompositeDependencySubstitutionCrossVersionSpec extends ToolingA
         def eclipseProject = loadToolingModel(EclipseProject)
 
         then:
-        eclipseProject.projectDependencies.collect {it.path}  == ['b1-renamed', 'b2-renamed']
+        eclipseProject.projectDependencies.collect {it.path}.sort()  == ['b1-renamed', 'b2-renamed']
     }
 
     @ToolingApiVersion(">=3.2")

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
@@ -18,6 +18,7 @@ package org.gradle.plugins.ide.eclipse.model;
 
 import com.google.common.base.Preconditions;
 import groovy.util.Node;
+import org.gradle.api.Incubating;
 import org.gradle.api.tasks.TaskDependency;
 
 import java.io.File;
@@ -45,6 +46,12 @@ public class ProjectDependency extends AbstractClasspathEntry {
         assertPathIsValid();
     }
 
+    /**
+     * Returns the file that can replace this ProjectDependency
+     *
+     * @since 5.6
+     */
+    @Incubating
     public File getPublication() {
         return publication;
     }
@@ -53,6 +60,12 @@ public class ProjectDependency extends AbstractClasspathEntry {
         this.publication = publication;
     }
 
+    /**
+     * Returns the TaskDependency that builds the the file returned by {@link #getPublication()}
+     *
+     * @since 5.6
+     */
+    @Incubating
     public TaskDependency getBuildDependencies() {
         return buildDependencies;
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
@@ -18,11 +18,18 @@ package org.gradle.plugins.ide.eclipse.model;
 
 import com.google.common.base.Preconditions;
 import groovy.util.Node;
+import org.gradle.api.tasks.TaskDependency;
+
+import java.io.File;
+import java.util.Objects;
 
 /**
  * A classpath entry representing a project dependency.
  */
 public class ProjectDependency extends AbstractClasspathEntry {
+
+    private File publication;
+    private TaskDependency buildDependencies;
 
     public ProjectDependency(Node node) {
         super(node);
@@ -38,8 +45,44 @@ public class ProjectDependency extends AbstractClasspathEntry {
         assertPathIsValid();
     }
 
+    public File getPublication() {
+        return publication;
+    }
+
+    public void setPublication(File publication) {
+        this.publication = publication;
+    }
+
+    public TaskDependency getBuildDependencies() {
+        return buildDependencies;
+    }
+
+    public void setBuildDependencies(TaskDependency buildDependencies) {
+        this.buildDependencies = buildDependencies;
+    }
+
     private void assertPathIsValid() {
         Preconditions.checkArgument(path.startsWith("/"));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ProjectDependency that = (ProjectDependency) o;
+        return Objects.equals(publication, that.publication);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), publication);
     }
 
     @Override
@@ -49,6 +92,12 @@ public class ProjectDependency extends AbstractClasspathEntry {
 
     @Override
     public String toString() {
-        return "ProjectDependency" + super.toString();
+        return "ProjectDependency{" +
+            "publication=" + publication +
+            ", path='" + path + '\'' +
+            ", exported=" + exported +
+            ", accessRules=" + accessRules +
+            ", entryAttributes=" + entryAttributes +
+            '}';
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/ProjectDependency.java
@@ -19,9 +19,9 @@ package org.gradle.plugins.ide.eclipse.model;
 import com.google.common.base.Preconditions;
 import groovy.util.Node;
 import org.gradle.api.Incubating;
+import org.gradle.api.internal.tasks.DefaultTaskDependency;
 import org.gradle.api.tasks.TaskDependency;
 
-import java.io.File;
 import java.util.Objects;
 
 /**
@@ -29,8 +29,10 @@ import java.util.Objects;
  */
 public class ProjectDependency extends AbstractClasspathEntry {
 
-    private File publication;
-    private TaskDependency buildDependencies;
+    private FileReference publication;
+    private FileReference publicationSourcePath;
+    private FileReference publicationJavadocPath;
+    private DefaultTaskDependency buildDependencies = new DefaultTaskDependency();
 
     public ProjectDependency(Node node) {
         super(node);
@@ -39,6 +41,7 @@ public class ProjectDependency extends AbstractClasspathEntry {
 
     /**
      * Create a dependency on another Eclipse project.
+     *
      * @param path The path to the Eclipse project, which is the name of the eclipse project preceded by "/".
      */
     public ProjectDependency(String path) {
@@ -52,16 +55,70 @@ public class ProjectDependency extends AbstractClasspathEntry {
      * @since 5.6
      */
     @Incubating
-    public File getPublication() {
+    public FileReference getPublication() {
         return publication;
     }
 
-    public void setPublication(File publication) {
+    /**
+     * Sets the file that can replace this ProjectDependency
+     *
+     * @since 5.6
+     */
+    @Incubating
+    public void setPublication(FileReference publication) {
         this.publication = publication;
     }
 
     /**
-     * Returns the TaskDependency that builds the the file returned by {@link #getPublication()}
+     * Returns the source artifact of the project publication
+     *
+     * @see #getPublication()
+     * @since 5.6
+     */
+    @Incubating
+    public FileReference getPublicationSourcePath() {
+        return publicationSourcePath;
+    }
+
+    /**
+     * Sets the source artifact of the project publication
+     *
+     * @see #getPublication()
+     * @since 5.6
+     */
+    @Incubating
+    public void setPublicationSourcePath(FileReference publicationSourcePath) {
+        this.publicationSourcePath = publicationSourcePath;
+    }
+
+    /**
+     * Returns the javadoc artifact of the project publication
+     *
+     * @see #getPublication()
+     * @since 5.6
+     */
+    @Incubating
+    public FileReference getPublicationJavadocPath() {
+        return publicationJavadocPath;
+    }
+
+    /**
+     * Sets the javadoc artifact of the project publication
+     *
+     * @see #getPublication()
+     * @since 5.6
+     */
+    @Incubating
+    public void setPublicationJavadocPath(FileReference publicationJavadocPath) {
+        this.publicationJavadocPath = publicationJavadocPath;
+    }
+
+    /**
+     * Returns the tasks to be executed to build the the file returned by {@link #getPublication()}
+     * <p>
+     * This property doesn't have a direct effect to the Gradle Eclipse plugin's behaviour. It is used, however, by
+     * Buildship to execute the configured tasks each time before the user imports the project or before a project
+     * synchronization starts in case this project is closed to build the substitute jar.
      *
      * @since 5.6
      */
@@ -70,8 +127,15 @@ public class ProjectDependency extends AbstractClasspathEntry {
         return buildDependencies;
     }
 
-    public void setBuildDependencies(TaskDependency buildDependencies) {
-        this.buildDependencies = buildDependencies;
+    /**
+     * Sets the tasks to be executed to build the the file returned by {@link #getPublication()}
+     *
+     * @see #getBuildDependencies()
+     * @since 5.6
+     */
+    @Incubating
+    public void buildDependencies(Object... buildDependencies) {
+        this.buildDependencies.add(buildDependencies);
     }
 
     private void assertPathIsValid() {
@@ -90,12 +154,14 @@ public class ProjectDependency extends AbstractClasspathEntry {
             return false;
         }
         ProjectDependency that = (ProjectDependency) o;
-        return Objects.equals(publication, that.publication);
+        return Objects.equals(publication, that.publication) &&
+            Objects.equals(publicationSourcePath, that.publicationSourcePath) &&
+            Objects.equals(publicationJavadocPath, that.publicationJavadocPath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), publication);
+        return Objects.hash(super.hashCode(), publication, publicationSourcePath, publicationJavadocPath);
     }
 
     @Override
@@ -107,6 +173,9 @@ public class ProjectDependency extends AbstractClasspathEntry {
     public String toString() {
         return "ProjectDependency{" +
             "publication=" + publication +
+            ", publicationSourcePath=" + publicationSourcePath +
+            ", publicationJavadocPath=" + publicationJavadocPath +
+            ", buildDependencies=" + buildDependencies +
             ", path='" + path + '\'' +
             ", exported=" + exported +
             ", accessRules=" + accessRules +

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
 import org.gradle.api.internal.artifacts.DefaultModuleVersionIdentifier;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.internal.component.model.ComponentArtifactMetadata;
 import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.model.AbstractClasspathEntry;
 import org.gradle.plugins.ide.eclipse.model.AbstractLibrary;
@@ -99,9 +100,12 @@ public class EclipseDependenciesCreator {
         @Override
         public void visitProjectDependency(ResolvedArtifactResult artifact) {
             ProjectComponentIdentifier componentIdentifier = (ProjectComponentIdentifier) artifact.getId().getComponentIdentifier();
-            if (!componentIdentifier.equals(currentProjectId)) {
-                projects.add(projectDependencyBuilder.build(componentIdentifier));
+            if (componentIdentifier.equals(currentProjectId)) {
+                return;
             }
+            ComponentArtifactMetadata artifactId = (ComponentArtifactMetadata) artifact.getId();
+            File binary = artifact.getFile();
+            projects.add(projectDependencyBuilder.build(componentIdentifier, binary, artifactId.getBuildDependencies(), pathToSourceSets.get(binary.getAbsolutePath())));
         }
 
         @Override

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/EclipseDependenciesCreator.java
@@ -106,8 +106,6 @@ public class EclipseDependenciesCreator {
             if (componentIdentifier.equals(currentProjectId)) {
                 return;
             }
-            // we're filtering here instead of in org.gradle.plugins.ide.internal.resolver.IdeDependencySet.IdeDependencyResult.getResolvedArtifacts
-            // since specifying attributes makes lots of IDEA tests fail.
             Usage usage = artifact.getVariant().getAttributes().getAttribute(Usage.USAGE_ATTRIBUTE);
             if (!RUNTIME_JARS_USAGE.equals(usage)) {
                 return;

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -16,10 +16,16 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
+import com.google.common.base.Joiner;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
+import org.gradle.api.tasks.TaskDependency;
+import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.internal.EclipseProjectMetadata;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
+
+import java.io.File;
+import java.util.Collection;
 
 public class ProjectDependencyBuilder {
     private final IdeArtifactRegistry ideArtifactRegistry;
@@ -28,8 +34,14 @@ public class ProjectDependencyBuilder {
         this.ideArtifactRegistry = ideArtifactRegistry;
     }
 
-    public ProjectDependency build(ProjectComponentIdentifier id) {
-        return buildProjectDependency(determineTargetProjectPath(id));
+    public ProjectDependency build(ProjectComponentIdentifier componentIdentifier, File publication, TaskDependency buildDependencies, Collection<String> sourceSets) {
+        ProjectDependency dependency = buildProjectDependency(determineTargetProjectPath(componentIdentifier));
+        dependency.setPublication(publication);
+        dependency.setBuildDependencies(buildDependencies);
+        if (sourceSets != null) {
+            dependency.getEntryAttributes().put(EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME, Joiner.on(',').join(sourceSets));
+        }
+        return dependency;
     }
 
     private String determineTargetProjectPath(ProjectComponentIdentifier id) {

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilder.java
@@ -16,16 +16,12 @@
 
 package org.gradle.plugins.ide.eclipse.model.internal;
 
-import com.google.common.base.Joiner;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.tasks.TaskDependency;
-import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants;
 import org.gradle.plugins.ide.eclipse.internal.EclipseProjectMetadata;
+import org.gradle.plugins.ide.eclipse.model.FileReference;
 import org.gradle.plugins.ide.eclipse.model.ProjectDependency;
 import org.gradle.plugins.ide.internal.IdeArtifactRegistry;
-
-import java.io.File;
-import java.util.Collection;
 
 public class ProjectDependencyBuilder {
     private final IdeArtifactRegistry ideArtifactRegistry;
@@ -34,12 +30,11 @@ public class ProjectDependencyBuilder {
         this.ideArtifactRegistry = ideArtifactRegistry;
     }
 
-    public ProjectDependency build(ProjectComponentIdentifier componentIdentifier, File publication, TaskDependency buildDependencies, Collection<String> sourceSets) {
+    public ProjectDependency build(ProjectComponentIdentifier componentIdentifier, FileReference publication, TaskDependency buildDependencies) {
         ProjectDependency dependency = buildProjectDependency(determineTargetProjectPath(componentIdentifier));
         dependency.setPublication(publication);
-        dependency.setBuildDependencies(buildDependencies);
-        if (sourceSets != null) {
-            dependency.getEntryAttributes().put(EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME, Joiner.on(',').join(sourceSets));
+        if (buildDependencies != null) {
+            dependency.buildDependencies(buildDependencies);
         }
         return dependency;
     }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -36,9 +36,7 @@ import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
-import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.Artifact;
-import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.jvm.JvmLibrary;
@@ -130,8 +128,8 @@ public class IdeDependencySet {
                 public void execute(ArtifactView.ViewConfiguration viewConfiguration) {
                     viewConfiguration.lenient(true);
                     viewConfiguration.componentFilter(getComponentFilter(visitor));
-                    // FIXME: This breaks org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy:130
-                    viewConfiguration.attributes(attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
+                    // TODO: Doing the restriction this way breaks a lot of test. The resulting start containing RUNTIME + TEST instead of COMPILE scopes for Idea for example.
+                    //viewConfiguration.attributes(attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
                 }
             }).getArtifacts();
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -36,7 +36,9 @@ import org.gradle.api.artifacts.result.ArtifactResult;
 import org.gradle.api.artifacts.result.ComponentArtifactsResult;
 import org.gradle.api.artifacts.result.ResolvedArtifactResult;
 import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
+import org.gradle.api.attributes.Usage;
 import org.gradle.api.component.Artifact;
+import org.gradle.api.internal.model.NamedObjectInstantiator;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.specs.Specs;
 import org.gradle.jvm.JvmLibrary;
@@ -128,6 +130,8 @@ public class IdeDependencySet {
                 public void execute(ArtifactView.ViewConfiguration viewConfiguration) {
                     viewConfiguration.lenient(true);
                     viewConfiguration.componentFilter(getComponentFilter(visitor));
+                    // FIXME: This breaks org/gradle/plugins/ide/idea/model/internal/IdeaDependenciesProviderTest.groovy:130
+                    viewConfiguration.attributes(attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
                 }
             }).getArtifacts();
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/resolver/IdeDependencySet.java
@@ -128,8 +128,6 @@ public class IdeDependencySet {
                 public void execute(ArtifactView.ViewConfiguration viewConfiguration) {
                     viewConfiguration.lenient(true);
                     viewConfiguration.componentFilter(getComponentFilter(visitor));
-                    // TODO: Doing the restriction this way breaks a lot of test. The resulting start containing RUNTIME + TEST instead of COMPILE scopes for Idea for example.
-                    //viewConfiguration.attributes(attrs -> attrs.attribute(Usage.USAGE_ATTRIBUTE, NamedObjectInstantiator.INSTANCE.named(Usage.class, Usage.JAVA_RUNTIME_JARS)));
                 }
             }).getArtifacts();
         }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/EclipseModelBuilder.java
@@ -26,6 +26,7 @@ import org.gradle.api.initialization.IncludedBuild;
 import org.gradle.api.internal.project.ProjectStateRegistry;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.TaskDependency;
 import org.gradle.internal.build.IncludedBuildState;
 import org.gradle.internal.service.ServiceRegistry;
 import org.gradle.internal.xml.XmlTransformer;
@@ -72,6 +73,7 @@ import org.gradle.util.GUtil;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +91,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
     private DefaultGradleProject rootGradleProject;
     private Project currentProject;
     private EclipseRuntime eclipseRuntime;
+    private Map<String, Boolean> projectOpenStatus = new HashMap<>();
 
     @VisibleForTesting
     public EclipseModelBuilder(GradleProjectBuilder gradleProjectBuilder, ServiceRegistry services, EclipseModelAwareUniqueProjectNameProvider uniqueProjectNameProvider) {
@@ -114,6 +117,9 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
     @Override
     public Object buildAll(String modelName, EclipseRuntime eclipseRuntime, Project project) {
         this.eclipseRuntime = eclipseRuntime;
+        projectOpenStatus = eclipseRuntime.getWorkspace().getProjects().stream()
+            .collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseWorkspaceProject::isOpen));
+
         return buildAll(modelName, project);
     }
 
@@ -185,63 +191,18 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
     private void populate(Project project) {
         EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
-        EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
 
-        eclipseClasspath.setProjectDependenciesOnly(projectDependenciesOnly);
+        boolean projectDependenciesOnly = this.projectDependenciesOnly;
 
-        List<ClasspathEntry> classpathEntries;
-        if (eclipseClasspath.getFile() == null) {
-            classpathEntries = eclipseClasspath.resolveDependencies();
-        } else {
-            Classpath classpath = new Classpath(eclipseClasspath.getFileReferenceFactory());
-            eclipseClasspath.mergeXmlClasspath(classpath);
-            classpathEntries = classpath.getEntries();
-        }
-
-        final List<DefaultEclipseExternalDependency> externalDependencies = new LinkedList<DefaultEclipseExternalDependency>();
-        final List<DefaultEclipseProjectDependency> projectDependencies = new LinkedList<DefaultEclipseProjectDependency>();
-        final List<DefaultEclipseSourceDirectory> sourceDirectories = new LinkedList<DefaultEclipseSourceDirectory>();
-        final List<DefaultEclipseClasspathContainer> classpathContainers = new LinkedList<DefaultEclipseClasspathContainer>();
-        DefaultEclipseOutputLocation outputLocation = null;
-
-        for (ClasspathEntry entry : classpathEntries) {
-            //we don't handle Variables at the moment because users didn't request it yet
-            //and it would probably push us to add support in the tooling api to retrieve the variable mappings.
-            if (entry instanceof Library) {
-                AbstractLibrary library = (AbstractLibrary) entry;
-                final File file = library.getLibrary().getFile();
-                final File source = library.getSourcePath() == null ? null : library.getSourcePath().getFile();
-                final File javadoc = library.getJavadocPath() == null ? null : library.getJavadocPath().getFile();
-                DefaultEclipseExternalDependency dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
-                externalDependencies.add(dependency);
-            } else if (entry instanceof ProjectDependency) {
-                final ProjectDependency projectDependency = (ProjectDependency) entry;
-                // By removing the leading "/", this is no longer a "path" as defined by Eclipse
-                final String path = StringUtils.removeStart(projectDependency.getPath(), "/");
-                DefaultEclipseProjectDependency dependency = new DefaultEclipseProjectDependency(path, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency));
-                projectDependencies.add(dependency);
-            } else if (entry instanceof SourceFolder) {
-                final SourceFolder sourceFolder = (SourceFolder) entry;
-                String path = sourceFolder.getPath();
-                List<String> excludes = sourceFolder.getExcludes();
-                List<String> includes = sourceFolder.getIncludes();
-                String output = sourceFolder.getOutput();
-                sourceDirectories.add(new DefaultEclipseSourceDirectory(path, sourceFolder.getDir(), excludes, includes, output, createAttributes(sourceFolder), createAccessRules(sourceFolder)));
-            } else if (entry instanceof Container) {
-                final Container container = (Container) entry;
-                classpathContainers.add(new DefaultEclipseClasspathContainer(container.getPath(), container.isExported(), createAttributes(container), createAccessRules(container)));
-            } else if (entry instanceof Output) {
-                outputLocation = new DefaultEclipseOutputLocation(((Output)entry).getPath());
-            }
-        }
+        ClasspathElements classpathElements = gatherClasspathElements(projectOpenStatus, eclipseModel.getClasspath(), projectDependenciesOnly);
 
         DefaultEclipseProject eclipseProject = findEclipseProject(project);
 
-        eclipseProject.setClasspath(externalDependencies);
-        eclipseProject.setProjectDependencies(projectDependencies);
-        eclipseProject.setSourceDirectories(sourceDirectories);
-        eclipseProject.setClasspathContainers(classpathContainers);
-        eclipseProject.setOutputLocation(outputLocation != null ? outputLocation : new DefaultEclipseOutputLocation("bin"));
+        eclipseProject.setClasspath(classpathElements.getExternalDependencies());
+        eclipseProject.setProjectDependencies(classpathElements.getProjectDependencies());
+        eclipseProject.setSourceDirectories(classpathElements.getSourceDirectories());
+        eclipseProject.setClasspathContainers(classpathElements.getClasspathContainers());
+        eclipseProject.setOutputLocation(classpathElements.getEclipseOutputLocation() != null ? classpathElements.getEclipseOutputLocation() : new DefaultEclipseOutputLocation("bin"));
         eclipseProject.setAutoBuildTasks(!eclipseModel.getAutoBuildTasks().getDependencies(null).isEmpty());
 
         org.gradle.plugins.ide.eclipse.model.Project xmlProject = new org.gradle.plugins.ide.eclipse.model.Project(new XmlTransformer());
@@ -260,6 +221,60 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
         for (Project childProject : project.getChildProjects().values()) {
             populate(childProject);
         }
+    }
+
+    public static ClasspathElements gatherClasspathElements(Map<String, Boolean> projectOpenStatus, EclipseClasspath eclipseClasspath, boolean projectDependenciesOnly) {
+        ClasspathElements classpathElements = new ClasspathElements();
+        eclipseClasspath.setProjectDependenciesOnly(projectDependenciesOnly);
+
+        List<ClasspathEntry> classpathEntries;
+        if (eclipseClasspath.getFile() == null) {
+            classpathEntries = eclipseClasspath.resolveDependencies();
+        } else {
+            Classpath classpath = new Classpath(eclipseClasspath.getFileReferenceFactory());
+            eclipseClasspath.mergeXmlClasspath(classpath);
+            classpathEntries = classpath.getEntries();
+        }
+
+        final Map<String, DefaultEclipseProjectDependency> projectDependencyMap = new HashMap<>();
+
+        for (ClasspathEntry entry : classpathEntries) {
+            //we don't handle Variables at the moment because users didn't request it yet
+            //and it would probably push us to add support in the tooling api to retrieve the variable mappings.
+            if (entry instanceof Library) {
+                AbstractLibrary library = (AbstractLibrary) entry;
+                final File file = library.getLibrary().getFile();
+                final File source = library.getSourcePath() == null ? null : library.getSourcePath().getFile();
+                final File javadoc = library.getJavadocPath() == null ? null : library.getJavadocPath().getFile();
+                DefaultEclipseExternalDependency dependency = new DefaultEclipseExternalDependency(file, javadoc, source, library.getModuleVersion(), library.isExported(), createAttributes(library), createAccessRules(library));
+                classpathElements.getExternalDependencies().add(dependency);
+            } else if (entry instanceof ProjectDependency) {
+                final ProjectDependency projectDependency = (ProjectDependency) entry;
+                // By removing the leading "/", this is no longer a "path" as defined by Eclipse
+                final String path = StringUtils.removeStart(projectDependency.getPath(), "/");
+                boolean isProjectOpen = projectOpenStatus.getOrDefault(path, true);
+                if (!isProjectOpen) {
+                    classpathElements.getExternalDependencies().add(new DefaultEclipseExternalDependency(projectDependency.getPublication(), null, null, null, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));
+                    classpathElements.getBuildDependencies().add(projectDependency.getBuildDependencies());
+                } else {
+                    projectDependencyMap.put(path, new DefaultEclipseProjectDependency(path, projectDependency.isExported(), createAttributes(projectDependency), createAccessRules(projectDependency)));
+                }
+            } else if (entry instanceof SourceFolder) {
+                final SourceFolder sourceFolder = (SourceFolder) entry;
+                String path = sourceFolder.getPath();
+                List<String> excludes = sourceFolder.getExcludes();
+                List<String> includes = sourceFolder.getIncludes();
+                String output = sourceFolder.getOutput();
+                classpathElements.getSourceDirectories().add(new DefaultEclipseSourceDirectory(path, sourceFolder.getDir(), excludes, includes, output, createAttributes(sourceFolder), createAccessRules(sourceFolder)));
+            } else if (entry instanceof Container) {
+                final Container container = (Container) entry;
+                classpathElements.getClasspathContainers().add(new DefaultEclipseClasspathContainer(container.getPath(), container.isExported(), createAttributes(container), createAccessRules(container)));
+            } else if (entry instanceof Output) {
+                classpathElements.setEclipseOutputLocation(new DefaultEclipseOutputLocation(((Output) entry).getPath()));
+            }
+        }
+        classpathElements.getProjectDependencies().addAll(projectDependencyMap.values());
+        return classpathElements;
     }
 
     private static void populateEclipseProjectTasks(DefaultEclipseProject eclipseProject, Iterable<Task> projectTasks) {
@@ -325,7 +340,7 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
 
     private static List<DefaultAccessRule> createAccessRules(AbstractClasspathEntry classpathEntry) {
         List<DefaultAccessRule> result = Lists.newArrayList();
-        for(AccessRule accessRule : classpathEntry.getAccessRules()) {
+        for (AccessRule accessRule : classpathEntry.getAccessRules()) {
             result.add(createAccessRule(accessRule));
         }
         return result;
@@ -402,5 +417,42 @@ public class EclipseModelBuilder implements ParameterizedToolingModelBuilder<Ecl
      */
     private static String convertGString(CharSequence original) {
         return original.toString();
+    }
+
+    public static class ClasspathElements {
+        private final List<DefaultEclipseExternalDependency> externalDependencies = new ArrayList<>();
+        private final List<DefaultEclipseProjectDependency> projectDependencies = new ArrayList<>();
+        private final List<DefaultEclipseSourceDirectory> sourceDirectories = new ArrayList<>();
+        private final List<DefaultEclipseClasspathContainer> classpathContainers = new ArrayList<>();
+        private final List<TaskDependency> buildDependencies = new ArrayList<>();
+        private DefaultEclipseOutputLocation eclipseOutputLocation;
+
+        public List<DefaultEclipseExternalDependency> getExternalDependencies() {
+            return externalDependencies;
+        }
+
+        public List<DefaultEclipseProjectDependency> getProjectDependencies() {
+            return projectDependencies;
+        }
+
+        public List<DefaultEclipseSourceDirectory> getSourceDirectories() {
+            return sourceDirectories;
+        }
+
+        public List<DefaultEclipseClasspathContainer> getClasspathContainers() {
+            return classpathContainers;
+        }
+
+        public List<TaskDependency> getBuildDependencies() {
+            return buildDependencies;
+        }
+
+        public DefaultEclipseOutputLocation getEclipseOutputLocation() {
+            return eclipseOutputLocation;
+        }
+
+        public void setEclipseOutputLocation(DefaultEclipseOutputLocation eclipseOutputLocation) {
+            this.eclipseOutputLocation = eclipseOutputLocation;
+        }
     }
 }

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/RunBuildDependenciesTaskBuilder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.tooling;
+
+import org.gradle.StartParameter;
+import org.gradle.api.NonNullApi;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.api.tasks.TaskDependency;
+import org.gradle.plugins.ide.eclipse.EclipsePlugin;
+import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
+import org.gradle.plugins.ide.internal.tooling.eclipse.DefaultRunClosedProjectBuildDependencies;
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
+import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies;
+import org.gradle.tooling.provider.model.ParameterizedToolingModelBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@NonNullApi
+public class RunBuildDependenciesTaskBuilder implements ParameterizedToolingModelBuilder<EclipseRuntime> {
+    private Map<String, Boolean> projectOpenStatus;
+
+    @Override
+    public Class<EclipseRuntime> getParameterType() {
+        return EclipseRuntime.class;
+    }
+
+    @Override
+    public RunClosedProjectBuildDependencies buildAll(String modelName, EclipseRuntime eclipseRuntime, Project project) {
+        this.projectOpenStatus = eclipseRuntime.getWorkspace().getProjects().stream()
+            .collect(Collectors.toMap(EclipseWorkspaceProject::getName, EclipseWorkspaceProject::isOpen));
+
+        List<TaskDependency> buildDependencies = populate(project.getRootProject());
+        if (!buildDependencies.isEmpty()) {
+            Gradle rootGradle = getRootGradle(project.getGradle());
+            Project rootProject = rootGradle.getRootProject();
+            StartParameter startParameter = rootGradle.getStartParameter();
+            List<String> taskPaths = new ArrayList<>(startParameter.getTaskNames());
+            String parentTaskName = parentTaskName(rootProject, "eclipseClosedDependencies");
+            Task task = rootProject.task(parentTaskName);
+            task.dependsOn(buildDependencies.toArray(new Object[0]));
+            taskPaths.add(parentTaskName);
+            startParameter.setTaskNames(taskPaths);
+        }
+        return DefaultRunClosedProjectBuildDependencies.INSTANCE;
+    }
+
+    private Gradle getRootGradle(Gradle gradle) {
+        Gradle parent = gradle.getParent();
+        if (parent == null) {
+            return gradle;
+        }
+        return getRootGradle(parent);
+    }
+
+    private List<TaskDependency> populate(Project project) {
+        project.getPluginManager().apply(EclipsePlugin.class);
+        EclipseModel eclipseModel = project.getExtensions().getByType(EclipseModel.class);
+        EclipseClasspath eclipseClasspath = eclipseModel.getClasspath();
+
+        EclipseModelBuilder.ClasspathElements elements = EclipseModelBuilder.gatherClasspathElements(projectOpenStatus, eclipseClasspath, false);
+        List<TaskDependency> buildDependencies = new ArrayList<>(elements.getBuildDependencies());
+
+        for (Project childProject : project.getChildProjects().values()) {
+            buildDependencies.addAll(populate(childProject));
+        }
+        return buildDependencies;
+    }
+
+    @Override
+    public boolean canBuild(String modelName) {
+        return "org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies".equals(modelName);
+    }
+
+    @Override
+    public Object buildAll(String modelName, Project project) {
+        // nothing to do if no EclipseRuntime is supplied.
+        return DefaultRunClosedProjectBuildDependencies.INSTANCE;
+    }
+
+    private static String parentTaskName(Project project, String baseName) {
+        if (project.getTasks().findByName(baseName) == null) {
+            return baseName;
+        } else {
+            return parentTaskName(project, baseName + "_");
+        }
+    }
+
+}

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/ToolingModelServices.java
@@ -51,6 +51,7 @@ public class ToolingModelServices extends AbstractPluginServiceRegistry {
                 public void execute(ToolingModelBuilderRegistry registry) {
                     GradleProjectBuilder gradleProjectBuilder = new GradleProjectBuilder();
                     IdeaModelBuilder ideaModelBuilder = new IdeaModelBuilder(gradleProjectBuilder, services);
+                    registry.register(new RunBuildDependenciesTaskBuilder());
                     registry.register(new RunEclipseTasksBuilder());
                     registry.register(new EclipseModelBuilder(gradleProjectBuilder, services));
                     registry.register(ideaModelBuilder);

--- a/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultRunClosedProjectBuildDependencies.java
+++ b/subprojects/ide/src/main/java/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultRunClosedProjectBuildDependencies.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.tooling.eclipse;
+
+import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies;
+
+import java.io.Serializable;
+
+public class DefaultRunClosedProjectBuildDependencies implements RunClosedProjectBuildDependencies, Serializable {
+    public static final RunClosedProjectBuildDependencies INSTANCE = new DefaultRunClosedProjectBuildDependencies();
+
+    private DefaultRunClosedProjectBuildDependencies() {
+    }
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
@@ -28,7 +28,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
 
     def "should create dependency using project name for project without eclipse plugin applied"() {
         when:
-        def dependency = builder.build(projectId)
+        def dependency = builder.build(projectId, null, null, null)
 
         then:
         dependency.path == "/project-name"
@@ -45,7 +45,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
         artifactRegistry.getIdeProject(EclipseProjectMetadata, projectId) >> projectMetadata
 
         when:
-        def dependency = builder.build(projectId)
+        def dependency = builder.build(projectId, null, null, null)
 
         then:
         dependency.path == '/foo'

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/eclipse/model/internal/ProjectDependencyBuilderTest.groovy
@@ -28,7 +28,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
 
     def "should create dependency using project name for project without eclipse plugin applied"() {
         when:
-        def dependency = builder.build(projectId, null, null, null)
+        def dependency = builder.build(projectId, null, null)
 
         then:
         dependency.path == "/project-name"
@@ -45,7 +45,7 @@ class ProjectDependencyBuilderTest extends AbstractProjectBuilderSpec {
         artifactRegistry.getIdeProject(EclipseProjectMetadata, projectId) >> projectMetadata
 
         when:
-        def dependency = builder.build(projectId, null, null, null)
+        def dependency = builder.build(projectId, null, null)
 
         then:
         dependency.path == '/foo'

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseRuntime.java
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseRuntime.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.tooling.eclipse;
+
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+
+public class DefaultEclipseRuntime implements EclipseRuntime {
+
+    private EclipseWorkspace workspace;
+
+    public DefaultEclipseRuntime(EclipseWorkspace workspace) {
+        this.workspace = workspace;
+    }
+
+    @Override
+    public EclipseWorkspace getWorkspace() {
+        return workspace;
+    }
+
+    @Override
+    public void setWorkspace(EclipseWorkspace eclipseWorkspace) {
+        this.workspace = eclipseWorkspace;
+    }
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseWorkspace.java
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseWorkspace.java
@@ -13,32 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests.tooling.r55;
+package org.gradle.plugins.ide.internal.tooling.eclipse;
 
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.List;
 
-public class DefaultEclipseWorkspaceProject implements EclipseWorkspaceProject, Serializable {
+public class DefaultEclipseWorkspace implements EclipseWorkspace, Serializable {
 
-    private final String name;
     private final File location;
-    private final boolean isOpen;
+    private final List<EclipseWorkspaceProject> workspaceProjects;
 
-    public DefaultEclipseWorkspaceProject(String name, File location, boolean isOpen) {
-        this.name = name;
+    public DefaultEclipseWorkspace(File location, List<EclipseWorkspaceProject> workspaceProjects) {
         this.location = location;
-        this.isOpen = isOpen;
-    }
-
-    public DefaultEclipseWorkspaceProject(String name, File location) {
-        this(name, location, true);
-    }
-
-    @Override
-    public String getName() {
-        return name;
+        this.workspaceProjects = workspaceProjects;
     }
 
     @Override
@@ -47,7 +38,7 @@ public class DefaultEclipseWorkspaceProject implements EclipseWorkspaceProject, 
     }
 
     @Override
-    public boolean isOpen() {
-        return isOpen;
+    public List<EclipseWorkspaceProject> getProjects() {
+        return workspaceProjects;
     }
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseWorkspaceProject.java
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/DefaultEclipseWorkspaceProject.java
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests.tooling.r55;
+package org.gradle.plugins.ide.internal.tooling.eclipse;
+
 
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
 
@@ -30,10 +31,6 @@ public class DefaultEclipseWorkspaceProject implements EclipseWorkspaceProject, 
         this.name = name;
         this.location = location;
         this.isOpen = isOpen;
-    }
-
-    public DefaultEclipseWorkspaceProject(String name, File location) {
-        this(name, location, true);
     }
 
     @Override

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.tooling.eclipse
+
+
+import org.gradle.api.Project
+import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
+import org.gradle.api.internal.composite.CompositeBuildContext
+import org.gradle.api.internal.project.ProjectStateRegistry
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.internal.service.DefaultServiceRegistry
+import org.gradle.jvm.tasks.Jar
+import org.gradle.plugins.ide.eclipse.EclipsePlugin
+import org.gradle.plugins.ide.internal.configurer.EclipseModelAwareUniqueProjectNameProvider
+import org.gradle.plugins.ide.internal.tooling.EclipseModelBuilder
+import org.gradle.plugins.ide.internal.tooling.GradleProjectBuilder
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.tooling.model.eclipse.EclipseRuntime
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
+import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
+
+@UsesNativeServices
+@CleanupTestDirectory
+class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
+    Project child1
+    Project child2
+
+    def setup() {
+        project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
+        child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
+        child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
+
+        def libsDir = new File(project.projectDir, "libs")
+        libsDir.mkdirs()
+        new File(libsDir, "test-1.0.jar").createNewFile()
+        [project, child1, child2].each { it.pluginManager.apply(EclipsePlugin) }
+        [child1, child2].each {
+            it.plugins.apply(JavaPlugin)
+            it.repositories.flatDir {
+                dirs libsDir
+            }
+        }
+
+        child1.configurations.create("testArtifacts")
+        def task = child1.tasks.create("testJar", Jar) {
+            classifier = "tests"
+            from(project.sourceSets.test.output)
+        }
+        child1.dependencies {
+            implementation "fakegroup:test:1.0"
+        }
+        child1.artifacts.add("testArtifacts", task)
+        child2.dependencies {
+            implementation child2.dependencies.project(path: ":child1")
+            testImplementation child2.dependencies.project(path: ":child1", configuration: "testArtifacts")
+        }
+    }
+
+    def "project dependencies are mapped to eclipse model"() {
+        setup:
+        def modelBuilder = createEclipseModelBuilder()
+
+        when:
+        def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", project)
+
+        then:
+        DefaultEclipseProject eclipseChild2 = eclipseModel.children.find { it.name == 'child2' }
+        eclipseChild2.projectDependencies.collect { it.path } == ['child1']
+        // verify we inherit the transitive dependency
+        eclipseChild2.classpath.collect { it.file.getName() } == ["test-1.0.jar"]
+    }
+
+    def "project dependencies are mapped to eclipse model with supplied runtime"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject("child1"), gradleProject("child2")])
+        def modelBuilder = createEclipseModelBuilder()
+
+        when:
+        def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", eclipseRuntime, project)
+
+        then:
+        DefaultEclipseProject eclipseChild2 = eclipseModel.children.find { it.name == 'child2' }
+        eclipseChild2.projectDependencies.collect { it.path } == ['child1']
+        // verify we inherit the transitive dependency
+        eclipseChild2.classpath.collect { it.file.getName() } == ["test-1.0.jar"]
+    }
+
+    private def createEclipseModelBuilder() {
+        def gradleProjectBuilder = new GradleProjectBuilder()
+        def serviceRegistry = new DefaultServiceRegistry()
+        def uniqueProjectNameProvider = Stub(EclipseModelAwareUniqueProjectNameProvider) {
+            getUniqueName(_ as Project) >> { Project p -> p.getName() }
+        }
+        serviceRegistry.add(LocalComponentRegistry, Stub(LocalComponentRegistry))
+        serviceRegistry.add(CompositeBuildContext, Stub(CompositeBuildContext))
+        serviceRegistry.add(ProjectStateRegistry, Stub(ProjectStateRegistry))
+        new EclipseModelBuilder(gradleProjectBuilder, serviceRegistry, uniqueProjectNameProvider)
+    }
+
+    EclipseRuntime eclipseRuntime(List<EclipseWorkspaceProject> projects) {
+        new DefaultEclipseRuntime(new DefaultEclipseWorkspace(new File("workspace"), projects))
+    }
+
+    EclipseWorkspaceProject gradleProject(String name, boolean isOpen = true) {
+        new DefaultEclipseWorkspaceProject(name, new File(name), isOpen)
+    }
+
+}

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderDependenciesTest.groovy
@@ -25,6 +25,8 @@ import org.gradle.api.plugins.JavaPlugin
 import org.gradle.internal.service.DefaultServiceRegistry
 import org.gradle.jvm.tasks.Jar
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
+import org.gradle.plugins.ide.eclipse.model.EclipseClasspath
+import org.gradle.plugins.ide.eclipse.model.ProjectDependency
 import org.gradle.plugins.ide.internal.configurer.EclipseModelAwareUniqueProjectNameProvider
 import org.gradle.plugins.ide.internal.tooling.EclipseModelBuilder
 import org.gradle.plugins.ide.internal.tooling.GradleProjectBuilder
@@ -41,17 +43,19 @@ import org.gradle.util.UsesNativeServices
 class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
     Project child1
     Project child2
+    Project child3
 
     def setup() {
         project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
         child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
         child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
+        child3 = ProjectBuilder.builder().withName("child3").withParent(project).build()
 
         def libsDir = new File(project.projectDir, "libs")
         libsDir.mkdirs()
         new File(libsDir, "test-1.0.jar").createNewFile()
-        [project, child1, child2].each { it.pluginManager.apply(EclipsePlugin) }
-        [child1, child2].each {
+        [project, child1, child2, child3].each { it.pluginManager.apply(EclipsePlugin) }
+        [child1, child2, child3].each {
             it.plugins.apply(JavaPlugin)
             it.repositories.flatDir {
                 dirs libsDir
@@ -71,6 +75,16 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
             implementation child2.dependencies.project(path: ":child1")
             testImplementation child2.dependencies.project(path: ":child1", configuration: "testArtifacts")
         }
+        child3.eclipse {
+            (classpath as EclipseClasspath).file.whenMerged {
+                def customDependency = new ProjectDependency("/child1")
+                customDependency.buildDependencies(":child1:jar")
+                customDependency.publication = fileReference("customJar.jar")
+                customDependency.publicationJavadocPath = fileReference("customJar-javadoc.jar")
+                customDependency.publicationSourcePath = fileReference("customJar-sources.jar")
+                entries += [customDependency]
+            }
+        }
     }
 
     def "project dependencies are mapped to eclipse model"() {
@@ -84,12 +98,12 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         DefaultEclipseProject eclipseChild2 = eclipseModel.children.find { it.name == 'child2' }
         eclipseChild2.projectDependencies.collect { it.path } == ['child1']
         // verify we inherit the transitive dependency
-        eclipseChild2.classpath.collect { it.file.getName() } == ["test-1.0.jar"]
+        eclipseChild2.classpath.collect { it.file.name } == ["test-1.0.jar"]
     }
 
     def "project dependencies are mapped to eclipse model with supplied runtime"() {
         setup:
-        def eclipseRuntime = eclipseRuntime([gradleProject("child1"), gradleProject("child2")])
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1), gradleProject(child2)])
         def modelBuilder = createEclipseModelBuilder()
 
         when:
@@ -99,14 +113,63 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         DefaultEclipseProject eclipseChild2 = eclipseModel.children.find { it.name == 'child2' }
         eclipseChild2.projectDependencies.collect { it.path } == ['child1']
         // verify we inherit the transitive dependency
-        eclipseChild2.classpath.collect { it.file.getName() } == ["test-1.0.jar"]
+        eclipseChild2.classpath.collect { it.file.name } == ["test-1.0.jar"]
     }
+
+
+    def "project dependency is replaced when project is closed"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1, false), gradleProject(child2)])
+        def modelBuilder = createEclipseModelBuilder()
+
+        when:
+        def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", eclipseRuntime, project)
+
+        then:
+        DefaultEclipseProject eclipseChild2 = eclipseModel.children.find { it.name == 'child2' }
+        eclipseChild2.projectDependencies.collect { it.path } == []
+        // jars that replace the project dependencies + the transitive dependency from :a
+        eclipseChild2.classpath.collect { it.file.name } == ['child1.jar', 'child1-tests.jar', 'test-1.0.jar']
+    }
+
+    def "custom project dependencies are replaced when project is closed"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1, false), gradleProject(child2), gradleProject(child3)])
+        def modelBuilder = createEclipseModelBuilder()
+
+        when:
+        def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", eclipseRuntime, project)
+
+        then:
+        DefaultEclipseProject eclipseChild3 = eclipseModel.children.find { it.name == 'child3' }
+        eclipseChild3.projectDependencies.collect { it.path } == []
+        // jars that replace the project dependencies + the transitive dependency from :a
+        eclipseChild3.classpath.collect { it.file.name } == ['customJar.jar']
+    }
+
+    def "source and javadoc artifacts are passed on for closed projects"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1, false), gradleProject(child2), gradleProject(child3)])
+        def modelBuilder = createEclipseModelBuilder()
+
+        when:
+        def eclipseModel = modelBuilder.buildAll("org.gradle.tooling.model.eclipse.EclipseProject", eclipseRuntime, project)
+
+        then:
+        DefaultEclipseProject eclipseChild3 = eclipseModel.children.find { it.name == 'child3' }
+        eclipseChild3.projectDependencies.collect { it.path } == []
+        // jars that replace the project dependencies + the transitive dependency from :a
+        eclipseChild3.classpath.collect { it.file.name } == ['customJar.jar']
+        eclipseChild3.classpath[0].source.name == 'customJar-sources.jar'
+        eclipseChild3.classpath[0].javadoc.name == 'customJar-javadoc.jar'
+    }
+
 
     private def createEclipseModelBuilder() {
         def gradleProjectBuilder = new GradleProjectBuilder()
         def serviceRegistry = new DefaultServiceRegistry()
         def uniqueProjectNameProvider = Stub(EclipseModelAwareUniqueProjectNameProvider) {
-            getUniqueName(_ as Project) >> { Project p -> p.getName() }
+            getUniqueName(_ as Project) >> { Project p -> p.name }
         }
         serviceRegistry.add(LocalComponentRegistry, Stub(LocalComponentRegistry))
         serviceRegistry.add(CompositeBuildContext, Stub(CompositeBuildContext))
@@ -118,8 +181,8 @@ class EclipseModelBuilderDependenciesTest extends AbstractProjectBuilderSpec {
         new DefaultEclipseRuntime(new DefaultEclipseWorkspace(new File("workspace"), projects))
     }
 
-    EclipseWorkspaceProject gradleProject(String name, boolean isOpen = true) {
-        new DefaultEclipseWorkspaceProject(name, new File(name), isOpen)
+    EclipseWorkspaceProject gradleProject(Project project, boolean isOpen = true) {
+        new DefaultEclipseWorkspaceProject(project.name, project.projectDir, isOpen)
     }
 
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/EclipseModelBuilderTest.groovy
@@ -20,6 +20,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.internal.artifacts.ivyservice.projectmodule.LocalComponentRegistry
 import org.gradle.api.internal.composite.CompositeBuildContext
+import org.gradle.api.internal.project.ProjectStateRegistry
 import org.gradle.api.plugins.GroovyBasePlugin
 import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaBasePlugin
@@ -331,6 +332,7 @@ class EclipseModelBuilderTest extends AbstractProjectBuilderSpec {
         }
         serviceRegistry.add(LocalComponentRegistry, Stub(LocalComponentRegistry))
         serviceRegistry.add(CompositeBuildContext, Stub(CompositeBuildContext))
+        serviceRegistry.add(ProjectStateRegistry, Stub(ProjectStateRegistry))
         new EclipseModelBuilder(gradleProjectBuilder, serviceRegistry, uniqueProjectNameProvider)
     }
 }

--- a/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/RunBuildDependenciesTaskBuilderTest.groovy
+++ b/subprojects/ide/src/test/groovy/org/gradle/plugins/ide/internal/tooling/eclipse/RunBuildDependenciesTaskBuilderTest.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.plugins.ide.internal.tooling.eclipse
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.jvm.tasks.Jar
+import org.gradle.plugins.ide.eclipse.EclipsePlugin
+import org.gradle.plugins.ide.internal.tooling.RunBuildDependenciesTaskBuilder
+import org.gradle.test.fixtures.AbstractProjectBuilderSpec
+import org.gradle.test.fixtures.file.CleanupTestDirectory
+import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.tooling.model.eclipse.EclipseRuntime
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
+import org.gradle.util.TestUtil
+import org.gradle.util.UsesNativeServices
+
+@UsesNativeServices
+@CleanupTestDirectory
+class RunBuildDependenciesTaskBuilderTest extends AbstractProjectBuilderSpec {
+    Project child1
+    Project child2
+
+    def setup() {
+        project = TestUtil.builder(temporaryFolder.testDirectory).withName("project").build()
+        child1 = ProjectBuilder.builder().withName("child1").withParent(project).build()
+        child2 = ProjectBuilder.builder().withName("child2").withParent(project).build()
+
+        [project, child1, child2].each { it.pluginManager.apply(EclipsePlugin) }
+        [child1, child2].each {
+            it.plugins.apply(JavaPlugin)
+        }
+
+        child1.configurations.create("testArtifacts")
+        def task = child1.tasks.create("testJar", Jar) {
+            classifier = "tests"
+            from(project.sourceSets.test.output)
+        }
+        child1.artifacts.add("testArtifacts", task)
+        child2.dependencies {
+            implementation child2.dependencies.project(path: ":child1")
+            testImplementation child2.dependencies.project(path: ":child1", configuration: "testArtifacts")
+        }
+    }
+
+    def "closed project build dependencies are executed on build"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1, false), gradleProject(child2)])
+        def modelBuilder = createBuilder()
+
+        when:
+        modelBuilder.buildAll("org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies", eclipseRuntime, project)
+
+        then:
+        def buildTask = project.tasks.getByName("eclipseClosedDependencies")
+        buildTask != null
+        buildTask.taskDependencies.getDependencies(buildTask).collect { it.path }.sort() == ([':child1:jar', ':child1:testJar'])
+        project.getGradle().getStartParameter().getTaskNames() == ['eclipseClosedDependencies']
+    }
+
+    def "build task is not added if no projects are closed"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1), gradleProject(child2)])
+        def modelBuilder = createBuilder()
+
+        when:
+        modelBuilder.buildAll("org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies", eclipseRuntime, project)
+
+        then:
+        project.tasks.findByName("eclipseClosedDependencies") == null
+        project.getGradle().getStartParameter().getTaskNames().isEmpty()
+    }
+
+    def "task name is deduplicated"() {
+        setup:
+        def eclipseRuntime = eclipseRuntime([gradleProject(child1, false), gradleProject(child2)])
+        project.tasks.create("eclipseClosedDependencies")
+        def modelBuilder = createBuilder()
+
+        when:
+        modelBuilder.buildAll("org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies", eclipseRuntime, project)
+
+        then:
+        def buildTask = project.tasks.getByName("eclipseClosedDependencies_")
+        buildTask != null
+        buildTask.taskDependencies.getDependencies(buildTask).collect { it.path }.sort() == ([':child1:jar', ':child1:testJar'])
+        project.getGradle().getStartParameter().getTaskNames() == ['eclipseClosedDependencies_']
+    }
+
+
+    private static def createBuilder() {
+        new RunBuildDependenciesTaskBuilder()
+    }
+
+    EclipseRuntime eclipseRuntime(List<EclipseWorkspaceProject> projects) {
+        new DefaultEclipseRuntime(new DefaultEclipseWorkspace(new File("workspace"), projects))
+    }
+
+    EclipseWorkspaceProject gradleProject(Project project, boolean isOpen = true) {
+        new DefaultEclipseWorkspaceProject(project.name, project.projectDir, isOpen)
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ClosedProjectSubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ClosedProjectSubstitutionCrossVersionSpec.groovy
@@ -19,7 +19,6 @@ package org.gradle.integtests.tooling.r56
 import org.gradle.integtests.tooling.fixture.TargetGradleVersion
 import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
 import org.gradle.integtests.tooling.fixture.ToolingApiVersion
-import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants
 import org.gradle.tooling.model.eclipse.EclipseProject
 import org.gradle.tooling.model.eclipse.EclipseWorkspace
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
@@ -30,7 +29,7 @@ import java.util.regex.Pattern
 
 @TargetGradleVersion(">=5.6")
 @ToolingApiVersion(">=5.6")
-class RunEclipseClosedProjectTasksCrossVersionSpec extends ToolingApiSpecification {
+class ClosedProjectSubstitutionCrossVersionSpec extends ToolingApiSpecification {
 
     @Rule
     TemporaryFolder externalProjectFolder = new TemporaryFolder()
@@ -80,8 +79,9 @@ class RunEclipseClosedProjectTasksCrossVersionSpec extends ToolingApiSpecificati
         def child2 = buildFinishedHandler.result.children.find { it.name == "child2" }
         child2.projectDependencies.isEmpty()
         child2.classpath.collect { it.file.name }.sort() == ['child1-1.0-tests.jar', 'child1-1.0.jar']
-        child2.classpath.find { it.file.name == 'child1-1.0.jar' }.classpathAttributes.find { it.name == EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME }.value == "main,test"
-        child2.classpath.find { it.file.name == 'child1-1.0-tests.jar' }.classpathAttributes.find { it.name == EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME }.value == "test"
+        // TODO: verify test-source usage after https://github.com/gradle/gradle/pull/9484 is merged
+        //child2.classpath.find { it.file.name == 'child1-1.0.jar' }.classpathAttributes.find { it.name == EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME }.value == "main,test"
+        //child2.classpath.find { it.file.name == 'child1-1.0-tests.jar' }.classpathAttributes.find { it.name == EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME }.value == "test"
         taskExecuted(out, ":eclipseClosedDependencies")
         taskExecuted(out, ":child1:testJar")
         taskExecuted(out, ":child1:jar")
@@ -222,6 +222,69 @@ class RunEclipseClosedProjectTasksCrossVersionSpec extends ToolingApiSpecificati
         then:
         !taskExecuted(out, ":eclipseClosedDependencies")
     }
+
+    def "javadoc and sources can be specified"() {
+        setup:
+        multiProjectBuildInRootFolder("root", ["child1", "child2"]) {
+            buildFile << """
+            subprojects {
+                apply plugin: 'java-library'
+                apply plugin: 'eclipse'
+            }
+            project(":child1") {
+                task sourceJar(type: Jar) {
+                    archiveClassifier = "sources"
+                    from sourceSets.main.allJava
+                }
+                task javadocJar(type: Jar) {
+                    from tasks.javadoc
+                    archiveClassifier = "javadoc"
+                }
+            }            
+            project(":child2") {
+                dependencies {
+                    implementation project(":child1");
+                }
+                eclipse {
+                    classpath.file.whenMerged { cp ->
+                        def dep = entries.find { it.path.endsWith('child1') }
+                        def sourceJar = this.project(":child1").tasks.getByName("sourceJar")
+                        def javadocJar = this.project(":child1").tasks.getByName("javadocJar")
+                        dep.buildDependencies(sourceJar, javadocJar)
+                        dep.publicationSourcePath = cp.fileReference(sourceJar.archiveFile.get().asFile)
+                        dep.publicationJavadocPath = cp.fileReference(javadocJar.archiveFile.get().asFile)
+                    }
+                }
+            }
+        """
+        }
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseProject>()
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("child1", false), gradleProject("child2")])
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunBuildDependencyTask(workspace), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(workspace), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        def child2 = buildFinishedHandler.result.children.find { it.name == "child2" }
+        child2.projectDependencies.isEmpty()
+        child2.classpath.collect { it.file.name }.sort() == ['child1-1.0.jar']
+        child2.classpath[0].source.name == 'child1-1.0-sources.jar'
+        child2.classpath[0].javadoc.name == 'child1-1.0-javadoc.jar'
+        taskExecuted(out, ":eclipseClosedDependencies")
+        taskExecuted(out, ":child1:javadocJar")
+        taskExecuted(out, ":child1:sourceJar")
+
+    }
+
 
     private static def taskExecuted(ByteArrayOutputStream out, String taskPath) {
         out.toString().find("(?m)> Task ${Pattern.quote(taskPath)}\$") != null

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/CompositeProjectSubstitutionCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/CompositeProjectSubstitutionCrossVersionSpec.groovy
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r56
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.test.fixtures.file.TestFile
+import org.gradle.tooling.model.eclipse.EclipseProject
+import org.gradle.tooling.model.eclipse.EclipseWorkspace
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
+import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies
+
+@TargetGradleVersion('>=5.6')
+@ToolingApiVersion(">=5.6")
+class CompositeProjectSubstitutionCrossVersionSpec extends ToolingApiSpecification {
+
+    TestFile buildA
+    TestFile buildB
+    TestFile buildC
+
+    def setup() {
+
+        buildA = singleProjectBuildInRootFolder("buildA") {
+            buildFile << """
+                apply plugin: 'java-library'
+                dependencies {
+                    testImplementation "org.test:b1:1.0"
+                }
+            """
+            settingsFile << """
+                includeBuild 'buildB'
+                includeBuild 'buildC'
+            """
+        }
+
+        buildB = multiProjectBuildInSubFolder("buildB", ['b1', 'b2']) {
+            buildFile << """
+                allprojects {
+                    apply plugin: 'java-library'
+                }
+                project(':b1') {
+                    dependencies {
+                        testImplementation "org.test:buildC:1.0"
+                    }
+                }
+            """
+        }
+
+        buildC = singleProjectBuildInSubfolder("buildC") {
+            buildFile << """
+                apply plugin: 'java-library'
+            """
+        }
+    }
+
+    def "EclipseProject model has closed project dependencies substituted in composite"() {
+        setup:
+        def workspace = eclipseWorkspace([project("buildA", buildA),
+                                          project("buildB", buildB),
+                                          project("buildC", buildC, false),
+                                          project("b1", buildB.file("b1")),
+                                          project("b2", buildB.file("b2"))])
+
+        when:
+        def eclipseProjects = withConnection { connection ->
+            connection.action(new ParameterizedLoadCompositeEclipseModels(workspace, EclipseProject)).run()
+        }
+
+        then:
+        def b1Model = eclipseProjects.collectMany { collectProjects(it) }.find { it.name == "b1" }
+        b1Model.projectDependencies.isEmpty()
+        b1Model.classpath.collect { it.file.name }.sort() == ['buildC-1.0.jar']
+    }
+
+    def "Closed project tasks are run in composite with substitution"() {
+        setup:
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<List<EclipseProject>>()
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([project("buildA", buildA),
+                                          project("buildB", buildB),
+                                          project("buildC", buildC, false),
+                                          project("b1", buildB.file("b1")),
+                                          project("b2", buildB.file("b2"))])
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new ParameterizedLoadCompositeEclipseModels(workspace, RunClosedProjectBuildDependencies), projectsLoadedHandler)
+                .buildFinished(new ParameterizedLoadCompositeEclipseModels(workspace, EclipseProject), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        def eclipseProjects = buildFinishedHandler.result
+
+        then:
+        def b1Model = eclipseProjects.collectMany { collectProjects(it) }.find { it.name == "b1" }
+        b1Model.projectDependencies.isEmpty()
+        b1Model.classpath.collect { it.file.name } == ['buildC-1.0.jar']
+        taskExecuted(out, ":eclipseClosedDependencies")
+        taskExecuted(out, ":buildC:jar")
+    }
+
+    private static def taskExecuted(ByteArrayOutputStream out, String taskPath) {
+        out.toString().contains("> Task $taskPath")
+    }
+
+    Collection<EclipseProject> collectProjects(EclipseProject parent) {
+        return parent.children.collect { collectProjects(it) }.flatten() + [parent]
+    }
+
+    EclipseWorkspace eclipseWorkspace(List<EclipseWorkspaceProject> projects) {
+        new DefaultEclipseWorkspace(temporaryFolder.file("workspace"), projects)
+    }
+
+
+    EclipseWorkspaceProject project(String name, File location, boolean isOpen = true) {
+        new DefaultEclipseWorkspaceProject(name, location, isOpen)
+    }
+
+    EclipseWorkspaceProject externalProject(String name) {
+        new DefaultEclipseWorkspaceProject(name, temporaryFolder.file("external/$name"))
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/DefaultEclipseWorkspace.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/DefaultEclipseWorkspace.java
@@ -13,32 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests.tooling.r55;
+package org.gradle.integtests.tooling.r56;
 
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
 
 import java.io.File;
 import java.io.Serializable;
+import java.util.List;
 
-public class DefaultEclipseWorkspaceProject implements EclipseWorkspaceProject, Serializable {
+public class DefaultEclipseWorkspace implements EclipseWorkspace, Serializable {
 
-    private final String name;
     private final File location;
-    private final boolean isOpen;
+    private final List<EclipseWorkspaceProject> workspaceProjects;
 
-    public DefaultEclipseWorkspaceProject(String name, File location, boolean isOpen) {
-        this.name = name;
+    public DefaultEclipseWorkspace(File location, List<EclipseWorkspaceProject> workspaceProjects) {
         this.location = location;
-        this.isOpen = isOpen;
-    }
-
-    public DefaultEclipseWorkspaceProject(String name, File location) {
-        this(name, location, true);
-    }
-
-    @Override
-    public String getName() {
-        return name;
+        this.workspaceProjects = workspaceProjects;
     }
 
     @Override
@@ -47,7 +38,7 @@ public class DefaultEclipseWorkspaceProject implements EclipseWorkspaceProject, 
     }
 
     @Override
-    public boolean isOpen() {
-        return isOpen;
+    public List<EclipseWorkspaceProject> getProjects() {
+        return workspaceProjects;
     }
 }

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/DefaultEclipseWorkspaceProject.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/DefaultEclipseWorkspaceProject.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.gradle.integtests.tooling.r55;
+package org.gradle.integtests.tooling.r56;
 
 import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject;
 

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/IntermediateResultHandlerCollector.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/IntermediateResultHandlerCollector.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r56;
+
+import org.gradle.tooling.IntermediateResultHandler;
+
+public class IntermediateResultHandlerCollector<T> implements IntermediateResultHandler<T> {
+    private T result = null;
+
+    @Override
+    public void onComplete(T result) {
+        this.result = result;
+    }
+
+    public T getResult() {
+        return result;
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/LoadEclipseModel.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/LoadEclipseModel.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r56;
+
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+
+import java.io.Serializable;
+
+public class LoadEclipseModel implements BuildAction<EclipseProject>, Serializable {
+
+    private final EclipseWorkspace workspace;
+
+    public LoadEclipseModel(EclipseWorkspace workspace) {
+
+        this.workspace = workspace;
+    }
+
+    @Override
+    public EclipseProject execute(BuildController controller) {
+        if (workspace != null) {
+            return controller.getModel(EclipseProject.class, EclipseRuntime.class, new EclipseRuntimeAction(workspace));
+        }
+        return controller.getModel(EclipseProject.class);
+    }
+
+    private static class EclipseRuntimeAction implements Action<EclipseRuntime>, Serializable {
+        private final EclipseWorkspace workspace;
+
+        public EclipseRuntimeAction(EclipseWorkspace workspace) {
+
+            this.workspace = workspace;
+        }
+
+        @Override
+        public void execute(EclipseRuntime eclipseRuntime) {
+            eclipseRuntime.setWorkspace(workspace);
+        }
+    }
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
@@ -18,8 +18,6 @@ package org.gradle.integtests.tooling.r56;
 import org.gradle.api.Action;
 import org.gradle.tooling.BuildAction;
 import org.gradle.tooling.BuildController;
-import org.gradle.tooling.model.Model;
-import org.gradle.tooling.model.eclipse.EclipseProject;
 import org.gradle.tooling.model.eclipse.EclipseRuntime;
 import org.gradle.tooling.model.eclipse.EclipseWorkspace;
 import org.gradle.tooling.model.gradle.GradleBuild;

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/ParameterizedLoadCompositeEclipseModels.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r56;
+
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.Model;
+import org.gradle.tooling.model.eclipse.EclipseProject;
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class ParameterizedLoadCompositeEclipseModels<T> implements BuildAction<Collection<T>>, Serializable {
+
+    private final EclipseWorkspace workspace;
+    private final Class<T> modelClass;
+
+    ParameterizedLoadCompositeEclipseModels(EclipseWorkspace workspace, Class<T> modelClass) {
+        this.workspace = workspace;
+        this.modelClass = modelClass;
+    }
+
+    @Override
+    public Collection<T> execute(BuildController controller) {
+        Collection<T> models = new ArrayList<>();
+        collectRootModels(controller, controller.getBuildModel(), models);
+        return models;
+    }
+
+    private void collectRootModels(BuildController controller, GradleBuild build, Collection<T> models) {
+        if (workspace != null) {
+            models.add(controller.getModel(build.getRootProject(), modelClass, EclipseRuntime.class, new EclipseRuntimeAction(workspace)));
+        } else {
+            models.add(controller.getModel(build.getRootProject(), modelClass));
+        }
+        for (GradleBuild includedBuild : build.getIncludedBuilds()) {
+            collectRootModels(controller, includedBuild, models);
+        }
+    }
+
+    private static class EclipseRuntimeAction implements Action<EclipseRuntime>, Serializable {
+        private final EclipseWorkspace workspace;
+
+        public EclipseRuntimeAction(EclipseWorkspace workspace) {
+
+            this.workspace = workspace;
+        }
+
+        @Override
+        public void execute(EclipseRuntime eclipseRuntime) {
+            eclipseRuntime.setWorkspace(workspace);
+        }
+    }
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/RunEclipseClosedProjectTasksCrossVersionSpec.groovy
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/RunEclipseClosedProjectTasksCrossVersionSpec.groovy
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.integtests.tooling.r56
+
+import org.gradle.integtests.tooling.fixture.TargetGradleVersion
+import org.gradle.integtests.tooling.fixture.ToolingApiSpecification
+import org.gradle.integtests.tooling.fixture.ToolingApiVersion
+import org.gradle.plugins.ide.eclipse.internal.EclipsePluginConstants
+import org.gradle.tooling.model.eclipse.EclipseProject
+import org.gradle.tooling.model.eclipse.EclipseWorkspace
+import org.gradle.tooling.model.eclipse.EclipseWorkspaceProject
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+import java.util.regex.Pattern
+
+@TargetGradleVersion(">=5.6")
+@ToolingApiVersion(">=5.6")
+class RunEclipseClosedProjectTasksCrossVersionSpec extends ToolingApiSpecification {
+
+    @Rule
+    TemporaryFolder externalProjectFolder = new TemporaryFolder()
+
+    def "will substitute and run build dependencies for closed projects on startup"() {
+        setup:
+        multiProjectBuildInRootFolder("parent", ["child1", "child2"]) {
+            buildFile << """
+            subprojects {
+                apply plugin: 'java-library'
+            }
+            project(":child1") {
+                configurations {
+                    testArtifacts
+                }
+                task testJar(type: Jar) {
+                    classifier = "tests"
+                }
+                artifacts {
+                    testArtifacts testJar
+                }
+            }
+            project(":child2") {
+                dependencies {
+                    implementation project(":child1");
+                    testImplementation project(path: ":child1", configuration: "testArtifacts")
+                }
+            }
+        """
+        }
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseProject>()
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("child1", false), gradleProject("child2")])
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunBuildDependencyTask(workspace), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(workspace), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        def child2 = buildFinishedHandler.result.children.find { it.name == "child2" }
+        child2.projectDependencies.isEmpty()
+        child2.classpath.collect { it.file.name }.sort() == ['child1-1.0-tests.jar', 'child1-1.0.jar']
+        child2.classpath.find { it.file.name == 'child1-1.0.jar' }.classpathAttributes.find { it.name == EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME }.value == "main,test"
+        child2.classpath.find { it.file.name == 'child1-1.0-tests.jar' }.classpathAttributes.find { it.name == EclipsePluginConstants.GRADLE_USED_BY_SCOPE_ATTRIBUTE_NAME }.value == "test"
+        taskExecuted(out, ":eclipseClosedDependencies")
+        taskExecuted(out, ":child1:testJar")
+        taskExecuted(out, ":child1:jar")
+    }
+
+    def "build task is not added if no projects are closed"() {
+        setup:
+        singleProjectBuildInRootFolder("root")
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseProject>()
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("project")])
+
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunBuildDependencyTask(workspace), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(workspace), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        !taskExecuted(out, ":eclipseClosedDependencies")
+
+
+    }
+
+    def "task name is deduplicated"() {
+        setup:
+        multiProjectBuildInRootFolder("root", ["child1", "child2"]) {
+            buildFile << """
+            subprojects {
+                apply plugin: 'java-library'
+            }
+            task eclipseClosedDependencies (){}
+            project(":child2") {
+                dependencies {
+                    implementation project(":child1");
+                }
+            }
+        """
+        }
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseProject>()
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("child1", false), gradleProject("child2")])
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunBuildDependencyTask(workspace), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(workspace), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        !taskExecuted(out, ":eclipseClosedDependencies")
+        taskExecuted(out, ":eclipseClosedDependencies_")
+
+    }
+
+    def "dependencies in minusConfigurations are removed"() {
+        setup:
+        multiProjectBuildInRootFolder("root", ["child1", "child2"]) {
+            buildFile << """
+            subprojects {
+                apply plugin: 'java-library'
+            }
+            project(":child2") {
+                apply plugin: 'eclipse'
+                configurations {
+                    toRemove
+                }
+                eclipse {
+                    classpath {
+                        minusConfigurations += [ configurations.toRemove ]
+                    }
+                }
+                dependencies {
+                    implementation project(":child1");
+                    toRemove project(":child1");
+                }
+            }
+        """
+        }
+
+        def projectsLoadedHandler = new IntermediateResultHandlerCollector<Void>()
+        def buildFinishedHandler = new IntermediateResultHandlerCollector<EclipseProject>()
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("child1", false), gradleProject("child2")])
+        when:
+        withConnection { connection ->
+            connection.action().projectsLoaded(new TellGradleToRunBuildDependencyTask(workspace), projectsLoadedHandler)
+                .buildFinished(new LoadEclipseModel(workspace), buildFinishedHandler)
+                .build()
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        def child2 = buildFinishedHandler.result.children.find { it.name == "child2" }
+        child2.projectDependencies.isEmpty()
+        child2.classpath.isEmpty()
+        !taskExecuted(out, ":eclipseClosedDependencies")
+    }
+
+    @TargetGradleVersion("=5.5")
+    def "will not fail against older gradle versions"() {
+        setup:
+        multiProjectBuildInRootFolder("root", ["child1", "child2"]) {
+            buildFile << """
+            subprojects {
+                apply plugin: 'java-library'
+            }
+            project(":child2") {
+                dependencies {
+                    implementation project(":child1");
+                }
+            }
+        """
+        }
+
+        def out = new ByteArrayOutputStream()
+        def workspace = eclipseWorkspace([gradleProject("child1", false), gradleProject("child2")])
+        when:
+        withConnection { connection ->
+            connection.action(new LoadEclipseModel(workspace))
+                .setStandardOutput(out)
+                .forTasks()
+                .run()
+        }
+
+        then:
+        !taskExecuted(out, ":eclipseClosedDependencies")
+    }
+
+    private static def taskExecuted(ByteArrayOutputStream out, String taskPath) {
+        out.toString().find("(?m)> Task ${Pattern.quote(taskPath)}\$") != null
+    }
+
+    EclipseWorkspace eclipseWorkspace(List<EclipseWorkspaceProject> projects) {
+        new DefaultEclipseWorkspace(temporaryFolder.file("workspace"), projects)
+    }
+
+    EclipseWorkspaceProject gradleProject(String name, boolean isOpen = true) {
+        project(name, file(name), isOpen)
+    }
+
+    EclipseWorkspaceProject project(String name, File location, boolean isOpen = true) {
+        new DefaultEclipseWorkspaceProject(name, location, isOpen)
+    }
+
+    EclipseWorkspaceProject externalProject(String name) {
+        new DefaultEclipseWorkspaceProject(name, temporaryFolder.file("external/$name"))
+    }
+
+
+}

--- a/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TellGradleToRunBuildDependencyTask.java
+++ b/subprojects/tooling-api/src/crossVersionTest/groovy/org/gradle/integtests/tooling/r56/TellGradleToRunBuildDependencyTask.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.gradle.integtests.tooling.r56;
+
+import org.gradle.api.Action;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.model.eclipse.EclipseRuntime;
+import org.gradle.tooling.model.eclipse.EclipseWorkspace;
+import org.gradle.tooling.model.eclipse.RunClosedProjectBuildDependencies;
+
+import java.io.Serializable;
+
+public class TellGradleToRunBuildDependencyTask implements BuildAction<Void>, Serializable {
+
+    private final EclipseWorkspace workspace;
+
+    public TellGradleToRunBuildDependencyTask(EclipseWorkspace workspace) {
+
+        this.workspace = workspace;
+    }
+
+    @Override
+    public Void execute(BuildController controller) {
+        if (workspace != null) {
+            controller.getModel(RunClosedProjectBuildDependencies.class, EclipseRuntime.class, new EclipseRuntimeAction(workspace));
+        } else {
+            controller.getModel(RunClosedProjectBuildDependencies.class);
+        }
+        return null;
+    }
+
+    private static class EclipseRuntimeAction implements Action<EclipseRuntime>, Serializable {
+        private final EclipseWorkspace workspace;
+
+        public EclipseRuntimeAction(EclipseWorkspace workspace) {
+
+            this.workspace = workspace;
+        }
+
+        @Override
+        public void execute(EclipseRuntime eclipseRuntime) {
+            eclipseRuntime.setWorkspace(workspace);
+        }
+    }
+
+}

--- a/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/RunClosedProjectBuildDependencies.java
+++ b/subprojects/tooling-api/src/main/java/org/gradle/tooling/model/eclipse/RunClosedProjectBuildDependencies.java
@@ -18,36 +18,18 @@ package org.gradle.tooling.model.eclipse;
 
 import org.gradle.api.Incubating;
 
-import java.io.File;
-
 /**
- * Information about a project in the eclipse workspace.
+ * A tooling model that instructs Gradle to run tasks to build artifacts for closed projects.
  *
- * @since 5.5
+ * Similarly to {@link RunEclipseSynchronizationTasks}, this is a special tooling model as it does
+ * not provide any information. However, when requested, Gradle will build the artifacts required
+ * to substitute the closed gradle projects in the eclipse workspace.
+ *
+ * This is a parameterized model and requires an {@link EclipseRuntime} parameter to calculate the
+ * closed projects.
+ *
+ * @since 5.6
  */
 @Incubating
-public interface EclipseWorkspaceProject {
-    /**
-     * The name of the eclipse project
-     *
-     * @return the name of the project, never null
-     */
-    @Incubating
-    String getName();
-
-    /**
-     * The filesystem location of the eclipse project
-     *
-     * @return the location of the eclipse project, may be null in case of remote projects
-     */
-    @Incubating
-    File getLocation();
-
-    /**
-     * The status of the eclipse project.
-     *
-     * @since 5.6
-     */
-    @Incubating
-    boolean isOpen();
+public interface RunClosedProjectBuildDependencies {
 }


### PR DESCRIPTION
### Context
<!--- Why do you believe many users will benefit from this change? -->
Closed Gradle projects in buildships currently result in missing build dependencies. This change
adds detection for closed projects in Gradle and logic for substituting those with references to the  corresponding jars. The jars in turn are built during synchronization using a special tooling model.

<!--- Link to relevant issues or forum discussions here -->
This is the gradle side of https://github.com/eclipse/buildship/issues/881

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [x] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [x] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [x] Verify design and implementation 
- [x] Verify test coverage and CI build status
- [x] Verify documentation
- [ ] Recognize contributor in release notes
