### PR TITLE
Enable the use of Java 8 syntax in Core API

### DIFF
--- a/subprojects/core-api/core-api.gradle.kts
+++ b/subprojects/core-api/core-api.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 }
 
 gradlebuildJava {
-    moduleType = ModuleType.WORKER
+    moduleType = ModuleType.CORE
 }
 
 testFixtures {


### PR DESCRIPTION
What it says on the tin.