### PR TITLE
Clarify what the Kotlin DSL script dependencies resolver uses from the environment provided by IntelliJ

### DIFF
--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/KotlinBuildScriptDependenciesResolver.kt
@@ -30,17 +30,12 @@ import org.gradle.tooling.BuildException
 import com.google.common.annotations.VisibleForTesting
 
 import java.io.File
-import java.net.URI
 
 import kotlin.script.dependencies.KotlinScriptExternalDependencies
 import kotlin.script.dependencies.ScriptContents
 import kotlin.script.dependencies.ScriptContents.Position
 import kotlin.script.dependencies.ScriptDependenciesResolver
 import kotlin.script.dependencies.ScriptDependenciesResolver.ReportSeverity
-
-
-internal
-typealias Environment = Map<String, Any?>
 
 
 private
@@ -177,33 +172,24 @@ class KotlinBuildScriptDependenciesResolver @VisibleForTesting constructor(
         scriptFile: File?,
         environment: Environment,
         correlationId: String
-    ): KotlinBuildScriptModelRequest {
+    ): KotlinBuildScriptModelRequest =
 
-        @Suppress("unchecked_cast")
-        fun stringList(key: String) =
-            (environment[key] as? List<String>) ?: emptyList()
-
-        fun path(key: String) =
-            (environment[key] as? String)?.let(::File)
-
-        val projectDir = environment["projectRoot"] as File
-        return KotlinBuildScriptModelRequest(
-            projectDir = projectDir,
+        KotlinBuildScriptModelRequest(
+            projectDir = environment.projectRoot,
             scriptFile = scriptFile,
             gradleInstallation = gradleInstallationFrom(environment),
-            gradleUserHome = path("gradleUserHome"),
-            javaHome = path("gradleJavaHome"),
-            options = stringList("gradleOptions"),
-            jvmOptions = stringList("gradleJvmOptions"),
+            gradleUserHome = environment.gradleUserHome,
+            javaHome = environment.gradleJavaHome,
+            options = environment.gradleOptions,
+            jvmOptions = environment.gradleJvmOptions,
             correlationId = correlationId
         )
-    }
 
     private
     fun gradleInstallationFrom(environment: Environment): GradleInstallation =
-        (environment["gradleHome"] as? File)?.let(GradleInstallation::Local)
-            ?: (environment["gradleUri"] as? URI)?.let(GradleInstallation::Remote)
-            ?: (environment["gradleVersion"] as? String)?.let(GradleInstallation::Version)
+        environment.gradleHome?.let(GradleInstallation::Local)
+            ?: environment.gradleUri?.let(GradleInstallation::Remote)
+            ?: environment.gradleVersion?.let(GradleInstallation::Version)
             ?: GradleInstallation.Wrapper
 
     private

--- a/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
+++ b/subprojects/kotlin-dsl/src/main/kotlin/org/gradle/kotlin/dsl/resolver/ResolverEnvironment.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.gradle.kotlin.dsl.resolver
+
+import java.io.File
+import java.net.URI
+
+
+/**
+ * Environment given to the [KotlinBuildScriptDependenciesResolver] by the Kotlin IntelliJ Plugin.
+ *
+ * See `GradleScriptTemplateProvider` in `jetbrains/kotlin`.
+ */
+internal
+typealias Environment = Map<String, Any?>
+
+
+/**
+ * Path of the root directory of the IntelliJ project.
+ */
+internal
+val Environment.projectRoot: File
+    get() = get("projectRoot") as File
+
+
+/**
+ * Path of the local Gradle installation as configured in IntelliJ.
+ */
+internal
+val Environment.gradleHome: File?
+    get() = get("gradleHome") as? File
+
+
+/**
+ * URI of the remote Gradle distribution as configured in IntelliJ.
+ */
+internal
+val Environment.gradleUri: URI?
+    get() = get("gradleUri") as? URI
+
+
+/**
+ * Version of Gradle as configured in IntelliJ.
+ */
+internal
+val Environment.gradleVersion: String?
+    get() = get("gradleVersion") as? String
+
+
+/**
+ * Path of the Gradle user home as configured in IntelliJ.
+ */
+internal
+val Environment.gradleUserHome: File?
+    get() = path("gradleUserHome")
+
+
+/**
+ * JAVA_HOME to use for Gradle as configured in IntelliJ.
+ */
+internal
+val Environment.gradleJavaHome: File?
+    get() = path("gradleJavaHome")
+
+
+/**
+ * TODO unknown.
+ */
+internal
+val Environment.gradleOptions: List<String>
+    get() = stringList("gradleOptions")
+
+
+/**
+ * Gradle JVM options as configured in IntelliJ.
+ */
+internal
+val Environment.gradleJvmOptions: List<String>
+    get() = stringList("gradleJvmOptions")
+
+
+private
+fun Environment.path(key: String): File? =
+    (get(key) as? String)?.let(::File)
+
+
+@Suppress("unchecked_cast")
+private
+fun Environment.stringList(key: String): List<String> =
+    (get(key) as? List<String>) ?: emptyList()


### PR DESCRIPTION
This PR makes no behavioral change, it only includes a small refactoring for clarity. There's now a single place to look at to know what entries from the environment provided by the IntelliJ Kotlin Plugin get used by our script dependencies resolver, plus some documentation.

The goal is to make it easier to understand what is happening when troubleshooting/discussing issues such as https://github.com/gradle/gradle/issues/9422