### PR TITLE
Recognize AdoptOpenJDK vendor

### DIFF
--- a/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
+++ b/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/internal/JavaInstallationProbe.java
@@ -199,6 +199,8 @@ public class JavaInstallationProbe {
         }
         if (vendor.contains("apple")) {
             return "Apple " + basename;
+        } else if (vendor.contains("adoptopenjdk")) {
+            return result == InstallType.IS_JDK ? "AdoptOpenJDK" : "AdoptOpenJDK JRE";
         } else if (vendor.contains("oracle") || vendor.contains("sun")) {
             String vm = metadata.get(JavaInstallationProbe.SysProp.VM);
             if (vm != null && vm.contains("OpenJDK")) {

--- a/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
+++ b/subprojects/platform-jvm/src/test/groovy/org/gradle/jvm/toolchain/internal/JavaInstallationProbeTest.groovy
@@ -78,38 +78,40 @@ class JavaInstallationProbeTest extends Specification {
         }
 
         where:
-        jdk                                   | systemProperties | javaVersion             | displayName     | exists | jre   | expectedResult
-        'localGradle'                         | currentGradle()  | JavaVersion.current()   | null            | true   | false | IS_JDK
-        'localGradle'                         | currentGradle()  | JavaVersion.current()   | null            | true   | true  | IS_JRE
-        'localGradle'                         | currentGradle()  | null                    | null            | false  | false | NO_SUCH_DIRECTORY
-        'openJdk4'                            | openJdkJvm('4')  | JavaVersion.VERSION_1_4 | 'OpenJDK 4'     | true   | false | IS_JDK
-        'openJdk5'                            | openJdkJvm('5')  | JavaVersion.VERSION_1_5 | 'OpenJDK 5'     | true   | false | IS_JDK
-        'openJdk6'                            | openJdkJvm('6')  | JavaVersion.VERSION_1_6 | 'OpenJDK 6'     | true   | false | IS_JDK
-        'openJdk7'                            | openJdkJvm('7')  | JavaVersion.VERSION_1_7 | 'OpenJDK 7'     | true   | false | IS_JDK
-        'openJdk8'                            | openJdkJvm('8')  | JavaVersion.VERSION_1_8 | 'OpenJDK 8'     | true   | false | IS_JDK
-        'openJdk9'                            | openJdkJvm('9')  | JavaVersion.VERSION_1_9 | 'OpenJDK 9'     | true   | false | IS_JDK
-        'openJdk9'                            | openJdkJvm('9')  | JavaVersion.VERSION_1_9 | 'OpenJDK JRE 9' | true   | true  | IS_JRE
-        'oracleJdk4'                          | oracleJvm('4')   | JavaVersion.VERSION_1_4 | 'Oracle JDK 4'  | true   | false | IS_JDK
-        'oracleJre4'                          | oracleJvm('4')   | JavaVersion.VERSION_1_4 | 'Oracle JRE 4'  | true   | true  | IS_JRE
-        'oracleJdk5'                          | oracleJvm('5')   | JavaVersion.VERSION_1_5 | 'Oracle JDK 5'  | true   | false | IS_JDK
-        'oracleJdk6'                          | oracleJvm('6')   | JavaVersion.VERSION_1_6 | 'Oracle JDK 6'  | true   | false | IS_JDK
-        'oracleJdk7'                          | oracleJvm('7')   | JavaVersion.VERSION_1_7 | 'Oracle JDK 7'  | true   | false | IS_JDK
-        'oracleJdk8'                          | oracleJvm('8')   | JavaVersion.VERSION_1_8 | 'Oracle JDK 8'  | true   | false | IS_JDK
-        'oracleJdk9'                          | oracleJvm('9')   | JavaVersion.VERSION_1_9 | 'Oracle JDK 9'  | true   | false | IS_JDK
-        'oracleJre9'                          | oracleJvm('9')   | JavaVersion.VERSION_1_9 | 'Oracle JRE 9'  | true   | true  | IS_JRE
-        'ibmJdk4'                             | ibmJvm('4')      | JavaVersion.VERSION_1_4 | 'IBM JDK 4'     | true   | false | IS_JDK
-        'ibmJre4'                             | ibmJvm('4')      | JavaVersion.VERSION_1_4 | 'IBM JRE 4'     | true   | true  | IS_JRE
-        'ibmJdk5'                             | ibmJvm('5')      | JavaVersion.VERSION_1_5 | 'IBM JDK 5'     | true   | false | IS_JDK
-        'ibmJdk6'                             | ibmJvm('6')      | JavaVersion.VERSION_1_6 | 'IBM JDK 6'     | true   | false | IS_JDK
-        'ibmJdk7'                             | ibmJvm('7')      | JavaVersion.VERSION_1_7 | 'IBM JDK 7'     | true   | false | IS_JDK
-        'ibmJdk8'                             | ibmJvm('8')      | JavaVersion.VERSION_1_8 | 'IBM JDK 8'     | true   | false | IS_JDK
-        'ibmJdk9'                             | ibmJvm('9')      | JavaVersion.VERSION_1_9 | 'IBM JDK 9'     | true   | false | IS_JDK
-        'zuluJre6'                            | zuluJvm('6')     | JavaVersion.VERSION_1_6 | 'Zulu JRE 6'    | true   | true  | IS_JRE
-        'zuluJdk8'                            | zuluJvm('8')     | JavaVersion.VERSION_1_8 | 'Zulu JDK 8'    | true   | false | IS_JDK
-        'hpuxJre6'                            | hpuxJvm('6')     | JavaVersion.VERSION_1_6 | 'HP-UX JRE 6'   | true   | true  | IS_JRE
-        'hpuxJdk7'                            | hpuxJvm('7')     | JavaVersion.VERSION_1_7 | 'HP-UX JDK 7'   | true   | false | IS_JDK
-        'binary that has invalid output'      | invalidOutput()  | null                    | null            | true   | false | INVALID_JDK
-        'binary that returns unknown version' | invalidVersion() | null                    | null            | true   | false | INVALID_JDK
+        jdk                                   | systemProperties       | javaVersion             | displayName           | exists | jre   | expectedResult
+        'localGradle'                         | currentGradle()        | JavaVersion.current()   | null                  | true   | false | IS_JDK
+        'localGradle'                         | currentGradle()        | JavaVersion.current()   | null                  | true   | true  | IS_JRE
+        'localGradle'                         | currentGradle()        | null                    | null                  | false  | false | NO_SUCH_DIRECTORY
+        'openJdk4'                            | openJdkJvm('4')        | JavaVersion.VERSION_1_4 | 'OpenJDK 4'           | true   | false | IS_JDK
+        'openJdk5'                            | openJdkJvm('5')        | JavaVersion.VERSION_1_5 | 'OpenJDK 5'           | true   | false | IS_JDK
+        'openJdk6'                            | openJdkJvm('6')        | JavaVersion.VERSION_1_6 | 'OpenJDK 6'           | true   | false | IS_JDK
+        'openJdk7'                            | openJdkJvm('7')        | JavaVersion.VERSION_1_7 | 'OpenJDK 7'           | true   | false | IS_JDK
+        'openJdk8'                            | openJdkJvm('8')        | JavaVersion.VERSION_1_8 | 'OpenJDK 8'           | true   | false | IS_JDK
+        'openJdk9'                            | openJdkJvm('9')        | JavaVersion.VERSION_1_9 | 'OpenJDK 9'           | true   | false | IS_JDK
+        'openJdk9'                            | openJdkJvm('9')        | JavaVersion.VERSION_1_9 | 'OpenJDK JRE 9'       | true   | true  | IS_JRE
+        'AdoptOpenJDK11'                      | adoptOpenJDK('11.0.3') | JavaVersion.VERSION_11  | 'AdoptOpenJDK 11'     | true   | false | IS_JDK
+        'AdoptOpenJDK11'                      | adoptOpenJDK('11.0.3') | JavaVersion.VERSION_11  | 'AdoptOpenJDK JRE 11' | true   | true  | IS_JRE
+        'oracleJdk4'                          | oracleJvm('4')         | JavaVersion.VERSION_1_4 | 'Oracle JDK 4'        | true   | false | IS_JDK
+        'oracleJre4'                          | oracleJvm('4')         | JavaVersion.VERSION_1_4 | 'Oracle JRE 4'        | true   | true  | IS_JRE
+        'oracleJdk5'                          | oracleJvm('5')         | JavaVersion.VERSION_1_5 | 'Oracle JDK 5'        | true   | false | IS_JDK
+        'oracleJdk6'                          | oracleJvm('6')         | JavaVersion.VERSION_1_6 | 'Oracle JDK 6'        | true   | false | IS_JDK
+        'oracleJdk7'                          | oracleJvm('7')         | JavaVersion.VERSION_1_7 | 'Oracle JDK 7'        | true   | false | IS_JDK
+        'oracleJdk8'                          | oracleJvm('8')         | JavaVersion.VERSION_1_8 | 'Oracle JDK 8'        | true   | false | IS_JDK
+        'oracleJdk9'                          | oracleJvm('9')         | JavaVersion.VERSION_1_9 | 'Oracle JDK 9'        | true   | false | IS_JDK
+        'oracleJre9'                          | oracleJvm('9')         | JavaVersion.VERSION_1_9 | 'Oracle JRE 9'        | true   | true  | IS_JRE
+        'ibmJdk4'                             | ibmJvm('4')            | JavaVersion.VERSION_1_4 | 'IBM JDK 4'           | true   | false | IS_JDK
+        'ibmJre4'                             | ibmJvm('4')            | JavaVersion.VERSION_1_4 | 'IBM JRE 4'           | true   | true  | IS_JRE
+        'ibmJdk5'                             | ibmJvm('5')            | JavaVersion.VERSION_1_5 | 'IBM JDK 5'           | true   | false | IS_JDK
+        'ibmJdk6'                             | ibmJvm('6')            | JavaVersion.VERSION_1_6 | 'IBM JDK 6'           | true   | false | IS_JDK
+        'ibmJdk7'                             | ibmJvm('7')            | JavaVersion.VERSION_1_7 | 'IBM JDK 7'           | true   | false | IS_JDK
+        'ibmJdk8'                             | ibmJvm('8')            | JavaVersion.VERSION_1_8 | 'IBM JDK 8'           | true   | false | IS_JDK
+        'ibmJdk9'                             | ibmJvm('9')            | JavaVersion.VERSION_1_9 | 'IBM JDK 9'           | true   | false | IS_JDK
+        'zuluJre6'                            | zuluJvm('6')           | JavaVersion.VERSION_1_6 | 'Zulu JRE 6'          | true   | true  | IS_JRE
+        'zuluJdk8'                            | zuluJvm('8')           | JavaVersion.VERSION_1_8 | 'Zulu JDK 8'          | true   | false | IS_JDK
+        'hpuxJre6'                            | hpuxJvm('6')           | JavaVersion.VERSION_1_6 | 'HP-UX JRE 6'         | true   | true  | IS_JRE
+        'hpuxJdk7'                            | hpuxJvm('7')           | JavaVersion.VERSION_1_7 | 'HP-UX JDK 7'         | true   | false | IS_JDK
+        'binary that has invalid output'      | invalidOutput()        | null                    | null                  | true   | false | INVALID_JDK
+        'binary that returns unknown version' | invalidVersion()       | null                    | null                  | true   | false | INVALID_JDK
     }
 
     private static Map<String, String> invalidOutput() {
@@ -140,6 +142,16 @@ class JavaInstallationProbeTest extends Specification {
          'java.vm.name': "OpenJDK 64-Bit Server VM",
          'java.vm.version': "25.40-b25",
          'java.runtime.name': "Java(TM) SE Runtime Environment"
+        ]
+    }
+
+    private static Map<String, String> adoptOpenJDK(String version) {
+        ['java.version': version,
+         'java.vendor': "AdoptOpenJDK",
+         'os.arch': "x86_64",
+         'java.vm.name': "OpenJDK 64-Bit Server VM",
+         'java.vm.version': "${version}+7",
+         'java.runtime.name': "OpenJDK Runtime Environment"
         ]
     }
 


### PR DESCRIPTION
### Context

Currently our internal JDK probe can't recognize AdoptOpenJDK. Oracle OpenJDK's `java.vendor` is `Oracle Coorpration` but AdoptOpenJDK's vendor is `AdoptOpenJDK`. This PR adds support for `AdoptOpenJDK` so we can recognize it in the future builds.