### PR TITLE
Do not cache type annotation metadata across builds

### DIFF
--- a/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
+++ b/subprojects/core/src/main/java/org/gradle/internal/service/scopes/ExecutionGlobalServices.java
@@ -139,8 +139,7 @@ public class ExecutionGlobalServices {
                 public boolean test(Method method) {
                     return method.isAnnotationPresent(Generated.class);
                 }
-            },
-            cacheFactory);
+            });
     }
 
     InspectionSchemeFactory createInspectionSchemeFactory(

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/project/taskfactory/AnnotationProcessingTaskFactoryTest.groovy
@@ -113,8 +113,7 @@ class AnnotationProcessingTaskFactoryTest extends AbstractProjectBuilderSpec {
         [Object, GroovyObject],
         [ConfigurableFileCollection, Property],
         Internal,
-        { false },
-        cacheFactory
+        { false }
     )
     def propertyWalker = new DefaultPropertyWalker(new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [], typeAnnotationMetadataStore, cacheFactory))
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskInputsTest.groovy
@@ -66,7 +66,7 @@ class DefaultTaskInputsTest extends Specification {
         getLocalState() >> Stub(TaskLocalStateInternal)
     }
     def cacheFactory = new TestCrossBuildInMemoryCacheFactory()
-    def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore([], [:], [Object, GroovyObject], [Object, GroovyObject], [ConfigurableFileCollection, Property], Internal, { false }, cacheFactory)
+    def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore([], [:], [Object, GroovyObject], [Object, GroovyObject], [ConfigurableFileCollection, Property], Internal, { false })
     def walker = new DefaultPropertyWalker(new DefaultTypeMetadataStore([], [], [], typeAnnotationMetadataStore, cacheFactory))
     private final DefaultTaskInputs inputs = new DefaultTaskInputs(task, taskStatusNagger, walker, fileCollectionFactory)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/DefaultTaskOutputsTest.groovy
@@ -68,7 +68,7 @@ class DefaultTaskOutputsTest extends Specification {
     }
 
     def cacheFactory = new TestCrossBuildInMemoryCacheFactory()
-    def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore([], [:], [Object, GroovyObject], [Object, GroovyObject], [ConfigurableFileCollection, Property], Internal, { false }, cacheFactory)
+    def typeAnnotationMetadataStore = new DefaultTypeAnnotationMetadataStore([], [:], [Object, GroovyObject], [Object, GroovyObject], [ConfigurableFileCollection, Property], Internal, { false })
     def walker = new DefaultPropertyWalker(new DefaultTypeMetadataStore([], [], [], typeAnnotationMetadataStore, cacheFactory))
     def outputs = new DefaultTaskOutputs(task, taskStatusNagger, walker, fileCollectionFactory)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultPropertyWalkerTest.groovy
@@ -242,8 +242,7 @@ class DefaultPropertyWalkerTest extends AbstractProjectBuilderSpec {
             [Object, GroovyObject],
             [ConfigurableFileCollection, Property],
             Internal,
-            { false },
-            cacheFactory
+            { false }
         )
         def typeMetadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [], typeAnnotationMetadataStore, cacheFactory)
         new DefaultPropertyWalker(typeMetadataStore).visitProperties(task, validationContext, visitor)

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/DefaultTypeMetadataStoreTest.groovy
@@ -75,8 +75,7 @@ class DefaultTypeMetadataStoreTest extends Specification {
         [Object, GroovyObject],
         [ConfigurableFileCollection, Property],
         Internal,
-        { false },
-        cacheFactory
+        { false }
     )
     def metadataStore = new DefaultTypeMetadataStore([], services.getAll(PropertyAnnotationHandler), [Classpath, CompileClasspath], typeAnnotationMetadataStore, cacheFactory)
 

--- a/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
+++ b/subprojects/core/src/test/groovy/org/gradle/api/internal/tasks/properties/InspectionSchemeFactoryTest.groovy
@@ -41,8 +41,7 @@ class InspectionSchemeFactoryTest extends Specification {
         [Object, GroovyObject],
         [ConfigurableFileCollection, Property],
         IgnoredThing,
-        { false },
-        cacheFactory
+        { false }
     )
     def factory = new InspectionSchemeFactory([], [handler1, handler2], typeAnnotationMetadataStore, cacheFactory)
 

--- a/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
+++ b/subprojects/model-core/src/test/groovy/org/gradle/internal/reflect/annotations/impl/DefaultTypeAnnotationMetadataStoreTest.groovy
@@ -19,7 +19,6 @@ package org.gradle.internal.reflect.annotations.impl
 import groovy.transform.Generated
 import groovy.transform.PackageScope
 import org.gradle.api.file.FileCollection
-import org.gradle.cache.internal.TestCrossBuildInMemoryCacheFactory
 import org.gradle.internal.reflect.AnnotationCategory
 import org.gradle.internal.reflect.ParameterValidationContext
 import spock.lang.Issue
@@ -45,8 +44,8 @@ class DefaultTypeAnnotationMetadataStoreTest extends Specification {
         [Object, GroovyObject],
         [MutableType, MutableSubType],
         Ignored,
-        { Method method -> method.isAnnotationPresent(Generated) },
-        new TestCrossBuildInMemoryCacheFactory())
+        { Method method -> method.isAnnotationPresent(Generated) }
+     )
 
     def "finds not-annotated properties"() {
         expect:


### PR DESCRIPTION
We only use it in DefaultTypeMetadataStore that is already cached across builds (and even that might not be worth it).
