### PR TITLE
Fix hyphen

### DIFF
--- a/subprojects/docs/src/docs/userguide/java_testing.adoc
+++ b/subprojects/docs/src/docs/userguide/java_testing.adoc
@@ -70,7 +70,7 @@ You can run your tests in parallel by setting this property to a value greater t
 +
 Your tests can distinguish between parallel test processes by using the value of the `org.gradle.test.worker` property, which is unique for each process. You can use this for anything you want, but it's particularly useful for filenames and other resource identifiers to prevent the kind of conflict we just mentioned.
 
-`forkEvery` - default: 0 (no maximum)::
+`forkEvery` — default: 0 (no maximum)::
 This property specifies the maximum number of test classes that Gradle should run on a test process before its disposed of and a fresh one created. This is mainly used as a way to manage leaky tests or frameworks that have static state that can't be cleared or reset between tests.
 +
 *Warning: a low value (other than 0) can severely hurt the performance of the tests*


### PR DESCRIPTION
### Context
The `-` from the `forkEvery` option is wrong [in the docs](https://docs.gradle.org/5.4.1/userguide/java_testing.html#sec:test_execution):
![Bildschirmfoto 2019-05-16 um 10 58 14](https://user-images.githubusercontent.com/10229883/57840778-8e3cec80-77c9-11e9-8a84-7e3e3e4390ba.png)

I fixed that by coping the hyphen from the `maxParallelForks` to the `forkEvery` option.

Unfortunately I don't see any difference in the `git diff` and I was to lazy to test if the copying fix that issue. But since I have copied the character I think the change should be correct 😅

### Contributor Checklist
- [ ] [Review Contribution Guidelines](https://github.com/gradle/gradle/blob/master/CONTRIBUTING.md)
- [ ] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Check ["Allow edit from maintainers" option](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) in pull request so that additional changes can be pushed by Gradle team
- [ ] Provide integration tests (under `<subproject>/src/integTest`) to verify changes from a user perspective
- [ ] Provide unit tests (under `<subproject>/src/test`) to verify logic
- [ ] Update User Guide, DSL Reference, and Javadoc for public-facing changes
- [ ] Ensure that tests pass locally: `./gradlew <changed-subproject>:check`

### Gradle Core Team Checklist
- [ ] Verify design and implementation 
- [ ] Verify test coverage and CI build status
- [ ] Verify documentation
- [ ] Recognize contributor in release notes
