### PR TITLE
Cross-OS reproducible archives

### DIFF
--- a/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
+++ b/subprojects/core/src/integTest/groovy/org/gradle/api/tasks/ReproducibleArchivesIntegrationTest.groovy
@@ -22,11 +22,13 @@ import org.gradle.test.fixtures.archive.ArchiveTestFixture
 import org.gradle.test.fixtures.archive.TarTestFixture
 import org.gradle.test.fixtures.archive.ZipTestFixture
 import org.gradle.test.fixtures.file.TestFile
+import spock.lang.Issue
 import spock.lang.Unroll
 
 @Unroll
 class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
 
+    @Issue("https://github.com/gradle/gradle/issues/8051")
     def "reproducible #taskName for directory - #files"() {
         given:
         files.each {
@@ -52,14 +54,14 @@ class ReproducibleArchivesIntegrationTest extends AbstractIntegrationSpec {
 
         where:
         input << [
-            ['dir1/file11.txt', 'dir2/file22.txt', 'dir3/file33.txt'].permutations(),
+            ['DIR1/FILE11.txt', 'dir2/file22.txt', 'DIR3/file33.txt'].permutations(),
             ['zip', 'tar']
         ].combinations()
         files = input[0]
         taskName = input[1]
         taskType = taskName.capitalize()
         fileExtension = taskName
-        expectedHash = taskName == 'tar' ? '4e9d60004783f52d612200aa73ee58f5' : 'cecc57bfa8747b4f39fa4a5e1c0dbd31'
+        expectedHash = taskName == 'tar' ? 'eff4909fee3367f576fe26537ff6403a' : '62b93684c0b891fcf905b4a6eaf32976'
     }
 
     def "timestamps are ignored in #taskName"() {

--- a/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
+++ b/subprojects/files/src/main/java/org/gradle/api/internal/file/collections/ReproducibleDirectoryWalker.java
@@ -16,6 +16,7 @@
 
 package org.gradle.api.internal.file.collections;
 
+import org.apache.commons.io.comparator.PathFileComparator;
 import org.gradle.internal.nativeintegration.filesystem.FileSystem;
 
 import java.io.File;
@@ -30,7 +31,7 @@ public class ReproducibleDirectoryWalker extends AbstractDirectoryWalker {
     protected File[] getChildren(File file) {
         File[] children = file.listFiles();
         if (children != null) {
-            Arrays.sort(children);
+            Arrays.sort(children, PathFileComparator.PATH_COMPARATOR);
         }
         return children;
     }


### PR DESCRIPTION
Issue: #8051

Create consistent file orders between windows and linux when `reproducibleFileOrder=true` for an archive task.

Signed-off-by: Andrew <akowpak@miovision.com>

### Context
<!--- Why do you believe many users will benefit from this change? -->
The documentation of the `AbstractArchiveTask` states that the `reproducibleFileOrder` property will 

> walk the directories on disk which are part of this archive in a reproducible order independent of file systems and operating systems. This helps Gradle reliably produce byte-for-byte reproducible archives.

The current implementation produces different file orders on windows and linux and will result in archives that are not byte-for-byte reproducible.

<!--- Link to relevant issues or forum discussions here -->

https://github.com/gradle/gradle/issues/8051

### Contributor Checklist
- [x] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [x] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [x] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [x] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
